### PR TITLE
Dockerfile: Enable CGO and copy required shared library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,16 @@ RUN go mod download
 
 COPY . .
 
-ENV CGO_ENABLED=0
-RUN go build .
+RUN go build -o /dist/app/ncps
+
+RUN ldd /dist/app/ncps | tr -s [:blank:] '\n' | grep ^/ | xargs -I % install -D % /dist/%
 
 FROM scratch
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 
-COPY --from=builder /app/ncps /app/ncps
+COPY --from=builder /dist /
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 
-COPY . .
+COPY *.go .
+COPY cmd cmd
+COPY pkg pkg
 
 RUN go build -ldflags='-s -w' -trimpath -o /dist/app/ncps
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN go mod download
 
 COPY . .
 
-RUN go build -o /dist/app/ncps
+RUN go build -ldflags='-s -w' -trimpath -o /dist/app/ncps
 
 RUN ldd /dist/app/ncps | tr -s [:blank:] '\n' | grep ^/ | xargs -I % install -D % /dist/%
 


### PR DESCRIPTION
Go's sqlite library requires C bindings.

closes #35 