### PR TITLE
GitHub: fix the release by building only for linux/amd64

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Build binaries
         run: |
           mkdir out
-          for os in linux darwin; do
-            for arch in amd64 arm64; do
+          for os in linux; do
+            for arch in amd64; do
               GOOS=$os GOARCH=$arch go build -o out/${{ github.event.repository.name }}-${os}-${arch}
             done
           done


### PR DESCRIPTION
I'm seeing this error, and this is a workaround for now:

```
# github.com/kalbasit/ncps/pkg/database
pkg/database/sqlite.go:180:33: undefined: sqlite3.Error
pkg/database/sqlite.go:181:38: undefined: sqlite3.ErrConstraint
pkg/database/sqlite.go:255:33: undefined: sqlite3.Error
pkg/database/sqlite.go:256:38: undefined: sqlite3.ErrConstraint
Error: Process completed with exit code 1.
```