### PR TITLE
pkg/cache: move narinfo files inside store/narinfo

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -290,11 +290,11 @@ func (c *Cache) pullNar(log log15.Logger, hash, compression string, doneC chan s
 }
 
 func (c *Cache) getNarPathInStore(hash, compression string) string {
-	return filepath.Join(c.storePath(), "nar", helper.NarFilePath(hash, compression))
+	return filepath.Join(c.storeNarPath(), helper.NarFilePath(hash, compression))
 }
 
 func (c *Cache) getNarInfoPathInStore(hash string) string {
-	return filepath.Join(c.storePath(), "", helper.NarInfoFilePath(hash))
+	return filepath.Join(c.storeNarInfoPath(), helper.NarInfoFilePath(hash))
 }
 
 func (c *Cache) hasNarInStore(log log15.Logger, hash, compression string) bool {
@@ -860,6 +860,7 @@ func (c *Cache) setupDirs() error {
 	allPaths := []string{
 		c.configPath(),
 		c.storePath(),
+		c.storeNarInfoPath(),
 		c.storeNarPath(),
 		c.storeTMPPath(),
 		c.dbDirPath(),
@@ -874,13 +875,14 @@ func (c *Cache) setupDirs() error {
 	return nil
 }
 
-func (c *Cache) configPath() string    { return filepath.Join(c.path, "config") }
-func (c *Cache) secretKeyPath() string { return filepath.Join(c.configPath(), "cache.key") }
-func (c *Cache) storePath() string     { return filepath.Join(c.path, "store") }
-func (c *Cache) storeNarPath() string  { return filepath.Join(c.storePath(), "nar") }
-func (c *Cache) storeTMPPath() string  { return filepath.Join(c.storePath(), "tmp") }
-func (c *Cache) dbDirPath() string     { return filepath.Join(c.path, "var", "ncps", "db") }
-func (c *Cache) dbKeyPath() string     { return filepath.Join(c.dbDirPath(), "db.sqlite") }
+func (c *Cache) configPath() string       { return filepath.Join(c.path, "config") }
+func (c *Cache) secretKeyPath() string    { return filepath.Join(c.configPath(), "cache.key") }
+func (c *Cache) storePath() string        { return filepath.Join(c.path, "store") }
+func (c *Cache) storeNarInfoPath() string { return filepath.Join(c.storePath(), "narinfo") }
+func (c *Cache) storeNarPath() string     { return filepath.Join(c.storePath(), "nar") }
+func (c *Cache) storeTMPPath() string     { return filepath.Join(c.storePath(), "tmp") }
+func (c *Cache) dbDirPath() string        { return filepath.Join(c.path, "var", "ncps", "db") }
+func (c *Cache) dbKeyPath() string        { return filepath.Join(c.dbDirPath(), "db.sqlite") }
 
 func (c *Cache) setupDataBase() error {
 	db, err := database.Open(c.logger, c.dbKeyPath())

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -81,6 +81,7 @@ func TestNew(t *testing.T) {
 			dirs := []string{
 				"config",
 				"store",
+				filepath.Join("store", "narinfo"),
 				filepath.Join("store", "nar"),
 				filepath.Join("store", "tmp"),
 				filepath.Join("var", "ncps", "db"),
@@ -203,7 +204,7 @@ func TestGetNarInfo(t *testing.T) {
 
 	t.Run("narinfo exists upstream", func(t *testing.T) {
 		t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
-			assert.NoFileExists(t, filepath.Join(dir, "store", testdata.Nar2.NarInfoPath))
+			assert.NoFileExists(t, filepath.Join(dir, "store", "narinfo", testdata.Nar2.NarInfoPath))
 		})
 
 		t.Run("nar does not exist in storage yet", func(t *testing.T) {
@@ -256,7 +257,7 @@ func TestGetNarInfo(t *testing.T) {
 		})
 
 		t.Run("it should now exist in the store", func(t *testing.T) {
-			assert.FileExists(t, filepath.Join(dir, "store", testdata.Nar2.NarInfoPath))
+			assert.FileExists(t, filepath.Join(dir, "store", "narinfo", testdata.Nar2.NarInfoPath))
 		})
 
 		t.Run("it should be signed by our server", func(t *testing.T) {
@@ -426,7 +427,7 @@ func TestGetNarInfo(t *testing.T) {
 		})
 
 		t.Run("no error is returned if the entry already exist in the database", func(t *testing.T) {
-			require.NoError(t, os.Remove(filepath.Join(dir, "store", testdata.Nar2.NarInfoPath)))
+			require.NoError(t, os.Remove(filepath.Join(dir, "store", "narinfo", testdata.Nar2.NarInfoPath)))
 
 			_, err := c.GetNarInfo(testdata.Nar2.NarInfoHash)
 			assert.NoError(t, err)
@@ -477,7 +478,7 @@ func TestPutNarInfo(t *testing.T) {
 	db, err := sql.Open("sqlite3", filepath.Join(dir, "var", "ncps", "db", "db.sqlite"))
 	require.NoError(t, err)
 
-	storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoPath)
+	storePath := filepath.Join(dir, "store", "narinfo", testdata.Nar1.NarInfoPath)
 
 	t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 		assert.NoFileExists(t, storePath)
@@ -609,7 +610,7 @@ func TestDeleteNarInfo(t *testing.T) {
 	c.SetRecordAgeIgnoreTouch(0)
 
 	t.Run("file does not exist in the store", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoPath)
+		storePath := filepath.Join(dir, "store", "narinfo", testdata.Nar1.NarInfoPath)
 
 		t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 			assert.NoFileExists(t, storePath)
@@ -622,7 +623,7 @@ func TestDeleteNarInfo(t *testing.T) {
 	})
 
 	t.Run("file does exist in the store", func(t *testing.T) {
-		storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoPath)
+		storePath := filepath.Join(dir, "store", "narinfo", testdata.Nar1.NarInfoPath)
 
 		t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 			assert.NoFileExists(t, storePath)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -95,7 +95,7 @@ func TestServeHTTP(t *testing.T) {
 			defer ts.Close()
 
 			t.Run("narInfo", func(t *testing.T) {
-				storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoPath)
+				storePath := filepath.Join(dir, "store", "narinfo", testdata.Nar1.NarInfoPath)
 
 				t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 					assert.NoFileExists(t, storePath)
@@ -311,7 +311,7 @@ func TestServeHTTP(t *testing.T) {
 			defer ts.Close()
 
 			t.Run("narInfo", func(t *testing.T) {
-				storePath := filepath.Join(dir, "store", testdata.Nar1.NarInfoPath)
+				storePath := filepath.Join(dir, "store", "narinfo", testdata.Nar1.NarInfoPath)
 
 				t.Run("narinfo does not exist in storage yet", func(t *testing.T) {
 					assert.NoFileExists(t, storePath)


### PR DESCRIPTION
This will make the store directory cleaner since narinfo and nar files are now stored within their own sub-directories.

ref #63 