### PR TITLE
testdata: add expected paths for each nar/narinfo

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -203,11 +203,11 @@ func TestGetNarInfo(t *testing.T) {
 
 	t.Run("narinfo exists upstream", func(t *testing.T) {
 		t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
-			assert.NoFileExists(t, filepath.Join(dir, "store", testdata.Nar2.NarInfoHash+".narinfo"))
+			assert.NoFileExists(t, filepath.Join(dir, "store", testdata.Nar2.NarInfoPath))
 		})
 
 		t.Run("nar does not exist in storage yet", func(t *testing.T) {
-			assert.NoFileExists(t, filepath.Join(dir, "store", "nar", testdata.Nar2.NarHash+".nar.xz"))
+			assert.NoFileExists(t, filepath.Join(dir, "store", "nar", testdata.Nar2.NarPath))
 		})
 
 		t.Run("narinfo does not exist in the database yet", func(t *testing.T) {
@@ -256,7 +256,7 @@ func TestGetNarInfo(t *testing.T) {
 		})
 
 		t.Run("it should now exist in the store", func(t *testing.T) {
-			assert.FileExists(t, filepath.Join(dir, "store", testdata.Nar2.NarInfoHash+".narinfo"))
+			assert.FileExists(t, filepath.Join(dir, "store", testdata.Nar2.NarInfoPath))
 		})
 
 		t.Run("it should be signed by our server", func(t *testing.T) {
@@ -285,7 +285,7 @@ func TestGetNarInfo(t *testing.T) {
 				// NOTE: I tried runtime.Gosched() but it makes the test flaky
 				time.Sleep(time.Millisecond)
 
-				_, err = os.Stat(filepath.Join(dir, "store", "nar", testdata.Nar2.NarHash+".nar.xz"))
+				_, err = os.Stat(filepath.Join(dir, "store", "nar", testdata.Nar2.NarPath))
 				if err == nil {
 					break
 				}
@@ -426,14 +426,14 @@ func TestGetNarInfo(t *testing.T) {
 		})
 
 		t.Run("no error is returned if the entry already exist in the database", func(t *testing.T) {
-			require.NoError(t, os.Remove(filepath.Join(dir, "store", testdata.Nar2.NarInfoHash+".narinfo")))
+			require.NoError(t, os.Remove(filepath.Join(dir, "store", testdata.Nar2.NarInfoPath)))
 
 			_, err := c.GetNarInfo(testdata.Nar2.NarInfoHash)
 			assert.NoError(t, err)
 		})
 
 		t.Run("nar does not exist in storage, it gets pulled automatically", func(t *testing.T) {
-			narFile := filepath.Join(dir, "store", "nar", testdata.Nar2.NarHash+".nar.xz")
+			narFile := filepath.Join(dir, "store", "nar", testdata.Nar2.NarPath)
 
 			require.NoError(t, os.Remove(narFile))
 
@@ -477,7 +477,7 @@ func TestPutNarInfo(t *testing.T) {
 	db, err := sql.Open("sqlite3", filepath.Join(dir, "var", "ncps", "db", "db.sqlite"))
 	require.NoError(t, err)
 
-	storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoHash+".narinfo")
+	storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoPath)
 
 	t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 		assert.NoFileExists(t, storePath)
@@ -609,7 +609,7 @@ func TestDeleteNarInfo(t *testing.T) {
 	c.SetRecordAgeIgnoreTouch(0)
 
 	t.Run("file does not exist in the store", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoHash+".narinfo")
+		storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoPath)
 
 		t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 			assert.NoFileExists(t, storePath)
@@ -622,7 +622,7 @@ func TestDeleteNarInfo(t *testing.T) {
 	})
 
 	t.Run("file does exist in the store", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoHash+".narinfo")
+		storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoPath)
 
 		t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 			assert.NoFileExists(t, storePath)
@@ -681,7 +681,7 @@ func TestGetNar(t *testing.T) {
 
 	t.Run("nar exists upstream", func(t *testing.T) {
 		t.Run("nar does not exist in storage yet", func(t *testing.T) {
-			assert.NoFileExists(t, filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar.xz"))
+			assert.NoFileExists(t, filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath))
 		})
 
 		t.Run("nar does not exist in database yet", func(t *testing.T) {
@@ -727,7 +727,7 @@ func TestGetNar(t *testing.T) {
 		})
 
 		t.Run("it should now exist in the store", func(t *testing.T) {
-			assert.FileExists(t, filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar.xz"))
+			assert.FileExists(t, filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath))
 		})
 
 		t.Run("getting the narinfo so the record in the database now exists", func(t *testing.T) {
@@ -863,7 +863,7 @@ func TestPutNar(t *testing.T) {
 
 	c.SetRecordAgeIgnoreTouch(0)
 
-	storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar.xz")
+	storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath)
 
 	t.Run("nar does not exist in storage yet", func(t *testing.T) {
 		assert.NoFileExists(t, storePath)
@@ -898,7 +898,7 @@ func TestDeleteNar(t *testing.T) {
 
 	c.SetRecordAgeIgnoreTouch(0)
 
-	storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar.xz")
+	storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath)
 
 	t.Run("file does not exist in the store", func(t *testing.T) {
 		t.Run("nar does not exist in storage yet", func(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -95,7 +95,7 @@ func TestServeHTTP(t *testing.T) {
 			defer ts.Close()
 
 			t.Run("narInfo", func(t *testing.T) {
-				storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoHash+".narinfo")
+				storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoPath)
 
 				t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 					assert.NoFileExists(t, storePath)
@@ -131,76 +131,38 @@ func TestServeHTTP(t *testing.T) {
 			})
 
 			t.Run("nar", func(t *testing.T) {
-				t.Run("nar without compression", func(t *testing.T) {
-					storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar")
+				storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath)
 
-					t.Run("nar does not exist in storage yet", func(t *testing.T) {
-						assert.NoFileExists(t, storePath)
-					})
-
-					f, err := os.Create(storePath)
-					require.NoError(t, err)
-
-					_, err = f.WriteString(testdata.Nar1.NarText)
-					require.NoError(t, err)
-
-					require.NoError(t, f.Close())
-
-					t.Run("nar does exist in storage", func(t *testing.T) {
-						assert.FileExists(t, storePath)
-					})
-
-					t.Run("DELETE returns no error", func(t *testing.T) {
-						url := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar"
-
-						r, err := http.NewRequestWithContext(context.Background(), "DELETE", url, nil)
-						require.NoError(t, err)
-
-						resp, err := ts.Client().Do(r)
-						require.NoError(t, err)
-
-						assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-					})
-
-					t.Run("narinfo is gone from the store", func(t *testing.T) {
-						assert.NoFileExists(t, storePath)
-					})
+				t.Run("nar does not exist in storage yet", func(t *testing.T) {
+					assert.NoFileExists(t, storePath)
 				})
 
-				t.Run("nar with compression", func(t *testing.T) {
-					storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar.xz")
+				f, err := os.Create(storePath)
+				require.NoError(t, err)
 
-					t.Run("nar does not exist in storage yet", func(t *testing.T) {
-						assert.NoFileExists(t, storePath)
-					})
+				_, err = f.WriteString(testdata.Nar1.NarText)
+				require.NoError(t, err)
 
-					f, err := os.Create(storePath)
+				require.NoError(t, f.Close())
+
+				t.Run("nar does exist in storage", func(t *testing.T) {
+					assert.FileExists(t, storePath)
+				})
+
+				t.Run("DELETE returns no error", func(t *testing.T) {
+					url := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar.xz"
+
+					r, err := http.NewRequestWithContext(context.Background(), "DELETE", url, nil)
 					require.NoError(t, err)
 
-					_, err = f.WriteString(testdata.Nar1.NarText)
+					resp, err := ts.Client().Do(r)
 					require.NoError(t, err)
 
-					require.NoError(t, f.Close())
+					assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+				})
 
-					t.Run("nar does exist in storage", func(t *testing.T) {
-						assert.FileExists(t, storePath)
-					})
-
-					t.Run("DELETE returns no error", func(t *testing.T) {
-						url := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar.xz"
-
-						r, err := http.NewRequestWithContext(context.Background(), "DELETE", url, nil)
-						require.NoError(t, err)
-
-						resp, err := ts.Client().Do(r)
-						require.NoError(t, err)
-
-						assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-					})
-
-					t.Run("narinfo is gone from the store", func(t *testing.T) {
-						assert.NoFileExists(t, storePath)
-					})
+				t.Run("narinfo is gone from the store", func(t *testing.T) {
+					assert.NoFileExists(t, storePath)
 				})
 			})
 		})
@@ -238,7 +200,7 @@ func TestServeHTTP(t *testing.T) {
 			})
 
 			t.Run("narinfo exists upstream", func(t *testing.T) {
-				r := httptest.NewRequest("GET", "/"+testdata.Nar1.NarInfoHash+".narinfo", nil)
+				r := httptest.NewRequest("GET", "/"+testdata.Nar1.NarInfoPath, nil)
 				w := httptest.NewRecorder()
 
 				s.ServeHTTP(w, r)
@@ -267,7 +229,7 @@ func TestServeHTTP(t *testing.T) {
 			})
 
 			t.Run("nar exists upstream", func(t *testing.T) {
-				r := httptest.NewRequest("GET", "/nar/"+testdata.Nar1.NarHash+".nar.xz", nil)
+				r := httptest.NewRequest("GET", "/nar/"+testdata.Nar1.NarPath, nil)
 				w := httptest.NewRecorder()
 
 				s.ServeHTTP(w, r)
@@ -349,7 +311,7 @@ func TestServeHTTP(t *testing.T) {
 			defer ts.Close()
 
 			t.Run("narInfo", func(t *testing.T) {
-				storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoHash+".narinfo")
+				storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoPath)
 
 				t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 					assert.NoFileExists(t, storePath)
@@ -396,64 +358,32 @@ func TestServeHTTP(t *testing.T) {
 				})
 			})
 
-			t.Run("nar without compression", func(t *testing.T) {
-				storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar")
+			storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath)
 
-				t.Run("nar does not exist in storage yet", func(t *testing.T) {
-					assert.NoFileExists(t, storePath)
-				})
-
-				t.Run("putNar does not return an error", func(t *testing.T) {
-					p := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar"
-
-					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(testdata.Nar1.NarText))
-					require.NoError(t, err)
-
-					resp, err := ts.Client().Do(r)
-					require.NoError(t, err)
-
-					assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-				})
-
-				t.Run("nar does exist in storage", func(t *testing.T) {
-					f, err := os.Open(storePath)
-					require.NoError(t, err)
-
-					bs, err := io.ReadAll(f)
-					require.NoError(t, err)
-
-					assert.Equal(t, testdata.Nar1.NarText, string(bs))
-				})
+			t.Run("nar does not exist in storage yet", func(t *testing.T) {
+				assert.NoFileExists(t, storePath)
 			})
 
-			t.Run("nar with compression", func(t *testing.T) {
-				storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarHash+".nar.xz")
+			t.Run("putNar does not return an error", func(t *testing.T) {
+				p := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar.xz"
 
-				t.Run("nar does not exist in storage yet", func(t *testing.T) {
-					assert.NoFileExists(t, storePath)
-				})
+				r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(testdata.Nar1.NarText))
+				require.NoError(t, err)
 
-				t.Run("putNar does not return an error", func(t *testing.T) {
-					p := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar.xz"
+				resp, err := ts.Client().Do(r)
+				require.NoError(t, err)
 
-					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(testdata.Nar1.NarText))
-					require.NoError(t, err)
+				assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+			})
 
-					resp, err := ts.Client().Do(r)
-					require.NoError(t, err)
+			t.Run("nar does exist in storage", func(t *testing.T) {
+				f, err := os.Open(storePath)
+				require.NoError(t, err)
 
-					assert.Equal(t, http.StatusNoContent, resp.StatusCode)
-				})
+				bs, err := io.ReadAll(f)
+				require.NoError(t, err)
 
-				t.Run("nar does exist in storage", func(t *testing.T) {
-					f, err := os.Open(storePath)
-					require.NoError(t, err)
-
-					bs, err := io.ReadAll(f)
-					require.NoError(t, err)
-
-					assert.Equal(t, testdata.Nar1.NarText, string(bs))
-				})
+				assert.Equal(t, testdata.Nar1.NarText, string(bs))
 			})
 		})
 	})

--- a/testdata/nar1.go
+++ b/testdata/nar1.go
@@ -1,15 +1,13 @@
 package testdata
 
 import (
-	"path/filepath"
-
 	"github.com/kalbasit/ncps/pkg/helper"
 )
 
 // Nar1 is the nar representing hello from release-23.11.
 var Nar1 = Entry{
 	NarInfoHash: "n5glp21rsz314qssw9fbvfswgy3kc68f",
-	NarInfoPath: filepath.Join("n", "n5", "n5glp21rsz314qssw9fbvfswgy3kc68f.narinfo"),
+	NarInfoPath: "n5glp21rsz314qssw9fbvfswgy3kc68f.narinfo",
 	NarInfoText: `StorePath: /nix/store/n5glp21rsz314qssw9fbvfswgy3kc68f-hello-2.12.1
 URL: nar/1lid9xrpirkzcpqsxfq02qwiq0yd70chfl860wzsqd1739ih0nri.nar.xz
 Compression: xz
@@ -22,6 +20,6 @@ Deriver: 1zpqmcicrg8smi9jlqv6dmd7v20d2fsn-hello-2.12.1.drv
 Sig: cache.nixos.org-1:MadTCU1OSFCGUw4aqCKpLCZJpqBc7AbLvO7wgdlls0eq1DwaSnF/82SZE+wJGEiwlHbnZR+14daSaec0W3XoBQ==`,
 
 	NarHash: "1lid9xrpirkzcpqsxfq02qwiq0yd70chfl860wzsqd1739ih0nri",
-	NarPath: filepath.Join("1", "1l", "1lid9xrpirkzcpqsxfq02qwiq0yd70chfl860wzsqd1739ih0nri.nar.xz"),
+	NarPath: "1lid9xrpirkzcpqsxfq02qwiq0yd70chfl860wzsqd1739ih0nri.nar.xz",
 	NarText: helper.MustRandString(50160, nil),
 }

--- a/testdata/nar1.go
+++ b/testdata/nar1.go
@@ -1,15 +1,15 @@
 package testdata
 
 import (
+	"path/filepath"
+
 	"github.com/kalbasit/ncps/pkg/helper"
 )
 
 // Nar1 is the nar representing hello from release-23.11.
 var Nar1 = Entry{
 	NarInfoHash: "n5glp21rsz314qssw9fbvfswgy3kc68f",
-	NarHash:     "1lid9xrpirkzcpqsxfq02qwiq0yd70chfl860wzsqd1739ih0nri",
-	NarText:     helper.MustRandString(50160, nil),
-
+	NarInfoPath: filepath.Join("n", "n5", "n5glp21rsz314qssw9fbvfswgy3kc68f.narinfo"),
 	NarInfoText: `StorePath: /nix/store/n5glp21rsz314qssw9fbvfswgy3kc68f-hello-2.12.1
 URL: nar/1lid9xrpirkzcpqsxfq02qwiq0yd70chfl860wzsqd1739ih0nri.nar.xz
 Compression: xz
@@ -20,4 +20,8 @@ NarSize: 226552
 References: n5glp21rsz314qssw9fbvfswgy3kc68f-hello-2.12.1 qdcbgcj27x2kpxj2sf9yfvva7qsgg64g-glibc-2.38-77
 Deriver: 1zpqmcicrg8smi9jlqv6dmd7v20d2fsn-hello-2.12.1.drv
 Sig: cache.nixos.org-1:MadTCU1OSFCGUw4aqCKpLCZJpqBc7AbLvO7wgdlls0eq1DwaSnF/82SZE+wJGEiwlHbnZR+14daSaec0W3XoBQ==`,
+
+	NarHash: "1lid9xrpirkzcpqsxfq02qwiq0yd70chfl860wzsqd1739ih0nri",
+	NarPath: filepath.Join("1", "1l", "1lid9xrpirkzcpqsxfq02qwiq0yd70chfl860wzsqd1739ih0nri.nar.xz"),
+	NarText: helper.MustRandString(50160, nil),
 }

--- a/testdata/nar2.go
+++ b/testdata/nar2.go
@@ -1,15 +1,15 @@
 package testdata
 
 import (
+	"path/filepath"
+
 	"github.com/kalbasit/ncps/pkg/helper"
 )
 
 // Nar2 is the nar representing hello from release-24.05.
 var Nar2 = Entry{
 	NarInfoHash: "3acqrvb06vw0w3s9fa3wci433snbi2bg",
-	NarHash:     "1xqqdh1yn5sz3d6wcz3qz3azm5mbypwq6mv8g2dal1v042h0sprf",
-	NarText:     helper.MustRandString(50308, nil),
-
+	NarInfoPath: filepath.Join("3", "3a", "3acqrvb06vw0w3s9fa3wci433snbi2bg.narinfo"),
 	NarInfoText: `StorePath: /nix/store/3acqrvb06vw0w3s9fa3wci433snbi2bg-hello-2.12.1
 URL: nar/1xqqdh1yn5sz3d6wcz3qz3azm5mbypwq6mv8g2dal1v042h0sprf.nar.xz
 Compression: xz
@@ -20,4 +20,8 @@ NarSize: 226560
 References: 3acqrvb06vw0w3s9fa3wci433snbi2bg-hello-2.12.1 kpy2cyd05vdr6j1h200av81fnlxl1jw0-glibc-2.39-52
 Deriver: 3gdc0qnmn6srg32sx019az6ll2mz1cda-hello-2.12.1.drv
 Sig: cache.nixos.org-1:eGSj5WPpZRjwzx7eWpCyZdNsFHjhtGTZF8T4FccYXjHNkTOZoGPfplgFP1w5bEST0/FtfV7f3AmQUVEv1NAEDg==`,
+
+	NarHash: "1xqqdh1yn5sz3d6wcz3qz3azm5mbypwq6mv8g2dal1v042h0sprf",
+	NarPath: filepath.Join("1", "1x", "1xqqdh1yn5sz3d6wcz3qz3azm5mbypwq6mv8g2dal1v042h0sprf.nar.xz"),
+	NarText: helper.MustRandString(50308, nil),
 }

--- a/testdata/nar2.go
+++ b/testdata/nar2.go
@@ -1,15 +1,13 @@
 package testdata
 
 import (
-	"path/filepath"
-
 	"github.com/kalbasit/ncps/pkg/helper"
 )
 
 // Nar2 is the nar representing hello from release-24.05.
 var Nar2 = Entry{
 	NarInfoHash: "3acqrvb06vw0w3s9fa3wci433snbi2bg",
-	NarInfoPath: filepath.Join("3", "3a", "3acqrvb06vw0w3s9fa3wci433snbi2bg.narinfo"),
+	NarInfoPath: "3acqrvb06vw0w3s9fa3wci433snbi2bg.narinfo",
 	NarInfoText: `StorePath: /nix/store/3acqrvb06vw0w3s9fa3wci433snbi2bg-hello-2.12.1
 URL: nar/1xqqdh1yn5sz3d6wcz3qz3azm5mbypwq6mv8g2dal1v042h0sprf.nar.xz
 Compression: xz
@@ -22,6 +20,6 @@ Deriver: 3gdc0qnmn6srg32sx019az6ll2mz1cda-hello-2.12.1.drv
 Sig: cache.nixos.org-1:eGSj5WPpZRjwzx7eWpCyZdNsFHjhtGTZF8T4FccYXjHNkTOZoGPfplgFP1w5bEST0/FtfV7f3AmQUVEv1NAEDg==`,
 
 	NarHash: "1xqqdh1yn5sz3d6wcz3qz3azm5mbypwq6mv8g2dal1v042h0sprf",
-	NarPath: filepath.Join("1", "1x", "1xqqdh1yn5sz3d6wcz3qz3azm5mbypwq6mv8g2dal1v042h0sprf.nar.xz"),
+	NarPath: "1xqqdh1yn5sz3d6wcz3qz3azm5mbypwq6mv8g2dal1v042h0sprf.nar.xz",
 	NarText: helper.MustRandString(50308, nil),
 }

--- a/testdata/nar3.go
+++ b/testdata/nar3.go
@@ -1,15 +1,13 @@
 package testdata
 
 import (
-	"path/filepath"
-
 	"github.com/kalbasit/ncps/pkg/helper"
 )
 
 // Nar3 is the nar representing hello from release-24.11.
 var Nar3 = Entry{
 	NarInfoHash: "1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl",
-	NarInfoPath: filepath.Join("1", "1q", "1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl.narinfo"),
+	NarInfoPath: "1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl.narinfo",
 	NarInfoText: `StorePath: /nix/store/1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl-hello-2.12.1
 URL: nar/1dglqjx5wm3sdq0ggngcyh4gpcwykngkxps0a8v4v1f1f2lzdwd1.nar.xz
 Compression: xz
@@ -22,6 +20,6 @@ Deriver: k1rx7pnkdlzfscv6jqzwl4x89kcknfy1-hello-2.12.1.drv
 Sig: cache.nixos.org-1:qt4d4o04/cklIMANVntoLYHh36t1j+y/35qWoK2GeeeEeYU5RElnV/gpXrc5jgx4p2MQ38TasPhHg8rN6O+5Dw==`,
 
 	NarHash: "1dglqjx5wm3sdq0ggngcyh4gpcwykngkxps0a8v4v1f1f2lzdwd1",
-	NarPath: filepath.Join("1", "1d", "1dglqjx5wm3sdq0ggngcyh4gpcwykngkxps0a8v4v1f1f2lzdwd1.nar.xz"),
+	NarPath: "1dglqjx5wm3sdq0ggngcyh4gpcwykngkxps0a8v4v1f1f2lzdwd1.nar.xz",
 	NarText: helper.MustRandString(50364, nil),
 }

--- a/testdata/nar3.go
+++ b/testdata/nar3.go
@@ -1,15 +1,15 @@
 package testdata
 
 import (
+	"path/filepath"
+
 	"github.com/kalbasit/ncps/pkg/helper"
 )
 
 // Nar3 is the nar representing hello from release-24.11.
 var Nar3 = Entry{
 	NarInfoHash: "1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl",
-	NarHash:     "1dglqjx5wm3sdq0ggngcyh4gpcwykngkxps0a8v4v1f1f2lzdwd1",
-	NarText:     helper.MustRandString(50364, nil),
-
+	NarInfoPath: filepath.Join("1", "1q", "1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl.narinfo"),
 	NarInfoText: `StorePath: /nix/store/1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl-hello-2.12.1
 URL: nar/1dglqjx5wm3sdq0ggngcyh4gpcwykngkxps0a8v4v1f1f2lzdwd1.nar.xz
 Compression: xz
@@ -20,4 +20,8 @@ NarSize: 226560
 References: 1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl-hello-2.12.1 wn7v2vhyyyi6clcyn0s9ixvl7d4d87ic-glibc-2.40-36
 Deriver: k1rx7pnkdlzfscv6jqzwl4x89kcknfy1-hello-2.12.1.drv
 Sig: cache.nixos.org-1:qt4d4o04/cklIMANVntoLYHh36t1j+y/35qWoK2GeeeEeYU5RElnV/gpXrc5jgx4p2MQ38TasPhHg8rN6O+5Dw==`,
+
+	NarHash: "1dglqjx5wm3sdq0ggngcyh4gpcwykngkxps0a8v4v1f1f2lzdwd1",
+	NarPath: filepath.Join("1", "1d", "1dglqjx5wm3sdq0ggngcyh4gpcwykngkxps0a8v4v1f1f2lzdwd1.nar.xz"),
+	NarText: helper.MustRandString(50364, nil),
 }

--- a/testdata/type.go
+++ b/testdata/type.go
@@ -2,8 +2,10 @@ package testdata
 
 type Entry struct {
 	NarInfoHash string
+	NarInfoPath string
 	NarInfoText string
 
 	NarHash string
+	NarPath string
 	NarText string
 }


### PR DESCRIPTION
By storing the expected paths in the testdata themselves, it makes the tests cleaner.

ref #63 