### PR TITLE
cache: prevent multiple downloads

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -58,8 +58,8 @@ type Cache struct {
 }
 
 // New returns a new Cache.
-func New(logger log15.Logger, hostName, cachePath string, ucs []upstream.Cache) (Cache, error) {
-	c := Cache{logger: logger, upstreamCaches: ucs}
+func New(logger log15.Logger, hostName, cachePath string, ucs []upstream.Cache) (*Cache, error) {
+	c := &Cache{logger: logger, upstreamCaches: ucs}
 
 	if err := c.validateHostname(hostName); err != nil {
 		return c, err
@@ -94,16 +94,16 @@ func New(logger log15.Logger, hostName, cachePath string, ucs []upstream.Cache) 
 }
 
 // GetHostname returns the hostname.
-func (c Cache) GetHostname() string { return c.hostName }
+func (c *Cache) GetHostname() string { return c.hostName }
 
 // PublicKey returns the public key of the server.
-func (c Cache) PublicKey() signature.PublicKey { return c.secretKey.ToPublicKey() }
+func (c *Cache) PublicKey() signature.PublicKey { return c.secretKey.ToPublicKey() }
 
 // GetNarInfo returns the nar given a hash and compression from the store. If
 // the nar is not found in the store, it's pulled from an upstream, stored in
 // the stored and finally returned.
 // NOTE: It's the caller responsibility to close the body.
-func (c Cache) GetNar(ctx context.Context, hash, compression string) (int64, io.ReadCloser, error) {
+func (c *Cache) GetNar(ctx context.Context, hash, compression string) (int64, io.ReadCloser, error) {
 	if c.hasNarInStore(hash, compression) {
 		return c.getNarFromStore(hash, compression)
 	}
@@ -127,15 +127,15 @@ func (c Cache) GetNar(ctx context.Context, hash, compression string) (int64, io.
 	return c.getNarFromStore(hash, compression)
 }
 
-func (c Cache) hasNarInStore(hash, compression string) bool {
+func (c *Cache) hasNarInStore(hash, compression string) bool {
 	return c.hasInStore(helper.NarPath(hash, compression))
 }
 
-func (c Cache) getNarFromStore(hash, compression string) (int64, io.ReadCloser, error) {
+func (c *Cache) getNarFromStore(hash, compression string) (int64, io.ReadCloser, error) {
 	return c.getFromStore(helper.NarPath(hash, compression))
 }
 
-func (c Cache) getNarFromUpstream(ctx context.Context, hash, compression string) (int64, io.ReadCloser, error) {
+func (c *Cache) getNarFromUpstream(ctx context.Context, hash, compression string) (int64, io.ReadCloser, error) {
 	for _, uc := range c.upstreamCaches {
 		size, nar, err := uc.GetNar(ctx, hash, compression)
 		if err != nil {
@@ -152,7 +152,7 @@ func (c Cache) getNarFromUpstream(ctx context.Context, hash, compression string)
 	return 0, nil, ErrNotFound
 }
 
-func (c Cache) putNarInStore(hash, compression string, r io.ReadCloser) (int64, error) {
+func (c *Cache) putNarInStore(hash, compression string, r io.ReadCloser) (int64, error) {
 	pattern := hash + "-*.nar"
 	if compression != "" {
 		pattern += "." + compression
@@ -187,7 +187,7 @@ func (c Cache) putNarInStore(hash, compression string, r io.ReadCloser) (int64, 
 // GetNarInfo returns the narInfo given a hash from the store. If the narInfo
 // is not found in the store, it's pulled from an upstream, stored in the
 // stored and finally returned.
-func (c Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, error) {
+func (c *Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, error) {
 	if c.hasNarInfoInStore(hash) {
 		return c.getNarInfoFromStore(hash)
 	}
@@ -208,7 +208,7 @@ func (c Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, e
 	return narInfo, nil
 }
 
-func (c Cache) signNarInfo(narInfo *narinfo.NarInfo) error {
+func (c *Cache) signNarInfo(narInfo *narinfo.NarInfo) error {
 	sig, err := c.secretKey.Sign(nil, narInfo.Fingerprint())
 	if err != nil {
 		return fmt.Errorf("error signing the fingerprint: %w", err)
@@ -219,11 +219,11 @@ func (c Cache) signNarInfo(narInfo *narinfo.NarInfo) error {
 	return nil
 }
 
-func (c Cache) hasNarInfoInStore(hash string) bool {
+func (c *Cache) hasNarInfoInStore(hash string) bool {
 	return c.hasInStore(helper.NarInfoPath(hash))
 }
 
-func (c Cache) getNarInfoFromStore(hash string) (*narinfo.NarInfo, error) {
+func (c *Cache) getNarInfoFromStore(hash string) (*narinfo.NarInfo, error) {
 	_, r, err := c.getFromStore(helper.NarInfoPath(hash))
 	if err != nil {
 		return nil, fmt.Errorf("error fetching the narinfo from the store: %w", err)
@@ -234,7 +234,7 @@ func (c Cache) getNarInfoFromStore(hash string) (*narinfo.NarInfo, error) {
 	return narinfo.Parse(r)
 }
 
-func (c Cache) getNarInfoFromUpstream(ctx context.Context, hash string) (*narinfo.NarInfo, error) {
+func (c *Cache) getNarInfoFromUpstream(ctx context.Context, hash string) (*narinfo.NarInfo, error) {
 	for _, uc := range c.upstreamCaches {
 		narInfo, err := uc.GetNarInfo(ctx, hash)
 		if err != nil {
@@ -251,7 +251,7 @@ func (c Cache) getNarInfoFromUpstream(ctx context.Context, hash string) (*narinf
 	return nil, ErrNotFound
 }
 
-func (c Cache) putNarInfoInStore(hash string, narInfo *narinfo.NarInfo) error {
+func (c *Cache) putNarInfoInStore(hash string, narInfo *narinfo.NarInfo) error {
 	f, err := os.CreateTemp(c.storeTMPPath(), hash+"-*.narinfo")
 	if err != nil {
 		return fmt.Errorf("error creating the temporary directory: %w", err)
@@ -277,7 +277,7 @@ func (c Cache) putNarInfoInStore(hash string, narInfo *narinfo.NarInfo) error {
 	return nil
 }
 
-func (c Cache) hasInStore(key string) bool {
+func (c *Cache) hasInStore(key string) bool {
 	_, err := os.Stat(filepath.Join(c.storePath(), key))
 
 	return err == nil
@@ -285,7 +285,7 @@ func (c Cache) hasInStore(key string) bool {
 
 // GetFile returns the file define by its key
 // NOTE: It's the caller responsibility to close the file after using it.
-func (c Cache) getFromStore(key string) (int64, io.ReadCloser, error) {
+func (c *Cache) getFromStore(key string) (int64, io.ReadCloser, error) {
 	p := filepath.Join(c.storePath(), key)
 
 	f, err := os.Open(p)
@@ -301,7 +301,7 @@ func (c Cache) getFromStore(key string) (int64, io.ReadCloser, error) {
 	return info.Size(), f, nil
 }
 
-func (c Cache) validateHostname(hostName string) error {
+func (c *Cache) validateHostname(hostName string) error {
 	if hostName == "" {
 		c.logger.Error("given hostname is empty", "hostName", hostName)
 
@@ -330,7 +330,7 @@ func (c Cache) validateHostname(hostName string) error {
 	return nil
 }
 
-func (c Cache) validatePath(cachePath string) error {
+func (c *Cache) validatePath(cachePath string) error {
 	if !filepath.IsAbs(cachePath) {
 		c.logger.Error("path is not absolute", "path", cachePath)
 
@@ -357,7 +357,7 @@ func (c Cache) validatePath(cachePath string) error {
 	return nil
 }
 
-func (c Cache) isWritable(cachePath string) bool {
+func (c *Cache) isWritable(cachePath string) bool {
 	tmpFile, err := os.CreateTemp(cachePath, "write_test")
 	if err != nil {
 		c.logger.Error("error writing a temp file in the path", "path", cachePath, "error", err)
@@ -371,7 +371,7 @@ func (c Cache) isWritable(cachePath string) bool {
 	return true
 }
 
-func (c Cache) setupDirs() error {
+func (c *Cache) setupDirs() error {
 	if err := os.RemoveAll(c.storeTMPPath()); err != nil {
 		return fmt.Errorf("error removing the temporary download directory: %w", err)
 	}
@@ -392,13 +392,13 @@ func (c Cache) setupDirs() error {
 	return nil
 }
 
-func (c Cache) configPath() string    { return filepath.Join(c.path, "config") }
-func (c Cache) secretKeyPath() string { return filepath.Join(c.configPath(), "cache.key") }
-func (c Cache) storePath() string     { return filepath.Join(c.path, "store") }
-func (c Cache) storeNarPath() string  { return filepath.Join(c.storePath(), "nar") }
-func (c Cache) storeTMPPath() string  { return filepath.Join(c.storePath(), "tmp") }
+func (c *Cache) configPath() string    { return filepath.Join(c.path, "config") }
+func (c *Cache) secretKeyPath() string { return filepath.Join(c.configPath(), "cache.key") }
+func (c *Cache) storePath() string     { return filepath.Join(c.path, "store") }
+func (c *Cache) storeNarPath() string  { return filepath.Join(c.storePath(), "nar") }
+func (c *Cache) storeTMPPath() string  { return filepath.Join(c.storePath(), "tmp") }
 
-func (c Cache) setupSecretKey() (signature.SecretKey, error) {
+func (c *Cache) setupSecretKey() (signature.SecretKey, error) {
 	f, err := os.Open(c.secretKeyPath())
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -422,7 +422,7 @@ func (c Cache) setupSecretKey() (signature.SecretKey, error) {
 	return sk, nil
 }
 
-func (c Cache) createNewKey() (signature.SecretKey, error) {
+func (c *Cache) createNewKey() (signature.SecretKey, error) {
 	if err := os.MkdirAll(filepath.Dir(c.secretKeyPath()), 0o700); err != nil {
 		return signature.SecretKey{}, fmt.Errorf("error creating the parent directories for %q: %w", c.secretKeyPath(), err)
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/inconshreveable/log15/v3"
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
@@ -116,14 +117,18 @@ func (c *Cache) GetNar(ctx context.Context, hash, compression string) (int64, io
 		return c.getNarFromStore(hash, compression)
 	}
 
+	log := c.logger.New("hash", hash, "compression", compression)
+
 	errC := make(chan error)
 
 	c.mu.Lock()
 	doneC, ok := c.upstreamJobs[hash]
-	if !ok {
+	if ok {
+		log.Info("waiting for an in-progress download to finish")
+	} else {
 		doneC = make(chan struct{})
 		c.upstreamJobs[hash] = doneC
-		go c.pullNar(ctx, hash, compression, doneC, errC)
+		go c.pullNar(log, ctx, hash, compression, doneC, errC)
 	}
 	c.mu.Unlock()
 
@@ -142,7 +147,10 @@ func (c *Cache) GetNar(ctx context.Context, hash, compression string) (int64, io
 	return c.getNarFromStore(hash, compression)
 }
 
-func (c *Cache) pullNar(ctx context.Context, hash, compression string, doneC chan struct{}, errC chan error) {
+func (c *Cache) pullNar(log log15.Logger, ctx context.Context, hash, compression string, doneC chan struct{}, errC chan error) {
+	now := time.Now()
+	log.Info("downloading the nar from upstream")
+
 	size, r, err := c.getNarFromUpstream(ctx, hash, compression)
 	if err != nil {
 		c.mu.Lock()
@@ -167,8 +175,10 @@ func (c *Cache) pullNar(ctx context.Context, hash, compression string, doneC cha
 		return
 	}
 
+	log.Info("download complete", "elapsed", time.Now().Sub(now))
+
 	if size > 0 && written != size {
-		c.logger.Error("bytes written is not the same as Content-Length", "Content-Length", size, "written", written)
+		log.Error("bytes written is not the same as Content-Length", "Content-Length", size, "written", written)
 	}
 
 	c.mu.Lock()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -35,13 +35,13 @@ Priority: 10`
 
 // Server represents the main HTTP server.
 type Server struct {
-	cache  cache.Cache
+	cache  *cache.Cache
 	logger log15.Logger
 	router *chi.Mux
 }
 
 // New returns a new server.
-func New(logger log15.Logger, cache cache.Cache) Server {
+func New(logger log15.Logger, cache *cache.Cache) Server {
 	s := Server{
 		cache:  cache,
 		logger: logger,


### PR DESCRIPTION
Multiple requests for the same NAR arriving concurrently is possible, and that  would cause ncps to pull the same NAR from upstream multiple times (one time per request). In order to avoid multiple downloads, keep track of ongoing download jobs so all requests are using the same download.