### PR TITLE
cache: fix the pattern for temp-dir cache-path (nit)

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -99,7 +99,7 @@ func TestNew(t *testing.T) {
 		})
 
 		t.Run("config/, store/nar and store/tmp were created", func(t *testing.T) {
-			dir, err := os.MkdirTemp("", "cache-path")
+			dir, err := os.MkdirTemp("", "cache-path-")
 			if err != nil {
 				t.Fatalf("expected no error, got: %q", err)
 			}
@@ -127,7 +127,7 @@ func TestNew(t *testing.T) {
 		})
 
 		t.Run("store/tmp is removed on boot", func(t *testing.T) {
-			dir, err := os.MkdirTemp("", "cache-path")
+			dir, err := os.MkdirTemp("", "cache-path-")
 			if err != nil {
 				t.Fatalf("expected no error, got: %q", err)
 			}


### PR DESCRIPTION
Nit: The pattern should end with a dash.