### PR TITLE
pkg/helper: add ParseSize a helper to parse size with units

### DIFF
--- a/pkg/helper/size_units.go
+++ b/pkg/helper/size_units.go
@@ -1,0 +1,35 @@
+package helper
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ErrInvalidSizeSuffix is returned if the suffix is not valid.
+var ErrInvalidSizeSuffix = errors.New("invalid size suffix")
+
+// ParseSize parses size with units and returns the same size in bytes.
+func ParseSize(str string) (uint64, error) {
+	num, err := strconv.ParseUint(str[:len(str)-1], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	suffix := strings.ToUpper(str[len(str)-1:])
+	switch suffix {
+	case "B":
+		return num, nil
+	case "K":
+		return num * 1024, nil
+	case "M":
+		return num * 1024 * 1024, nil
+	case "G":
+		return num * 1024 * 1024 * 1024, nil
+	case "T":
+		return num * 1024 * 1024 * 1024 * 1024, nil
+	default:
+		return 0, fmt.Errorf("error parsing the unit for %q: %w", str, ErrInvalidSizeSuffix)
+	}
+}

--- a/pkg/helper/size_units_test.go
+++ b/pkg/helper/size_units_test.go
@@ -1,0 +1,56 @@
+package helper_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kalbasit/ncps/pkg/helper"
+)
+
+func TestParseSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		sizeStr string
+		size    uint64
+		err     string
+	}{
+		// uppercase
+		{sizeStr: "2B", size: 2, err: ""},
+		{sizeStr: "3K", size: 3072, err: ""},
+		{sizeStr: "4M", size: 4194304, err: ""},
+		{sizeStr: "9G", size: 9663676416, err: ""},
+		{sizeStr: "10T", size: 10995116277760, err: ""},
+
+		// lowercase
+		{sizeStr: "2b", size: 2, err: ""},
+		{sizeStr: "3k", size: 3072, err: ""},
+		{sizeStr: "4m", size: 4194304, err: ""},
+		{sizeStr: "9g", size: 9663676416, err: ""},
+		{sizeStr: "10t", size: 10995116277760, err: ""},
+
+		// errors
+		{sizeStr: "20", err: "error parsing the unit for \"20\": invalid size suffix"},
+		{sizeStr: "2a", err: "error parsing the unit for \"2a\": invalid size suffix"},
+		{sizeStr: "2A", err: "error parsing the unit for \"2A\": invalid size suffix"},
+		{sizeStr: "2Gb", err: "strconv.ParseUint: parsing \"2G\": invalid syntax"},
+	}
+
+	for _, test := range tests {
+		tn := fmt.Sprintf("ParseSize(%q) -> (%d, %q)", test.sizeStr, test.size, test.err)
+		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+
+			s, err := helper.ParseSize(test.sizeStr)
+			assert.Equal(t, test.size, s)
+
+			if test.err == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, test.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
For LRU functionality, I need a way to parse "9G" or "10T" etc..

ref #21 