### PR TITLE
treewide: extract testdata into a testdata package

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -496,7 +496,7 @@ func (c *Cache) getNarInfoFromUpstream(log log15.Logger, hash string) (*narinfo.
 		narInfo, err := uc.GetNarInfo(ctx, hash)
 		if err != nil {
 			if !errors.Is(err, upstream.ErrNotFound) {
-				log.Error("error fetching the narInfo from upstream", "hash", hash, "hostname", uc.GetHostname(), "error", err)
+				log.Error("error fetching the narInfo from upstream", "hostname", uc.GetHostname(), "error", err)
 			}
 
 			continue

--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -2,16 +2,15 @@ package cache
 
 import (
 	"math/rand/v2"
-	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"strconv"
 	"testing"
 
 	"github.com/inconshreveable/log15/v3"
 
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
+	"github.com/kalbasit/ncps/testdata"
 )
 
 //nolint:gochecknoglobals
@@ -26,28 +25,10 @@ func TestNew(t *testing.T) {
 	t.Run("upstream caches", func(t *testing.T) {
 		t.Parallel()
 
-		handlerFunc := func(priority int) http.Handler {
-			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path != "/nix-cache-info" {
-					w.WriteHeader(http.StatusNotFound)
-
-					return
-				}
-
-				body := `StoreDir: /nix/store
-WantMassQuery: 1
-Priority: ` + strconv.Itoa(priority)
-
-				if _, err := w.Write([]byte(body)); err != nil {
-					t.Fatalf("expected no error got: %s", err)
-				}
-			})
-		}
-
 		testServers := make(map[int]*httptest.Server)
 
 		for i := 1; i < 10; i++ {
-			ts := httptest.NewServer(handlerFunc(i))
+			ts := testdata.HTTPTestServer(t, i)
 			defer ts.Close()
 			testServers[i] = ts
 		}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kalbasit/ncps/pkg/cache"
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
 	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/testdata"
 
 	// Import the SQLite driver.
 	_ "github.com/mattn/go-sqlite3"
@@ -38,42 +39,6 @@ const (
 	nixStoreInfo = `StoreDir: /nix/store
 WantMassQuery: 1
 Priority: 40`
-
-	narInfoHash1 = "7bn85d74qa0127p85rrswfyghxsqmcf7"
-
-	//nolint:lll
-	narInfoText1 = `StorePath: /nix/store/7bn85d74qa0127p85rrswfyghxsqmcf7-iputils-20210722
-URL: nar/136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00.nar
-Compression: xz
-FileHash: sha256:136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00
-FileSize: 132228
-NarHash: sha256:1rzb80kz42wy067pp160rridw41dnc09d2a3cqj2wdg6ylklhxkh
-NarSize: 534160
-References: 7bn85d74qa0127p85rrswfyghxsqmcf7-iputils-20210722 892cxk44qxzzlw9h90a781zpy1j7gmmn-libidn2-2.3.2 l25bc19is0s27929kxkfhgdzhc7x9g5m-libcap-2.49-lib rir9pf0kz1mb84x5bd3yr0fx415yy423-glibc-2.33-123
-Deriver: 9fs4vq4gdsb8r9ywawb5f6zl40ycp1bh-iputils-20210722.drv
-Sig: cache.nixos.org-1:WzhkqDdkgPz2qU/0QyEA6wUIm7EMR5MY8nTb5jAmmoh5b80ACIp/+Zpgi5t1KvmO8uG8GVrkPejCxbyQ2gNXDQ==`
-
-	narHash1 = "136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00"
-
-	narText1 = "Hello, World" // fake nar for above nar info
-
-	narInfoHash2 = "a6hiaxlxf7arxsf59f4rzs7b337z6a11"
-
-	//nolint:lll
-	narInfoText2 = `StorePath: /nix/store/a6hiaxlxf7arxsf59f4rzs7b337z6a11-brave-1.73.91
-URL: nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar
-Compression: xz
-FileHash: sha256:1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps
-FileSize: 125606280
-NarHash: sha256:1q95nilzb512ckljzj7h8bsdnj4qhpvyddp74bhsf8sxb8vjmpsj
-NarSize: 388038816
-References: 08mdbxgs2m7fz3hx2xrqrbmhldxagpf8-pango-1.54.0-bin 0irlcqx2n3qm6b1pc9rsd2i8qpvcccaj-bash-5.2p37 2542sr1ch7ypz52w423vyn0fhn934rj7-dbus-1.14.10 3c603pkfh9fq13lrm6rdqynb7xxwazv7-libXrandr-1.5.4 3ma7c4syxds2wrp03ax3b7p9fdsh1lwg-nss-3.101.2 4qiqy2z0facj37682n9x0mz0isd9k3qb-libXScrnSaver-1.2.4 4zjxqvvnnisn8nqmibgy40rvm087v85n-cups-2.4.11-lib 566jyp236h118ad005mxqs7sb9ivv4yj-libXrender-0.9.11 5lq743a2jp3v4kgr80y0sw8jr70pl6gj-libXi-1.8.2 7c88jgbh10zvlv91bmhyc40h8l9b3wf5-librsvg-2.58.3 84839y8j0d4l4d3q048v00h20jdk9lh0-wayland-1.23.1 946m0cmd00hcw2s6slzp5qc01krgrzks-dbus-1.14.10-lib 9i9wrwdi1hkcklzya0yhci0d0vkyl79k-alsa-lib-1.2.12 a6hiaxlxf7arxsf59f4rzs7b337z6a11-brave-1.73.91 apmrnyl4b6fj9czqkb8vwpf6cvfvs0ba-glib-2.82.1-bin arrgysrp5ks44qidsf8byjj11pnkaf65-cairo-1.18.2 b4ph9mwdv628db2vqhhhp3azalq6cwbq-libxcb-1.17.0 c1lszwlw825y6vr4qik6dqv2lszqk08r-libdrm-2.4.123-bin ckfsxyla4krxn4zdlmxkp6lk8nsscr5v-libXcursor-1.2.2 dcj4w0a7472g86yf5wqz5vfbd809s4cj-snappy-1.2.1 gsdkqm4qfbzr22m20cns3iilxd55ridd-freetype-2.13.3 hm2rpszabwpvs28jwkaz7pg0dqslm4bd-util-linux-minimal-2.39.4-lib hpd1dss7lmrywlr37vncyzbhzp6rgri5-libXext-1.3.6 i0d0ws5xwix1dvmwp8w1fr4kz61k11x4-libxkbcommon-1.7.0 i66c6m4680fdgfj5fmaclma1bbl9y8i6-systemd-minimal-libs-256.7 ibr7wf806ns8517zggai9yygz07kp85a-libdrm-2.4.123 idrnfiw9r87giqiqwr36xkch4dsr0rdz-pango-1.54.0 j6wpl172pz2323fia7cbjx9lznsc47ri-at-spi2-core-2.54.0 jbck0ahim6cbjjzl1wmrch5inhbhkkra-gtk4-4.16.3 jq1ydifw3ip1vx94dl8w8bgvr07l6s3x-glib-2.82.1 jx4rwrk7cg5v64ygbpyi1v3gfp8c7k9h-fontconfig-2.15.0-bin k48bha2fjqzarg52picsdfwlqx75aqbb-coreutils-9.5 lafwzwzrj53prpzgmmq0aq5spal91q7s-libXdamage-1.1.6 lcq3ibmsb6c2jgqp3yfi1yp773x5wz19-mesa-24.2.6 ldqjvk81fdzygd85505lzc781vssfpdy-libXtst-1.2.5 m761lp9x14i33hb3q7a8wm52rsnk6ab1-expat-2.6.4 mafw0r1djqvl36by8qhz02kmaggh24v8-gdk-pixbuf-2.42.12 mhp5jkwqgyz0s7klvpl23x3axgvn6msm-pipewire-1.2.6 ms2562w6dkqa6xzpaxi4n2ib9kbb3gya-libXcomposite-0.4.6 p5nz6gdblng41fiqqb7z88l119dc9v56-gsettings-desktop-schemas-47.1 pacbfvpzqz2mksby36awvbcn051zcji3-glibc-2.40-36 pg3xw94i23l4dkrxcp7l11a2iydxc1za-dconf-0.40.0-lib q8y8kgidr4mg0q7zr2h1ddpd7ijy3wna-libpulseaudio-17.0 qrj5f1mb08k5jg7y9ikzb1njli0gvmxz-libX11-1.8.10 rdjcf9pxdlcd6ncsiqm97gq4ard6c91f-nspr-4.36 rh6zrnvbzjsfy444w5w2k5sz72cl6f4z-libva-2.22.0 rmfav7fq6rmpv3d785v462shsy1njq6f-fontconfig-2.15.0-lib sawcd2sh4p7kdggj00i67wa59swaid5b-util-linux-minimal-2.39.4-bin vbw9c3pvwli5iidik8dddgz423wr1h18-gtk+3-3.24.43 w3clwb8c7c8vc7ls163p5pjspccgcrhj-cups-2.4.11 w9g781rqrc12870vji13hycwh47lwsgd-qtbase-6.8.0 wfqs8h2mf4ib7f1phpsgv0b20xny9zzl-libXfixes-6.0.1 wjnznkh0x4744mcvhlnr4qnnig15287c-xdg-utils-1.2.1 xghyamhbjj0rfavxj76l52mv7zr7dfiw-krb5-1.21.3-lib xk9b2k475ab7q9xmcqcfb1xcyh9arswj-krb5-1.21.3 y6bcc1vzg315zzzpir608zkhnmvp49kc-zlib-1.3.1 ymhcg6x5jrw3hx8ik1cji6awiybgp9f7-libglvnd-1.7.0 zm54lx2l4jsc0dw1cnmyg8ilcn07v6zb-libxshmfence-1.3.2
-Deriver: n85jhy5b8c9l1a4d9pnf3dv8bfvmyzhb-brave-1.73.91.drv
-Sig: cache.nixos.org-1:QVc2ad4OI/2G5gVyFsoWYr+AECFDXjwF6o1HOfSbMJhPp5l4iD38WgJhf2w/3kZ/B5ftq6ytDijcAWCSDItJDQ==`
-
-	narHash2 = "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps"
-
-	narText2 = "Wave, World" // fake nar for above nar info
 )
 
 func TestNew(t *testing.T) {
@@ -308,14 +273,14 @@ func TestGetNarInfo(t *testing.T) {
 
 	t.Run("narinfo exists upstream", func(t *testing.T) {
 		t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
-			_, err := os.Stat(filepath.Join(dir, "store", narInfoHash2+".narinfo"))
+			_, err := os.Stat(filepath.Join(dir, "store", testdata.NarInfoHash2+".narinfo"))
 			if err == nil {
 				t.Fatal("expected an error but got none")
 			}
 		})
 
 		t.Run("nar does not exist in storage yet", func(t *testing.T) {
-			_, err := os.Stat(filepath.Join(dir, "store", narHash2+".nar"))
+			_, err := os.Stat(filepath.Join(dir, "store", testdata.NarHash2+".nar"))
 			if err == nil {
 				t.Fatal("expected an error but got none")
 			}
@@ -375,7 +340,7 @@ func TestGetNarInfo(t *testing.T) {
 			}
 		})
 
-		ni, err := c.GetNarInfo(narInfoHash2)
+		ni, err := c.GetNarInfo(testdata.NarInfoHash2)
 		if err != nil {
 			t.Fatalf("no error expected, got: %s", err)
 		}
@@ -387,7 +352,7 @@ func TestGetNarInfo(t *testing.T) {
 		})
 
 		t.Run("it should now exist in the store", func(t *testing.T) {
-			_, err := os.Stat(filepath.Join(dir, "store", narInfoHash2+".narinfo"))
+			_, err := os.Stat(filepath.Join(dir, "store", testdata.NarInfoHash2+".narinfo"))
 			if err != nil {
 				t.Fatalf("expected no error got %s", err)
 			}
@@ -425,7 +390,7 @@ func TestGetNarInfo(t *testing.T) {
 				// NOTE: I tried runtime.Gosched() but it makes the test flaky
 				time.Sleep(time.Millisecond)
 
-				_, err = os.Stat(filepath.Join(dir, "store", "nar", narHash2+".nar"))
+				_, err = os.Stat(filepath.Join(dir, "store", "nar", testdata.NarHash2+".nar"))
 				if err == nil {
 					break
 				}
@@ -467,7 +432,7 @@ func TestGetNarInfo(t *testing.T) {
 				t.Fatalf("want %d got %d", want, got)
 			}
 
-			if want, got := narInfoHash2, nims[0].Hash; want != got {
+			if want, got := testdata.NarInfoHash2, nims[0].Hash; want != got {
 				t.Errorf("want %q got %q", want, got)
 			}
 
@@ -512,7 +477,7 @@ func TestGetNarInfo(t *testing.T) {
 				t.Fatalf("want %d got %d", want, got)
 			}
 
-			if want, got := narHash2, nims[0].Hash; want != got {
+			if want, got := testdata.NarHash2, nims[0].Hash; want != got {
 				t.Errorf("want %q got %q", want, got)
 			}
 
@@ -530,7 +495,7 @@ func TestGetNarInfo(t *testing.T) {
 				c.SetRecordAgeIgnoreTouch(0)
 			}()
 
-			_, err := c.GetNarInfo(narInfoHash2)
+			_, err := c.GetNarInfo(testdata.NarInfoHash2)
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
@@ -566,7 +531,7 @@ func TestGetNarInfo(t *testing.T) {
 					t.Fatalf("want %d got %d", want, got)
 				}
 
-				if want, got := narInfoHash2, nims[0].Hash; want != got {
+				if want, got := testdata.NarInfoHash2, nims[0].Hash; want != got {
 					t.Errorf("want %q got %q", want, got)
 				}
 
@@ -579,7 +544,7 @@ func TestGetNarInfo(t *testing.T) {
 		t.Run("pulling it another time should update last_accessed_at only for narinfo", func(t *testing.T) {
 			time.Sleep(time.Second)
 
-			_, err := c.GetNarInfo(narInfoHash2)
+			_, err := c.GetNarInfo(testdata.NarInfoHash2)
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
@@ -615,7 +580,7 @@ func TestGetNarInfo(t *testing.T) {
 					t.Fatalf("want %d got %d", want, got)
 				}
 
-				if want, got := narInfoHash2, nims[0].Hash; want != got {
+				if want, got := testdata.NarInfoHash2, nims[0].Hash; want != got {
 					t.Errorf("want %q got %q", want, got)
 				}
 
@@ -626,11 +591,11 @@ func TestGetNarInfo(t *testing.T) {
 		})
 
 		t.Run("no error is returned if the entry already exist in the database", func(t *testing.T) {
-			if err := os.Remove(filepath.Join(dir, "store", narInfoHash2+".narinfo")); err != nil {
+			if err := os.Remove(filepath.Join(dir, "store", testdata.NarInfoHash2+".narinfo")); err != nil {
 				t.Fatalf("error removing the narinfo from the store: %s", err)
 			}
 
-			_, err := c.GetNarInfo(narInfoHash2)
+			_, err := c.GetNarInfo(testdata.NarInfoHash2)
 			if err != nil {
 				t.Errorf("no error expected, got: %s", err)
 			}
@@ -658,7 +623,7 @@ func TestPutNarInfo(t *testing.T) {
 		t.Fatalf("error opening the database: %s", err)
 	}
 
-	storePath := filepath.Join(dir, "store", narInfoHash1+".narinfo")
+	storePath := filepath.Join(dir, "store", testdata.NarInfoHash1+".narinfo")
 
 	t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 		_, err := os.Stat(storePath)
@@ -722,9 +687,9 @@ func TestPutNarInfo(t *testing.T) {
 	})
 
 	t.Run("PutNarInfo does not return an error", func(t *testing.T) {
-		r := io.NopCloser(strings.NewReader(narInfoText1))
+		r := io.NopCloser(strings.NewReader(testdata.NarInfoText1))
 
-		err := c.PutNarInfo(context.Background(), narInfoHash1, r)
+		err := c.PutNarInfo(context.Background(), testdata.NarInfoHash1, r)
 		if err != nil {
 			t.Errorf("error not expected got %s", err)
 		}
@@ -796,7 +761,7 @@ func TestPutNarInfo(t *testing.T) {
 			t.Fatalf("want %d got %d", want, got)
 		}
 
-		if want, got := narInfoHash1, hashes[0]; want != got {
+		if want, got := testdata.NarInfoHash1, hashes[0]; want != got {
 			t.Errorf("want %q got %q", want, got)
 		}
 	})
@@ -827,7 +792,7 @@ func TestPutNarInfo(t *testing.T) {
 			t.Fatalf("want %d got %d", want, got)
 		}
 
-		if want, got := narHash1, hashes[0]; want != got {
+		if want, got := testdata.NarHash1, hashes[0]; want != got {
 			t.Errorf("want %q got %q", want, got)
 		}
 	})
@@ -849,7 +814,7 @@ func TestDeleteNarInfo(t *testing.T) {
 	c.SetRecordAgeIgnoreTouch(0)
 
 	t.Run("file does not exist in the store", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", narInfoHash1+".narinfo")
+		storePath := filepath.Join(dir, "store", testdata.NarInfoHash1+".narinfo")
 
 		t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 			_, err := os.Stat(storePath)
@@ -859,7 +824,7 @@ func TestDeleteNarInfo(t *testing.T) {
 		})
 
 		t.Run("DeleteNarInfo does return an error", func(t *testing.T) {
-			err := c.DeleteNarInfo(context.Background(), narInfoHash1)
+			err := c.DeleteNarInfo(context.Background(), testdata.NarInfoHash1)
 			if want, got := cache.ErrNotFound, err; !errors.Is(got, want) {
 				t.Errorf("want %q got %q", want, got)
 			}
@@ -867,7 +832,7 @@ func TestDeleteNarInfo(t *testing.T) {
 	})
 
 	t.Run("file does exist in the store", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", narInfoHash1+".narinfo")
+		storePath := filepath.Join(dir, "store", testdata.NarInfoHash1+".narinfo")
 
 		t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 			_, err := os.Stat(storePath)
@@ -881,7 +846,7 @@ func TestDeleteNarInfo(t *testing.T) {
 			t.Fatalf("expecting no error got %s", err)
 		}
 
-		if _, err := f.WriteString(narInfoText1); err != nil {
+		if _, err := f.WriteString(testdata.NarInfoText1); err != nil {
 			t.Fatalf("expecting no error got %s", err)
 		}
 
@@ -897,7 +862,7 @@ func TestDeleteNarInfo(t *testing.T) {
 		})
 
 		t.Run("DeleteNarInfo does not return an error", func(t *testing.T) {
-			if err := c.DeleteNarInfo(context.Background(), narInfoHash1); err != nil {
+			if err := c.DeleteNarInfo(context.Background(), testdata.NarInfoHash1); err != nil {
 				t.Errorf("error not expected got %s", err)
 			}
 		})
@@ -944,7 +909,7 @@ func TestGetNar(t *testing.T) {
 		t.Fatalf("error opening the database: %s", err)
 	}
 
-	narName := narHash1 + ".nar"
+	narName := testdata.NarHash1 + ".nar"
 
 	t.Run("nar does not exist upstream", func(t *testing.T) {
 		_, _, err := c.GetNar("doesnotexist", "")
@@ -989,20 +954,20 @@ func TestGetNar(t *testing.T) {
 		})
 
 		t.Run("getting the narinfo so the record in the database now exists", func(t *testing.T) {
-			_, err := c.GetNarInfo(narInfoHash1)
+			_, err := c.GetNarInfo(testdata.NarInfoHash1)
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
 		})
 
-		size, r, err := c.GetNar(narHash1, "")
+		size, r, err := c.GetNar(testdata.NarHash1, "")
 		if err != nil {
 			t.Fatalf("no error expected, got: %s", err)
 		}
 		defer r.Close()
 
 		t.Run("size is correct", func(t *testing.T) {
-			if want, got := int64(len(narText1)), size; want != got {
+			if want, got := int64(len(testdata.NarText1)), size; want != got {
 				t.Errorf("want %d got %d", want, got)
 			}
 		})
@@ -1013,7 +978,7 @@ func TestGetNar(t *testing.T) {
 				t.Fatalf("expected no error, got: %s", err)
 			}
 
-			if want, got := narText1, string(body); want != got {
+			if want, got := testdata.NarText1, string(body); want != got {
 				t.Errorf("want %q got %q", want, got)
 			}
 		})
@@ -1026,7 +991,7 @@ func TestGetNar(t *testing.T) {
 		})
 
 		t.Run("getting the narinfo so the record in the database now exists", func(t *testing.T) {
-			_, err := c.GetNarInfo(narInfoHash1)
+			_, err := c.GetNarInfo(testdata.NarInfoHash1)
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
@@ -1068,7 +1033,7 @@ func TestGetNar(t *testing.T) {
 				t.Fatalf("want %d got %d", want, got)
 			}
 
-			if want, got := narHash1, nims[0].Hash; want != got {
+			if want, got := testdata.NarHash1, nims[0].Hash; want != got {
 				t.Errorf("want %q got %q", want, got)
 			}
 
@@ -1086,7 +1051,7 @@ func TestGetNar(t *testing.T) {
 				c.SetRecordAgeIgnoreTouch(0)
 			}()
 
-			_, r, err := c.GetNar(narHash1, "")
+			_, r, err := c.GetNar(testdata.NarHash1, "")
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
@@ -1128,7 +1093,7 @@ func TestGetNar(t *testing.T) {
 					t.Fatalf("want %d got %d", want, got)
 				}
 
-				if want, got := narHash1, nims[0].Hash; want != got {
+				if want, got := testdata.NarHash1, nims[0].Hash; want != got {
 					t.Errorf("want %q got %q", want, got)
 				}
 
@@ -1141,7 +1106,7 @@ func TestGetNar(t *testing.T) {
 		t.Run("pulling it another time should update last_accessed_at", func(t *testing.T) {
 			time.Sleep(time.Second)
 
-			_, r, err := c.GetNar(narHash1, "")
+			_, r, err := c.GetNar(testdata.NarHash1, "")
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
@@ -1183,7 +1148,7 @@ func TestGetNar(t *testing.T) {
 					t.Fatalf("want %d got %d", want, got)
 				}
 
-				if want, got := narHash1, nims[0].Hash; want != got {
+				if want, got := testdata.NarHash1, nims[0].Hash; want != got {
 					t.Errorf("want %q got %q", want, got)
 				}
 
@@ -1211,7 +1176,7 @@ func TestPutNar(t *testing.T) {
 	c.SetRecordAgeIgnoreTouch(0)
 
 	t.Run("without compression", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", "nar", narHash1+".nar")
+		storePath := filepath.Join(dir, "store", "nar", testdata.NarHash1+".nar")
 
 		t.Run("nar does not exist in storage yet", func(t *testing.T) {
 			_, err := os.Stat(storePath)
@@ -1221,9 +1186,9 @@ func TestPutNar(t *testing.T) {
 		})
 
 		t.Run("putNar does not return an error", func(t *testing.T) {
-			r := io.NopCloser(strings.NewReader(narText1))
+			r := io.NopCloser(strings.NewReader(testdata.NarText1))
 
-			err := c.PutNar(context.Background(), narHash1, "", r)
+			err := c.PutNar(context.Background(), testdata.NarHash1, "", r)
 			if err != nil {
 				t.Errorf("error not expected got %s", err)
 			}
@@ -1240,14 +1205,14 @@ func TestPutNar(t *testing.T) {
 				t.Fatalf("expected no error but got: %s", err)
 			}
 
-			if want, got := narText1, string(bs); want != got {
+			if want, got := testdata.NarText1, string(bs); want != got {
 				t.Errorf("want %q got %q", want, got)
 			}
 		})
 	})
 
 	t.Run("with compression", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", "nar", narHash1+".nar.xz")
+		storePath := filepath.Join(dir, "store", "nar", testdata.NarHash1+".nar.xz")
 
 		t.Run("nar does not exist in storage yet", func(t *testing.T) {
 			_, err := os.Stat(storePath)
@@ -1257,9 +1222,9 @@ func TestPutNar(t *testing.T) {
 		})
 
 		t.Run("putNar does not return an error", func(t *testing.T) {
-			r := io.NopCloser(strings.NewReader(narText1))
+			r := io.NopCloser(strings.NewReader(testdata.NarText1))
 
-			err := c.PutNar(context.Background(), narHash1, "xz", r)
+			err := c.PutNar(context.Background(), testdata.NarHash1, "xz", r)
 			if err != nil {
 				t.Errorf("error not expected got %s", err)
 			}
@@ -1276,7 +1241,7 @@ func TestPutNar(t *testing.T) {
 				t.Fatalf("expected no error but got: %s", err)
 			}
 
-			if want, got := narText1, string(bs); want != got {
+			if want, got := testdata.NarText1, string(bs); want != got {
 				t.Errorf("want %q got %q", want, got)
 			}
 		})
@@ -1299,7 +1264,7 @@ func TestDeleteNar(t *testing.T) {
 	c.SetRecordAgeIgnoreTouch(0)
 
 	t.Run("without compression", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", "nar", narHash1+".nar")
+		storePath := filepath.Join(dir, "store", "nar", testdata.NarHash1+".nar")
 
 		t.Run("file does not exist in the store", func(t *testing.T) {
 			t.Run("nar does not exist in storage yet", func(t *testing.T) {
@@ -1310,7 +1275,7 @@ func TestDeleteNar(t *testing.T) {
 			})
 
 			t.Run("DeleteNar does return an error", func(t *testing.T) {
-				err := c.DeleteNar(context.Background(), narHash1, "")
+				err := c.DeleteNar(context.Background(), testdata.NarHash1, "")
 				if want, got := cache.ErrNotFound, err; !errors.Is(got, want) {
 					t.Errorf("want %q got %q", want, got)
 				}
@@ -1330,7 +1295,7 @@ func TestDeleteNar(t *testing.T) {
 				t.Fatalf("expecting no error got %s", err)
 			}
 
-			if _, err := f.WriteString(narText1); err != nil {
+			if _, err := f.WriteString(testdata.NarText1); err != nil {
 				t.Fatalf("expecting no error got %s", err)
 			}
 
@@ -1346,7 +1311,7 @@ func TestDeleteNar(t *testing.T) {
 			})
 
 			t.Run("deleteNar does not return an error", func(t *testing.T) {
-				if err := c.DeleteNar(context.Background(), narHash1, ""); err != nil {
+				if err := c.DeleteNar(context.Background(), testdata.NarHash1, ""); err != nil {
 					t.Errorf("error not expected got %s", err)
 				}
 			})
@@ -1361,7 +1326,7 @@ func TestDeleteNar(t *testing.T) {
 	})
 
 	t.Run("with compression", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", "nar", narHash1+".nar.xz")
+		storePath := filepath.Join(dir, "store", "nar", testdata.NarHash1+".nar.xz")
 
 		t.Run("file does not exist in the store", func(t *testing.T) {
 			t.Run("nar does not exist in storage yet", func(t *testing.T) {
@@ -1372,7 +1337,7 @@ func TestDeleteNar(t *testing.T) {
 			})
 
 			t.Run("DeleteNar does return an error", func(t *testing.T) {
-				err := c.DeleteNar(context.Background(), narHash1, "xz")
+				err := c.DeleteNar(context.Background(), testdata.NarHash1, "xz")
 				if want, got := cache.ErrNotFound, err; !errors.Is(got, want) {
 					t.Errorf("want %q got %q", want, got)
 				}
@@ -1392,7 +1357,7 @@ func TestDeleteNar(t *testing.T) {
 				t.Fatalf("expecting no error got %s", err)
 			}
 
-			if _, err := f.WriteString(narText1); err != nil {
+			if _, err := f.WriteString(testdata.NarText1); err != nil {
 				t.Fatalf("expecting no error got %s", err)
 			}
 
@@ -1408,7 +1373,7 @@ func TestDeleteNar(t *testing.T) {
 			})
 
 			t.Run("deleteNar does not return an error", func(t *testing.T) {
-				if err := c.DeleteNar(context.Background(), narHash1, "xz"); err != nil {
+				if err := c.DeleteNar(context.Background(), testdata.NarHash1, "xz"); err != nil {
 					t.Errorf("error not expected got %s", err)
 				}
 			})
@@ -1435,32 +1400,32 @@ func startServer(t *testing.T) *httptest.Server {
 			return
 		}
 
-		if r.URL.Path == "/"+narInfoHash1+".narinfo" {
-			if _, err := w.Write([]byte(narInfoText1)); err != nil {
+		if r.URL.Path == "/"+testdata.NarInfoHash1+".narinfo" {
+			if _, err := w.Write([]byte(testdata.NarInfoText1)); err != nil {
 				t.Fatalf("expected no error got: %s", err)
 			}
 
 			return
 		}
 
-		if r.URL.Path == "/nar/"+narHash1+".nar" {
-			if _, err := w.Write([]byte(narText1)); err != nil {
+		if r.URL.Path == "/nar/"+testdata.NarHash1+".nar" {
+			if _, err := w.Write([]byte(testdata.NarText1)); err != nil {
 				t.Fatalf("expected no error got: %s", err)
 			}
 
 			return
 		}
 
-		if r.URL.Path == "/"+narInfoHash2+".narinfo" {
-			if _, err := w.Write([]byte(narInfoText2)); err != nil {
+		if r.URL.Path == "/"+testdata.NarInfoHash2+".narinfo" {
+			if _, err := w.Write([]byte(testdata.NarInfoText2)); err != nil {
 				t.Fatalf("expected no error got: %s", err)
 			}
 
 			return
 		}
 
-		if r.URL.Path == "/nar/"+narHash2+".nar" {
-			if _, err := w.Write([]byte(narText2)); err != nil {
+		if r.URL.Path == "/nar/"+testdata.NarHash2+".nar" {
+			if _, err := w.Write([]byte(testdata.NarText2)); err != nil {
 				t.Fatalf("expected no error got: %s", err)
 			}
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -273,14 +273,14 @@ func TestGetNarInfo(t *testing.T) {
 
 	t.Run("narinfo exists upstream", func(t *testing.T) {
 		t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
-			_, err := os.Stat(filepath.Join(dir, "store", testdata.NarInfoHash2+".narinfo"))
+			_, err := os.Stat(filepath.Join(dir, "store", testdata.Nar2.NarInfoHash+".narinfo"))
 			if err == nil {
 				t.Fatal("expected an error but got none")
 			}
 		})
 
 		t.Run("nar does not exist in storage yet", func(t *testing.T) {
-			_, err := os.Stat(filepath.Join(dir, "store", testdata.NarHash2+".nar"))
+			_, err := os.Stat(filepath.Join(dir, "store", testdata.Nar2.NarHash+".nar"))
 			if err == nil {
 				t.Fatal("expected an error but got none")
 			}
@@ -340,7 +340,7 @@ func TestGetNarInfo(t *testing.T) {
 			}
 		})
 
-		ni, err := c.GetNarInfo(testdata.NarInfoHash2)
+		ni, err := c.GetNarInfo(testdata.Nar2.NarInfoHash)
 		if err != nil {
 			t.Fatalf("no error expected, got: %s", err)
 		}
@@ -352,7 +352,7 @@ func TestGetNarInfo(t *testing.T) {
 		})
 
 		t.Run("it should now exist in the store", func(t *testing.T) {
-			_, err := os.Stat(filepath.Join(dir, "store", testdata.NarInfoHash2+".narinfo"))
+			_, err := os.Stat(filepath.Join(dir, "store", testdata.Nar2.NarInfoHash+".narinfo"))
 			if err != nil {
 				t.Fatalf("expected no error got %s", err)
 			}
@@ -390,7 +390,7 @@ func TestGetNarInfo(t *testing.T) {
 				// NOTE: I tried runtime.Gosched() but it makes the test flaky
 				time.Sleep(time.Millisecond)
 
-				_, err = os.Stat(filepath.Join(dir, "store", "nar", testdata.NarHash2+".nar"))
+				_, err = os.Stat(filepath.Join(dir, "store", "nar", testdata.Nar2.NarHash+".nar"))
 				if err == nil {
 					break
 				}
@@ -432,7 +432,7 @@ func TestGetNarInfo(t *testing.T) {
 				t.Fatalf("want %d got %d", want, got)
 			}
 
-			if want, got := testdata.NarInfoHash2, nims[0].Hash; want != got {
+			if want, got := testdata.Nar2.NarInfoHash, nims[0].Hash; want != got {
 				t.Errorf("want %q got %q", want, got)
 			}
 
@@ -477,7 +477,7 @@ func TestGetNarInfo(t *testing.T) {
 				t.Fatalf("want %d got %d", want, got)
 			}
 
-			if want, got := testdata.NarHash2, nims[0].Hash; want != got {
+			if want, got := testdata.Nar2.NarHash, nims[0].Hash; want != got {
 				t.Errorf("want %q got %q", want, got)
 			}
 
@@ -495,7 +495,7 @@ func TestGetNarInfo(t *testing.T) {
 				c.SetRecordAgeIgnoreTouch(0)
 			}()
 
-			_, err := c.GetNarInfo(testdata.NarInfoHash2)
+			_, err := c.GetNarInfo(testdata.Nar2.NarInfoHash)
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
@@ -531,7 +531,7 @@ func TestGetNarInfo(t *testing.T) {
 					t.Fatalf("want %d got %d", want, got)
 				}
 
-				if want, got := testdata.NarInfoHash2, nims[0].Hash; want != got {
+				if want, got := testdata.Nar2.NarInfoHash, nims[0].Hash; want != got {
 					t.Errorf("want %q got %q", want, got)
 				}
 
@@ -544,7 +544,7 @@ func TestGetNarInfo(t *testing.T) {
 		t.Run("pulling it another time should update last_accessed_at only for narinfo", func(t *testing.T) {
 			time.Sleep(time.Second)
 
-			_, err := c.GetNarInfo(testdata.NarInfoHash2)
+			_, err := c.GetNarInfo(testdata.Nar2.NarInfoHash)
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
@@ -580,7 +580,7 @@ func TestGetNarInfo(t *testing.T) {
 					t.Fatalf("want %d got %d", want, got)
 				}
 
-				if want, got := testdata.NarInfoHash2, nims[0].Hash; want != got {
+				if want, got := testdata.Nar2.NarInfoHash, nims[0].Hash; want != got {
 					t.Errorf("want %q got %q", want, got)
 				}
 
@@ -591,11 +591,11 @@ func TestGetNarInfo(t *testing.T) {
 		})
 
 		t.Run("no error is returned if the entry already exist in the database", func(t *testing.T) {
-			if err := os.Remove(filepath.Join(dir, "store", testdata.NarInfoHash2+".narinfo")); err != nil {
+			if err := os.Remove(filepath.Join(dir, "store", testdata.Nar2.NarInfoHash+".narinfo")); err != nil {
 				t.Fatalf("error removing the narinfo from the store: %s", err)
 			}
 
-			_, err := c.GetNarInfo(testdata.NarInfoHash2)
+			_, err := c.GetNarInfo(testdata.Nar2.NarInfoHash)
 			if err != nil {
 				t.Errorf("no error expected, got: %s", err)
 			}
@@ -623,7 +623,7 @@ func TestPutNarInfo(t *testing.T) {
 		t.Fatalf("error opening the database: %s", err)
 	}
 
-	storePath := filepath.Join(dir, "store", testdata.NarInfoHash1+".narinfo")
+	storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoHash+".narinfo")
 
 	t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 		_, err := os.Stat(storePath)
@@ -687,9 +687,9 @@ func TestPutNarInfo(t *testing.T) {
 	})
 
 	t.Run("PutNarInfo does not return an error", func(t *testing.T) {
-		r := io.NopCloser(strings.NewReader(testdata.NarInfoText1))
+		r := io.NopCloser(strings.NewReader(testdata.Nar1.NarInfoText))
 
-		err := c.PutNarInfo(context.Background(), testdata.NarInfoHash1, r)
+		err := c.PutNarInfo(context.Background(), testdata.Nar1.NarInfoHash, r)
 		if err != nil {
 			t.Errorf("error not expected got %s", err)
 		}
@@ -761,7 +761,7 @@ func TestPutNarInfo(t *testing.T) {
 			t.Fatalf("want %d got %d", want, got)
 		}
 
-		if want, got := testdata.NarInfoHash1, hashes[0]; want != got {
+		if want, got := testdata.Nar1.NarInfoHash, hashes[0]; want != got {
 			t.Errorf("want %q got %q", want, got)
 		}
 	})
@@ -792,7 +792,7 @@ func TestPutNarInfo(t *testing.T) {
 			t.Fatalf("want %d got %d", want, got)
 		}
 
-		if want, got := testdata.NarHash1, hashes[0]; want != got {
+		if want, got := testdata.Nar1.NarHash, hashes[0]; want != got {
 			t.Errorf("want %q got %q", want, got)
 		}
 	})
@@ -814,7 +814,7 @@ func TestDeleteNarInfo(t *testing.T) {
 	c.SetRecordAgeIgnoreTouch(0)
 
 	t.Run("file does not exist in the store", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", testdata.NarInfoHash1+".narinfo")
+		storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoHash+".narinfo")
 
 		t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 			_, err := os.Stat(storePath)
@@ -824,7 +824,7 @@ func TestDeleteNarInfo(t *testing.T) {
 		})
 
 		t.Run("DeleteNarInfo does return an error", func(t *testing.T) {
-			err := c.DeleteNarInfo(context.Background(), testdata.NarInfoHash1)
+			err := c.DeleteNarInfo(context.Background(), testdata.Nar1.NarInfoHash)
 			if want, got := cache.ErrNotFound, err; !errors.Is(got, want) {
 				t.Errorf("want %q got %q", want, got)
 			}
@@ -832,7 +832,7 @@ func TestDeleteNarInfo(t *testing.T) {
 	})
 
 	t.Run("file does exist in the store", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", testdata.NarInfoHash1+".narinfo")
+		storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoHash+".narinfo")
 
 		t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 			_, err := os.Stat(storePath)
@@ -846,7 +846,7 @@ func TestDeleteNarInfo(t *testing.T) {
 			t.Fatalf("expecting no error got %s", err)
 		}
 
-		if _, err := f.WriteString(testdata.NarInfoText1); err != nil {
+		if _, err := f.WriteString(testdata.Nar1.NarInfoText); err != nil {
 			t.Fatalf("expecting no error got %s", err)
 		}
 
@@ -862,7 +862,7 @@ func TestDeleteNarInfo(t *testing.T) {
 		})
 
 		t.Run("DeleteNarInfo does not return an error", func(t *testing.T) {
-			if err := c.DeleteNarInfo(context.Background(), testdata.NarInfoHash1); err != nil {
+			if err := c.DeleteNarInfo(context.Background(), testdata.Nar1.NarInfoHash); err != nil {
 				t.Errorf("error not expected got %s", err)
 			}
 		})
@@ -909,7 +909,7 @@ func TestGetNar(t *testing.T) {
 		t.Fatalf("error opening the database: %s", err)
 	}
 
-	narName := testdata.NarHash1 + ".nar"
+	narName := testdata.Nar1.NarHash + ".nar"
 
 	t.Run("nar does not exist upstream", func(t *testing.T) {
 		_, _, err := c.GetNar("doesnotexist", "")
@@ -954,20 +954,20 @@ func TestGetNar(t *testing.T) {
 		})
 
 		t.Run("getting the narinfo so the record in the database now exists", func(t *testing.T) {
-			_, err := c.GetNarInfo(testdata.NarInfoHash1)
+			_, err := c.GetNarInfo(testdata.Nar1.NarInfoHash)
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
 		})
 
-		size, r, err := c.GetNar(testdata.NarHash1, "")
+		size, r, err := c.GetNar(testdata.Nar1.NarHash, "")
 		if err != nil {
 			t.Fatalf("no error expected, got: %s", err)
 		}
 		defer r.Close()
 
 		t.Run("size is correct", func(t *testing.T) {
-			if want, got := int64(len(testdata.NarText1)), size; want != got {
+			if want, got := int64(len(testdata.Nar1.NarText)), size; want != got {
 				t.Errorf("want %d got %d", want, got)
 			}
 		})
@@ -978,7 +978,7 @@ func TestGetNar(t *testing.T) {
 				t.Fatalf("expected no error, got: %s", err)
 			}
 
-			if want, got := testdata.NarText1, string(body); want != got {
+			if want, got := testdata.Nar1.NarText, string(body); want != got {
 				t.Errorf("want %q got %q", want, got)
 			}
 		})
@@ -991,7 +991,7 @@ func TestGetNar(t *testing.T) {
 		})
 
 		t.Run("getting the narinfo so the record in the database now exists", func(t *testing.T) {
-			_, err := c.GetNarInfo(testdata.NarInfoHash1)
+			_, err := c.GetNarInfo(testdata.Nar1.NarInfoHash)
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
@@ -1033,7 +1033,7 @@ func TestGetNar(t *testing.T) {
 				t.Fatalf("want %d got %d", want, got)
 			}
 
-			if want, got := testdata.NarHash1, nims[0].Hash; want != got {
+			if want, got := testdata.Nar1.NarHash, nims[0].Hash; want != got {
 				t.Errorf("want %q got %q", want, got)
 			}
 
@@ -1051,7 +1051,7 @@ func TestGetNar(t *testing.T) {
 				c.SetRecordAgeIgnoreTouch(0)
 			}()
 
-			_, r, err := c.GetNar(testdata.NarHash1, "")
+			_, r, err := c.GetNar(testdata.Nar1.NarHash, "")
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
@@ -1093,7 +1093,7 @@ func TestGetNar(t *testing.T) {
 					t.Fatalf("want %d got %d", want, got)
 				}
 
-				if want, got := testdata.NarHash1, nims[0].Hash; want != got {
+				if want, got := testdata.Nar1.NarHash, nims[0].Hash; want != got {
 					t.Errorf("want %q got %q", want, got)
 				}
 
@@ -1106,7 +1106,7 @@ func TestGetNar(t *testing.T) {
 		t.Run("pulling it another time should update last_accessed_at", func(t *testing.T) {
 			time.Sleep(time.Second)
 
-			_, r, err := c.GetNar(testdata.NarHash1, "")
+			_, r, err := c.GetNar(testdata.Nar1.NarHash, "")
 			if err != nil {
 				t.Fatalf("no error expected, got: %s", err)
 			}
@@ -1148,7 +1148,7 @@ func TestGetNar(t *testing.T) {
 					t.Fatalf("want %d got %d", want, got)
 				}
 
-				if want, got := testdata.NarHash1, nims[0].Hash; want != got {
+				if want, got := testdata.Nar1.NarHash, nims[0].Hash; want != got {
 					t.Errorf("want %q got %q", want, got)
 				}
 
@@ -1176,7 +1176,7 @@ func TestPutNar(t *testing.T) {
 	c.SetRecordAgeIgnoreTouch(0)
 
 	t.Run("without compression", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", "nar", testdata.NarHash1+".nar")
+		storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar")
 
 		t.Run("nar does not exist in storage yet", func(t *testing.T) {
 			_, err := os.Stat(storePath)
@@ -1186,9 +1186,9 @@ func TestPutNar(t *testing.T) {
 		})
 
 		t.Run("putNar does not return an error", func(t *testing.T) {
-			r := io.NopCloser(strings.NewReader(testdata.NarText1))
+			r := io.NopCloser(strings.NewReader(testdata.Nar1.NarText))
 
-			err := c.PutNar(context.Background(), testdata.NarHash1, "", r)
+			err := c.PutNar(context.Background(), testdata.Nar1.NarHash, "", r)
 			if err != nil {
 				t.Errorf("error not expected got %s", err)
 			}
@@ -1205,14 +1205,14 @@ func TestPutNar(t *testing.T) {
 				t.Fatalf("expected no error but got: %s", err)
 			}
 
-			if want, got := testdata.NarText1, string(bs); want != got {
+			if want, got := testdata.Nar1.NarText, string(bs); want != got {
 				t.Errorf("want %q got %q", want, got)
 			}
 		})
 	})
 
 	t.Run("with compression", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", "nar", testdata.NarHash1+".nar.xz")
+		storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar.xz")
 
 		t.Run("nar does not exist in storage yet", func(t *testing.T) {
 			_, err := os.Stat(storePath)
@@ -1222,9 +1222,9 @@ func TestPutNar(t *testing.T) {
 		})
 
 		t.Run("putNar does not return an error", func(t *testing.T) {
-			r := io.NopCloser(strings.NewReader(testdata.NarText1))
+			r := io.NopCloser(strings.NewReader(testdata.Nar1.NarText))
 
-			err := c.PutNar(context.Background(), testdata.NarHash1, "xz", r)
+			err := c.PutNar(context.Background(), testdata.Nar1.NarHash, "xz", r)
 			if err != nil {
 				t.Errorf("error not expected got %s", err)
 			}
@@ -1241,7 +1241,7 @@ func TestPutNar(t *testing.T) {
 				t.Fatalf("expected no error but got: %s", err)
 			}
 
-			if want, got := testdata.NarText1, string(bs); want != got {
+			if want, got := testdata.Nar1.NarText, string(bs); want != got {
 				t.Errorf("want %q got %q", want, got)
 			}
 		})
@@ -1264,7 +1264,7 @@ func TestDeleteNar(t *testing.T) {
 	c.SetRecordAgeIgnoreTouch(0)
 
 	t.Run("without compression", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", "nar", testdata.NarHash1+".nar")
+		storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar")
 
 		t.Run("file does not exist in the store", func(t *testing.T) {
 			t.Run("nar does not exist in storage yet", func(t *testing.T) {
@@ -1275,7 +1275,7 @@ func TestDeleteNar(t *testing.T) {
 			})
 
 			t.Run("DeleteNar does return an error", func(t *testing.T) {
-				err := c.DeleteNar(context.Background(), testdata.NarHash1, "")
+				err := c.DeleteNar(context.Background(), testdata.Nar1.NarHash, "")
 				if want, got := cache.ErrNotFound, err; !errors.Is(got, want) {
 					t.Errorf("want %q got %q", want, got)
 				}
@@ -1295,7 +1295,7 @@ func TestDeleteNar(t *testing.T) {
 				t.Fatalf("expecting no error got %s", err)
 			}
 
-			if _, err := f.WriteString(testdata.NarText1); err != nil {
+			if _, err := f.WriteString(testdata.Nar1.NarText); err != nil {
 				t.Fatalf("expecting no error got %s", err)
 			}
 
@@ -1311,7 +1311,7 @@ func TestDeleteNar(t *testing.T) {
 			})
 
 			t.Run("deleteNar does not return an error", func(t *testing.T) {
-				if err := c.DeleteNar(context.Background(), testdata.NarHash1, ""); err != nil {
+				if err := c.DeleteNar(context.Background(), testdata.Nar1.NarHash, ""); err != nil {
 					t.Errorf("error not expected got %s", err)
 				}
 			})
@@ -1326,7 +1326,7 @@ func TestDeleteNar(t *testing.T) {
 	})
 
 	t.Run("with compression", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", "nar", testdata.NarHash1+".nar.xz")
+		storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar.xz")
 
 		t.Run("file does not exist in the store", func(t *testing.T) {
 			t.Run("nar does not exist in storage yet", func(t *testing.T) {
@@ -1337,7 +1337,7 @@ func TestDeleteNar(t *testing.T) {
 			})
 
 			t.Run("DeleteNar does return an error", func(t *testing.T) {
-				err := c.DeleteNar(context.Background(), testdata.NarHash1, "xz")
+				err := c.DeleteNar(context.Background(), testdata.Nar1.NarHash, "xz")
 				if want, got := cache.ErrNotFound, err; !errors.Is(got, want) {
 					t.Errorf("want %q got %q", want, got)
 				}
@@ -1357,7 +1357,7 @@ func TestDeleteNar(t *testing.T) {
 				t.Fatalf("expecting no error got %s", err)
 			}
 
-			if _, err := f.WriteString(testdata.NarText1); err != nil {
+			if _, err := f.WriteString(testdata.Nar1.NarText); err != nil {
 				t.Fatalf("expecting no error got %s", err)
 			}
 
@@ -1373,7 +1373,7 @@ func TestDeleteNar(t *testing.T) {
 			})
 
 			t.Run("deleteNar does not return an error", func(t *testing.T) {
-				if err := c.DeleteNar(context.Background(), testdata.NarHash1, "xz"); err != nil {
+				if err := c.DeleteNar(context.Background(), testdata.Nar1.NarHash, "xz"); err != nil {
 					t.Errorf("error not expected got %s", err)
 				}
 			})
@@ -1400,32 +1400,32 @@ func startServer(t *testing.T) *httptest.Server {
 			return
 		}
 
-		if r.URL.Path == "/"+testdata.NarInfoHash1+".narinfo" {
-			if _, err := w.Write([]byte(testdata.NarInfoText1)); err != nil {
+		if r.URL.Path == "/"+testdata.Nar1.NarInfoHash+".narinfo" {
+			if _, err := w.Write([]byte(testdata.Nar1.NarInfoText)); err != nil {
 				t.Fatalf("expected no error got: %s", err)
 			}
 
 			return
 		}
 
-		if r.URL.Path == "/nar/"+testdata.NarHash1+".nar" {
-			if _, err := w.Write([]byte(testdata.NarText1)); err != nil {
+		if r.URL.Path == "/nar/"+testdata.Nar1.NarHash+".nar" {
+			if _, err := w.Write([]byte(testdata.Nar1.NarText)); err != nil {
 				t.Fatalf("expected no error got: %s", err)
 			}
 
 			return
 		}
 
-		if r.URL.Path == "/"+testdata.NarInfoHash2+".narinfo" {
-			if _, err := w.Write([]byte(testdata.NarInfoText2)); err != nil {
+		if r.URL.Path == "/"+testdata.Nar2.NarInfoHash+".narinfo" {
+			if _, err := w.Write([]byte(testdata.Nar2.NarInfoText)); err != nil {
 				t.Fatalf("expected no error got: %s", err)
 			}
 
 			return
 		}
 
-		if r.URL.Path == "/nar/"+testdata.NarHash2+".nar" {
-			if _, err := w.Write([]byte(testdata.NarText2)); err != nil {
+		if r.URL.Path == "/nar/"+testdata.Nar2.NarHash+".nar" {
+			if _, err := w.Write([]byte(testdata.Nar2.NarText)); err != nil {
 				t.Fatalf("expected no error got: %s", err)
 			}
 

--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/inconshreveable/log15/v3"
 
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
+	"github.com/kalbasit/ncps/testdata"
 )
 
 //nolint:gochecknoglobals
@@ -120,9 +121,7 @@ func TestGetNarInfo(t *testing.T) {
 	t.Run("hash is found", func(t *testing.T) {
 		t.Parallel()
 
-		hash := "7bn85d74qa0127p85rrswfyghxsqmcf7"
-
-		ni, err := c.GetNarInfo(context.Background(), hash)
+		ni, err := c.GetNarInfo(context.Background(), testdata.Nar1.NarInfoHash)
 		if err != nil {
 			t.Fatalf("expected no error, got %s", err)
 		}
@@ -135,7 +134,7 @@ func TestGetNarInfo(t *testing.T) {
 	t.Run("check has failed", func(t *testing.T) {
 		t.Parallel()
 
-		hash := "7bn85d74qa0127p85rrswfyghxsqmcf7"
+		hash := testdata.Nar1.NarInfoHash
 
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/nix-cache-info" {
@@ -150,17 +149,11 @@ Priority: 40`))
 			}
 
 			if r.URL.Path == "/"+hash+".narinfo" {
-				//nolint:lll
-				_, err := w.Write([]byte(`StorePath: /nix/store/7bn85d74qa0127p85rrswfyghxsqmcf7-iputils-20210722
-URL: nar/136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00.nar.xz
-Compression: xz
-FileHash: sha256:136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00
-FileSize: 132228
-NarHash: sha256:1rzb80kz42wy067pp160rridw41dnc09d2a3cqj2wdg6ylklhxkh
-NarSize: 534160
-References: notfound-path 7bn85d74qa0127p85rrswfyghxsqmcf7-iputils-20210722 892cxk44qxzzlw9h90a781zpy1j7gmmn-libidn2-2.3.2 l25bc19is0s27929kxkfhgdzhc7x9g5m-libcap-2.49-lib rir9pf0kz1mb84x5bd3yr0fx415yy423-glibc-2.33-123
-Deriver: 9fs4vq4gdsb8r9ywawb5f6zl40ycp1bh-iputils-20210722.drv
-Sig: cache.nixos.org-1:WzhkqDdkgPz2qU/0QyEA6wUIm7EMR5MY8nTb5jAmmoh5b80ACIp/+Zpgi5t1KvmO8uG8GVrkPejCxbyQ2gNXDQ==`))
+				// mutate the inside
+				b := testdata.Nar1.NarInfoText
+				b = strings.Replace(b, "References:", "References: notfound-path", -1)
+
+				_, err := w.Write([]byte(b))
 				if err != nil {
 					t.Fatalf("expected no error, got %s", err)
 				}
@@ -187,6 +180,10 @@ Sig: cache.nixos.org-1:WzhkqDdkgPz2qU/0QyEA6wUIm7EMR5MY8nTb5jAmmoh5b80ACIp/+Zpgi
 		}
 
 		_, err = c.GetNarInfo(context.Background(), hash)
+		if err == nil {
+			t.Fatal("error expected but got none")
+		}
+
 		if want, got := "error while checking the narInfo: invalid Reference[0]: notfound-path", err.Error(); want != got {
 			t.Errorf("want %q got %q", want, got)
 		}
@@ -215,7 +212,7 @@ func TestGetNar(t *testing.T) {
 	t.Run("hash is found", func(t *testing.T) {
 		t.Parallel()
 
-		hash := "136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00"
+		hash := testdata.Nar1.NarHash
 
 		cl, body, err := c.GetNar(context.Background(), hash, "xz")
 		if err != nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kalbasit/ncps/pkg/cache"
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
 	"github.com/kalbasit/ncps/pkg/server"
+	"github.com/kalbasit/ncps/testdata"
 )
 
 //nolint:gochecknoglobals
@@ -27,31 +28,6 @@ var logger = log15.New()
 func init() {
 	logger.SetHandler(log15.DiscardHandler())
 }
-
-const (
-	nixStoreInfo = `StoreDir: /nix/store
-WantMassQuery: 1
-Priority: 40`
-
-	narInfoHash = "7bn85d74qa0127p85rrswfyghxsqmcf7"
-
-	//nolint:lll
-	narInfoText = `StorePath: /nix/store/7bn85d74qa0127p85rrswfyghxsqmcf7-iputils-20210722
-URL: nar/136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00.nar.xz
-Compression: xz
-FileHash: sha256:136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00
-FileSize: 132228
-NarHash: sha256:1rzb80kz42wy067pp160rridw41dnc09d2a3cqj2wdg6ylklhxkh
-NarSize: 534160
-References: 7bn85d74qa0127p85rrswfyghxsqmcf7-iputils-20210722 892cxk44qxzzlw9h90a781zpy1j7gmmn-libidn2-2.3.2 l25bc19is0s27929kxkfhgdzhc7x9g5m-libcap-2.49-lib rir9pf0kz1mb84x5bd3yr0fx415yy423-glibc-2.33-123
-Deriver: 9fs4vq4gdsb8r9ywawb5f6zl40ycp1bh-iputils-20210722.drv
-Sig: cache.nixos.org-1:WzhkqDdkgPz2qU/0QyEA6wUIm7EMR5MY8nTb5jAmmoh5b80ACIp/+Zpgi5t1KvmO8uG8GVrkPejCxbyQ2gNXDQ==
-`
-
-	narHash = "136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00"
-
-	narText = "Hello, World" // fake nar for above nar info
-)
 
 //nolint:paralleltest
 func TestServeHTTP(t *testing.T) {
@@ -75,7 +51,7 @@ func TestServeHTTP(t *testing.T) {
 			defer ts.Close()
 
 			t.Run("narInfo", func(t *testing.T) {
-				r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/"+narInfoHash+".narinfo", nil)
+				r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/"+testdata.Nar1.NarInfoHash+".narinfo", nil)
 				if err != nil {
 					t.Fatalf("expecting no error got %s", err)
 				}
@@ -92,7 +68,7 @@ func TestServeHTTP(t *testing.T) {
 
 			t.Run("nar", func(t *testing.T) {
 				t.Run("without compression", func(t *testing.T) {
-					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+narHash+".nar", nil)
+					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+testdata.Nar1.NarHash+".nar", nil)
 					if err != nil {
 						t.Fatalf("expecting no error got %s", err)
 					}
@@ -108,7 +84,7 @@ func TestServeHTTP(t *testing.T) {
 				})
 
 				t.Run("with compression", func(t *testing.T) {
-					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+narHash+".nar.xz", nil)
+					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+testdata.Nar1.NarHash+".nar.xz", nil)
 					if err != nil {
 						t.Fatalf("expecting no error got %s", err)
 					}
@@ -133,7 +109,7 @@ func TestServeHTTP(t *testing.T) {
 			defer ts.Close()
 
 			t.Run("narInfo", func(t *testing.T) {
-				storePath := filepath.Join(dir, "store", narInfoHash+".narinfo")
+				storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoHash+".narinfo")
 
 				t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 					_, err := os.Stat(storePath)
@@ -147,7 +123,7 @@ func TestServeHTTP(t *testing.T) {
 					t.Fatalf("expecting no error got %s", err)
 				}
 
-				if _, err := f.WriteString(narInfoText); err != nil {
+				if _, err := f.WriteString(testdata.Nar1.NarInfoText); err != nil {
 					t.Fatalf("expecting no error got %s", err)
 				}
 
@@ -163,7 +139,7 @@ func TestServeHTTP(t *testing.T) {
 				})
 
 				t.Run("DELETE returns no error", func(t *testing.T) {
-					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/"+narInfoHash+".narinfo", nil)
+					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/"+testdata.Nar1.NarInfoHash+".narinfo", nil)
 					if err != nil {
 						t.Fatalf("expecting no error got %s", err)
 					}
@@ -188,7 +164,7 @@ func TestServeHTTP(t *testing.T) {
 
 			t.Run("nar", func(t *testing.T) {
 				t.Run("nar without compression", func(t *testing.T) {
-					storePath := filepath.Join(dir, "store", "nar", narHash+".nar")
+					storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar")
 
 					t.Run("nar does not exist in storage yet", func(t *testing.T) {
 						_, err := os.Stat(storePath)
@@ -202,7 +178,7 @@ func TestServeHTTP(t *testing.T) {
 						t.Fatalf("expecting no error got %s", err)
 					}
 
-					if _, err := f.WriteString(narText); err != nil {
+					if _, err := f.WriteString(testdata.Nar1.NarText); err != nil {
 						t.Fatalf("expecting no error got %s", err)
 					}
 
@@ -218,7 +194,7 @@ func TestServeHTTP(t *testing.T) {
 					})
 
 					t.Run("DELETE returns no error", func(t *testing.T) {
-						r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+narHash+".nar", nil)
+						r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+testdata.Nar1.NarHash+".nar", nil)
 						if err != nil {
 							t.Fatalf("expecting no error got %s", err)
 						}
@@ -242,7 +218,7 @@ func TestServeHTTP(t *testing.T) {
 				})
 
 				t.Run("nar with compression", func(t *testing.T) {
-					storePath := filepath.Join(dir, "store", "nar", narHash+".nar.xz")
+					storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar.xz")
 
 					t.Run("nar does not exist in storage yet", func(t *testing.T) {
 						_, err := os.Stat(storePath)
@@ -256,7 +232,7 @@ func TestServeHTTP(t *testing.T) {
 						t.Fatalf("expecting no error got %s", err)
 					}
 
-					if _, err := f.WriteString(narText); err != nil {
+					if _, err := f.WriteString(testdata.Nar1.NarText); err != nil {
 						t.Fatalf("expecting no error got %s", err)
 					}
 
@@ -272,7 +248,7 @@ func TestServeHTTP(t *testing.T) {
 					})
 
 					t.Run("DELETE returns no error", func(t *testing.T) {
-						r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+narHash+".nar.xz", nil)
+						r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+testdata.Nar1.NarHash+".nar.xz", nil)
 						if err != nil {
 							t.Fatalf("expecting no error got %s", err)
 						}
@@ -299,41 +275,7 @@ func TestServeHTTP(t *testing.T) {
 	})
 
 	t.Run("GET requests", func(t *testing.T) {
-		us := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/nix-cache-info" {
-				if _, err := w.Write([]byte(nixStoreInfo)); err != nil {
-					t.Fatalf("expected no error got: %s", err)
-				}
-
-				return
-			}
-
-			if r.URL.Path == "/"+narInfoHash+".narinfo" {
-				if _, err := w.Write([]byte(narInfoText)); err != nil {
-					t.Fatalf("expected no error got: %s", err)
-				}
-
-				return
-			}
-
-			if r.URL.Path == "/nar/"+narHash+".nar" {
-				if _, err := w.Write([]byte(narText)); err != nil {
-					t.Fatalf("expected no error got: %s", err)
-				}
-
-				return
-			}
-
-			if r.URL.Path == "/nar/"+narHash+".nar.xz" {
-				if _, err := w.Write([]byte(narText + "xz")); err != nil {
-					t.Fatalf("expected no error got: %s", err)
-				}
-
-				return
-			}
-
-			w.WriteHeader(http.StatusNotFound)
-		}))
+		us := testdata.HTTPTestServer(t, 40)
 		defer us.Close()
 
 		uu, err := url.Parse(us.URL)
@@ -372,7 +314,7 @@ func TestServeHTTP(t *testing.T) {
 			})
 
 			t.Run("narinfo exists upstream", func(t *testing.T) {
-				r := httptest.NewRequest("GET", "/"+narInfoHash+".narinfo", nil)
+				r := httptest.NewRequest("GET", "/"+testdata.Nar1.NarInfoHash+".narinfo", nil)
 				w := httptest.NewRecorder()
 
 				s.ServeHTTP(w, r)
@@ -390,7 +332,7 @@ func TestServeHTTP(t *testing.T) {
 				}
 
 				// NOTE: HasPrefix instead equality because we add our signature to the narInfo.
-				if !strings.HasPrefix(string(body), narInfoText) {
+				if !strings.HasPrefix(string(body), testdata.Nar1.NarInfoText) {
 					t.Error("expected the body to start with narInfo but it did not")
 				}
 			})
@@ -409,7 +351,7 @@ func TestServeHTTP(t *testing.T) {
 			})
 
 			t.Run("nar exists upstream without compression", func(t *testing.T) {
-				r := httptest.NewRequest("GET", "/nar/"+narHash+".nar", nil)
+				r := httptest.NewRequest("GET", "/nar/"+testdata.Nar1.NarHash+".nar", nil)
 				w := httptest.NewRecorder()
 
 				s.ServeHTTP(w, r)
@@ -426,13 +368,13 @@ func TestServeHTTP(t *testing.T) {
 					t.Fatalf("expected no error got %s", err)
 				}
 
-				if want, got := narText, string(body); want != got {
+				if want, got := testdata.Nar1.NarText, string(body); want != got {
 					t.Errorf("want %q got %q", want, got)
 				}
 			})
 
 			t.Run("nar exists upstream with compression", func(t *testing.T) {
-				r := httptest.NewRequest("GET", "/nar/"+narHash+".nar.xz", nil)
+				r := httptest.NewRequest("GET", "/nar/"+testdata.Nar1.NarHash+".nar.xz", nil)
 				w := httptest.NewRecorder()
 
 				s.ServeHTTP(w, r)
@@ -449,7 +391,7 @@ func TestServeHTTP(t *testing.T) {
 					t.Fatalf("expected no error got %s", err)
 				}
 
-				if want, got := narText+"xz", string(body); want != got {
+				if want, got := testdata.Nar1.NarText+"xz", string(body); want != got {
 					t.Errorf("want %q got %q", want, got)
 				}
 			})
@@ -476,9 +418,9 @@ func TestServeHTTP(t *testing.T) {
 			defer ts.Close()
 
 			t.Run("narInfo", func(t *testing.T) {
-				p := ts.URL + "/" + narInfoHash + ".narinfo"
+				p := ts.URL + "/" + testdata.Nar1.NarInfoHash + ".narinfo"
 
-				r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narInfoText))
+				r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(testdata.Nar1.NarInfoText))
 				if err != nil {
 					t.Fatalf("expecting no error got %s", err)
 				}
@@ -495,9 +437,9 @@ func TestServeHTTP(t *testing.T) {
 
 			t.Run("nar", func(t *testing.T) {
 				t.Run("without compression", func(t *testing.T) {
-					p := ts.URL + "/nar/" + narInfoHash + ".nar"
+					p := ts.URL + "/nar/" + testdata.Nar1.NarInfoHash + ".nar"
 
-					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narText))
+					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(testdata.Nar1.NarText))
 					if err != nil {
 						t.Fatalf("expecting no error got %s", err)
 					}
@@ -513,9 +455,9 @@ func TestServeHTTP(t *testing.T) {
 				})
 
 				t.Run("with compression", func(t *testing.T) {
-					p := ts.URL + "/nar/" + narInfoHash + ".nar.xz"
+					p := ts.URL + "/nar/" + testdata.Nar1.NarInfoHash + ".nar.xz"
 
-					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narText))
+					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(testdata.Nar1.NarText))
 					if err != nil {
 						t.Fatalf("expecting no error got %s", err)
 					}
@@ -540,7 +482,7 @@ func TestServeHTTP(t *testing.T) {
 			defer ts.Close()
 
 			t.Run("narInfo", func(t *testing.T) {
-				storePath := filepath.Join(dir, "store", narInfoHash+".narinfo")
+				storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoHash+".narinfo")
 
 				t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 					_, err := os.Stat(storePath)
@@ -550,9 +492,9 @@ func TestServeHTTP(t *testing.T) {
 				})
 
 				t.Run("putNarInfo does not return an error", func(t *testing.T) {
-					p := ts.URL + "/" + narInfoHash + ".narinfo"
+					p := ts.URL + "/" + testdata.Nar1.NarInfoHash + ".narinfo"
 
-					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narInfoText))
+					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(testdata.Nar1.NarInfoText))
 					if err != nil {
 						t.Fatalf("error Do(r): %s", err)
 					}
@@ -609,7 +551,7 @@ func TestServeHTTP(t *testing.T) {
 			})
 
 			t.Run("nar without compression", func(t *testing.T) {
-				storePath := filepath.Join(dir, "store", "nar", narHash+".nar")
+				storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar")
 
 				t.Run("nar does not exist in storage yet", func(t *testing.T) {
 					_, err := os.Stat(storePath)
@@ -619,9 +561,9 @@ func TestServeHTTP(t *testing.T) {
 				})
 
 				t.Run("putNar does not return an error", func(t *testing.T) {
-					p := ts.URL + "/nar/" + narHash + ".nar"
+					p := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar"
 
-					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narText))
+					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(testdata.Nar1.NarText))
 					if err != nil {
 						t.Fatalf("error Do(r): %s", err)
 					}
@@ -647,14 +589,14 @@ func TestServeHTTP(t *testing.T) {
 						t.Fatalf("expected no error but got: %s", err)
 					}
 
-					if want, got := narText, string(bs); want != got {
+					if want, got := testdata.Nar1.NarText, string(bs); want != got {
 						t.Errorf("want %q got %q", want, got)
 					}
 				})
 			})
 
 			t.Run("nar with compression", func(t *testing.T) {
-				storePath := filepath.Join(dir, "store", "nar", narHash+".nar.xz")
+				storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar.xz")
 
 				t.Run("nar does not exist in storage yet", func(t *testing.T) {
 					_, err := os.Stat(storePath)
@@ -664,9 +606,9 @@ func TestServeHTTP(t *testing.T) {
 				})
 
 				t.Run("putNar does not return an error", func(t *testing.T) {
-					p := ts.URL + "/nar/" + narHash + ".nar.xz"
+					p := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar.xz"
 
-					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(narText))
+					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(testdata.Nar1.NarText))
 					if err != nil {
 						t.Fatalf("error Do(r): %s", err)
 					}
@@ -692,7 +634,7 @@ func TestServeHTTP(t *testing.T) {
 						t.Fatalf("expected no error but got: %s", err)
 					}
 
-					if want, got := narText, string(bs); want != got {
+					if want, got := testdata.Nar1.NarText, string(bs); want != got {
 						t.Errorf("want %q got %q", want, got)
 					}
 				})

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -51,7 +51,9 @@ func TestServeHTTP(t *testing.T) {
 			defer ts.Close()
 
 			t.Run("narInfo", func(t *testing.T) {
-				r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/"+testdata.Nar1.NarInfoHash+".narinfo", nil)
+				url := ts.URL + "/" + testdata.Nar1.NarInfoHash + ".narinfo"
+
+				r, err := http.NewRequestWithContext(context.Background(), "DELETE", url, nil)
 				if err != nil {
 					t.Fatalf("expecting no error got %s", err)
 				}
@@ -68,7 +70,9 @@ func TestServeHTTP(t *testing.T) {
 
 			t.Run("nar", func(t *testing.T) {
 				t.Run("without compression", func(t *testing.T) {
-					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+testdata.Nar1.NarHash+".nar", nil)
+					url := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar"
+
+					r, err := http.NewRequestWithContext(context.Background(), "DELETE", url, nil)
 					if err != nil {
 						t.Fatalf("expecting no error got %s", err)
 					}
@@ -84,7 +88,9 @@ func TestServeHTTP(t *testing.T) {
 				})
 
 				t.Run("with compression", func(t *testing.T) {
-					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+testdata.Nar1.NarHash+".nar.xz", nil)
+					url := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar.xz"
+
+					r, err := http.NewRequestWithContext(context.Background(), "DELETE", url, nil)
 					if err != nil {
 						t.Fatalf("expecting no error got %s", err)
 					}
@@ -139,7 +145,9 @@ func TestServeHTTP(t *testing.T) {
 				})
 
 				t.Run("DELETE returns no error", func(t *testing.T) {
-					r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/"+testdata.Nar1.NarInfoHash+".narinfo", nil)
+					url := ts.URL + "/" + testdata.Nar1.NarInfoHash + ".narinfo"
+
+					r, err := http.NewRequestWithContext(context.Background(), "DELETE", url, nil)
 					if err != nil {
 						t.Fatalf("expecting no error got %s", err)
 					}
@@ -194,7 +202,9 @@ func TestServeHTTP(t *testing.T) {
 					})
 
 					t.Run("DELETE returns no error", func(t *testing.T) {
-						r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+testdata.Nar1.NarHash+".nar", nil)
+						url := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar"
+
+						r, err := http.NewRequestWithContext(context.Background(), "DELETE", url, nil)
 						if err != nil {
 							t.Fatalf("expecting no error got %s", err)
 						}
@@ -248,7 +258,9 @@ func TestServeHTTP(t *testing.T) {
 					})
 
 					t.Run("DELETE returns no error", func(t *testing.T) {
-						r, err := http.NewRequestWithContext(context.Background(), "DELETE", ts.URL+"/nar/"+testdata.Nar1.NarHash+".nar.xz", nil)
+						url := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar.xz"
+
+						r, err := http.NewRequestWithContext(context.Background(), "DELETE", url, nil)
 						if err != nil {
 							t.Fatalf("expecting no error got %s", err)
 						}

--- a/testdata/entries.go
+++ b/testdata/entries.go
@@ -1,0 +1,6 @@
+package testdata
+
+var Entries = []Entry{
+	Nar1,
+	Nar2,
+}

--- a/testdata/nar1.go
+++ b/testdata/nar1.go
@@ -1,0 +1,21 @@
+package testdata
+
+const (
+	NarInfoHash1 = "7bn85d74qa0127p85rrswfyghxsqmcf7"
+
+	//nolint:lll
+	NarInfoText1 = `StorePath: /nix/store/7bn85d74qa0127p85rrswfyghxsqmcf7-iputils-20210722
+URL: nar/136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00.nar
+Compression: xz
+FileHash: sha256:136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00
+FileSize: 132228
+NarHash: sha256:1rzb80kz42wy067pp160rridw41dnc09d2a3cqj2wdg6ylklhxkh
+NarSize: 534160
+References: 7bn85d74qa0127p85rrswfyghxsqmcf7-iputils-20210722 892cxk44qxzzlw9h90a781zpy1j7gmmn-libidn2-2.3.2 l25bc19is0s27929kxkfhgdzhc7x9g5m-libcap-2.49-lib rir9pf0kz1mb84x5bd3yr0fx415yy423-glibc-2.33-123
+Deriver: 9fs4vq4gdsb8r9ywawb5f6zl40ycp1bh-iputils-20210722.drv
+Sig: cache.nixos.org-1:WzhkqDdkgPz2qU/0QyEA6wUIm7EMR5MY8nTb5jAmmoh5b80ACIp/+Zpgi5t1KvmO8uG8GVrkPejCxbyQ2gNXDQ==`
+
+	NarHash1 = "136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00"
+
+	NarText1 = "Hello, World" // fake nar for above nar info
+)

--- a/testdata/nar1.go
+++ b/testdata/nar1.go
@@ -1,10 +1,8 @@
 package testdata
 
-const (
-	NarInfoHash1 = "7bn85d74qa0127p85rrswfyghxsqmcf7"
-
-	//nolint:lll
-	NarInfoText1 = `StorePath: /nix/store/7bn85d74qa0127p85rrswfyghxsqmcf7-iputils-20210722
+var Nar1 = Entry{
+	NarInfoHash: "7bn85d74qa0127p85rrswfyghxsqmcf7",
+	NarInfoText: `StorePath: /nix/store/7bn85d74qa0127p85rrswfyghxsqmcf7-iputils-20210722
 URL: nar/136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00.nar
 Compression: xz
 FileHash: sha256:136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00
@@ -13,9 +11,8 @@ NarHash: sha256:1rzb80kz42wy067pp160rridw41dnc09d2a3cqj2wdg6ylklhxkh
 NarSize: 534160
 References: 7bn85d74qa0127p85rrswfyghxsqmcf7-iputils-20210722 892cxk44qxzzlw9h90a781zpy1j7gmmn-libidn2-2.3.2 l25bc19is0s27929kxkfhgdzhc7x9g5m-libcap-2.49-lib rir9pf0kz1mb84x5bd3yr0fx415yy423-glibc-2.33-123
 Deriver: 9fs4vq4gdsb8r9ywawb5f6zl40ycp1bh-iputils-20210722.drv
-Sig: cache.nixos.org-1:WzhkqDdkgPz2qU/0QyEA6wUIm7EMR5MY8nTb5jAmmoh5b80ACIp/+Zpgi5t1KvmO8uG8GVrkPejCxbyQ2gNXDQ==`
+Sig: cache.nixos.org-1:WzhkqDdkgPz2qU/0QyEA6wUIm7EMR5MY8nTb5jAmmoh5b80ACIp/+Zpgi5t1KvmO8uG8GVrkPejCxbyQ2gNXDQ==`,
 
-	NarHash1 = "136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00"
-
-	NarText1 = "Hello, World" // fake nar for above nar info
-)
+	NarHash: "136jk8xlxqzqd16d00dpnnpgffmycwm66zgky6397x75yg7ylz00",
+	NarText: "Hello, World",
+}

--- a/testdata/nar2.go
+++ b/testdata/nar2.go
@@ -1,10 +1,8 @@
 package testdata
 
-const (
-	NarInfoHash2 = "a6hiaxlxf7arxsf59f4rzs7b337z6a11"
-
-	//nolint:lll
-	NarInfoText2 = `StorePath: /nix/store/a6hiaxlxf7arxsf59f4rzs7b337z6a11-brave-1.73.91
+var Nar2 = Entry{
+	NarInfoHash: "a6hiaxlxf7arxsf59f4rzs7b337z6a11",
+	NarInfoText: `StorePath: /nix/store/a6hiaxlxf7arxsf59f4rzs7b337z6a11-brave-1.73.91
 URL: nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar
 Compression: xz
 FileHash: sha256:1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps
@@ -13,9 +11,8 @@ NarHash: sha256:1q95nilzb512ckljzj7h8bsdnj4qhpvyddp74bhsf8sxb8vjmpsj
 NarSize: 388038816
 References: 08mdbxgs2m7fz3hx2xrqrbmhldxagpf8-pango-1.54.0-bin 0irlcqx2n3qm6b1pc9rsd2i8qpvcccaj-bash-5.2p37 2542sr1ch7ypz52w423vyn0fhn934rj7-dbus-1.14.10 3c603pkfh9fq13lrm6rdqynb7xxwazv7-libXrandr-1.5.4 3ma7c4syxds2wrp03ax3b7p9fdsh1lwg-nss-3.101.2 4qiqy2z0facj37682n9x0mz0isd9k3qb-libXScrnSaver-1.2.4 4zjxqvvnnisn8nqmibgy40rvm087v85n-cups-2.4.11-lib 566jyp236h118ad005mxqs7sb9ivv4yj-libXrender-0.9.11 5lq743a2jp3v4kgr80y0sw8jr70pl6gj-libXi-1.8.2 7c88jgbh10zvlv91bmhyc40h8l9b3wf5-librsvg-2.58.3 84839y8j0d4l4d3q048v00h20jdk9lh0-wayland-1.23.1 946m0cmd00hcw2s6slzp5qc01krgrzks-dbus-1.14.10-lib 9i9wrwdi1hkcklzya0yhci0d0vkyl79k-alsa-lib-1.2.12 a6hiaxlxf7arxsf59f4rzs7b337z6a11-brave-1.73.91 apmrnyl4b6fj9czqkb8vwpf6cvfvs0ba-glib-2.82.1-bin arrgysrp5ks44qidsf8byjj11pnkaf65-cairo-1.18.2 b4ph9mwdv628db2vqhhhp3azalq6cwbq-libxcb-1.17.0 c1lszwlw825y6vr4qik6dqv2lszqk08r-libdrm-2.4.123-bin ckfsxyla4krxn4zdlmxkp6lk8nsscr5v-libXcursor-1.2.2 dcj4w0a7472g86yf5wqz5vfbd809s4cj-snappy-1.2.1 gsdkqm4qfbzr22m20cns3iilxd55ridd-freetype-2.13.3 hm2rpszabwpvs28jwkaz7pg0dqslm4bd-util-linux-minimal-2.39.4-lib hpd1dss7lmrywlr37vncyzbhzp6rgri5-libXext-1.3.6 i0d0ws5xwix1dvmwp8w1fr4kz61k11x4-libxkbcommon-1.7.0 i66c6m4680fdgfj5fmaclma1bbl9y8i6-systemd-minimal-libs-256.7 ibr7wf806ns8517zggai9yygz07kp85a-libdrm-2.4.123 idrnfiw9r87giqiqwr36xkch4dsr0rdz-pango-1.54.0 j6wpl172pz2323fia7cbjx9lznsc47ri-at-spi2-core-2.54.0 jbck0ahim6cbjjzl1wmrch5inhbhkkra-gtk4-4.16.3 jq1ydifw3ip1vx94dl8w8bgvr07l6s3x-glib-2.82.1 jx4rwrk7cg5v64ygbpyi1v3gfp8c7k9h-fontconfig-2.15.0-bin k48bha2fjqzarg52picsdfwlqx75aqbb-coreutils-9.5 lafwzwzrj53prpzgmmq0aq5spal91q7s-libXdamage-1.1.6 lcq3ibmsb6c2jgqp3yfi1yp773x5wz19-mesa-24.2.6 ldqjvk81fdzygd85505lzc781vssfpdy-libXtst-1.2.5 m761lp9x14i33hb3q7a8wm52rsnk6ab1-expat-2.6.4 mafw0r1djqvl36by8qhz02kmaggh24v8-gdk-pixbuf-2.42.12 mhp5jkwqgyz0s7klvpl23x3axgvn6msm-pipewire-1.2.6 ms2562w6dkqa6xzpaxi4n2ib9kbb3gya-libXcomposite-0.4.6 p5nz6gdblng41fiqqb7z88l119dc9v56-gsettings-desktop-schemas-47.1 pacbfvpzqz2mksby36awvbcn051zcji3-glibc-2.40-36 pg3xw94i23l4dkrxcp7l11a2iydxc1za-dconf-0.40.0-lib q8y8kgidr4mg0q7zr2h1ddpd7ijy3wna-libpulseaudio-17.0 qrj5f1mb08k5jg7y9ikzb1njli0gvmxz-libX11-1.8.10 rdjcf9pxdlcd6ncsiqm97gq4ard6c91f-nspr-4.36 rh6zrnvbzjsfy444w5w2k5sz72cl6f4z-libva-2.22.0 rmfav7fq6rmpv3d785v462shsy1njq6f-fontconfig-2.15.0-lib sawcd2sh4p7kdggj00i67wa59swaid5b-util-linux-minimal-2.39.4-bin vbw9c3pvwli5iidik8dddgz423wr1h18-gtk+3-3.24.43 w3clwb8c7c8vc7ls163p5pjspccgcrhj-cups-2.4.11 w9g781rqrc12870vji13hycwh47lwsgd-qtbase-6.8.0 wfqs8h2mf4ib7f1phpsgv0b20xny9zzl-libXfixes-6.0.1 wjnznkh0x4744mcvhlnr4qnnig15287c-xdg-utils-1.2.1 xghyamhbjj0rfavxj76l52mv7zr7dfiw-krb5-1.21.3-lib xk9b2k475ab7q9xmcqcfb1xcyh9arswj-krb5-1.21.3 y6bcc1vzg315zzzpir608zkhnmvp49kc-zlib-1.3.1 ymhcg6x5jrw3hx8ik1cji6awiybgp9f7-libglvnd-1.7.0 zm54lx2l4jsc0dw1cnmyg8ilcn07v6zb-libxshmfence-1.3.2
 Deriver: n85jhy5b8c9l1a4d9pnf3dv8bfvmyzhb-brave-1.73.91.drv
-Sig: cache.nixos.org-1:QVc2ad4OI/2G5gVyFsoWYr+AECFDXjwF6o1HOfSbMJhPp5l4iD38WgJhf2w/3kZ/B5ftq6ytDijcAWCSDItJDQ==`
+Sig: cache.nixos.org-1:QVc2ad4OI/2G5gVyFsoWYr+AECFDXjwF6o1HOfSbMJhPp5l4iD38WgJhf2w/3kZ/B5ftq6ytDijcAWCSDItJDQ==`,
 
-	NarHash2 = "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps"
-
-	NarText2 = "Wave, World" // fake nar for above nar info
-)
+	NarHash: "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+	NarText: "Wave, World",
+}

--- a/testdata/nar2.go
+++ b/testdata/nar2.go
@@ -1,0 +1,21 @@
+package testdata
+
+const (
+	NarInfoHash2 = "a6hiaxlxf7arxsf59f4rzs7b337z6a11"
+
+	//nolint:lll
+	NarInfoText2 = `StorePath: /nix/store/a6hiaxlxf7arxsf59f4rzs7b337z6a11-brave-1.73.91
+URL: nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar
+Compression: xz
+FileHash: sha256:1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps
+FileSize: 125606280
+NarHash: sha256:1q95nilzb512ckljzj7h8bsdnj4qhpvyddp74bhsf8sxb8vjmpsj
+NarSize: 388038816
+References: 08mdbxgs2m7fz3hx2xrqrbmhldxagpf8-pango-1.54.0-bin 0irlcqx2n3qm6b1pc9rsd2i8qpvcccaj-bash-5.2p37 2542sr1ch7ypz52w423vyn0fhn934rj7-dbus-1.14.10 3c603pkfh9fq13lrm6rdqynb7xxwazv7-libXrandr-1.5.4 3ma7c4syxds2wrp03ax3b7p9fdsh1lwg-nss-3.101.2 4qiqy2z0facj37682n9x0mz0isd9k3qb-libXScrnSaver-1.2.4 4zjxqvvnnisn8nqmibgy40rvm087v85n-cups-2.4.11-lib 566jyp236h118ad005mxqs7sb9ivv4yj-libXrender-0.9.11 5lq743a2jp3v4kgr80y0sw8jr70pl6gj-libXi-1.8.2 7c88jgbh10zvlv91bmhyc40h8l9b3wf5-librsvg-2.58.3 84839y8j0d4l4d3q048v00h20jdk9lh0-wayland-1.23.1 946m0cmd00hcw2s6slzp5qc01krgrzks-dbus-1.14.10-lib 9i9wrwdi1hkcklzya0yhci0d0vkyl79k-alsa-lib-1.2.12 a6hiaxlxf7arxsf59f4rzs7b337z6a11-brave-1.73.91 apmrnyl4b6fj9czqkb8vwpf6cvfvs0ba-glib-2.82.1-bin arrgysrp5ks44qidsf8byjj11pnkaf65-cairo-1.18.2 b4ph9mwdv628db2vqhhhp3azalq6cwbq-libxcb-1.17.0 c1lszwlw825y6vr4qik6dqv2lszqk08r-libdrm-2.4.123-bin ckfsxyla4krxn4zdlmxkp6lk8nsscr5v-libXcursor-1.2.2 dcj4w0a7472g86yf5wqz5vfbd809s4cj-snappy-1.2.1 gsdkqm4qfbzr22m20cns3iilxd55ridd-freetype-2.13.3 hm2rpszabwpvs28jwkaz7pg0dqslm4bd-util-linux-minimal-2.39.4-lib hpd1dss7lmrywlr37vncyzbhzp6rgri5-libXext-1.3.6 i0d0ws5xwix1dvmwp8w1fr4kz61k11x4-libxkbcommon-1.7.0 i66c6m4680fdgfj5fmaclma1bbl9y8i6-systemd-minimal-libs-256.7 ibr7wf806ns8517zggai9yygz07kp85a-libdrm-2.4.123 idrnfiw9r87giqiqwr36xkch4dsr0rdz-pango-1.54.0 j6wpl172pz2323fia7cbjx9lznsc47ri-at-spi2-core-2.54.0 jbck0ahim6cbjjzl1wmrch5inhbhkkra-gtk4-4.16.3 jq1ydifw3ip1vx94dl8w8bgvr07l6s3x-glib-2.82.1 jx4rwrk7cg5v64ygbpyi1v3gfp8c7k9h-fontconfig-2.15.0-bin k48bha2fjqzarg52picsdfwlqx75aqbb-coreutils-9.5 lafwzwzrj53prpzgmmq0aq5spal91q7s-libXdamage-1.1.6 lcq3ibmsb6c2jgqp3yfi1yp773x5wz19-mesa-24.2.6 ldqjvk81fdzygd85505lzc781vssfpdy-libXtst-1.2.5 m761lp9x14i33hb3q7a8wm52rsnk6ab1-expat-2.6.4 mafw0r1djqvl36by8qhz02kmaggh24v8-gdk-pixbuf-2.42.12 mhp5jkwqgyz0s7klvpl23x3axgvn6msm-pipewire-1.2.6 ms2562w6dkqa6xzpaxi4n2ib9kbb3gya-libXcomposite-0.4.6 p5nz6gdblng41fiqqb7z88l119dc9v56-gsettings-desktop-schemas-47.1 pacbfvpzqz2mksby36awvbcn051zcji3-glibc-2.40-36 pg3xw94i23l4dkrxcp7l11a2iydxc1za-dconf-0.40.0-lib q8y8kgidr4mg0q7zr2h1ddpd7ijy3wna-libpulseaudio-17.0 qrj5f1mb08k5jg7y9ikzb1njli0gvmxz-libX11-1.8.10 rdjcf9pxdlcd6ncsiqm97gq4ard6c91f-nspr-4.36 rh6zrnvbzjsfy444w5w2k5sz72cl6f4z-libva-2.22.0 rmfav7fq6rmpv3d785v462shsy1njq6f-fontconfig-2.15.0-lib sawcd2sh4p7kdggj00i67wa59swaid5b-util-linux-minimal-2.39.4-bin vbw9c3pvwli5iidik8dddgz423wr1h18-gtk+3-3.24.43 w3clwb8c7c8vc7ls163p5pjspccgcrhj-cups-2.4.11 w9g781rqrc12870vji13hycwh47lwsgd-qtbase-6.8.0 wfqs8h2mf4ib7f1phpsgv0b20xny9zzl-libXfixes-6.0.1 wjnznkh0x4744mcvhlnr4qnnig15287c-xdg-utils-1.2.1 xghyamhbjj0rfavxj76l52mv7zr7dfiw-krb5-1.21.3-lib xk9b2k475ab7q9xmcqcfb1xcyh9arswj-krb5-1.21.3 y6bcc1vzg315zzzpir608zkhnmvp49kc-zlib-1.3.1 ymhcg6x5jrw3hx8ik1cji6awiybgp9f7-libglvnd-1.7.0 zm54lx2l4jsc0dw1cnmyg8ilcn07v6zb-libxshmfence-1.3.2
+Deriver: n85jhy5b8c9l1a4d9pnf3dv8bfvmyzhb-brave-1.73.91.drv
+Sig: cache.nixos.org-1:QVc2ad4OI/2G5gVyFsoWYr+AECFDXjwF6o1HOfSbMJhPp5l4iD38WgJhf2w/3kZ/B5ftq6ytDijcAWCSDItJDQ==`
+
+	NarHash2 = "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps"
+
+	NarText2 = "Wave, World" // fake nar for above nar info
+)

--- a/testdata/server.go
+++ b/testdata/server.go
@@ -49,7 +49,7 @@ func HTTPTestServer(t *testing.T, priority int) *httptest.Server {
 			}
 
 			if r.URL.Path == "/nar/"+entry.NarHash+".nar.xz" {
-				if _, err := w.Write([]byte(entry.NarText)); err != nil {
+				if _, err := w.Write([]byte(entry.NarText + "xz")); err != nil {
 					t.Fatalf("error writing the nar to the response: %s", err)
 				}
 

--- a/testdata/server.go
+++ b/testdata/server.go
@@ -1,0 +1,62 @@
+package testdata
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func HTTPTestServer(t *testing.T, priority int) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/nix-cache-info" {
+			if _, err := w.Write([]byte(NixStoreInfo(priority))); err != nil {
+				t.Fatalf("expected no error got: %s", err)
+			}
+
+			return
+		}
+
+		for _, entry := range Entries {
+			if r.URL.Path == "/broken-"+entry.NarInfoHash+".narinfo" {
+				// mutate the inside
+				b := entry.NarInfoText
+				b = strings.Replace(b, "References:", "References: notfound-path", -1)
+
+				if _, err := w.Write([]byte(b)); err != nil {
+					t.Fatalf("error writing the nar to the response: %s", err)
+				}
+
+				return
+			}
+
+			if r.URL.Path == "/"+entry.NarInfoHash+".narinfo" {
+				if _, err := w.Write([]byte(entry.NarInfoText)); err != nil {
+					t.Fatalf("error writing the nar to the response: %s", err)
+				}
+
+				return
+			}
+
+			if r.URL.Path == "/nar/"+entry.NarHash+".nar" {
+				if _, err := w.Write([]byte(entry.NarText)); err != nil {
+					t.Fatalf("error writing the nar to the response: %s", err)
+				}
+
+				return
+			}
+
+			if r.URL.Path == "/nar/"+entry.NarHash+".nar.xz" {
+				if _, err := w.Write([]byte(entry.NarText)); err != nil {
+					t.Fatalf("error writing the nar to the response: %s", err)
+				}
+
+				return
+			}
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}

--- a/testdata/storeinfo.go
+++ b/testdata/storeinfo.go
@@ -1,0 +1,13 @@
+package testdata
+
+import "strconv"
+
+const (
+	nixStoreInfo = `StoreDir: /nix/store
+WantMassQuery: 1
+Priority: `
+)
+
+func NixStoreInfo(priority int) string {
+	return nixStoreInfo + strconv.Itoa(priority)
+}

--- a/testdata/type.go
+++ b/testdata/type.go
@@ -1,0 +1,9 @@
+package testdata
+
+type Entry struct {
+	NarInfoHash string
+	NarInfoText string
+
+	NarHash string
+	NarText string
+}


### PR DESCRIPTION
Move the hardcoded testdata from the tests and store them in the testdata package.