### PR TITLE
go: update go-nix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,16 +2,12 @@ module github.com/kalbasit/ncps
 
 go 1.23.3
 
-// TODO: Remove the following line once this PR is merged upstream:
-// https://github.com/nix-community/go-nix/pull/125
-replace github.com/nix-community/go-nix => github.com/kalbasit/go-nix v1.0.0
-
 require (
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/inconshreveable/log15/v3 v3.0.0-testing.5
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-sqlite3 v1.14.24
-	github.com/nix-community/go-nix v0.0.0-20241202132706-bf395042f3ee
+	github.com/nix-community/go-nix v0.0.0-20241207090453-00891a7727c2
 	github.com/urfave/cli/v3 v3.0.0-beta1
 	golang.org/x/term v0.27.0
 )

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/inconshreveable/log15 v3.0.0-testing.5+incompatible h1:VryeOTiaZfAzwx
 github.com/inconshreveable/log15 v3.0.0-testing.5+incompatible/go.mod h1:cOaXtrgN4ScfRrD9Bre7U1thNq5RtJ8ZoP4iXVGRj6o=
 github.com/inconshreveable/log15/v3 v3.0.0-testing.5 h1:h4e0f3kjgg+RJBlKOabrohjHe47D3bbAB9BgMrc3DYA=
 github.com/inconshreveable/log15/v3 v3.0.0-testing.5/go.mod h1:3GQg1SVrLoWGfRv/kAZMsdyU5cp8eFc1P3cw+Wwku94=
-github.com/kalbasit/go-nix v1.0.0 h1:fl9WfntLtOi3RPG1ku/uWPG9QfFcDCCBnGPkn9zM1TA=
-github.com/kalbasit/go-nix v1.0.0/go.mod h1:qgCw4bBKZX8qMgGeEZzGFVT3notl42dBjNqO2jut0M0=
 github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
 github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
@@ -27,6 +25,8 @@ github.com/multiformats/go-multihash v0.2.3 h1:7Lyc8XfX/IY2jWb/gI7JP+o7JEq9hOa7B
 github.com/multiformats/go-multihash v0.2.3/go.mod h1:dXgKXCXjBzdscBLk9JkjINiEsCKRVch90MdaGiKsvSM=
 github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/nEGOHFS8=
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
+github.com/nix-community/go-nix v0.0.0-20241207090453-00891a7727c2 h1:KVBAi/cviLGNx7EjhPog1a9dYVvmoI4Ha+ullP4Z5TI=
+github.com/nix-community/go-nix v0.0.0-20241207090453-00891a7727c2/go.mod h1:qgCw4bBKZX8qMgGeEZzGFVT3notl42dBjNqO2jut0M0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=


### PR DESCRIPTION
https://github.com/nix-community/go-nix/pull/125 was merged upstream, so the replacement using my fork can now be removed.