### PR TITLE
pkg/nixcacheinfo: Add a few more tests to the splitOnce  func

### DIFF
--- a/pkg/nixcacheinfo/splitonce_test.go
+++ b/pkg/nixcacheinfo/splitonce_test.go
@@ -15,8 +15,11 @@ func TestSplitOnce(t *testing.T) {
 		err  string
 	}{
 		{"hello:world", ":", "hello", "world", ""},
+		{":helloworld", ":", "", "helloworld", ""},
+		{"helloworld:", ":", "helloworld", "", ""},
 		{"helloworld", ":", "", "", "found no separators in the string: separator=\":\" string=\"helloworld\""},
 		{"hello:wo:rld", ":", "", "", "found multiple separators in the string: separator=\":\" string=\"hello:wo:rld\""},
+		{"hello::world", ":", "", "", "found multiple separators in the string: separator=\":\" string=\"hello::world\""},
 	}
 
 	t.Parallel()


### PR DESCRIPTION
@zimbatm added few more tests to my [pr upstream](https://github.com/nix-community/go-nix/pull/124), adding them back here for consistency. Thanks @zimbatm!