### PR TITLE
pkg/cache: Purge narinfo/nar if nar file was not found in store

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -355,8 +355,10 @@ func (c *Cache) deleteNarFromStore(log log15.Logger, hash, compression string) e
 func (c *Cache) GetNarInfo(hash string) (*narinfo.NarInfo, error) {
 	log := c.logger.New("hash", hash)
 
-	var narInfo *narinfo.NarInfo
-	var err error
+	var (
+		narInfo *narinfo.NarInfo
+		err     error
+	)
 
 	if c.hasNarInfoInStore(log, hash) {
 		narInfo, err = c.getNarInfoFromStore(log, hash)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -350,7 +350,7 @@ func (c *Cache) deleteNarFromStore(log log15.Logger, hash, compression string) e
 // is not found in the store, it's pulled from an upstream, stored in the
 // stored and finally returned.
 func (c *Cache) GetNarInfo(hash string) (*narinfo.NarInfo, error) {
-	log := log15.New("hash", hash)
+	log := c.logger.New("hash", hash)
 
 	var narInfo *narinfo.NarInfo
 	var err error
@@ -404,7 +404,7 @@ func (c *Cache) PutNarInfo(_ context.Context, hash string, r io.ReadCloser) erro
 		r.Close()
 	}()
 
-	log := log15.New("hash", hash)
+	log := c.logger.New("hash", hash)
 
 	narInfo, err := narinfo.Parse(r)
 	if err != nil {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -362,14 +362,17 @@ func (c *Cache) GetNarInfo(hash string) (*narinfo.NarInfo, error) {
 		}
 
 		narHash, narCompression, err := helper.ParseNarURL(narInfo.URL)
-		if err != nil {
-			log.Error("error parsing the nar URL from narinfo", "narinfo", narInfo, "nar-url", narInfo.URL)
-		} else if c.hasNarInStore(log.New("nar-hash", narHash, "nar-compression", narCompression), narHash, narCompression) {
-			return narInfo, err
-		} else {
+		if err == nil {
+			log = log.New("nar-hash", narHash, "nar-compression", narCompression)
+			if c.hasNarInStore(log, narHash, narCompression) {
+				return narInfo, err
+			}
+
 			if err := c.purgeNarInfo(log, hash, narHash, narCompression); err != nil {
 				return nil, fmt.Errorf("error purging the narinfo: %w", err)
 			}
+		} else {
+			log.Error("error parsing the nar URL from narinfo", "narinfo", narInfo, "nar-url", narInfo.URL)
 		}
 	}
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -366,10 +366,10 @@ func (c *Cache) GetNarInfo(hash string) (*narinfo.NarInfo, error) {
 			log.Error("error parsing the nar URL from narinfo", "narinfo", narInfo, "nar-url", narInfo.URL)
 		} else if c.hasNarInStore(log.New("nar-hash", narHash, "nar-compression", narCompression), narHash, narCompression) {
 			return narInfo, err
-		}
-
-		if err := c.purgeNarInfo(log, hash, narHash, narCompression); err != nil {
-			return nil, fmt.Errorf("error purging the narinfo: %w", err)
+		} else {
+			if err := c.purgeNarInfo(log, hash, narHash, narCompression); err != nil {
+				return nil, fmt.Errorf("error purging the narinfo: %w", err)
+			}
 		}
 	}
 

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -70,6 +70,16 @@ const (
 		  updated_at = CURRENT_TIMESTAMP
 	WHERE hash = ?
 	`
+
+	deletNarInfoQuery = `
+	DELETE FROM narinfos
+	WHERE hash = ?
+	`
+
+	deletNarQuery = `
+	DELETE FROM nars
+	WHERE hash = ?
+	`
 )
 
 var (
@@ -194,6 +204,11 @@ func (db *DB) TouchNarInfoRecord(tx *sql.Tx, hash string) (sql.Result, error) {
 	return db.touchRecord(tx, touchNarInfoQuery, hash)
 }
 
+// DeleteNarInfoRecord deletes the narinfo record.
+func (db *DB) DeleteNarInfoRecord(tx *sql.Tx, hash string) error {
+	return db.deleteRecord(tx, deletNarInfoQuery, hash)
+}
+
 func (db *DB) GetNarRecord(tx *sql.Tx, hash string) (NarModel, error) {
 	var nm NarModel
 
@@ -267,6 +282,11 @@ func (db *DB) TouchNarRecord(tx *sql.Tx, hash string) (sql.Result, error) {
 	return db.touchRecord(tx, touchNarQuery, hash)
 }
 
+// DeleteNarInfoRecord deletes the narinfo record.
+func (db *DB) DeleteNarRecord(tx *sql.Tx, hash string) error {
+	return db.deleteRecord(tx, deletNarQuery, hash)
+}
+
 func (db *DB) touchRecord(tx *sql.Tx, query, hash string) (sql.Result, error) {
 	stmt, err := tx.Prepare(query)
 	if err != nil {
@@ -280,6 +300,10 @@ func (db *DB) touchRecord(tx *sql.Tx, query, hash string) (sql.Result, error) {
 	}
 
 	return res, nil
+}
+
+func (db *DB) deleteRecord(tx *sql.Tx, query, hash string) error {
+	return errors.New("not implemented")
 }
 
 func (db *DB) createTables() error {

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -201,12 +201,14 @@ func (db *DB) InsertNarInfoRecord(tx *sql.Tx, hash string) (sql.Result, error) {
 // TouchNarInfoRecord updates the last_accessed_at of a narinfo record in the
 // database.
 func (db *DB) TouchNarInfoRecord(tx *sql.Tx, hash string) (sql.Result, error) {
-	return db.touchRecord(tx, touchNarInfoQuery, hash)
+	return db.doQuery(tx, touchNarInfoQuery, hash)
 }
 
 // DeleteNarInfoRecord deletes the narinfo record.
 func (db *DB) DeleteNarInfoRecord(tx *sql.Tx, hash string) error {
-	return db.deleteRecord(tx, deletNarInfoQuery, hash)
+	_, err := db.doQuery(tx, deletNarInfoQuery, hash)
+
+	return err
 }
 
 func (db *DB) GetNarRecord(tx *sql.Tx, hash string) (NarModel, error) {
@@ -279,31 +281,29 @@ func (db *DB) InsertNarRecord(tx *sql.Tx, narInfoID int64,
 }
 
 func (db *DB) TouchNarRecord(tx *sql.Tx, hash string) (sql.Result, error) {
-	return db.touchRecord(tx, touchNarQuery, hash)
+	return db.doQuery(tx, touchNarQuery, hash)
 }
 
 // DeleteNarInfoRecord deletes the narinfo record.
 func (db *DB) DeleteNarRecord(tx *sql.Tx, hash string) error {
-	return db.deleteRecord(tx, deletNarQuery, hash)
+	_, err := db.doQuery(tx, deletNarQuery, hash)
+
+	return err
 }
 
-func (db *DB) touchRecord(tx *sql.Tx, query, hash string) (sql.Result, error) {
+func (db *DB) doQuery(tx *sql.Tx, query string, args ...any) (sql.Result, error) {
 	stmt, err := tx.Prepare(query)
 	if err != nil {
 		return nil, fmt.Errorf("error preparing a statement: %w", err)
 	}
 	defer stmt.Close()
 
-	res, err := stmt.Exec(hash)
+	res, err := stmt.Exec(args...)
 	if err != nil {
 		return nil, fmt.Errorf("error executing the statement: %w", err)
 	}
 
 	return res, nil
-}
-
-func (db *DB) deleteRecord(tx *sql.Tx, query, hash string) error {
-	return errors.New("not implemented")
 }
 
 func (db *DB) createTables() error {


### PR DESCRIPTION
If a nar file does not exist in the store but a narfile does, purge everything about the narfile and proceed to pull it from upstream as usual.

closes #50