### PR TITLE
cache: pull from upstream without context from user's request

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -103,12 +103,12 @@ func (c Cache) PublicKey() signature.PublicKey { return c.secretKey.ToPublicKey(
 // the nar is not found in the store, it's pulled from an upstream, stored in
 // the stored and finally returned.
 // NOTE: It's the caller responsibility to close the body.
-func (c Cache) GetNar(ctx context.Context, hash, compression string) (int64, io.ReadCloser, error) {
+func (c Cache) GetNar(hash, compression string) (int64, io.ReadCloser, error) {
 	if c.hasNarInStore(hash, compression) {
 		return c.getNarFromStore(hash, compression)
 	}
 
-	size, r, err := c.getNarFromUpstream(ctx, hash, compression)
+	size, r, err := c.getNarFromUpstream(hash, compression)
 	if err != nil {
 		return 0, nil, fmt.Errorf("error getting the narInfo from upstream caches: %w", err)
 	}
@@ -135,7 +135,11 @@ func (c Cache) getNarFromStore(hash, compression string) (int64, io.ReadCloser, 
 	return c.getFromStore(helper.NarPath(hash, compression))
 }
 
-func (c Cache) getNarFromUpstream(ctx context.Context, hash, compression string) (int64, io.ReadCloser, error) {
+func (c Cache) getNarFromUpstream(hash, compression string) (int64, io.ReadCloser, error) {
+	// create a new context not associated with any request because we don't want
+	// pulling from upstream to be associated with a user request.
+	ctx := context.Background()
+
 	for _, uc := range c.upstreamCaches {
 		size, nar, err := uc.GetNar(ctx, hash, compression)
 		if err != nil {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -368,7 +368,7 @@ func TestGetNar(t *testing.T) {
 	}
 
 	t.Run("nar does not exist upstream", func(t *testing.T) {
-		_, _, err := c.GetNar(context.Background(), "doesnotexist", "")
+		_, _, err := c.GetNar("doesnotexist", "")
 		if want, got := cache.ErrNotFound, err; !errors.Is(got, want) {
 			t.Errorf("want %s got %s", want, got)
 		}
@@ -382,7 +382,7 @@ func TestGetNar(t *testing.T) {
 			}
 		})
 
-		size, r, err := c.GetNar(context.Background(), narHash, "")
+		size, r, err := c.GetNar(narHash, "")
 		if err != nil {
 			t.Fatalf("no error expected, got: %s", err)
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -184,7 +184,7 @@ func (s Server) getNar(withBody bool) http.HandlerFunc {
 		hash := chi.URLParam(r, "hash")
 		compression := chi.URLParam(r, "compression")
 
-		size, reader, err := s.cache.GetNar(r.Context(), hash, compression)
+		size, reader, err := s.cache.GetNar(hash, compression)
 		if err != nil {
 			if errors.Is(err, cache.ErrNotFound) {
 				w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
If the request from a user was canceled, it should not stop pulling from upstream cache!