### PR TITLE
pkg/server: Fix a flaky test

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -295,339 +295,339 @@ func TestServeHTTP(t *testing.T) {
 				})
 			})
 		})
+	})
 
-		t.Run("GET requests", func(t *testing.T) {
-			us := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == "/nix-cache-info" {
-					if _, err := w.Write([]byte(nixStoreInfo)); err != nil {
-						t.Fatalf("expected no error got: %s", err)
-					}
-
-					return
+	t.Run("GET requests", func(t *testing.T) {
+		us := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/nix-cache-info" {
+				if _, err := w.Write([]byte(nixStoreInfo)); err != nil {
+					t.Fatalf("expected no error got: %s", err)
 				}
 
-				if r.URL.Path == "/"+narInfoHash+".narinfo" {
-					if _, err := w.Write([]byte(narInfoText)); err != nil {
-						t.Fatalf("expected no error got: %s", err)
-					}
+				return
+			}
 
-					return
+			if r.URL.Path == "/"+narInfoHash+".narinfo" {
+				if _, err := w.Write([]byte(narInfoText)); err != nil {
+					t.Fatalf("expected no error got: %s", err)
 				}
 
-				if r.URL.Path == "/nar/"+narHash+".nar" {
-					if _, err := w.Write([]byte(narText)); err != nil {
-						t.Fatalf("expected no error got: %s", err)
-					}
+				return
+			}
 
-					return
+			if r.URL.Path == "/nar/"+narHash+".nar" {
+				if _, err := w.Write([]byte(narText)); err != nil {
+					t.Fatalf("expected no error got: %s", err)
 				}
 
-				if r.URL.Path == "/nar/"+narHash+".nar.xz" {
-					if _, err := w.Write([]byte(narText + "xz")); err != nil {
-						t.Fatalf("expected no error got: %s", err)
-					}
+				return
+			}
 
-					return
+			if r.URL.Path == "/nar/"+narHash+".nar.xz" {
+				if _, err := w.Write([]byte(narText + "xz")); err != nil {
+					t.Fatalf("expected no error got: %s", err)
 				}
 
-				w.WriteHeader(http.StatusNotFound)
-			}))
-			defer us.Close()
-
-			uu, err := url.Parse(us.URL)
-			if err != nil {
-				t.Fatalf("error not expected, got %s", err)
+				return
 			}
 
-			dir, err := os.MkdirTemp("", "cache-path-")
-			if err != nil {
-				t.Fatalf("expected no error, got: %q", err)
-			}
-			defer os.RemoveAll(dir) // clean up
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer us.Close()
 
-			uc, err := upstream.New(logger, uu.Host, []string{"cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="})
-			if err != nil {
-				t.Fatalf("expected no error, got %s", err)
-			}
+		uu, err := url.Parse(us.URL)
+		if err != nil {
+			t.Fatalf("error not expected, got %s", err)
+		}
 
-			c, err := cache.New(logger, "cache.example.com", dir, []upstream.Cache{uc})
-			if err != nil {
-				t.Fatalf("expected no error, got %q", err)
-			}
+		dir, err := os.MkdirTemp("", "cache-path-")
+		if err != nil {
+			t.Fatalf("expected no error, got: %q", err)
+		}
+		defer os.RemoveAll(dir) // clean up
 
-			s := server.New(logger, c)
+		uc, err := upstream.New(logger, uu.Host, []string{"cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="})
+		if err != nil {
+			t.Fatalf("expected no error, got %s", err)
+		}
 
-			t.Run("narinfo", func(t *testing.T) {
-				t.Run("narinfo does not exist upstream", func(t *testing.T) {
-					r := httptest.NewRequest("GET", "/doesnotexist.narinfo", nil)
-					w := httptest.NewRecorder()
+		c, err := cache.New(logger, "cache.example.com", dir, []upstream.Cache{uc})
+		if err != nil {
+			t.Fatalf("expected no error, got %q", err)
+		}
 
-					s.ServeHTTP(w, r)
+		s := server.New(logger, c)
 
-					if want, got := http.StatusNotFound, w.Code; want != got {
-						t.Errorf("want %d got %d", want, got)
-					}
-				})
+		t.Run("narinfo", func(t *testing.T) {
+			t.Run("narinfo does not exist upstream", func(t *testing.T) {
+				r := httptest.NewRequest("GET", "/doesnotexist.narinfo", nil)
+				w := httptest.NewRecorder()
 
-				t.Run("narinfo exists upstream", func(t *testing.T) {
-					r := httptest.NewRequest("GET", "/"+narInfoHash+".narinfo", nil)
-					w := httptest.NewRecorder()
+				s.ServeHTTP(w, r)
 
-					s.ServeHTTP(w, r)
-
-					if want, got := http.StatusOK, w.Code; want != got {
-						t.Errorf("want %d got %d", want, got)
-					}
-
-					resp := w.Result()
-					defer resp.Body.Close()
-
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						t.Fatalf("expected no error got %s", err)
-					}
-
-					// NOTE: HasPrefix instead equality because we add our signature to the narInfo.
-					if !strings.HasPrefix(string(body), narInfoText) {
-						t.Error("expected the body to start with narInfo but it did not")
-					}
-				})
+				if want, got := http.StatusNotFound, w.Code; want != got {
+					t.Errorf("want %d got %d", want, got)
+				}
 			})
 
-			t.Run("nar", func(t *testing.T) {
-				t.Run("nar does not exist upstream", func(t *testing.T) {
-					r := httptest.NewRequest("GET", "/nar/doesnotexist.nar", nil)
-					w := httptest.NewRecorder()
+			t.Run("narinfo exists upstream", func(t *testing.T) {
+				r := httptest.NewRequest("GET", "/"+narInfoHash+".narinfo", nil)
+				w := httptest.NewRecorder()
 
-					s.ServeHTTP(w, r)
+				s.ServeHTTP(w, r)
 
-					if want, got := http.StatusNotFound, w.Code; want != got {
-						t.Errorf("want %d got %d", want, got)
-					}
-				})
+				if want, got := http.StatusOK, w.Code; want != got {
+					t.Errorf("want %d got %d", want, got)
+				}
 
-				t.Run("nar exists upstream without compression", func(t *testing.T) {
-					r := httptest.NewRequest("GET", "/nar/"+narHash+".nar", nil)
-					w := httptest.NewRecorder()
+				resp := w.Result()
+				defer resp.Body.Close()
 
-					s.ServeHTTP(w, r)
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatalf("expected no error got %s", err)
+				}
 
-					if want, got := http.StatusOK, w.Code; want != got {
-						t.Errorf("want %d got %d", want, got)
-					}
-
-					resp := w.Result()
-					defer resp.Body.Close()
-
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						t.Fatalf("expected no error got %s", err)
-					}
-
-					if want, got := narText, string(body); want != got {
-						t.Errorf("want %q got %q", want, got)
-					}
-				})
-
-				t.Run("nar exists upstream with compression", func(t *testing.T) {
-					r := httptest.NewRequest("GET", "/nar/"+narHash+".nar.xz", nil)
-					w := httptest.NewRecorder()
-
-					s.ServeHTTP(w, r)
-
-					if want, got := http.StatusOK, w.Code; want != got {
-						t.Errorf("want %d got %d", want, got)
-					}
-
-					resp := w.Result()
-					defer resp.Body.Close()
-
-					body, err := io.ReadAll(resp.Body)
-					if err != nil {
-						t.Fatalf("expected no error got %s", err)
-					}
-
-					if want, got := narText+"xz", string(body); want != got {
-						t.Errorf("want %q got %q", want, got)
-					}
-				})
+				// NOTE: HasPrefix instead equality because we add our signature to the narInfo.
+				if !strings.HasPrefix(string(body), narInfoText) {
+					t.Error("expected the body to start with narInfo but it did not")
+				}
 			})
 		})
 
-		t.Run("PUT requests", func(t *testing.T) {
-			dir, err := os.MkdirTemp("", "cache-path-")
-			if err != nil {
-				t.Fatalf("expected no error, got: %q", err)
-			}
-			defer os.RemoveAll(dir) // clean up
+		t.Run("nar", func(t *testing.T) {
+			t.Run("nar does not exist upstream", func(t *testing.T) {
+				r := httptest.NewRequest("GET", "/nar/doesnotexist.nar", nil)
+				w := httptest.NewRecorder()
 
-			c, err := cache.New(logger, "cache.example.com", dir, nil)
-			if err != nil {
-				t.Fatalf("expected no error, got %q", err)
-			}
+				s.ServeHTTP(w, r)
 
-			s := server.New(logger, c)
-
-			ts := httptest.NewServer(s)
-			defer ts.Close()
-
-			t.Run("narInfo", func(t *testing.T) {
-				storePath := filepath.Join(dir, "store", narInfoHash+".narinfo")
-
-				t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
-					_, err := os.Stat(storePath)
-					if err == nil {
-						t.Fatal("expected an error but got none")
-					}
-				})
-
-				t.Run("putNarInfo does not return an error", func(t *testing.T) {
-					p := ts.URL + "/" + narInfoHash + ".narinfo"
-
-					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narInfoText))
-					if err != nil {
-						t.Fatalf("error Do(r): %s", err)
-					}
-
-					resp, err := ts.Client().Do(r)
-					if err != nil {
-						t.Fatalf("error Do(r): %s", err)
-					}
-
-					if want, got := http.StatusNoContent, resp.StatusCode; want != got {
-						t.Errorf("want %d got %d", want, got)
-					}
-				})
-
-				t.Run("narinfo does exist in storage", func(t *testing.T) {
-					_, err := os.Stat(storePath)
-					if err != nil {
-						t.Fatalf("expected no error but got: %s", err)
-					}
-				})
-
-				t.Run("it should be signed by our server", func(t *testing.T) {
-					f, err := os.Open(storePath)
-					if err != nil {
-						t.Fatalf("no error was expected, got: %s", err)
-					}
-
-					ni, err := narinfo.Parse(f)
-					if err != nil {
-						t.Fatalf("no error was expected, got: %s", err)
-					}
-
-					var found bool
-
-					var sig signature.Signature
-					for _, sig = range ni.Signatures {
-						if sig.Name == "cache.example.com" {
-							found = true
-
-							break
-						}
-					}
-
-					if want, got := true, found; want != got {
-						t.Errorf("want %t got %t", want, got)
-					}
-
-					validSig := signature.VerifyFirst(ni.Fingerprint(), ni.Signatures, []signature.PublicKey{c.PublicKey()})
-
-					if want, got := true, validSig; want != got {
-						t.Errorf("want %t got %t", want, got)
-					}
-				})
+				if want, got := http.StatusNotFound, w.Code; want != got {
+					t.Errorf("want %d got %d", want, got)
+				}
 			})
 
-			t.Run("nar without compression", func(t *testing.T) {
-				storePath := filepath.Join(dir, "store", "nar", narHash+".nar")
+			t.Run("nar exists upstream without compression", func(t *testing.T) {
+				r := httptest.NewRequest("GET", "/nar/"+narHash+".nar", nil)
+				w := httptest.NewRecorder()
 
-				t.Run("nar does not exist in storage yet", func(t *testing.T) {
-					_, err := os.Stat(storePath)
-					if err == nil {
-						t.Fatal("expected an error but got none")
-					}
-				})
+				s.ServeHTTP(w, r)
 
-				t.Run("putNar does not return an error", func(t *testing.T) {
-					p := ts.URL + "/nar/" + narHash + ".nar"
+				if want, got := http.StatusOK, w.Code; want != got {
+					t.Errorf("want %d got %d", want, got)
+				}
 
-					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narText))
-					if err != nil {
-						t.Fatalf("error Do(r): %s", err)
-					}
+				resp := w.Result()
+				defer resp.Body.Close()
 
-					resp, err := ts.Client().Do(r)
-					if err != nil {
-						t.Fatalf("error Do(r): %s", err)
-					}
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatalf("expected no error got %s", err)
+				}
 
-					if want, got := http.StatusNoContent, resp.StatusCode; want != got {
-						t.Errorf("want %d got %d", want, got)
-					}
-				})
-
-				t.Run("nar does exist in storage", func(t *testing.T) {
-					f, err := os.Open(storePath)
-					if err != nil {
-						t.Fatalf("expected no error but got: %s", err)
-					}
-
-					bs, err := io.ReadAll(f)
-					if err != nil {
-						t.Fatalf("expected no error but got: %s", err)
-					}
-
-					if want, got := narText, string(bs); want != got {
-						t.Errorf("want %q got %q", want, got)
-					}
-				})
+				if want, got := narText, string(body); want != got {
+					t.Errorf("want %q got %q", want, got)
+				}
 			})
 
-			t.Run("nar with compression", func(t *testing.T) {
-				storePath := filepath.Join(dir, "store", "nar", narHash+".nar.xz")
+			t.Run("nar exists upstream with compression", func(t *testing.T) {
+				r := httptest.NewRequest("GET", "/nar/"+narHash+".nar.xz", nil)
+				w := httptest.NewRecorder()
 
-				t.Run("nar does not exist in storage yet", func(t *testing.T) {
-					_, err := os.Stat(storePath)
-					if err == nil {
-						t.Fatal("expected an error but got none")
+				s.ServeHTTP(w, r)
+
+				if want, got := http.StatusOK, w.Code; want != got {
+					t.Errorf("want %d got %d", want, got)
+				}
+
+				resp := w.Result()
+				defer resp.Body.Close()
+
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatalf("expected no error got %s", err)
+				}
+
+				if want, got := narText+"xz", string(body); want != got {
+					t.Errorf("want %q got %q", want, got)
+				}
+			})
+		})
+	})
+
+	t.Run("PUT requests", func(t *testing.T) {
+		dir, err := os.MkdirTemp("", "cache-path-")
+		if err != nil {
+			t.Fatalf("expected no error, got: %q", err)
+		}
+		defer os.RemoveAll(dir) // clean up
+
+		c, err := cache.New(logger, "cache.example.com", dir, nil)
+		if err != nil {
+			t.Fatalf("expected no error, got %q", err)
+		}
+
+		s := server.New(logger, c)
+
+		ts := httptest.NewServer(s)
+		defer ts.Close()
+
+		t.Run("narInfo", func(t *testing.T) {
+			storePath := filepath.Join(dir, "store", narInfoHash+".narinfo")
+
+			t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
+				_, err := os.Stat(storePath)
+				if err == nil {
+					t.Fatal("expected an error but got none")
+				}
+			})
+
+			t.Run("putNarInfo does not return an error", func(t *testing.T) {
+				p := ts.URL + "/" + narInfoHash + ".narinfo"
+
+				r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narInfoText))
+				if err != nil {
+					t.Fatalf("error Do(r): %s", err)
+				}
+
+				resp, err := ts.Client().Do(r)
+				if err != nil {
+					t.Fatalf("error Do(r): %s", err)
+				}
+
+				if want, got := http.StatusNoContent, resp.StatusCode; want != got {
+					t.Errorf("want %d got %d", want, got)
+				}
+			})
+
+			t.Run("narinfo does exist in storage", func(t *testing.T) {
+				_, err := os.Stat(storePath)
+				if err != nil {
+					t.Fatalf("expected no error but got: %s", err)
+				}
+			})
+
+			t.Run("it should be signed by our server", func(t *testing.T) {
+				f, err := os.Open(storePath)
+				if err != nil {
+					t.Fatalf("no error was expected, got: %s", err)
+				}
+
+				ni, err := narinfo.Parse(f)
+				if err != nil {
+					t.Fatalf("no error was expected, got: %s", err)
+				}
+
+				var found bool
+
+				var sig signature.Signature
+				for _, sig = range ni.Signatures {
+					if sig.Name == "cache.example.com" {
+						found = true
+
+						break
 					}
-				})
+				}
 
-				t.Run("putNar does not return an error", func(t *testing.T) {
-					p := ts.URL + "/nar/" + narHash + ".nar.xz"
+				if want, got := true, found; want != got {
+					t.Errorf("want %t got %t", want, got)
+				}
 
-					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narText))
-					if err != nil {
-						t.Fatalf("error Do(r): %s", err)
-					}
+				validSig := signature.VerifyFirst(ni.Fingerprint(), ni.Signatures, []signature.PublicKey{c.PublicKey()})
 
-					resp, err := ts.Client().Do(r)
-					if err != nil {
-						t.Fatalf("error Do(r): %s", err)
-					}
+				if want, got := true, validSig; want != got {
+					t.Errorf("want %t got %t", want, got)
+				}
+			})
+		})
 
-					if want, got := http.StatusNoContent, resp.StatusCode; want != got {
-						t.Errorf("want %d got %d", want, got)
-					}
-				})
+		t.Run("nar without compression", func(t *testing.T) {
+			storePath := filepath.Join(dir, "store", "nar", narHash+".nar")
 
-				t.Run("nar does exist in storage", func(t *testing.T) {
-					f, err := os.Open(storePath)
-					if err != nil {
-						t.Fatalf("expected no error but got: %s", err)
-					}
+			t.Run("nar does not exist in storage yet", func(t *testing.T) {
+				_, err := os.Stat(storePath)
+				if err == nil {
+					t.Fatal("expected an error but got none")
+				}
+			})
 
-					bs, err := io.ReadAll(f)
-					if err != nil {
-						t.Fatalf("expected no error but got: %s", err)
-					}
+			t.Run("putNar does not return an error", func(t *testing.T) {
+				p := ts.URL + "/nar/" + narHash + ".nar"
 
-					if want, got := narText, string(bs); want != got {
-						t.Errorf("want %q got %q", want, got)
-					}
-				})
+				r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narText))
+				if err != nil {
+					t.Fatalf("error Do(r): %s", err)
+				}
+
+				resp, err := ts.Client().Do(r)
+				if err != nil {
+					t.Fatalf("error Do(r): %s", err)
+				}
+
+				if want, got := http.StatusNoContent, resp.StatusCode; want != got {
+					t.Errorf("want %d got %d", want, got)
+				}
+			})
+
+			t.Run("nar does exist in storage", func(t *testing.T) {
+				f, err := os.Open(storePath)
+				if err != nil {
+					t.Fatalf("expected no error but got: %s", err)
+				}
+
+				bs, err := io.ReadAll(f)
+				if err != nil {
+					t.Fatalf("expected no error but got: %s", err)
+				}
+
+				if want, got := narText, string(bs); want != got {
+					t.Errorf("want %q got %q", want, got)
+				}
+			})
+		})
+
+		t.Run("nar with compression", func(t *testing.T) {
+			storePath := filepath.Join(dir, "store", "nar", narHash+".nar.xz")
+
+			t.Run("nar does not exist in storage yet", func(t *testing.T) {
+				_, err := os.Stat(storePath)
+				if err == nil {
+					t.Fatal("expected an error but got none")
+				}
+			})
+
+			t.Run("putNar does not return an error", func(t *testing.T) {
+				p := ts.URL + "/nar/" + narHash + ".nar.xz"
+
+				r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narText))
+				if err != nil {
+					t.Fatalf("error Do(r): %s", err)
+				}
+
+				resp, err := ts.Client().Do(r)
+				if err != nil {
+					t.Fatalf("error Do(r): %s", err)
+				}
+
+				if want, got := http.StatusNoContent, resp.StatusCode; want != got {
+					t.Errorf("want %d got %d", want, got)
+				}
+			})
+
+			t.Run("nar does exist in storage", func(t *testing.T) {
+				f, err := os.Open(storePath)
+				if err != nil {
+					t.Fatalf("expected no error but got: %s", err)
+				}
+
+				bs, err := io.ReadAll(f)
+				if err != nil {
+					t.Fatalf("expected no error but got: %s", err)
+				}
+
+				if want, got := narText, string(bs); want != got {
+					t.Errorf("want %q got %q", want, got)
+				}
 			})
 		})
 	})


### PR DESCRIPTION
I accidentally put GET/PUT tests underneath the DELETE tests and because of that the test was flaky and failing about 5% of the runs.