### PR TITLE
golangci-lint: configure the gci linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,3 +38,23 @@ linters:
     - wastedassign
     - whitespace
     - wsl
+
+linters-settings:
+  gci:
+    # Section configuration to compare against.
+    # Section names are case-insensitive and may contain parameters in ().
+    # The default order of sections is `standard > default > custom > blank > dot > alias > localmodule`,
+    # If `custom-order` is `true`, it follows the order of `sections` option.
+    # Default: ["standard", "default"]
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - alias # Alias section: contains all alias imports. This section is not present unless explicitly enabled.
+      # - prefix(github.com/org/project) # Custom section: groups all imports with the specified Prefix.
+      - localmodule # Local module section: contains all local packages. This section is not present unless explicitly enabled.
+      - blank # Blank section: contains all blank imports. This section is not present unless explicitly enabled.
+      - dot # Dot section: contains all dot imports. This section is not present unless explicitly enabled.
+    # Enable custom order of sections.
+    # If `true`, make the section order the same as the order of `sections`.
+    # Default: false
+    custom-order: true

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -8,10 +8,11 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15/v3"
+	"github.com/urfave/cli/v3"
+
 	"github.com/kalbasit/ncps/pkg/cache"
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
 	"github.com/kalbasit/ncps/pkg/server"
-	"github.com/urfave/cli/v3"
 )
 
 func serveCommand(logger log15.Logger) *cli.Command {

--- a/main.go
+++ b/main.go
@@ -6,9 +6,10 @@ import (
 	"os"
 
 	"github.com/inconshreveable/log15/v3"
-	"github.com/kalbasit/ncps/cmd"
 	"github.com/mattn/go-colorable"
 	"golang.org/x/term"
+
+	"github.com/kalbasit/ncps/cmd"
 )
 
 func main() {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -15,10 +15,11 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15/v3"
-	"github.com/kalbasit/ncps/pkg/cache/upstream"
-	"github.com/kalbasit/ncps/pkg/helper"
 	"github.com/nix-community/go-nix/pkg/narinfo"
 	"github.com/nix-community/go-nix/pkg/narinfo/signature"
+
+	"github.com/kalbasit/ncps/pkg/cache/upstream"
+	"github.com/kalbasit/ncps/pkg/helper"
 )
 
 var (

--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15/v3"
+
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
 )
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -14,10 +14,11 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15/v3"
-	"github.com/kalbasit/ncps/pkg/cache"
-	"github.com/kalbasit/ncps/pkg/cache/upstream"
 	"github.com/nix-community/go-nix/pkg/narinfo"
 	"github.com/nix-community/go-nix/pkg/narinfo/signature"
+
+	"github.com/kalbasit/ncps/pkg/cache"
+	"github.com/kalbasit/ncps/pkg/cache/upstream"
 )
 
 //nolint:gochecknoglobals

--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -11,10 +11,11 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15/v3"
-	"github.com/kalbasit/ncps/pkg/helper"
-	"github.com/kalbasit/ncps/pkg/nixcacheinfo"
 	"github.com/nix-community/go-nix/pkg/narinfo"
 	"github.com/nix-community/go-nix/pkg/narinfo/signature"
+
+	"github.com/kalbasit/ncps/pkg/helper"
+	"github.com/kalbasit/ncps/pkg/nixcacheinfo"
 )
 
 var (

--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15/v3"
+
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
 )
 

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15/v3"
+
 	// Import the SQLite driver.
 	_ "github.com/mattn/go-sqlite3"
 )

--- a/pkg/database/sqlite_test.go
+++ b/pkg/database/sqlite_test.go
@@ -10,9 +10,10 @@ import (
 	"time"
 
 	"github.com/inconshreveable/log15/v3"
+	"github.com/mattn/go-sqlite3"
+
 	"github.com/kalbasit/ncps/pkg/database"
 	"github.com/kalbasit/ncps/pkg/helper"
-	"github.com/mattn/go-sqlite3"
 )
 
 //nolint:gochecknoglobals

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/inconshreveable/log15/v3"
+
 	"github.com/kalbasit/ncps/pkg/cache"
 )
 

--- a/pkg/server/server_internal_test.go
+++ b/pkg/server/server_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15/v3"
+
 	"github.com/kalbasit/ncps/pkg/cache"
 )
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -12,11 +12,12 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15/v3"
+	"github.com/nix-community/go-nix/pkg/narinfo"
+	"github.com/nix-community/go-nix/pkg/narinfo/signature"
+
 	"github.com/kalbasit/ncps/pkg/cache"
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
 	"github.com/kalbasit/ncps/pkg/server"
-	"github.com/nix-community/go-nix/pkg/narinfo"
-	"github.com/nix-community/go-nix/pkg/narinfo/signature"
 )
 
 //nolint:gochecknoglobals


### PR DESCRIPTION
I was working on #27 and I couldn't get the linter to pass; Configuring it with an order made it work.