### PR TITLE
cache: sign narinfo before storing it in the store

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -195,7 +195,7 @@ func TestPublicKey(t *testing.T) {
 		t.Fatalf("error not expected, got an error: %s", err)
 	}
 
-	pubKey := c.PublicKey()
+	pubKey := c.PublicKey().String()
 
 	t.Run("should return a public key with the correct prefix", func(t *testing.T) {
 		t.Parallel()
@@ -293,6 +293,28 @@ func TestGetNarInfo(t *testing.T) {
 			_, err := os.Stat(filepath.Join(dir, "store", narInfoHash+".narinfo"))
 			if err != nil {
 				t.Fatalf("expected no error got %s", err)
+			}
+		})
+
+		t.Run("it should be signed by our server", func(t *testing.T) {
+			var found bool
+			var sig signature.Signature
+
+			for _, sig = range ni.Signatures {
+				if sig.Name == "cache.example.com" {
+					found = true
+					break
+				}
+			}
+
+			if want, got := true, found; want != got {
+				t.Errorf("want %t got %t", want, got)
+			}
+
+			validSig := signature.VerifyFirst(ni.Fingerprint(), ni.Signatures, []signature.PublicKey{c.PublicKey()})
+
+			if want, got := true, validSig; want != got {
+				t.Errorf("want %t got %t", want, got)
 			}
 		})
 	})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -121,7 +121,7 @@ func (s *Server) getIndex(w http.ResponseWriter, _ *http.Request) {
 		Publickey string `json:"publicKey"`
 	}{
 		Hostname:  s.cache.GetHostname(),
-		Publickey: s.cache.PublicKey(),
+		Publickey: s.cache.PublicKey().String(),
 	}
 
 	if err := json.NewEncoder(w).Encode(body); err != nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/inconshreveable/log15/v3"
@@ -139,8 +140,9 @@ func TestServeHTTP(t *testing.T) {
 				t.Fatalf("expected no error got %s", err)
 			}
 
-			if want, got := narInfoText, string(body); want != got {
-				t.Errorf("want %q got %q", want, got)
+			// NOTE: HasPrefix instead equality because we add our signature to the narInfo.
+			if !strings.HasPrefix(string(body), narInfoText) {
+				t.Error("expected the body to start with narInfo but it did not")
 			}
 		})
 	})


### PR DESCRIPTION
The narinfo should be signed before placed into our store so Nix can validate the narinfo/nar served by the server.