### PR TITLE
pkg/server: Respond to  DELETE for  nar and narinfo files

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ spec:
 
 ncps can be configured using the following flags:
 
+- `--allow-delete`: Whether to allow the DELETE verb to delete `narinfo` and `nar` files from the cache (default: false). (Environment variable: `$ALLOW_DELETE`)
 - `--cache-hostname`: The hostname of the cache server. **This is used to generate the private key used for signing store paths (.narinfo).** (Environment variable: `$CACHE_HOSTNAME`)
 - `--cache-data-path`: The local directory for storing configuration and cached store paths. (Environment variable: `$CACHE_DATA_PATH`)
 - `--server-addr`: The address and port the server listens on (default: ":8501"). (Environment variable: `$SERVER_ADDR`)

--- a/cmd/ncps/serve.go
+++ b/cmd/ncps/serve.go
@@ -22,7 +22,7 @@ var serveCommand = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:    "allow-delete",
-			Usage:   "Wether to allow the DELETE verb to delete narInfo and nar files",
+			Usage:   "Whether to allow the DELETE verb to delete narInfo and nar files",
 			Sources: cli.EnvVars("ALLOW_DELETE"),
 		},
 		&cli.StringFlag{

--- a/cmd/ncps/serve.go
+++ b/cmd/ncps/serve.go
@@ -20,6 +20,11 @@ var serveCommand = &cli.Command{
 	Usage:   "serve the nix binary cache over http",
 	Action:  serveAction,
 	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:    "allow-delete",
+			Usage:   "Wether to allow the DELETE verb to delete narInfo and nar files",
+			Sources: cli.EnvVars("ALLOW_DELETE"),
+		},
 		&cli.StringFlag{
 			Name:     "cache-hostname",
 			Usage:    "The hostname of the cache server",
@@ -65,6 +70,7 @@ func serveAction(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	srv := server.New(logger, cache)
+	srv.SetDeletePermitted(cmd.Bool("allow-delete"))
 
 	logger.Info("Server started", "server-addr", cmd.String("server-addr"))
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -163,6 +163,11 @@ func (c *Cache) PutNar(_ context.Context, hash, compression string, r io.ReadClo
 	return err
 }
 
+// DeleteNar deletes the nar from the store.
+func (c *Cache) DeleteNar(_ context.Context, hash string, r io.ReadCloser) error {
+	return errors.New("not implemented")
+}
+
 func (c *Cache) pullNar(log log15.Logger, hash, compression string, doneC chan struct{}, errC chan error) {
 	now := time.Now()
 
@@ -316,6 +321,11 @@ func (c *Cache) PutNarInfo(_ context.Context, hash string, r io.ReadCloser) erro
 	}
 
 	return nil
+}
+
+// DeleteNarInfo deletes the narInfo from the store.
+func (c *Cache) DeleteNarInfo(_ context.Context, hash string, r io.ReadCloser) error {
+	return errors.New("not implemented")
 }
 
 func (c *Cache) prePullNar(url string) {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -164,8 +164,8 @@ func (c *Cache) PutNar(_ context.Context, hash, compression string, r io.ReadClo
 }
 
 // DeleteNar deletes the nar from the store.
-func (c *Cache) DeleteNar(_ context.Context, hash string, r io.ReadCloser) error {
-	return errors.New("not implemented")
+func (c *Cache) DeleteNar(_ context.Context, hash, compression string) error {
+	return c.deleteNarFromStore(hash, compression)
 }
 
 func (c *Cache) pullNar(log log15.Logger, hash, compression string, doneC chan struct{}, errC chan error) {
@@ -271,6 +271,14 @@ func (c *Cache) putNarInStore(hash, compression string, r io.ReadCloser) (int64,
 	return written, nil
 }
 
+func (c *Cache) deleteNarFromStore(hash, compression string) error {
+	if !c.hasNarInStore(hash, compression) {
+		return ErrNotFound
+	}
+
+	return os.Remove(filepath.Join(c.storePath(), helper.NarPath(hash, compression)))
+}
+
 // GetNarInfo returns the narInfo given a hash from the store. If the narInfo
 // is not found in the store, it's pulled from an upstream, stored in the
 // stored and finally returned.
@@ -324,8 +332,8 @@ func (c *Cache) PutNarInfo(_ context.Context, hash string, r io.ReadCloser) erro
 }
 
 // DeleteNarInfo deletes the narInfo from the store.
-func (c *Cache) DeleteNarInfo(_ context.Context, hash string, r io.ReadCloser) error {
-	return errors.New("not implemented")
+func (c *Cache) DeleteNarInfo(_ context.Context, hash string) error {
+	return c.deleteNarInfoFromStore(hash)
 }
 
 func (c *Cache) prePullNar(url string) {
@@ -415,6 +423,14 @@ func (c *Cache) putNarInfoInStore(hash string, narInfo *narinfo.NarInfo) error {
 	}
 
 	return nil
+}
+
+func (c *Cache) deleteNarInfoFromStore(hash string) error {
+	if !c.hasNarInfoInStore(hash) {
+		return ErrNotFound
+	}
+
+	return os.Remove(filepath.Join(c.storePath(), helper.NarInfoPath(hash)))
 }
 
 func (c *Cache) hasInStore(key string) bool {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -266,15 +266,15 @@ func TestGetNarInfo(t *testing.T) {
 		t.Errorf("expected no error, got %q", err)
 	}
 
-	t.Run("narfile does not exist upstream", func(t *testing.T) {
+	t.Run("narinfo does not exist upstream", func(t *testing.T) {
 		_, err := c.GetNarInfo(context.Background(), "doesnotexist")
 		if want, got := cache.ErrNotFound, err; !errors.Is(got, want) {
 			t.Errorf("want %s got %s", want, got)
 		}
 	})
 
-	t.Run("narfile exists upstream", func(t *testing.T) {
-		t.Run("narfile does not exist in storage yet", func(t *testing.T) {
+	t.Run("narinfo exists upstream", func(t *testing.T) {
+		t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 			_, err := os.Stat(filepath.Join(dir, "store", narInfoHash2+".narinfo"))
 			if err == nil {
 				t.Fatal("expected an error but got none")
@@ -371,7 +371,7 @@ func TestPutNarInfo(t *testing.T) {
 
 	storePath := filepath.Join(dir, "store", narInfoHash1+".narinfo")
 
-	t.Run("narfile does not exist in storage yet", func(t *testing.T) {
+	t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 		_, err := os.Stat(storePath)
 		if err == nil {
 			t.Fatal("expected an error but got none")
@@ -396,7 +396,7 @@ func TestPutNarInfo(t *testing.T) {
 		}
 	})
 
-	t.Run("narfile does exist in storage", func(t *testing.T) {
+	t.Run("narinfo does exist in storage", func(t *testing.T) {
 		_, err := os.Stat(storePath)
 		if err != nil {
 			t.Fatalf("expected no error but got: %s", err)

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -802,7 +802,7 @@ func TestDeleteNar(t *testing.T) {
 			})
 
 			t.Run("deleteNar does not return an error", func(t *testing.T) {
-				p := ts.URL + "/" + narHash1 + ".narinfo"
+				p := ts.URL + "/nar/" + narHash1 + ".nar"
 
 				r, err := http.NewRequestWithContext(context.Background(), "DELETE", p, nil)
 				if err != nil {
@@ -887,7 +887,7 @@ func TestDeleteNar(t *testing.T) {
 			})
 
 			t.Run("deleteNar does not return an error", func(t *testing.T) {
-				p := ts.URL + "/" + narHash1 + ".narinfo"
+				p := ts.URL + "/nar/" + narHash1 + ".nar.xz"
 
 				r, err := http.NewRequestWithContext(context.Background(), "DELETE", p, nil)
 				if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -202,7 +202,29 @@ func (s Server) putNarInfo(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (s Server) deleteNarInfo(w http.ResponseWriter, r *http.Request) {}
+func (s Server) deleteNarInfo(w http.ResponseWriter, r *http.Request) {
+	hash := chi.URLParam(r, "hash")
+
+	if err := s.cache.DeleteNarInfo(r.Context(), hash); err != nil {
+		if err == cache.ErrNotFound {
+			w.WriteHeader(http.StatusNotFound)
+			if _, err := w.Write([]byte(http.StatusText(http.StatusNotFound))); err != nil {
+				s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
+			}
+
+			return
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		if _, err := w.Write([]byte(http.StatusText(http.StatusInternalServerError))); err != nil {
+			s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
+		}
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
 
 func (s Server) getNar(withBody bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -272,4 +294,27 @@ func (s Server) putNar(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (s Server) deleteNar(w http.ResponseWriter, r *http.Request) {}
+func (s Server) deleteNar(w http.ResponseWriter, r *http.Request) {
+	hash := chi.URLParam(r, "hash")
+	compression := chi.URLParam(r, "compression")
+
+	if err := s.cache.DeleteNar(r.Context(), hash, compression); err != nil {
+		if err == cache.ErrNotFound {
+			w.WriteHeader(http.StatusNotFound)
+			if _, err := w.Write([]byte(http.StatusText(http.StatusNotFound))); err != nil {
+				s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
+			}
+
+			return
+		}
+
+		w.WriteHeader(http.StatusInternalServerError)
+		if _, err := w.Write([]byte(http.StatusText(http.StatusInternalServerError))); err != nil {
+			s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
+		}
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -206,8 +206,9 @@ func (s Server) deleteNarInfo(w http.ResponseWriter, r *http.Request) {
 	hash := chi.URLParam(r, "hash")
 
 	if err := s.cache.DeleteNarInfo(r.Context(), hash); err != nil {
-		if err == cache.ErrNotFound {
+		if errors.Is(err, cache.ErrNotFound) {
 			w.WriteHeader(http.StatusNotFound)
+
 			if _, err := w.Write([]byte(http.StatusText(http.StatusNotFound))); err != nil {
 				s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
 			}
@@ -216,6 +217,7 @@ func (s Server) deleteNarInfo(w http.ResponseWriter, r *http.Request) {
 		}
 
 		w.WriteHeader(http.StatusInternalServerError)
+
 		if _, err := w.Write([]byte(http.StatusText(http.StatusInternalServerError))); err != nil {
 			s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
 		}
@@ -299,8 +301,9 @@ func (s Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 	compression := chi.URLParam(r, "compression")
 
 	if err := s.cache.DeleteNar(r.Context(), hash, compression); err != nil {
-		if err == cache.ErrNotFound {
+		if errors.Is(err, cache.ErrNotFound) {
 			w.WriteHeader(http.StatusNotFound)
+
 			if _, err := w.Write([]byte(http.StatusText(http.StatusNotFound))); err != nil {
 				s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
 			}
@@ -309,6 +312,7 @@ func (s Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 		}
 
 		w.WriteHeader(http.StatusInternalServerError)
+
 		if _, err := w.Write([]byte(http.StatusText(http.StatusInternalServerError))); err != nil {
 			s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -207,7 +207,6 @@ func (s *Server) putNarInfo(w http.ResponseWriter, r *http.Request) {
 func (s *Server) deleteNarInfo(w http.ResponseWriter, r *http.Request) {
 	hash := chi.URLParam(r, "hash")
 
-	fmt.Printf("%#v\n", s)
 	if !s.deletePermitted {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -70,14 +70,17 @@ func createRouter(s Server) *chi.Mux {
 	router.Head(routeNarInfo, s.getNarInfo(false))
 	router.Get(routeNarInfo, s.getNarInfo(true))
 	router.Put(routeNarInfo, s.putNarInfo)
+	router.Delete(routeNarInfo, s.deleteNarInfo)
 
 	router.Head(routeNarCompression, s.getNar(false))
 	router.Get(routeNarCompression, s.getNar(true))
 	router.Put(routeNarCompression, s.putNar)
+	router.Delete(routeNarCompression, s.deleteNar)
 
 	router.Head(routeNar, s.getNar(false))
 	router.Get(routeNar, s.getNar(true))
 	router.Put(routeNar, s.putNar)
+	router.Delete(routeNar, s.deleteNar)
 
 	return router
 }
@@ -199,6 +202,8 @@ func (s Server) putNarInfo(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (s Server) deleteNarInfo(w http.ResponseWriter, r *http.Request) {}
+
 func (s Server) getNar(withBody bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		hash := chi.URLParam(r, "hash")
@@ -266,3 +271,5 @@ func (s Server) putNar(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusNoContent)
 }
+
+func (s Server) deleteNar(w http.ResponseWriter, r *http.Request) {}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -35,54 +35,56 @@ Priority: 10`
 
 // Server represents the main HTTP server.
 type Server struct {
-	cache  *cache.Cache
-	logger log15.Logger
-	router *chi.Mux
+	cache           *cache.Cache
+	deletePermitted bool
+	logger          log15.Logger
+	router          *chi.Mux
 }
 
 // New returns a new server.
-func New(logger log15.Logger, cache *cache.Cache) Server {
-	s := Server{
+func New(logger log15.Logger, cache *cache.Cache) *Server {
+	s := &Server{
 		cache:  cache,
 		logger: logger,
 	}
 
-	s.router = createRouter(s)
+	s.createRouter()
 
 	return s
 }
 
+// SetDeletePermitted configures the server to either allow or deny access to DELETE.
+func (s *Server) SetDeletePermitted(dp bool) { s.deletePermitted = dp }
+
 // ServeHTTP implements http.Handler and turns the Server type into a handler.
-func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) { s.router.ServeHTTP(w, r) }
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) { s.router.ServeHTTP(w, r) }
 
-func createRouter(s Server) *chi.Mux {
-	router := chi.NewRouter()
+func (s *Server) createRouter() {
+	s.router = chi.NewRouter()
 
-	router.Use(middleware.RequestID)
-	router.Use(middleware.RealIP)
-	router.Use(requestLogger(s.logger))
-	router.Use(middleware.Recoverer)
+	s.router.Use(middleware.RequestID)
+	s.router.Use(middleware.RealIP)
+	s.router.Use(requestLogger(s.logger))
+	s.router.Use(middleware.Recoverer)
 
-	router.Get(routeIndex, s.getIndex)
+	s.router.Get(routeIndex, s.getIndex)
 
-	router.Get(routeCacheInfo, s.getNixCacheInfo)
+	s.router.Get(routeCacheInfo, s.getNixCacheInfo)
 
-	router.Head(routeNarInfo, s.getNarInfo(false))
-	router.Get(routeNarInfo, s.getNarInfo(true))
-	router.Put(routeNarInfo, s.putNarInfo)
-	router.Delete(routeNarInfo, s.deleteNarInfo)
+	s.router.Head(routeNarInfo, s.getNarInfo(false))
+	s.router.Get(routeNarInfo, s.getNarInfo(true))
+	s.router.Put(routeNarInfo, s.putNarInfo)
+	s.router.Delete(routeNarInfo, s.deleteNarInfo)
 
-	router.Head(routeNarCompression, s.getNar(false))
-	router.Get(routeNarCompression, s.getNar(true))
-	router.Put(routeNarCompression, s.putNar)
-	router.Delete(routeNarCompression, s.deleteNar)
+	s.router.Head(routeNarCompression, s.getNar(false))
+	s.router.Get(routeNarCompression, s.getNar(true))
+	s.router.Put(routeNarCompression, s.putNar)
+	s.router.Delete(routeNarCompression, s.deleteNar)
 
-	router.Head(routeNar, s.getNar(false))
-	router.Get(routeNar, s.getNar(true))
-	router.Put(routeNar, s.putNar)
-	router.Delete(routeNar, s.deleteNar)
-
-	return router
+	s.router.Head(routeNar, s.getNar(false))
+	s.router.Get(routeNar, s.getNar(true))
+	s.router.Put(routeNar, s.putNar)
+	s.router.Delete(routeNar, s.deleteNar)
 }
 
 func requestLogger(logger log15.Logger) func(handler http.Handler) http.Handler {
@@ -135,13 +137,13 @@ func (s *Server) getIndex(w http.ResponseWriter, _ *http.Request) {
 	}
 }
 
-func (s Server) getNixCacheInfo(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) getNixCacheInfo(w http.ResponseWriter, _ *http.Request) {
 	if _, err := w.Write([]byte(nixCacheInfo)); err != nil {
 		s.logger.Error("error writing the response", "error", err)
 	}
 }
 
-func (s Server) getNarInfo(withBody bool) http.HandlerFunc {
+func (s *Server) getNarInfo(withBody bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		hash := chi.URLParam(r, "hash")
 
@@ -185,7 +187,7 @@ func (s Server) getNarInfo(withBody bool) http.HandlerFunc {
 	}
 }
 
-func (s Server) putNarInfo(w http.ResponseWriter, r *http.Request) {
+func (s *Server) putNarInfo(w http.ResponseWriter, r *http.Request) {
 	hash := chi.URLParam(r, "hash")
 
 	if err := s.cache.PutNarInfo(r.Context(), hash, r.Body); err != nil {
@@ -202,8 +204,19 @@ func (s Server) putNarInfo(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (s Server) deleteNarInfo(w http.ResponseWriter, r *http.Request) {
+func (s *Server) deleteNarInfo(w http.ResponseWriter, r *http.Request) {
 	hash := chi.URLParam(r, "hash")
+
+	fmt.Printf("%#v\n", s)
+	if !s.deletePermitted {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+
+		if _, err := w.Write([]byte(http.StatusText(http.StatusMethodNotAllowed))); err != nil {
+			s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
+		}
+
+		return
+	}
 
 	if err := s.cache.DeleteNarInfo(r.Context(), hash); err != nil {
 		if errors.Is(err, cache.ErrNotFound) {
@@ -228,7 +241,7 @@ func (s Server) deleteNarInfo(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (s Server) getNar(withBody bool) http.HandlerFunc {
+func (s *Server) getNar(withBody bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		hash := chi.URLParam(r, "hash")
 		compression := chi.URLParam(r, "compression")
@@ -278,7 +291,7 @@ func (s Server) getNar(withBody bool) http.HandlerFunc {
 	}
 }
 
-func (s Server) putNar(w http.ResponseWriter, r *http.Request) {
+func (s *Server) putNar(w http.ResponseWriter, r *http.Request) {
 	hash := chi.URLParam(r, "hash")
 	compression := chi.URLParam(r, "compression")
 
@@ -296,9 +309,19 @@ func (s Server) putNar(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (s Server) deleteNar(w http.ResponseWriter, r *http.Request) {
+func (s *Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 	hash := chi.URLParam(r, "hash")
 	compression := chi.URLParam(r, "compression")
+
+	if !s.deletePermitted {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+
+		if _, err := w.Write([]byte(http.StatusText(http.StatusMethodNotAllowed))); err != nil {
+			s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
+		}
+
+		return
+	}
 
 	if err := s.cache.DeleteNar(r.Context(), hash, compression); err != nil {
 		if errors.Is(err, cache.ErrNotFound) {

--- a/pkg/server/server_internal_test.go
+++ b/pkg/server/server_internal_test.go
@@ -1,0 +1,51 @@
+//nolint:testpackage
+package server
+
+import (
+	"os"
+	"testing"
+
+	"github.com/inconshreveable/log15/v3"
+	"github.com/kalbasit/ncps/pkg/cache"
+)
+
+//nolint:gochecknoglobals
+var logger = log15.New()
+
+//nolint:gochecknoinits
+func init() {
+	logger.SetHandler(log15.DiscardHandler())
+}
+
+func TestSetDeletePermitted(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "cache-path-")
+	if err != nil {
+		t.Fatalf("expected no error, got: %q", err)
+	}
+	defer os.RemoveAll(dir) // clean up
+
+	c, err := cache.New(logger, "cache.example.com", dir, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %q", err)
+	}
+
+	t.Run("false", func(t *testing.T) {
+		s := New(logger, c)
+		s.SetDeletePermitted(false)
+
+		if want, got := false, s.deletePermitted; want != got {
+			t.Errorf("want %t got %t", want, got)
+		}
+	})
+
+	t.Run("true", func(t *testing.T) {
+		s := New(logger, c)
+		s.SetDeletePermitted(true)
+
+		if want, got := true, s.deletePermitted; want != got {
+			t.Errorf("want %t got %t", want, got)
+		}
+	})
+}

--- a/pkg/server/server_internal_test.go
+++ b/pkg/server/server_internal_test.go
@@ -1,4 +1,3 @@
-//nolint:testpackage
 package server
 
 import (
@@ -18,8 +17,6 @@ func init() {
 }
 
 func TestSetDeletePermitted(t *testing.T) {
-	t.Parallel()
-
 	dir, err := os.MkdirTemp("", "cache-path-")
 	if err != nil {
 		t.Fatalf("expected no error, got: %q", err)
@@ -32,6 +29,8 @@ func TestSetDeletePermitted(t *testing.T) {
 	}
 
 	t.Run("false", func(t *testing.T) {
+		t.Parallel()
+
 		s := New(logger, c)
 		s.SetDeletePermitted(false)
 
@@ -41,6 +40,8 @@ func TestSetDeletePermitted(t *testing.T) {
 	})
 
 	t.Run("true", func(t *testing.T) {
+		t.Parallel()
+
 		s := New(logger, c)
 		s.SetDeletePermitted(true)
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -102,7 +102,7 @@ func TestServeHTTP(t *testing.T) {
 			})
 
 			t.Run("DELETE returns no error", func(t *testing.T) {
-				r, err := http.NewRequest("DELETE", ts.URL+"/"+narInfoHash+".narinfo", nil)
+				r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/"+narInfoHash+".narinfo", nil)
 				if err != nil {
 					t.Fatalf("expecting no error got %s", err)
 				}
@@ -157,7 +157,7 @@ func TestServeHTTP(t *testing.T) {
 				})
 
 				t.Run("DELETE returns no error", func(t *testing.T) {
-					r, err := http.NewRequest("DELETE", ts.URL+"/nar/"+narHash+".nar", nil)
+					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+narHash+".nar", nil)
 					if err != nil {
 						t.Fatalf("expecting no error got %s", err)
 					}
@@ -211,7 +211,7 @@ func TestServeHTTP(t *testing.T) {
 				})
 
 				t.Run("DELETE returns no error", func(t *testing.T) {
-					r, err := http.NewRequest("DELETE", ts.URL+"/nar/"+narHash+".nar.xz", nil)
+					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+narHash+".nar.xz", nil)
 					if err != nil {
 						t.Fatalf("expecting no error got %s", err)
 					}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -71,10 +71,10 @@ func TestServeHTTP(t *testing.T) {
 		ts := httptest.NewServer(s)
 		defer ts.Close()
 
-		t.Run("narFile", func(t *testing.T) {
+		t.Run("narInfo", func(t *testing.T) {
 			storePath := filepath.Join(dir, "store", narInfoHash+".narinfo")
 
-			t.Run("narfile does not exist in storage yet", func(t *testing.T) {
+			t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 				_, err := os.Stat(storePath)
 				if err == nil {
 					t.Fatal("expected an error but got none")
@@ -94,7 +94,7 @@ func TestServeHTTP(t *testing.T) {
 				t.Fatalf("expecting no error got %s", err)
 			}
 
-			t.Run("narfile does exist in storage", func(t *testing.T) {
+			t.Run("narinfo does exist in storage", func(t *testing.T) {
 				_, err := os.Stat(storePath)
 				if err != nil {
 					t.Fatalf("expected no error but got: %s", err)
@@ -117,7 +117,7 @@ func TestServeHTTP(t *testing.T) {
 				}
 			})
 
-			t.Run("narfile is gone from the store", func(t *testing.T) {
+			t.Run("narinfo is gone from the store", func(t *testing.T) {
 				_, err := os.Stat(storePath)
 				if err == nil {
 					t.Fatal("expected an error but got none")
@@ -172,7 +172,7 @@ func TestServeHTTP(t *testing.T) {
 					}
 				})
 
-				t.Run("narfile is gone from the store", func(t *testing.T) {
+				t.Run("narinfo is gone from the store", func(t *testing.T) {
 					_, err := os.Stat(storePath)
 					if err == nil {
 						t.Fatal("expected an error but got none")
@@ -226,7 +226,7 @@ func TestServeHTTP(t *testing.T) {
 					}
 				})
 
-				t.Run("narfile is gone from the store", func(t *testing.T) {
+				t.Run("narinfo is gone from the store", func(t *testing.T) {
 					_, err := os.Stat(storePath)
 					if err == nil {
 						t.Fatal("expected an error but got none")
@@ -298,7 +298,7 @@ func TestServeHTTP(t *testing.T) {
 		s := server.New(logger, c)
 
 		t.Run("narinfo", func(t *testing.T) {
-			t.Run("narfile does not exist upstream", func(t *testing.T) {
+			t.Run("narinfo does not exist upstream", func(t *testing.T) {
 				r := httptest.NewRequest("GET", "/doesnotexist.narinfo", nil)
 				w := httptest.NewRecorder()
 
@@ -309,7 +309,7 @@ func TestServeHTTP(t *testing.T) {
 				}
 			})
 
-			t.Run("narfile exists upstream", func(t *testing.T) {
+			t.Run("narinfo exists upstream", func(t *testing.T) {
 				r := httptest.NewRequest("GET", "/"+narInfoHash+".narinfo", nil)
 				w := httptest.NewRecorder()
 
@@ -414,14 +414,14 @@ func TestServeHTTP(t *testing.T) {
 		t.Run("narInfo", func(t *testing.T) {
 			storePath := filepath.Join(dir, "store", narInfoHash+".narinfo")
 
-			t.Run("narfile does not exist in storage yet", func(t *testing.T) {
+			t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 				_, err := os.Stat(storePath)
 				if err == nil {
 					t.Fatal("expected an error but got none")
 				}
 			})
 
-			t.Run("putNarFile does not return an error", func(t *testing.T) {
+			t.Run("putNarInfo does not return an error", func(t *testing.T) {
 				p := ts.URL + "/" + narInfoHash + ".narinfo"
 
 				r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narInfoText))
@@ -439,7 +439,7 @@ func TestServeHTTP(t *testing.T) {
 				}
 			})
 
-			t.Run("narfile does exist in storage", func(t *testing.T) {
+			t.Run("narinfo does exist in storage", func(t *testing.T) {
 				_, err := os.Stat(storePath)
 				if err != nil {
 					t.Fatalf("expected no error but got: %s", err)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -66,42 +66,14 @@ func TestServeHTTP(t *testing.T) {
 			t.Fatalf("expected no error, got %q", err)
 		}
 
-		s := server.New(logger, c)
+		t.Run("DELETE is not permitted", func(t *testing.T) {
+			s := server.New(logger, c)
+			s.SetDeletePermitted(false)
 
-		ts := httptest.NewServer(s)
-		defer ts.Close()
+			ts := httptest.NewServer(s)
+			defer ts.Close()
 
-		t.Run("narInfo", func(t *testing.T) {
-			storePath := filepath.Join(dir, "store", narInfoHash+".narinfo")
-
-			t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
-				_, err := os.Stat(storePath)
-				if err == nil {
-					t.Fatal("expected an error but got none")
-				}
-			})
-
-			f, err := os.Create(storePath)
-			if err != nil {
-				t.Fatalf("expecting no error got %s", err)
-			}
-
-			if _, err := f.WriteString(narInfoText); err != nil {
-				t.Fatalf("expecting no error got %s", err)
-			}
-
-			if err := f.Close(); err != nil {
-				t.Fatalf("expecting no error got %s", err)
-			}
-
-			t.Run("narinfo does exist in storage", func(t *testing.T) {
-				_, err := os.Stat(storePath)
-				if err != nil {
-					t.Fatalf("expected no error but got: %s", err)
-				}
-			})
-
-			t.Run("DELETE returns no error", func(t *testing.T) {
+			t.Run("narInfo", func(t *testing.T) {
 				r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/"+narInfoHash+".narinfo", nil)
 				if err != nil {
 					t.Fatalf("expecting no error got %s", err)
@@ -112,24 +84,57 @@ func TestServeHTTP(t *testing.T) {
 					t.Fatalf("expecting no error got %s", err)
 				}
 
-				if want, got := http.StatusNoContent, resp.StatusCode; want != got {
+				if want, got := http.StatusMethodNotAllowed, resp.StatusCode; want != got {
 					t.Errorf("want %d got %d", want, got)
 				}
 			})
 
-			t.Run("narinfo is gone from the store", func(t *testing.T) {
-				_, err := os.Stat(storePath)
-				if err == nil {
-					t.Fatal("expected an error but got none")
-				}
+			t.Run("nar", func(t *testing.T) {
+				t.Run("without compression", func(t *testing.T) {
+					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+narHash+".nar", nil)
+					if err != nil {
+						t.Fatalf("expecting no error got %s", err)
+					}
+
+					resp, err := ts.Client().Do(r)
+					if err != nil {
+						t.Fatalf("expecting no error got %s", err)
+					}
+
+					if want, got := http.StatusMethodNotAllowed, resp.StatusCode; want != got {
+						t.Errorf("want %d got %d", want, got)
+					}
+				})
+
+				t.Run("with compression", func(t *testing.T) {
+					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+narHash+".nar.xz", nil)
+					if err != nil {
+						t.Fatalf("expecting no error got %s", err)
+					}
+
+					resp, err := ts.Client().Do(r)
+					if err != nil {
+						t.Fatalf("expecting no error got %s", err)
+					}
+
+					if want, got := http.StatusMethodNotAllowed, resp.StatusCode; want != got {
+						t.Errorf("want %d got %d", want, got)
+					}
+				})
 			})
 		})
 
-		t.Run("nar", func(t *testing.T) {
-			t.Run("nar without compression", func(t *testing.T) {
-				storePath := filepath.Join(dir, "store", "nar", narHash+".nar")
+		t.Run("DELETE is permitted", func(t *testing.T) {
+			s := server.New(logger, c)
+			s.SetDeletePermitted(true)
 
-				t.Run("nar does not exist in storage yet", func(t *testing.T) {
+			ts := httptest.NewServer(s)
+			defer ts.Close()
+
+			t.Run("narInfo", func(t *testing.T) {
+				storePath := filepath.Join(dir, "store", narInfoHash+".narinfo")
+
+				t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 					_, err := os.Stat(storePath)
 					if err == nil {
 						t.Fatal("expected an error but got none")
@@ -141,7 +146,7 @@ func TestServeHTTP(t *testing.T) {
 					t.Fatalf("expecting no error got %s", err)
 				}
 
-				if _, err := f.WriteString(narText); err != nil {
+				if _, err := f.WriteString(narInfoText); err != nil {
 					t.Fatalf("expecting no error got %s", err)
 				}
 
@@ -149,7 +154,7 @@ func TestServeHTTP(t *testing.T) {
 					t.Fatalf("expecting no error got %s", err)
 				}
 
-				t.Run("nar does exist in storage", func(t *testing.T) {
+				t.Run("narinfo does exist in storage", func(t *testing.T) {
 					_, err := os.Stat(storePath)
 					if err != nil {
 						t.Fatalf("expected no error but got: %s", err)
@@ -157,7 +162,7 @@ func TestServeHTTP(t *testing.T) {
 				})
 
 				t.Run("DELETE returns no error", func(t *testing.T) {
-					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+narHash+".nar", nil)
+					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/"+narInfoHash+".narinfo", nil)
 					if err != nil {
 						t.Fatalf("expecting no error got %s", err)
 					}
@@ -176,6 +181,406 @@ func TestServeHTTP(t *testing.T) {
 					_, err := os.Stat(storePath)
 					if err == nil {
 						t.Fatal("expected an error but got none")
+					}
+				})
+			})
+
+			t.Run("nar", func(t *testing.T) {
+				t.Run("nar without compression", func(t *testing.T) {
+					storePath := filepath.Join(dir, "store", "nar", narHash+".nar")
+
+					t.Run("nar does not exist in storage yet", func(t *testing.T) {
+						_, err := os.Stat(storePath)
+						if err == nil {
+							t.Fatal("expected an error but got none")
+						}
+					})
+
+					f, err := os.Create(storePath)
+					if err != nil {
+						t.Fatalf("expecting no error got %s", err)
+					}
+
+					if _, err := f.WriteString(narText); err != nil {
+						t.Fatalf("expecting no error got %s", err)
+					}
+
+					if err := f.Close(); err != nil {
+						t.Fatalf("expecting no error got %s", err)
+					}
+
+					t.Run("nar does exist in storage", func(t *testing.T) {
+						_, err := os.Stat(storePath)
+						if err != nil {
+							t.Fatalf("expected no error but got: %s", err)
+						}
+					})
+
+					t.Run("DELETE returns no error", func(t *testing.T) {
+						r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+narHash+".nar", nil)
+						if err != nil {
+							t.Fatalf("expecting no error got %s", err)
+						}
+
+						resp, err := ts.Client().Do(r)
+						if err != nil {
+							t.Fatalf("expecting no error got %s", err)
+						}
+
+						if want, got := http.StatusNoContent, resp.StatusCode; want != got {
+							t.Errorf("want %d got %d", want, got)
+						}
+					})
+
+					t.Run("narinfo is gone from the store", func(t *testing.T) {
+						_, err := os.Stat(storePath)
+						if err == nil {
+							t.Fatal("expected an error but got none")
+						}
+					})
+				})
+
+				t.Run("nar with compression", func(t *testing.T) {
+					storePath := filepath.Join(dir, "store", "nar", narHash+".nar.xz")
+
+					t.Run("nar does not exist in storage yet", func(t *testing.T) {
+						_, err := os.Stat(storePath)
+						if err == nil {
+							t.Fatal("expected an error but got none")
+						}
+					})
+
+					f, err := os.Create(storePath)
+					if err != nil {
+						t.Fatalf("expecting no error got %s", err)
+					}
+
+					if _, err := f.WriteString(narText); err != nil {
+						t.Fatalf("expecting no error got %s", err)
+					}
+
+					if err := f.Close(); err != nil {
+						t.Fatalf("expecting no error got %s", err)
+					}
+
+					t.Run("nar does exist in storage", func(t *testing.T) {
+						_, err := os.Stat(storePath)
+						if err != nil {
+							t.Fatalf("expected no error but got: %s", err)
+						}
+					})
+
+					t.Run("DELETE returns no error", func(t *testing.T) {
+						r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+narHash+".nar.xz", nil)
+						if err != nil {
+							t.Fatalf("expecting no error got %s", err)
+						}
+
+						resp, err := ts.Client().Do(r)
+						if err != nil {
+							t.Fatalf("expecting no error got %s", err)
+						}
+
+						if want, got := http.StatusNoContent, resp.StatusCode; want != got {
+							t.Errorf("want %d got %d", want, got)
+						}
+					})
+
+					t.Run("narinfo is gone from the store", func(t *testing.T) {
+						_, err := os.Stat(storePath)
+						if err == nil {
+							t.Fatal("expected an error but got none")
+						}
+					})
+				})
+			})
+		})
+
+		t.Run("GET requests", func(t *testing.T) {
+			us := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/nix-cache-info" {
+					if _, err := w.Write([]byte(nixStoreInfo)); err != nil {
+						t.Fatalf("expected no error got: %s", err)
+					}
+
+					return
+				}
+
+				if r.URL.Path == "/"+narInfoHash+".narinfo" {
+					if _, err := w.Write([]byte(narInfoText)); err != nil {
+						t.Fatalf("expected no error got: %s", err)
+					}
+
+					return
+				}
+
+				if r.URL.Path == "/nar/"+narHash+".nar" {
+					if _, err := w.Write([]byte(narText)); err != nil {
+						t.Fatalf("expected no error got: %s", err)
+					}
+
+					return
+				}
+
+				if r.URL.Path == "/nar/"+narHash+".nar.xz" {
+					if _, err := w.Write([]byte(narText + "xz")); err != nil {
+						t.Fatalf("expected no error got: %s", err)
+					}
+
+					return
+				}
+
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer us.Close()
+
+			uu, err := url.Parse(us.URL)
+			if err != nil {
+				t.Fatalf("error not expected, got %s", err)
+			}
+
+			dir, err := os.MkdirTemp("", "cache-path-")
+			if err != nil {
+				t.Fatalf("expected no error, got: %q", err)
+			}
+			defer os.RemoveAll(dir) // clean up
+
+			uc, err := upstream.New(logger, uu.Host, []string{"cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="})
+			if err != nil {
+				t.Fatalf("expected no error, got %s", err)
+			}
+
+			c, err := cache.New(logger, "cache.example.com", dir, []upstream.Cache{uc})
+			if err != nil {
+				t.Fatalf("expected no error, got %q", err)
+			}
+
+			s := server.New(logger, c)
+
+			t.Run("narinfo", func(t *testing.T) {
+				t.Run("narinfo does not exist upstream", func(t *testing.T) {
+					r := httptest.NewRequest("GET", "/doesnotexist.narinfo", nil)
+					w := httptest.NewRecorder()
+
+					s.ServeHTTP(w, r)
+
+					if want, got := http.StatusNotFound, w.Code; want != got {
+						t.Errorf("want %d got %d", want, got)
+					}
+				})
+
+				t.Run("narinfo exists upstream", func(t *testing.T) {
+					r := httptest.NewRequest("GET", "/"+narInfoHash+".narinfo", nil)
+					w := httptest.NewRecorder()
+
+					s.ServeHTTP(w, r)
+
+					if want, got := http.StatusOK, w.Code; want != got {
+						t.Errorf("want %d got %d", want, got)
+					}
+
+					resp := w.Result()
+					defer resp.Body.Close()
+
+					body, err := io.ReadAll(resp.Body)
+					if err != nil {
+						t.Fatalf("expected no error got %s", err)
+					}
+
+					// NOTE: HasPrefix instead equality because we add our signature to the narInfo.
+					if !strings.HasPrefix(string(body), narInfoText) {
+						t.Error("expected the body to start with narInfo but it did not")
+					}
+				})
+			})
+
+			t.Run("nar", func(t *testing.T) {
+				t.Run("nar does not exist upstream", func(t *testing.T) {
+					r := httptest.NewRequest("GET", "/nar/doesnotexist.nar", nil)
+					w := httptest.NewRecorder()
+
+					s.ServeHTTP(w, r)
+
+					if want, got := http.StatusNotFound, w.Code; want != got {
+						t.Errorf("want %d got %d", want, got)
+					}
+				})
+
+				t.Run("nar exists upstream without compression", func(t *testing.T) {
+					r := httptest.NewRequest("GET", "/nar/"+narHash+".nar", nil)
+					w := httptest.NewRecorder()
+
+					s.ServeHTTP(w, r)
+
+					if want, got := http.StatusOK, w.Code; want != got {
+						t.Errorf("want %d got %d", want, got)
+					}
+
+					resp := w.Result()
+					defer resp.Body.Close()
+
+					body, err := io.ReadAll(resp.Body)
+					if err != nil {
+						t.Fatalf("expected no error got %s", err)
+					}
+
+					if want, got := narText, string(body); want != got {
+						t.Errorf("want %q got %q", want, got)
+					}
+				})
+
+				t.Run("nar exists upstream with compression", func(t *testing.T) {
+					r := httptest.NewRequest("GET", "/nar/"+narHash+".nar.xz", nil)
+					w := httptest.NewRecorder()
+
+					s.ServeHTTP(w, r)
+
+					if want, got := http.StatusOK, w.Code; want != got {
+						t.Errorf("want %d got %d", want, got)
+					}
+
+					resp := w.Result()
+					defer resp.Body.Close()
+
+					body, err := io.ReadAll(resp.Body)
+					if err != nil {
+						t.Fatalf("expected no error got %s", err)
+					}
+
+					if want, got := narText+"xz", string(body); want != got {
+						t.Errorf("want %q got %q", want, got)
+					}
+				})
+			})
+		})
+
+		t.Run("PUT requests", func(t *testing.T) {
+			dir, err := os.MkdirTemp("", "cache-path-")
+			if err != nil {
+				t.Fatalf("expected no error, got: %q", err)
+			}
+			defer os.RemoveAll(dir) // clean up
+
+			c, err := cache.New(logger, "cache.example.com", dir, nil)
+			if err != nil {
+				t.Fatalf("expected no error, got %q", err)
+			}
+
+			s := server.New(logger, c)
+
+			ts := httptest.NewServer(s)
+			defer ts.Close()
+
+			t.Run("narInfo", func(t *testing.T) {
+				storePath := filepath.Join(dir, "store", narInfoHash+".narinfo")
+
+				t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
+					_, err := os.Stat(storePath)
+					if err == nil {
+						t.Fatal("expected an error but got none")
+					}
+				})
+
+				t.Run("putNarInfo does not return an error", func(t *testing.T) {
+					p := ts.URL + "/" + narInfoHash + ".narinfo"
+
+					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narInfoText))
+					if err != nil {
+						t.Fatalf("error Do(r): %s", err)
+					}
+
+					resp, err := ts.Client().Do(r)
+					if err != nil {
+						t.Fatalf("error Do(r): %s", err)
+					}
+
+					if want, got := http.StatusNoContent, resp.StatusCode; want != got {
+						t.Errorf("want %d got %d", want, got)
+					}
+				})
+
+				t.Run("narinfo does exist in storage", func(t *testing.T) {
+					_, err := os.Stat(storePath)
+					if err != nil {
+						t.Fatalf("expected no error but got: %s", err)
+					}
+				})
+
+				t.Run("it should be signed by our server", func(t *testing.T) {
+					f, err := os.Open(storePath)
+					if err != nil {
+						t.Fatalf("no error was expected, got: %s", err)
+					}
+
+					ni, err := narinfo.Parse(f)
+					if err != nil {
+						t.Fatalf("no error was expected, got: %s", err)
+					}
+
+					var found bool
+
+					var sig signature.Signature
+					for _, sig = range ni.Signatures {
+						if sig.Name == "cache.example.com" {
+							found = true
+
+							break
+						}
+					}
+
+					if want, got := true, found; want != got {
+						t.Errorf("want %t got %t", want, got)
+					}
+
+					validSig := signature.VerifyFirst(ni.Fingerprint(), ni.Signatures, []signature.PublicKey{c.PublicKey()})
+
+					if want, got := true, validSig; want != got {
+						t.Errorf("want %t got %t", want, got)
+					}
+				})
+			})
+
+			t.Run("nar without compression", func(t *testing.T) {
+				storePath := filepath.Join(dir, "store", "nar", narHash+".nar")
+
+				t.Run("nar does not exist in storage yet", func(t *testing.T) {
+					_, err := os.Stat(storePath)
+					if err == nil {
+						t.Fatal("expected an error but got none")
+					}
+				})
+
+				t.Run("putNar does not return an error", func(t *testing.T) {
+					p := ts.URL + "/nar/" + narHash + ".nar"
+
+					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narText))
+					if err != nil {
+						t.Fatalf("error Do(r): %s", err)
+					}
+
+					resp, err := ts.Client().Do(r)
+					if err != nil {
+						t.Fatalf("error Do(r): %s", err)
+					}
+
+					if want, got := http.StatusNoContent, resp.StatusCode; want != got {
+						t.Errorf("want %d got %d", want, got)
+					}
+				})
+
+				t.Run("nar does exist in storage", func(t *testing.T) {
+					f, err := os.Open(storePath)
+					if err != nil {
+						t.Fatalf("expected no error but got: %s", err)
+					}
+
+					bs, err := io.ReadAll(f)
+					if err != nil {
+						t.Fatalf("expected no error but got: %s", err)
+					}
+
+					if want, got := narText, string(bs); want != got {
+						t.Errorf("want %q got %q", want, got)
 					}
 				})
 			})
@@ -190,35 +595,17 @@ func TestServeHTTP(t *testing.T) {
 					}
 				})
 
-				f, err := os.Create(storePath)
-				if err != nil {
-					t.Fatalf("expecting no error got %s", err)
-				}
+				t.Run("putNar does not return an error", func(t *testing.T) {
+					p := ts.URL + "/nar/" + narHash + ".nar.xz"
 
-				if _, err := f.WriteString(narText); err != nil {
-					t.Fatalf("expecting no error got %s", err)
-				}
-
-				if err := f.Close(); err != nil {
-					t.Fatalf("expecting no error got %s", err)
-				}
-
-				t.Run("nar does exist in storage", func(t *testing.T) {
-					_, err := os.Stat(storePath)
+					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narText))
 					if err != nil {
-						t.Fatalf("expected no error but got: %s", err)
-					}
-				})
-
-				t.Run("DELETE returns no error", func(t *testing.T) {
-					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+narHash+".nar.xz", nil)
-					if err != nil {
-						t.Fatalf("expecting no error got %s", err)
+						t.Fatalf("error Do(r): %s", err)
 					}
 
 					resp, err := ts.Client().Do(r)
 					if err != nil {
-						t.Fatalf("expecting no error got %s", err)
+						t.Fatalf("error Do(r): %s", err)
 					}
 
 					if want, got := http.StatusNoContent, resp.StatusCode; want != got {
@@ -226,347 +613,21 @@ func TestServeHTTP(t *testing.T) {
 					}
 				})
 
-				t.Run("narinfo is gone from the store", func(t *testing.T) {
-					_, err := os.Stat(storePath)
-					if err == nil {
-						t.Fatal("expected an error but got none")
+				t.Run("nar does exist in storage", func(t *testing.T) {
+					f, err := os.Open(storePath)
+					if err != nil {
+						t.Fatalf("expected no error but got: %s", err)
+					}
+
+					bs, err := io.ReadAll(f)
+					if err != nil {
+						t.Fatalf("expected no error but got: %s", err)
+					}
+
+					if want, got := narText, string(bs); want != got {
+						t.Errorf("want %q got %q", want, got)
 					}
 				})
-			})
-		})
-	})
-
-	t.Run("GET requests", func(t *testing.T) {
-		us := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/nix-cache-info" {
-				if _, err := w.Write([]byte(nixStoreInfo)); err != nil {
-					t.Fatalf("expected no error got: %s", err)
-				}
-
-				return
-			}
-
-			if r.URL.Path == "/"+narInfoHash+".narinfo" {
-				if _, err := w.Write([]byte(narInfoText)); err != nil {
-					t.Fatalf("expected no error got: %s", err)
-				}
-
-				return
-			}
-
-			if r.URL.Path == "/nar/"+narHash+".nar" {
-				if _, err := w.Write([]byte(narText)); err != nil {
-					t.Fatalf("expected no error got: %s", err)
-				}
-
-				return
-			}
-
-			if r.URL.Path == "/nar/"+narHash+".nar.xz" {
-				if _, err := w.Write([]byte(narText + "xz")); err != nil {
-					t.Fatalf("expected no error got: %s", err)
-				}
-
-				return
-			}
-
-			w.WriteHeader(http.StatusNotFound)
-		}))
-		defer us.Close()
-
-		uu, err := url.Parse(us.URL)
-		if err != nil {
-			t.Fatalf("error not expected, got %s", err)
-		}
-
-		dir, err := os.MkdirTemp("", "cache-path-")
-		if err != nil {
-			t.Fatalf("expected no error, got: %q", err)
-		}
-		defer os.RemoveAll(dir) // clean up
-
-		uc, err := upstream.New(logger, uu.Host, []string{"cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="})
-		if err != nil {
-			t.Fatalf("expected no error, got %s", err)
-		}
-
-		c, err := cache.New(logger, "cache.example.com", dir, []upstream.Cache{uc})
-		if err != nil {
-			t.Fatalf("expected no error, got %q", err)
-		}
-
-		s := server.New(logger, c)
-
-		t.Run("narinfo", func(t *testing.T) {
-			t.Run("narinfo does not exist upstream", func(t *testing.T) {
-				r := httptest.NewRequest("GET", "/doesnotexist.narinfo", nil)
-				w := httptest.NewRecorder()
-
-				s.ServeHTTP(w, r)
-
-				if want, got := http.StatusNotFound, w.Code; want != got {
-					t.Errorf("want %d got %d", want, got)
-				}
-			})
-
-			t.Run("narinfo exists upstream", func(t *testing.T) {
-				r := httptest.NewRequest("GET", "/"+narInfoHash+".narinfo", nil)
-				w := httptest.NewRecorder()
-
-				s.ServeHTTP(w, r)
-
-				if want, got := http.StatusOK, w.Code; want != got {
-					t.Errorf("want %d got %d", want, got)
-				}
-
-				resp := w.Result()
-				defer resp.Body.Close()
-
-				body, err := io.ReadAll(resp.Body)
-				if err != nil {
-					t.Fatalf("expected no error got %s", err)
-				}
-
-				// NOTE: HasPrefix instead equality because we add our signature to the narInfo.
-				if !strings.HasPrefix(string(body), narInfoText) {
-					t.Error("expected the body to start with narInfo but it did not")
-				}
-			})
-		})
-
-		t.Run("nar", func(t *testing.T) {
-			t.Run("nar does not exist upstream", func(t *testing.T) {
-				r := httptest.NewRequest("GET", "/nar/doesnotexist.nar", nil)
-				w := httptest.NewRecorder()
-
-				s.ServeHTTP(w, r)
-
-				if want, got := http.StatusNotFound, w.Code; want != got {
-					t.Errorf("want %d got %d", want, got)
-				}
-			})
-
-			t.Run("nar exists upstream without compression", func(t *testing.T) {
-				r := httptest.NewRequest("GET", "/nar/"+narHash+".nar", nil)
-				w := httptest.NewRecorder()
-
-				s.ServeHTTP(w, r)
-
-				if want, got := http.StatusOK, w.Code; want != got {
-					t.Errorf("want %d got %d", want, got)
-				}
-
-				resp := w.Result()
-				defer resp.Body.Close()
-
-				body, err := io.ReadAll(resp.Body)
-				if err != nil {
-					t.Fatalf("expected no error got %s", err)
-				}
-
-				if want, got := narText, string(body); want != got {
-					t.Errorf("want %q got %q", want, got)
-				}
-			})
-
-			t.Run("nar exists upstream with compression", func(t *testing.T) {
-				r := httptest.NewRequest("GET", "/nar/"+narHash+".nar.xz", nil)
-				w := httptest.NewRecorder()
-
-				s.ServeHTTP(w, r)
-
-				if want, got := http.StatusOK, w.Code; want != got {
-					t.Errorf("want %d got %d", want, got)
-				}
-
-				resp := w.Result()
-				defer resp.Body.Close()
-
-				body, err := io.ReadAll(resp.Body)
-				if err != nil {
-					t.Fatalf("expected no error got %s", err)
-				}
-
-				if want, got := narText+"xz", string(body); want != got {
-					t.Errorf("want %q got %q", want, got)
-				}
-			})
-		})
-	})
-
-	t.Run("PUT requests", func(t *testing.T) {
-		dir, err := os.MkdirTemp("", "cache-path-")
-		if err != nil {
-			t.Fatalf("expected no error, got: %q", err)
-		}
-		defer os.RemoveAll(dir) // clean up
-
-		c, err := cache.New(logger, "cache.example.com", dir, nil)
-		if err != nil {
-			t.Fatalf("expected no error, got %q", err)
-		}
-
-		s := server.New(logger, c)
-
-		ts := httptest.NewServer(s)
-		defer ts.Close()
-
-		t.Run("narInfo", func(t *testing.T) {
-			storePath := filepath.Join(dir, "store", narInfoHash+".narinfo")
-
-			t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
-				_, err := os.Stat(storePath)
-				if err == nil {
-					t.Fatal("expected an error but got none")
-				}
-			})
-
-			t.Run("putNarInfo does not return an error", func(t *testing.T) {
-				p := ts.URL + "/" + narInfoHash + ".narinfo"
-
-				r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narInfoText))
-				if err != nil {
-					t.Fatalf("error Do(r): %s", err)
-				}
-
-				resp, err := ts.Client().Do(r)
-				if err != nil {
-					t.Fatalf("error Do(r): %s", err)
-				}
-
-				if want, got := http.StatusNoContent, resp.StatusCode; want != got {
-					t.Errorf("want %d got %d", want, got)
-				}
-			})
-
-			t.Run("narinfo does exist in storage", func(t *testing.T) {
-				_, err := os.Stat(storePath)
-				if err != nil {
-					t.Fatalf("expected no error but got: %s", err)
-				}
-			})
-
-			t.Run("it should be signed by our server", func(t *testing.T) {
-				f, err := os.Open(storePath)
-				if err != nil {
-					t.Fatalf("no error was expected, got: %s", err)
-				}
-
-				ni, err := narinfo.Parse(f)
-				if err != nil {
-					t.Fatalf("no error was expected, got: %s", err)
-				}
-
-				var found bool
-
-				var sig signature.Signature
-				for _, sig = range ni.Signatures {
-					if sig.Name == "cache.example.com" {
-						found = true
-
-						break
-					}
-				}
-
-				if want, got := true, found; want != got {
-					t.Errorf("want %t got %t", want, got)
-				}
-
-				validSig := signature.VerifyFirst(ni.Fingerprint(), ni.Signatures, []signature.PublicKey{c.PublicKey()})
-
-				if want, got := true, validSig; want != got {
-					t.Errorf("want %t got %t", want, got)
-				}
-			})
-		})
-
-		t.Run("nar without compression", func(t *testing.T) {
-			storePath := filepath.Join(dir, "store", "nar", narHash+".nar")
-
-			t.Run("nar does not exist in storage yet", func(t *testing.T) {
-				_, err := os.Stat(storePath)
-				if err == nil {
-					t.Fatal("expected an error but got none")
-				}
-			})
-
-			t.Run("putNar does not return an error", func(t *testing.T) {
-				p := ts.URL + "/nar/" + narHash + ".nar"
-
-				r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narText))
-				if err != nil {
-					t.Fatalf("error Do(r): %s", err)
-				}
-
-				resp, err := ts.Client().Do(r)
-				if err != nil {
-					t.Fatalf("error Do(r): %s", err)
-				}
-
-				if want, got := http.StatusNoContent, resp.StatusCode; want != got {
-					t.Errorf("want %d got %d", want, got)
-				}
-			})
-
-			t.Run("nar does exist in storage", func(t *testing.T) {
-				f, err := os.Open(storePath)
-				if err != nil {
-					t.Fatalf("expected no error but got: %s", err)
-				}
-
-				bs, err := io.ReadAll(f)
-				if err != nil {
-					t.Fatalf("expected no error but got: %s", err)
-				}
-
-				if want, got := narText, string(bs); want != got {
-					t.Errorf("want %q got %q", want, got)
-				}
-			})
-		})
-
-		t.Run("nar with compression", func(t *testing.T) {
-			storePath := filepath.Join(dir, "store", "nar", narHash+".nar.xz")
-
-			t.Run("nar does not exist in storage yet", func(t *testing.T) {
-				_, err := os.Stat(storePath)
-				if err == nil {
-					t.Fatal("expected an error but got none")
-				}
-			})
-
-			t.Run("putNar does not return an error", func(t *testing.T) {
-				p := ts.URL + "/nar/" + narHash + ".nar.xz"
-
-				r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narText))
-				if err != nil {
-					t.Fatalf("error Do(r): %s", err)
-				}
-
-				resp, err := ts.Client().Do(r)
-				if err != nil {
-					t.Fatalf("error Do(r): %s", err)
-				}
-
-				if want, got := http.StatusNoContent, resp.StatusCode; want != got {
-					t.Errorf("want %d got %d", want, got)
-				}
-			})
-
-			t.Run("nar does exist in storage", func(t *testing.T) {
-				f, err := os.Open(storePath)
-				if err != nil {
-					t.Fatalf("expected no error but got: %s", err)
-				}
-
-				bs, err := io.ReadAll(f)
-				if err != nil {
-					t.Fatalf("expected no error but got: %s", err)
-				}
-
-				if want, got := narText, string(bs); want != got {
-					t.Errorf("want %q got %q", want, got)
-				}
 			})
 		})
 	})


### PR DESCRIPTION
Add a new API to respond to:
- `DELETE /<hash>.narinfo`
- `DELETE /<hash>.nar[.<compression>]`

This API is disabled by default. It can be enabled with the `--allow-delete` flag.

ref #21 