### PR TITLE
GitHub: Improve go-test performance by enable Go cache

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -21,8 +21,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/docker
         with:
+          # NOTE: Enable more platform when we have demand for them and I can test them.
+          # platforms: linux/amd64,linux/arm64,linux/arm/v7
           images: kalbasit/ncps
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup_devbox
+      - uses: ./.github/actions/setup_go
       - uses: ./.github/actions/go_test
 
   docker:


### PR DESCRIPTION
Also remove platforms, I do not use them and they take a while to build. I left a TODO to enable other platforms later.