### PR TITLE
 pkg/cache: add nar/info to DB after pushing to the cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -332,7 +332,7 @@ func (c *Cache) PutNarInfo(_ context.Context, hash string, r io.ReadCloser) erro
 		return fmt.Errorf("error storing the narInfo in the store: %w", err)
 	}
 
-	return nil
+	return c.storeInDatabase(hash, narInfo)
 }
 
 // DeleteNarInfo deletes the narInfo from the store.


### PR DESCRIPTION
In order to drive the LRU cache, we need records in the database when narinfo is pushed from downstream.

ref #21 