### PR TITLE
GitHub: Remove the caching of Go build and Go module cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,18 @@ jobs:
         with:
           enable-cache: "true"
 
+      - name: Prepare Go build cache
+        id: go-cache-paths
+        run: |
+          devbox run -- echo "go_mod_cache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+
+      # Cache go mod cache, used to speedup builds
+      - name: Go Mod Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go_mod_cache }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
       - name: Run the tests
         if: success()
         run: devbox run -- go test -race -bench='.+' -v ./...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,15 @@ jobs:
       - name: Prepare Go build cache
         id: go-cache-paths
         run: |
+          devbox run -- echo "go_build_cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
           devbox run -- echo "go_mod_cache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+
+      # Cache go build cache, used to speedup go test
+      - name: Go Build Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.go-cache-paths.outputs.go_build_cache }}
+          key: ${{ runner.os }}-go-todo-build-${{ hashFiles('**/go.sum') }}
 
       # Cache go mod cache, used to speedup builds
       - name: Go Mod Cache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,14 +23,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.go-cache-paths.outputs.go_build_cache }}
-          key: ${{ runner.os }}-go-todo-build-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
 
       # Cache go mod cache, used to speedup builds
       - name: Go Mod Cache
         uses: actions/cache@v4
         with:
           path: ${{ steps.go-cache-paths.outputs.go_mod_cache }}
-          key: ${{ runner.os }}-go-todo-mod-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Run the tests
         if: success()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,26 +12,6 @@ jobs:
         with:
           enable-cache: "true"
 
-      - name: Prepare Go build cache
-        id: go-cache-paths
-        run: |
-          devbox run -- echo "go_build_cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-          devbox run -- echo "go_mod_cache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
-
-      # Cache go build cache, used to speedup go test
-      - name: Go Build Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go_build_cache }}
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-
-      # Cache go mod cache, used to speedup builds
-      - name: Go Mod Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go_mod_cache }}
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
-
       - name: Run the tests
         if: success()
         run: devbox run -- go test -race -bench='.+' -v ./...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
 
       # Cache go mod cache, used to speedup builds
       - name: Go Mod Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.go-cache-paths.outputs.go_mod_cache }}
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.go-cache-paths.outputs.go_mod_cache }}
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-todo-mod-${{ hashFiles('**/go.sum') }}
 
       - name: Run the tests
         if: success()


### PR DESCRIPTION
After some testing, the best time is to keep both caches enabled, just update the `actions/cache` to v4 which uses the new version of cache that improves performance.

Investigation:
- The [last build](https://github.com/kalbasit/ncps/actions/runs/12186933686/job/33996550045?pr=32) with both build and mod cache enabled took 6m31s. 
- With both build and mod cache removed, [the build](https://github.com/kalbasit/ncps/actions/runs/12187073768/job/33997012726?pr=33) now only takes 1m23s.
- With only the mod cache enabled with actions/cache@v2 and no cache present, [the build](https://github.com/kalbasit/ncps/actions/runs/12187104484/job/33997123694?pr=33) took 3m43s. With cache present, [the build](https://github.com/kalbasit/ncps/actions/runs/12187160459/job/33997317235?pr=33) took 1m23s.
- With only the mod cache enable with actions/cache@v4 and no cache present, [the build](https://github.com/kalbasit/ncps/actions/runs/12187261670/job/33997653299?pr=33) took 1m34. With cache present, [the build](https://github.com/kalbasit/ncps/actions/runs/12187196389/job/33997436406?pr=33) took 1m41s.
- With both enabled at v4, [the build](https://github.com/kalbasit/ncps/actions/runs/12187369038/job/33997998527?pr=33) took 1m28s. With cache present, [the build](https://github.com/kalbasit/ncps/actions/runs/12187408536/job/33998125474) took 51s.