### PR TITLE
cache: pull NAR files when narinfo files are pulled from upstream

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -266,23 +266,7 @@ func (c *Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, 
 	}
 
 	// start a job to also pull the nar
-	go func() {
-		hash, compression, err := helper.ParseNarURL(narInfo.URL)
-		c.logger.Info("pre-caching NAR ahead of time", "URL", narInfo.URL, "hash", hash, "compression", compression)
-		if err != nil {
-			c.logger.Error("error parsing the nar URL %q: %w", narInfo.URL, err)
-
-			return
-		}
-		_, nar, err := c.GetNar(hash, compression)
-		if err != nil {
-			c.logger.Error("error fetching the NAR: %w", err)
-
-			return
-		}
-
-		nar.Close()
-	}()
+	go c.prePullNar(narInfo.URL)
 
 	if err := c.signNarInfo(narInfo); err != nil {
 		return nil, fmt.Errorf("error signing the narinfo: %w", err)
@@ -293,6 +277,26 @@ func (c *Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, 
 	}
 
 	return narInfo, nil
+}
+
+func (c *Cache) prePullNar(url string) {
+	hash, compression, err := helper.ParseNarURL(url)
+	if err != nil {
+		c.logger.Error("error parsing the nar URL %q: %w", url, err)
+
+		return
+	}
+
+	c.logger.Info("pre-caching NAR ahead of time", "URL", url, "hash", hash, "compression", compression)
+
+	_, nar, err := c.GetNar(hash, compression)
+	if err != nil {
+		c.logger.Error("error fetching the NAR: %w", err)
+
+		return
+	}
+
+	nar.Close()
 }
 
 func (c *Cache) signNarInfo(narInfo *narinfo.NarInfo) error {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -309,7 +309,7 @@ func TestGetNarInfo(t *testing.T) {
 		})
 
 		t.Run("it should have also pulled the nar", func(t *testing.T) {
-			_, err := os.Stat(filepath.Join(dir, "store", narHash+".nar"))
+			_, err := os.Stat(filepath.Join(dir, "store", "nar", narHash+".nar"))
 			if err != nil {
 				t.Fatalf("expected no error got %s", err)
 			}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -330,16 +330,17 @@ func TestGetNarInfo(t *testing.T) {
 		t.Run("it should have also pulled the nar", func(t *testing.T) {
 			// Force the other goroutine to run so it actually download the file
 			// Try at least 10 times before announcing an error
+			var err error
 			for i := 0; i < 9; i++ {
 				runtime.Gosched()
 
-				_, err := os.Stat(filepath.Join(dir, "store", "nar", narHash2+".nar"))
+				_, err = os.Stat(filepath.Join(dir, "store", "nar", narHash2+".nar"))
 				if err == nil {
 					break
 				}
 			}
 			if err != nil {
-				t.Fatalf("expected no error got %s", err)
+				t.Errorf("expected no error got %s", err)
 			}
 		})
 	})

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -49,6 +49,24 @@ Sig: cache.nixos.org-1:WzhkqDdkgPz2qU/0QyEA6wUIm7EMR5MY8nTb5jAmmoh5b80ACIp/+Zpgi
 	narHash1 = "136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00"
 
 	narText1 = "Hello, World" // fake nar for above nar info
+
+	narInfoHash2 = "a6hiaxlxf7arxsf59f4rzs7b337z6a11"
+
+	//nolint:lll
+	narInfoText2 = `StorePath: /nix/store/a6hiaxlxf7arxsf59f4rzs7b337z6a11-brave-1.73.91
+URL: nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar
+Compression: xz
+FileHash: sha256:1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps
+FileSize: 125606280
+NarHash: sha256:1q95nilzb512ckljzj7h8bsdnj4qhpvyddp74bhsf8sxb8vjmpsj
+NarSize: 388038816
+References: 08mdbxgs2m7fz3hx2xrqrbmhldxagpf8-pango-1.54.0-bin 0irlcqx2n3qm6b1pc9rsd2i8qpvcccaj-bash-5.2p37 2542sr1ch7ypz52w423vyn0fhn934rj7-dbus-1.14.10 3c603pkfh9fq13lrm6rdqynb7xxwazv7-libXrandr-1.5.4 3ma7c4syxds2wrp03ax3b7p9fdsh1lwg-nss-3.101.2 4qiqy2z0facj37682n9x0mz0isd9k3qb-libXScrnSaver-1.2.4 4zjxqvvnnisn8nqmibgy40rvm087v85n-cups-2.4.11-lib 566jyp236h118ad005mxqs7sb9ivv4yj-libXrender-0.9.11 5lq743a2jp3v4kgr80y0sw8jr70pl6gj-libXi-1.8.2 7c88jgbh10zvlv91bmhyc40h8l9b3wf5-librsvg-2.58.3 84839y8j0d4l4d3q048v00h20jdk9lh0-wayland-1.23.1 946m0cmd00hcw2s6slzp5qc01krgrzks-dbus-1.14.10-lib 9i9wrwdi1hkcklzya0yhci0d0vkyl79k-alsa-lib-1.2.12 a6hiaxlxf7arxsf59f4rzs7b337z6a11-brave-1.73.91 apmrnyl4b6fj9czqkb8vwpf6cvfvs0ba-glib-2.82.1-bin arrgysrp5ks44qidsf8byjj11pnkaf65-cairo-1.18.2 b4ph9mwdv628db2vqhhhp3azalq6cwbq-libxcb-1.17.0 c1lszwlw825y6vr4qik6dqv2lszqk08r-libdrm-2.4.123-bin ckfsxyla4krxn4zdlmxkp6lk8nsscr5v-libXcursor-1.2.2 dcj4w0a7472g86yf5wqz5vfbd809s4cj-snappy-1.2.1 gsdkqm4qfbzr22m20cns3iilxd55ridd-freetype-2.13.3 hm2rpszabwpvs28jwkaz7pg0dqslm4bd-util-linux-minimal-2.39.4-lib hpd1dss7lmrywlr37vncyzbhzp6rgri5-libXext-1.3.6 i0d0ws5xwix1dvmwp8w1fr4kz61k11x4-libxkbcommon-1.7.0 i66c6m4680fdgfj5fmaclma1bbl9y8i6-systemd-minimal-libs-256.7 ibr7wf806ns8517zggai9yygz07kp85a-libdrm-2.4.123 idrnfiw9r87giqiqwr36xkch4dsr0rdz-pango-1.54.0 j6wpl172pz2323fia7cbjx9lznsc47ri-at-spi2-core-2.54.0 jbck0ahim6cbjjzl1wmrch5inhbhkkra-gtk4-4.16.3 jq1ydifw3ip1vx94dl8w8bgvr07l6s3x-glib-2.82.1 jx4rwrk7cg5v64ygbpyi1v3gfp8c7k9h-fontconfig-2.15.0-bin k48bha2fjqzarg52picsdfwlqx75aqbb-coreutils-9.5 lafwzwzrj53prpzgmmq0aq5spal91q7s-libXdamage-1.1.6 lcq3ibmsb6c2jgqp3yfi1yp773x5wz19-mesa-24.2.6 ldqjvk81fdzygd85505lzc781vssfpdy-libXtst-1.2.5 m761lp9x14i33hb3q7a8wm52rsnk6ab1-expat-2.6.4 mafw0r1djqvl36by8qhz02kmaggh24v8-gdk-pixbuf-2.42.12 mhp5jkwqgyz0s7klvpl23x3axgvn6msm-pipewire-1.2.6 ms2562w6dkqa6xzpaxi4n2ib9kbb3gya-libXcomposite-0.4.6 p5nz6gdblng41fiqqb7z88l119dc9v56-gsettings-desktop-schemas-47.1 pacbfvpzqz2mksby36awvbcn051zcji3-glibc-2.40-36 pg3xw94i23l4dkrxcp7l11a2iydxc1za-dconf-0.40.0-lib q8y8kgidr4mg0q7zr2h1ddpd7ijy3wna-libpulseaudio-17.0 qrj5f1mb08k5jg7y9ikzb1njli0gvmxz-libX11-1.8.10 rdjcf9pxdlcd6ncsiqm97gq4ard6c91f-nspr-4.36 rh6zrnvbzjsfy444w5w2k5sz72cl6f4z-libva-2.22.0 rmfav7fq6rmpv3d785v462shsy1njq6f-fontconfig-2.15.0-lib sawcd2sh4p7kdggj00i67wa59swaid5b-util-linux-minimal-2.39.4-bin vbw9c3pvwli5iidik8dddgz423wr1h18-gtk+3-3.24.43 w3clwb8c7c8vc7ls163p5pjspccgcrhj-cups-2.4.11 w9g781rqrc12870vji13hycwh47lwsgd-qtbase-6.8.0 wfqs8h2mf4ib7f1phpsgv0b20xny9zzl-libXfixes-6.0.1 wjnznkh0x4744mcvhlnr4qnnig15287c-xdg-utils-1.2.1 xghyamhbjj0rfavxj76l52mv7zr7dfiw-krb5-1.21.3-lib xk9b2k475ab7q9xmcqcfb1xcyh9arswj-krb5-1.21.3 y6bcc1vzg315zzzpir608zkhnmvp49kc-zlib-1.3.1 ymhcg6x5jrw3hx8ik1cji6awiybgp9f7-libglvnd-1.7.0 zm54lx2l4jsc0dw1cnmyg8ilcn07v6zb-libxshmfence-1.3.2
+Deriver: n85jhy5b8c9l1a4d9pnf3dv8bfvmyzhb-brave-1.73.91.drv
+Sig: cache.nixos.org-1:QVc2ad4OI/2G5gVyFsoWYr+AECFDXjwF6o1HOfSbMJhPp5l4iD38WgJhf2w/3kZ/B5ftq6ytDijcAWCSDItJDQ==`
+
+	narHash2 = "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps"
+
+	narText2 = "Wave, World" // fake nar for above nar info
 )
 
 func TestNew(t *testing.T) {
@@ -255,32 +273,32 @@ func TestGetNarInfo(t *testing.T) {
 
 	t.Run("narfile exists upstream", func(t *testing.T) {
 		t.Run("narfile does not exist in storage yet", func(t *testing.T) {
-			_, err := os.Stat(filepath.Join(dir, "store", narInfoHash1+".narinfo"))
+			_, err := os.Stat(filepath.Join(dir, "store", narInfoHash2+".narinfo"))
 			if err == nil {
 				t.Fatal("expected an error but got none")
 			}
 		})
 
 		t.Run("nar does not exist in storage yet", func(t *testing.T) {
-			_, err := os.Stat(filepath.Join(dir, "store", narHash1+".nar"))
+			_, err := os.Stat(filepath.Join(dir, "store", narHash2+".nar"))
 			if err == nil {
 				t.Fatal("expected an error but got none")
 			}
 		})
 
-		ni, err := c.GetNarInfo(context.Background(), narInfoHash1)
+		ni, err := c.GetNarInfo(context.Background(), narInfoHash2)
 		if err != nil {
 			t.Fatalf("no error expected, got: %s", err)
 		}
 
 		t.Run("size is correct", func(t *testing.T) {
-			if want, got := uint64(132228), ni.FileSize; want != got {
+			if want, got := uint64(125606280), ni.FileSize; want != got {
 				t.Errorf("want %d got %d", want, got)
 			}
 		})
 
 		t.Run("it should now exist in the store", func(t *testing.T) {
-			_, err := os.Stat(filepath.Join(dir, "store", narInfoHash1+".narinfo"))
+			_, err := os.Stat(filepath.Join(dir, "store", narInfoHash2+".narinfo"))
 			if err != nil {
 				t.Fatalf("expected no error got %s", err)
 			}
@@ -315,7 +333,7 @@ func TestGetNarInfo(t *testing.T) {
 			for i := 0; i < 9; i++ {
 				runtime.Gosched()
 
-				_, err := os.Stat(filepath.Join(dir, "store", "nar", narHash1+".nar"))
+				_, err := os.Stat(filepath.Join(dir, "store", "nar", narHash2+".nar"))
 				if err == nil {
 					break
 				}
@@ -424,6 +442,22 @@ func startServer(t *testing.T) *httptest.Server {
 
 		if r.URL.Path == "/nar/"+narHash1+".nar" {
 			if _, err := w.Write([]byte(narText1)); err != nil {
+				t.Fatalf("expected no error got: %s", err)
+			}
+
+			return
+		}
+
+		if r.URL.Path == "/"+narInfoHash2+".narinfo" {
+			if _, err := w.Write([]byte(narInfoText2)); err != nil {
+				t.Fatalf("expected no error got: %s", err)
+			}
+
+			return
+		}
+
+		if r.URL.Path == "/nar/"+narHash2+".nar" {
+			if _, err := w.Write([]byte(narText2)); err != nil {
 				t.Fatalf("expected no error got: %s", err)
 			}
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -331,6 +331,7 @@ func TestGetNarInfo(t *testing.T) {
 			// Force the other goroutine to run so it actually download the file
 			// Try at least 10 times before announcing an error
 			var err error
+
 			for i := 0; i < 9; i++ {
 				// NOTE: I tried runtime.Gosched() but it makes the test flaky
 				time.Sleep(time.Millisecond)
@@ -340,6 +341,7 @@ func TestGetNarInfo(t *testing.T) {
 					break
 				}
 			}
+
 			if err != nil {
 				t.Errorf("expected no error got %s", err)
 			}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -260,6 +260,13 @@ func TestGetNarInfo(t *testing.T) {
 			}
 		})
 
+		t.Run("nar does not exist in storage yet", func(t *testing.T) {
+			_, err := os.Stat(filepath.Join(dir, "store", narHash+".nar"))
+			if err == nil {
+				t.Fatal("expected an error but got none")
+			}
+		})
+
 		ni, err := c.GetNarInfo(context.Background(), narInfoHash)
 		if err != nil {
 			t.Fatalf("no error expected, got: %s", err)
@@ -298,6 +305,13 @@ func TestGetNarInfo(t *testing.T) {
 
 			if want, got := true, validSig; want != got {
 				t.Errorf("want %t got %t", want, got)
+			}
+		})
+
+		t.Run("it should have also pulled the nar", func(t *testing.T) {
+			_, err := os.Stat(filepath.Join(dir, "store", narHash+".nar"))
+			if err != nil {
+				t.Fatalf("expected no error got %s", err)
 			}
 		})
 	})

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -32,10 +32,10 @@ const (
 WantMassQuery: 1
 Priority: 40`
 
-	narInfoHash = "7bn85d74qa0127p85rrswfyghxsqmcf7"
+	narInfoHash1 = "7bn85d74qa0127p85rrswfyghxsqmcf7"
 
 	//nolint:lll
-	narInfoText = `StorePath: /nix/store/7bn85d74qa0127p85rrswfyghxsqmcf7-iputils-20210722
+	narInfoText1 = `StorePath: /nix/store/7bn85d74qa0127p85rrswfyghxsqmcf7-iputils-20210722
 URL: nar/136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00.nar
 Compression: xz
 FileHash: sha256:136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00
@@ -46,9 +46,9 @@ References: 7bn85d74qa0127p85rrswfyghxsqmcf7-iputils-20210722 892cxk44qxzzlw9h90
 Deriver: 9fs4vq4gdsb8r9ywawb5f6zl40ycp1bh-iputils-20210722.drv
 Sig: cache.nixos.org-1:WzhkqDdkgPz2qU/0QyEA6wUIm7EMR5MY8nTb5jAmmoh5b80ACIp/+Zpgi5t1KvmO8uG8GVrkPejCxbyQ2gNXDQ==`
 
-	narHash = "136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00"
+	narHash1 = "136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00"
 
-	narText = "Hello, World" // fake nar for above nar info
+	narText1 = "Hello, World" // fake nar for above nar info
 )
 
 func TestNew(t *testing.T) {
@@ -255,20 +255,20 @@ func TestGetNarInfo(t *testing.T) {
 
 	t.Run("narfile exists upstream", func(t *testing.T) {
 		t.Run("narfile does not exist in storage yet", func(t *testing.T) {
-			_, err := os.Stat(filepath.Join(dir, "store", narInfoHash+".narinfo"))
+			_, err := os.Stat(filepath.Join(dir, "store", narInfoHash1+".narinfo"))
 			if err == nil {
 				t.Fatal("expected an error but got none")
 			}
 		})
 
 		t.Run("nar does not exist in storage yet", func(t *testing.T) {
-			_, err := os.Stat(filepath.Join(dir, "store", narHash+".nar"))
+			_, err := os.Stat(filepath.Join(dir, "store", narHash1+".nar"))
 			if err == nil {
 				t.Fatal("expected an error but got none")
 			}
 		})
 
-		ni, err := c.GetNarInfo(context.Background(), narInfoHash)
+		ni, err := c.GetNarInfo(context.Background(), narInfoHash1)
 		if err != nil {
 			t.Fatalf("no error expected, got: %s", err)
 		}
@@ -280,7 +280,7 @@ func TestGetNarInfo(t *testing.T) {
 		})
 
 		t.Run("it should now exist in the store", func(t *testing.T) {
-			_, err := os.Stat(filepath.Join(dir, "store", narInfoHash+".narinfo"))
+			_, err := os.Stat(filepath.Join(dir, "store", narInfoHash1+".narinfo"))
 			if err != nil {
 				t.Fatalf("expected no error got %s", err)
 			}
@@ -315,7 +315,7 @@ func TestGetNarInfo(t *testing.T) {
 			for i := 0; i < 9; i++ {
 				runtime.Gosched()
 
-				_, err := os.Stat(filepath.Join(dir, "store", "nar", narHash+".nar"))
+				_, err := os.Stat(filepath.Join(dir, "store", "nar", narHash1+".nar"))
 				if err == nil {
 					break
 				}
@@ -353,7 +353,7 @@ func TestGetNar(t *testing.T) {
 		t.Errorf("expected no error, got %q", err)
 	}
 
-	narName := narHash + ".nar"
+	narName := narHash1 + ".nar"
 
 	t.Run("nar does not exist upstream", func(t *testing.T) {
 		_, _, err := c.GetNar("doesnotexist", "")
@@ -370,14 +370,14 @@ func TestGetNar(t *testing.T) {
 			}
 		})
 
-		size, r, err := c.GetNar(narHash, "")
+		size, r, err := c.GetNar(narHash1, "")
 		if err != nil {
 			t.Fatalf("no error expected, got: %s", err)
 		}
 		defer r.Close()
 
 		t.Run("size is correct", func(t *testing.T) {
-			if want, got := int64(len(narText)), size; want != got {
+			if want, got := int64(len(narText1)), size; want != got {
 				t.Errorf("want %d got %d", want, got)
 			}
 		})
@@ -388,7 +388,7 @@ func TestGetNar(t *testing.T) {
 				t.Fatalf("expected no error, got: %s", err)
 			}
 
-			if want, got := narText, string(body); want != got {
+			if want, got := narText1, string(body); want != got {
 				t.Errorf("want %q got %q", want, got)
 			}
 		})
@@ -414,16 +414,16 @@ func startServer(t *testing.T) *httptest.Server {
 			return
 		}
 
-		if r.URL.Path == "/"+narInfoHash+".narinfo" {
-			if _, err := w.Write([]byte(narInfoText)); err != nil {
+		if r.URL.Path == "/"+narInfoHash1+".narinfo" {
+			if _, err := w.Write([]byte(narInfoText1)); err != nil {
 				t.Fatalf("expected no error got: %s", err)
 			}
 
 			return
 		}
 
-		if r.URL.Path == "/nar/"+narHash+".nar" {
-			if _, err := w.Write([]byte(narText)); err != nil {
+		if r.URL.Path == "/nar/"+narHash1+".nar" {
+			if _, err := w.Write([]byte(narText1)); err != nil {
 				t.Fatalf("expected no error got: %s", err)
 			}
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -9,9 +9,9 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/inconshreveable/log15/v3"
 	"github.com/kalbasit/ncps/pkg/cache"
@@ -332,7 +332,8 @@ func TestGetNarInfo(t *testing.T) {
 			// Try at least 10 times before announcing an error
 			var err error
 			for i := 0; i < 9; i++ {
-				runtime.Gosched()
+				// NOTE: I tried runtime.Gosched() but it makes the test flaky
+				time.Sleep(time.Millisecond)
 
 				_, err = os.Stat(filepath.Join(dir, "store", "nar", narHash2+".nar"))
 				if err == nil {

--- a/pkg/helper/parser.go
+++ b/pkg/helper/parser.go
@@ -1,0 +1,27 @@
+package helper
+
+import (
+	"errors"
+	"regexp"
+)
+
+var (
+	// ErrNoMatchesInURL is returned if the regexp did not match the given URL.
+	ErrNoMatchesInURL = errors.New("no matches were found in the URL")
+
+	narRegexp = regexp.MustCompile(`^nar/([a-z0-9]+)\.nar(?:\.([a-z0-9]+))?$`)
+)
+
+// ParseNarURL parses a nar URL (as present in narinfo) and returns its components.
+func ParseNarURL(URL string) (string, string, error) {
+	if URL == "" {
+		return "", "", ErrNoMatchesInURL
+	}
+
+	sm := narRegexp.FindStringSubmatch(URL)
+	if len(sm) != 3 {
+		return "", "", ErrNoMatchesInURL
+	}
+
+	return sm[1], sm[2], nil
+}

--- a/pkg/helper/parser.go
+++ b/pkg/helper/parser.go
@@ -3,24 +3,25 @@ package helper
 import (
 	"errors"
 	"regexp"
+	"strings"
 )
 
 var (
-	// ErrNoMatchesInURL is returned if the regexp did not match the given URL.
-	ErrNoMatchesInURL = errors.New("no matches were found in the URL")
+	// ErrInvalidNarURL is returned if the regexp did not match the given URL.
+	ErrInvalidNarURL = errors.New("invalid nar URL")
 
 	narRegexp = regexp.MustCompile(`^nar/([a-z0-9]+)\.nar(?:\.([a-z0-9]+))?$`)
 )
 
 // ParseNarURL parses a nar URL (as present in narinfo) and returns its components.
 func ParseNarURL(URL string) (string, string, error) {
-	if URL == "" {
-		return "", "", ErrNoMatchesInURL
+	if URL == "" || !strings.HasPrefix(URL, "nar/") {
+		return "", "", ErrInvalidNarURL
 	}
 
 	sm := narRegexp.FindStringSubmatch(URL)
 	if len(sm) != 3 {
-		return "", "", ErrNoMatchesInURL
+		return "", "", ErrInvalidNarURL
 	}
 
 	return sm[1], sm[2], nil

--- a/pkg/helper/parser_test.go
+++ b/pkg/helper/parser_test.go
@@ -15,11 +15,11 @@ func TestParseNarURL(t *testing.T) {
 	}{
 		{
 			url: "",
-			err: ErrNoMatchesInURL,
+			err: ErrInvalidNarURL,
 		},
 		{
 			url: "helloworld",
-			err: ErrNoMatchesInURL,
+			err: ErrInvalidNarURL,
 		},
 		{
 			url:         "nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar",

--- a/pkg/helper/parser_test.go
+++ b/pkg/helper/parser_test.go
@@ -1,0 +1,55 @@
+//nolint:testpackage
+package helper
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParseNarURL(t *testing.T) {
+	tests := []struct {
+		url         string
+		hash        string
+		compression string
+		err         error
+	}{
+		{
+			url: "",
+			err: ErrNoMatchesInURL,
+		},
+		{
+			url: "helloworld",
+			err: ErrNoMatchesInURL,
+		},
+		{
+			url:         "nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar",
+			hash:        "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+			compression: "",
+			err:         nil,
+		},
+		{
+			url:         "nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.xz",
+			hash:        "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+			compression: "xz",
+			err:         nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("ParseNarURL(%q) -> (%q, %q, %s)", test.url, test.hash, test.compression, test.err), func(t *testing.T) {
+			hash, compression, err := ParseNarURL(test.url)
+
+			if want, got := test.hash, hash; want != got {
+				t.Errorf("want %q got %q", want, got)
+			}
+
+			if want, got := test.compression, compression; want != got {
+				t.Errorf("want %q got %q", want, got)
+			}
+
+			if want, got := test.err, err; want != got {
+				t.Errorf("want %q got %q", want, got)
+			}
+		})
+	}
+}

--- a/pkg/helper/parser_test.go
+++ b/pkg/helper/parser_test.go
@@ -2,6 +2,7 @@
 package helper
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 )
@@ -35,8 +36,13 @@ func TestParseNarURL(t *testing.T) {
 		},
 	}
 
+	t.Parallel()
+
 	for _, test := range tests {
-		t.Run(fmt.Sprintf("ParseNarURL(%q) -> (%q, %q, %s)", test.url, test.hash, test.compression, test.err), func(t *testing.T) {
+		t.Run(fmt.Sprintf("ParseNarURL(%q) -> (%q, %q, %s)",
+			test.url, test.hash, test.compression, test.err), func(t *testing.T) {
+			t.Parallel()
+
 			hash, compression, err := ParseNarURL(test.url)
 
 			if want, got := test.hash, hash; want != got {
@@ -47,8 +53,8 @@ func TestParseNarURL(t *testing.T) {
 				t.Errorf("want %q got %q", want, got)
 			}
 
-			if want, got := test.err, err; want != got {
-				t.Errorf("want %q got %q", want, got)
+			if want, got := test.err, err; !errors.Is(got, want) {
+				t.Errorf("want %s got %s", want, got)
 			}
 		})
 	}


### PR DESCRIPTION
When a client requests a narinfo file they will most likely also pull the NAR file itself, so download the NAR file right away after the narinfo file was pulled.