### PR TITLE
fix: Add support for cachix using base16 encoding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.0
 	github.com/klauspost/compress v1.17.11
 	github.com/mattn/go-sqlite3 v1.14.24
-	github.com/nix-community/go-nix v0.0.0-20241220082528-4ad2fe83d684
+	github.com/nix-community/go-nix v0.0.0-20241231094847-b5eacc9958cd
 	github.com/riandyrn/otelchi v0.11.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/zerolog v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/n
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
 github.com/nix-community/go-nix v0.0.0-20241220082528-4ad2fe83d684 h1:r4z1TDM6mf46CnkxOErnWxcDVkTx11vXuAQ2nTaaifA=
 github.com/nix-community/go-nix v0.0.0-20241220082528-4ad2fe83d684/go.mod h1:qgCw4bBKZX8qMgGeEZzGFVT3notl42dBjNqO2jut0M0=
+github.com/nix-community/go-nix v0.0.0-20241231094847-b5eacc9958cd h1:SHwu+Di8uuowbCkuYJeRon3ciXAl5pAme1xItHkIf30=
+github.com/nix-community/go-nix v0.0.0-20241231094847-b5eacc9958cd/go.mod h1:qgCw4bBKZX8qMgGeEZzGFVT3notl42dBjNqO2jut0M0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/nix/packages/ncps.nix
+++ b/nix/packages/ncps.nix
@@ -38,7 +38,7 @@
 
           subPackages = [ "." ];
 
-          vendorHash = "sha256-RUD4vITOHbJeNEN8hSibIs4DGHiyb6gxtYeNfJIxCMc=";
+          vendorHash = "sha256-FM5wvMzmHXue/mU/TurCGw04ZfYZEkFmehYT2T08FVw=";
 
           doCheck = true;
 

--- a/testdata/entries.go
+++ b/testdata/entries.go
@@ -6,4 +6,5 @@ var Entries = []Entry{
 	Nar2,
 	Nar3,
 	Nar4,
+	Nar5,
 }

--- a/testdata/nar5.go
+++ b/testdata/nar5.go
@@ -1,0 +1,30 @@
+package testdata
+
+import (
+	"path/filepath"
+
+	"github.com/kalbasit/ncps/pkg/helper"
+)
+
+// Nar5 is the nar representing a nar from nix-community that was failing to
+// parse because the FileHash is encoded in sha256/base-16.
+//
+//nolint:gochecknoglobals,lll
+var Nar5 = Entry{
+	NarInfoHash: "7k3i624w0rfrvcrbbdrw0zrvasywxmz4",
+	NarInfoPath: filepath.Join("7", "7k", "7k3i624w0rfrvcrbbdrw0zrvasywxmz4.narinfo"),
+	NarInfoText: `StorePath: /nix/store/7k3i624w0rfrvcrbbdrw0zrvasywxmz4-check-link-targets.sh
+URL: nar/abf8c1a50684c2d706c991f0d332dec9eff89eb3a3c17687141ce1ddb795cc38.nar.zst
+Compression: zstd
+FileHash: sha256:abf8c1a50684c2d706c991f0d332dec9eff89eb3a3c17687141ce1ddb795cc38
+FileSize: 1156
+NarHash: sha256:0v4mgmqzp5s7mscgad21nr49svk97y7pq0y49i11k1hii04syj74
+NarSize: 2312
+References: 7m5x92fbfc3zxqmbkhl5fqqydsmdpggb-hm-modules-messages zhrjg6wxrxmdlpn6iapzpp2z2vylpvw5-home-manager.sh
+Deriver: 2w91y8xfpfpamqjzy223i8ivhz4dviwz-check-link-targets.sh.drv
+Sig: nix-community.cachix.org-1:RcmngYq9PZMjZVwQdZK8mUmOjmj964GqM18zWkj/Qpw17ns1CmGnYGCrvbj/Q/+K1jU3HbFH9ABtft+3TUgHAA==`,
+
+	NarHash: "abf8c1a50684c2d706c991f0d332dec9eff89eb3a3c17687141ce1ddb795cc38",
+	NarPath: filepath.Join("a", "ab", "abf8c1a50684c2d706c991f0d332dec9eff89eb3a3c17687141ce1ddb795cc38.nar.xz"),
+	NarText: helper.MustRandString(1156, nil),
+}

--- a/testdata/nars_test.go
+++ b/testdata/nars_test.go
@@ -1,0 +1,23 @@
+package testdata_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nix-community/go-nix/pkg/narinfo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/testdata"
+)
+
+func TestNarsValid(t *testing.T) {
+	t.Parallel()
+
+	for _, nar := range testdata.Entries {
+		ni, err := narinfo.Parse(strings.NewReader(nar.NarInfoText))
+		require.NoError(t, err)
+		require.NoError(t, ni.Check())
+		assert.EqualValues(t, ni.FileSize, len(nar.NarText)) //nolint:testifylint
+	}
+}


### PR DESCRIPTION
### TL;DR

Added support for handling sha256/base-16 encoded FileHash in NAR files

### What changed?

- Added a new test case `Nar5` that includes a FileHash encoded in sha256/base-16 format
- Created a new test file to verify NAR file parsing and validation
- Added `Nar5` to the list of test entries
- Updated go-nix dependency to latest version

### How to test?

Run the new test suite:
```bash
go test ./testdata -v
```

### Why make this change?

Some NAR files from cachix use sha256/base-16 encoding for their FileHash instead of the standard format. This addition ensures proper handling and validation of these differently encoded hashes, improving compatibility with cachix cache entries.