### PR TITLE
pkg/database: Limit the number of open connections to 1

### DIFF
--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -101,6 +101,11 @@ func Open(logger log15.Logger, dbpath string) (*DB, error) {
 		return nil, fmt.Errorf("error opening the SQLite3 database at %q: %w", dbpath, err)
 	}
 
+	// Getting an error `database is locked` when data is being inserted in the
+	// database at a fast rate. This will slow down read/write from the database
+	// but at least none of them will fail due to connection issues.
+	sdb.SetMaxOpenConns(1)
+
 	db := &DB{DB: sdb, logger: logger.New("dbpath", dbpath)}
 
 	return db, db.createTables()

--- a/pkg/database/sqlite_test.go
+++ b/pkg/database/sqlite_test.go
@@ -261,7 +261,7 @@ func TestInsertNarInfoRecord(t *testing.T) {
 
 		errC := make(chan error)
 
-		for i := 0; i < 500; i++ {
+		for i := 0; i < 10000; i++ {
 			wg.Add(1)
 
 			go func() {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -159,7 +159,7 @@ func (s *Server) getNarInfo(withBody bool) http.HandlerFunc {
 				w.WriteHeader(http.StatusNotFound)
 
 				if _, err := w.Write([]byte(http.StatusText(http.StatusNotFound))); err != nil {
-					s.logger.Error("error writing the response", "hash", hash, "error", err)
+					s.logger.Error("error writing the response", "error", err)
 				}
 
 				return
@@ -169,7 +169,7 @@ func (s *Server) getNarInfo(withBody bool) http.HandlerFunc {
 			w.WriteHeader(http.StatusInternalServerError)
 
 			if _, err := w.Write([]byte(http.StatusText(http.StatusInternalServerError))); err != nil {
-				s.logger.Error("error writing the response", "hash", hash, "error", err)
+				s.logger.Error("error writing the response", "error", err)
 			}
 
 			return
@@ -188,7 +188,7 @@ func (s *Server) getNarInfo(withBody bool) http.HandlerFunc {
 		}
 
 		if _, err := w.Write(narInfoBytes); err != nil {
-			s.logger.Error("error writing the narinfo to the response", "hash", hash, "error", err)
+			s.logger.Error("error writing the narinfo to the response", "error", err)
 		}
 	}
 }
@@ -207,7 +207,7 @@ func (s *Server) putNarInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.cache.PutNarInfo(r.Context(), hash, r.Body); err != nil {
-		s.logger.Error("error putting the NAR in cache", "hash", hash, "error", err)
+		s.logger.Error("error putting the NAR in cache: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
 
 		if _, err2 := w.Write([]byte(http.StatusText(http.StatusInternalServerError) + err.Error())); err2 != nil {
@@ -267,7 +267,7 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 				w.WriteHeader(http.StatusNotFound)
 
 				if _, err := w.Write([]byte(http.StatusText(http.StatusNotFound))); err != nil {
-					s.logger.Error("error writing the response", "hash", hash, "compression", compression, "error", err)
+					s.logger.Error("error writing the response", "error", err)
 				}
 
 				return
@@ -277,7 +277,7 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 			w.WriteHeader(http.StatusInternalServerError)
 
 			if _, err := w.Write([]byte(http.StatusText(http.StatusInternalServerError))); err != nil {
-				s.logger.Error("error writing the response", "hash", hash, "compression", compression, "error", err)
+				s.logger.Error("error writing the response", "error", err)
 			}
 
 			return
@@ -295,13 +295,13 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 
 		written, err := io.Copy(w, reader)
 		if err != nil {
-			s.logger.Error("error writing the response", "hash", hash, "compression", compression, "error", err)
+			s.logger.Error("error writing the response", "error", err)
 
 			return
 		}
 
 		if written != size {
-			s.logger.Error("Bytes copied does not match object size", "hash", hash, "compression", compression, "expected", size, "written", written)
+			s.logger.Error("Bytes copied does not match object size", "expected", size, "written", written)
 		}
 	}
 }
@@ -314,18 +314,18 @@ func (s *Server) putNar(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 
 		if _, err := w.Write([]byte(http.StatusText(http.StatusMethodNotAllowed))); err != nil {
-			s.logger.Error("error writing the body to the response", "hash", hash, "compression", compression, "error", err)
+			s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
 		}
 
 		return
 	}
 
 	if err := s.cache.PutNar(r.Context(), hash, compression, r.Body); err != nil {
-		s.logger.Error("error putting the NAR in cache", "hash", hash, "compression", compression, "error", err)
+		s.logger.Error("error putting the NAR in cache: %s", err)
 		w.WriteHeader(http.StatusInternalServerError)
 
 		if _, err2 := w.Write([]byte(http.StatusText(http.StatusInternalServerError) + err.Error())); err2 != nil {
-			s.logger.Error("error writing the body to the response", "hash", hash, "compression", compression, "error", err)
+			s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
 		}
 
 		return
@@ -342,7 +342,7 @@ func (s *Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 
 		if _, err := w.Write([]byte(http.StatusText(http.StatusMethodNotAllowed))); err != nil {
-			s.logger.Error("error writing the body to the response", "hash", hash, "compression", compression, "error", err)
+			s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
 		}
 
 		return
@@ -353,7 +353,7 @@ func (s *Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 
 			if _, err := w.Write([]byte(http.StatusText(http.StatusNotFound))); err != nil {
-				s.logger.Error("error writing the body to the response", "hash", hash, "compression", compression, "error", err)
+				s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
 			}
 
 			return
@@ -362,7 +362,7 @@ func (s *Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 
 		if _, err := w.Write([]byte(http.StatusText(http.StatusInternalServerError))); err != nil {
-			s.logger.Error("error writing the body to the response", "hash", hash, "compression", compression, "error", err)
+			s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
 		}
 
 		return

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -159,7 +159,7 @@ func (s *Server) getNarInfo(withBody bool) http.HandlerFunc {
 				w.WriteHeader(http.StatusNotFound)
 
 				if _, err := w.Write([]byte(http.StatusText(http.StatusNotFound))); err != nil {
-					s.logger.Error("error writing the response", "error", err)
+					s.logger.Error("error writing the response", "hash", hash, "error", err)
 				}
 
 				return
@@ -169,7 +169,7 @@ func (s *Server) getNarInfo(withBody bool) http.HandlerFunc {
 			w.WriteHeader(http.StatusInternalServerError)
 
 			if _, err := w.Write([]byte(http.StatusText(http.StatusInternalServerError))); err != nil {
-				s.logger.Error("error writing the response", "error", err)
+				s.logger.Error("error writing the response", "hash", hash, "error", err)
 			}
 
 			return
@@ -188,7 +188,7 @@ func (s *Server) getNarInfo(withBody bool) http.HandlerFunc {
 		}
 
 		if _, err := w.Write(narInfoBytes); err != nil {
-			s.logger.Error("error writing the narinfo to the response", "error", err)
+			s.logger.Error("error writing the narinfo to the response", "hash", hash, "error", err)
 		}
 	}
 }
@@ -207,7 +207,7 @@ func (s *Server) putNarInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.cache.PutNarInfo(r.Context(), hash, r.Body); err != nil {
-		s.logger.Error("error putting the NAR in cache: %s", err)
+		s.logger.Error("error putting the NAR in cache", "hash", hash, "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 
 		if _, err2 := w.Write([]byte(http.StatusText(http.StatusInternalServerError) + err.Error())); err2 != nil {
@@ -267,7 +267,7 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 				w.WriteHeader(http.StatusNotFound)
 
 				if _, err := w.Write([]byte(http.StatusText(http.StatusNotFound))); err != nil {
-					s.logger.Error("error writing the response", "error", err)
+					s.logger.Error("error writing the response", "hash", hash, "compression", compression, "error", err)
 				}
 
 				return
@@ -277,7 +277,7 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 			w.WriteHeader(http.StatusInternalServerError)
 
 			if _, err := w.Write([]byte(http.StatusText(http.StatusInternalServerError))); err != nil {
-				s.logger.Error("error writing the response", "error", err)
+				s.logger.Error("error writing the response", "hash", hash, "compression", compression, "error", err)
 			}
 
 			return
@@ -295,13 +295,13 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 
 		written, err := io.Copy(w, reader)
 		if err != nil {
-			s.logger.Error("error writing the response", "error", err)
+			s.logger.Error("error writing the response", "hash", hash, "compression", compression, "error", err)
 
 			return
 		}
 
 		if written != size {
-			s.logger.Error("Bytes copied does not match object size", "expected", size, "written", written)
+			s.logger.Error("Bytes copied does not match object size", "hash", hash, "compression", compression, "expected", size, "written", written)
 		}
 	}
 }
@@ -314,18 +314,18 @@ func (s *Server) putNar(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 
 		if _, err := w.Write([]byte(http.StatusText(http.StatusMethodNotAllowed))); err != nil {
-			s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
+			s.logger.Error("error writing the body to the response", "hash", hash, "compression", compression, "error", err)
 		}
 
 		return
 	}
 
 	if err := s.cache.PutNar(r.Context(), hash, compression, r.Body); err != nil {
-		s.logger.Error("error putting the NAR in cache: %s", err)
+		s.logger.Error("error putting the NAR in cache", "hash", hash, "compression", compression, "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 
 		if _, err2 := w.Write([]byte(http.StatusText(http.StatusInternalServerError) + err.Error())); err2 != nil {
-			s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
+			s.logger.Error("error writing the body to the response", "hash", hash, "compression", compression, "error", err)
 		}
 
 		return
@@ -342,7 +342,7 @@ func (s *Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 
 		if _, err := w.Write([]byte(http.StatusText(http.StatusMethodNotAllowed))); err != nil {
-			s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
+			s.logger.Error("error writing the body to the response", "hash", hash, "compression", compression, "error", err)
 		}
 
 		return
@@ -353,7 +353,7 @@ func (s *Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 
 			if _, err := w.Write([]byte(http.StatusText(http.StatusNotFound))); err != nil {
-				s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
+				s.logger.Error("error writing the body to the response", "hash", hash, "compression", compression, "error", err)
 			}
 
 			return
@@ -362,7 +362,7 @@ func (s *Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 
 		if _, err := w.Write([]byte(http.StatusText(http.StatusInternalServerError))); err != nil {
-			s.logger.Error("error writing the body to the response", "hash", hash, "error", err)
+			s.logger.Error("error writing the body to the response", "hash", hash, "compression", compression, "error", err)
 		}
 
 		return


### PR DESCRIPTION
Getting a `database is locked` error. This [upstream issue](https://github.com/mattn/go-sqlite3/issues/274#issuecomment-191597862) suggested limiting the number of connection to one and it seems to have helped. It's not idea, but I need to move on.

ref #38 