### PR TITLE
pkg/cache: decouple upstream requests from downstream requests

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -342,7 +342,7 @@ func (c *Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, 
 		return c.getNarInfoFromStore(hash)
 	}
 
-	narInfo, err := c.getNarInfoFromUpstream(ctx, hash)
+	narInfo, err := c.getNarInfoFromUpstream(hash)
 	if err != nil {
 		return nil, fmt.Errorf("error getting the narInfo from upstream caches: %w", err)
 	}
@@ -475,7 +475,11 @@ func (c *Cache) getNarInfoFromStore(hash string) (*narinfo.NarInfo, error) {
 	return ni, nil
 }
 
-func (c *Cache) getNarInfoFromUpstream(ctx context.Context, hash string) (*narinfo.NarInfo, error) {
+func (c *Cache) getNarInfoFromUpstream(hash string) (*narinfo.NarInfo, error) {
+	// create a new context not associated with any request because we don't want
+	// pulling from upstream to be associated with a user request.
+	ctx := context.Background()
+
 	for _, uc := range c.upstreamCaches {
 		narInfo, err := uc.GetNarInfo(ctx, hash)
 		if err != nil {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -337,7 +337,7 @@ func (c *Cache) deleteNarFromStore(hash, compression string) error {
 // GetNarInfo returns the narInfo given a hash from the store. If the narInfo
 // is not found in the store, it's pulled from an upstream, stored in the
 // stored and finally returned.
-func (c *Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, error) {
+func (c *Cache) GetNarInfo(hash string) (*narinfo.NarInfo, error) {
 	if c.hasNarInfoInStore(hash) {
 		return c.getNarInfoFromStore(hash)
 	}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -300,7 +300,7 @@ func TestGetNarInfo(t *testing.T) {
 	}
 
 	t.Run("narinfo does not exist upstream", func(t *testing.T) {
-		_, err := c.GetNarInfo(context.Background(), "doesnotexist")
+		_, err := c.GetNarInfo("doesnotexist")
 		if want, got := cache.ErrNotFound, err; !errors.Is(got, want) {
 			t.Errorf("want %s got %s", want, got)
 		}
@@ -375,7 +375,7 @@ func TestGetNarInfo(t *testing.T) {
 			}
 		})
 
-		ni, err := c.GetNarInfo(context.Background(), narInfoHash2)
+		ni, err := c.GetNarInfo(narInfoHash2)
 		if err != nil {
 			t.Fatalf("no error expected, got: %s", err)
 		}
@@ -530,7 +530,7 @@ func TestGetNarInfo(t *testing.T) {
 				c.SetRecordAgeIgnoreTouch(0)
 			}()
 
-			_, err := c.GetNarInfo(context.Background(), narInfoHash2)
+			_, err := c.GetNarInfo(narInfoHash2)
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
@@ -579,7 +579,7 @@ func TestGetNarInfo(t *testing.T) {
 		t.Run("pulling it another time should update last_accessed_at only for narinfo", func(t *testing.T) {
 			time.Sleep(time.Second)
 
-			_, err := c.GetNarInfo(context.Background(), narInfoHash2)
+			_, err := c.GetNarInfo(narInfoHash2)
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
@@ -630,7 +630,7 @@ func TestGetNarInfo(t *testing.T) {
 				t.Fatalf("error removing the narinfo from the store: %s", err)
 			}
 
-			_, err := c.GetNarInfo(context.Background(), narInfoHash2)
+			_, err := c.GetNarInfo(narInfoHash2)
 			if err != nil {
 				t.Errorf("no error expected, got: %s", err)
 			}
@@ -989,7 +989,7 @@ func TestGetNar(t *testing.T) {
 		})
 
 		t.Run("getting the narinfo so the record in the database now exists", func(t *testing.T) {
-			_, err := c.GetNarInfo(context.Background(), narInfoHash1)
+			_, err := c.GetNarInfo(narInfoHash1)
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
@@ -1026,7 +1026,7 @@ func TestGetNar(t *testing.T) {
 		})
 
 		t.Run("getting the narinfo so the record in the database now exists", func(t *testing.T) {
-			_, err := c.GetNarInfo(context.Background(), narInfoHash1)
+			_, err := c.GetNarInfo(narInfoHash1)
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -155,7 +155,7 @@ func (s *Server) getNarInfo(withBody bool) http.HandlerFunc {
 
 		log := s.logger.New("hash", hash)
 
-		narInfo, err := s.cache.GetNarInfo(r.Context(), hash)
+		narInfo, err := s.cache.GetNarInfo(hash)
 		if err != nil {
 			if errors.Is(err, cache.ErrNotFound) {
 				w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
If the user cancels their request, the store will cancel all of its requests causing entries in the database to exist whilst the files are not in the store.