### PR TITLE
Dockerfile: Include dbmate and db migrations in the final image

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,22 @@ spec:
         app: nix-cache
         tier: proxy
     spec:
+      initContainers:
+        - image: kalbasit/ncps:latest # NOTE: It's recommended to use a tag here!
+          name: migrate-database
+          args:
+            - /bin/dbmate
+            - --url=sqlite:/storage/var/ncps/db/db.sqlite
+            - migrate
+            - up
+          volumeMounts:
+            - name: nix-cache-persistent-storage
+              mountPath: /storage
       containers:
         - image: kalbasit/ncps:latest # NOTE: It's recommended to use a tag here!
           name: nix-cache
           args:
-            - /app/ncps
+            - /bin/ncps
             - serve
             - --cache-hostname=nix-cache.yournetwork.local # TODO: Replace with your own hostname
             - --cache-data-path=/storage

--- a/devbox.json
+++ b/devbox.json
@@ -9,8 +9,10 @@
   "shell": {
     "init_hook": [
       "export _GO_VERSION=$(go version | sed -e 's:^go version go\\([0-9.]*\\) .*$:\\1:')",
+      "export _DBMATE_VERSION=$(dbmate --version | sed -e 's:^dbmate version \\([0-9.]*\\)$:\\1:')",
       "sed -e \"s:^\\(go \\)[0-9.]*$:\\1${_GO_VERSION}:\" -i go.mod",
       "sed -e \"s:^\\(ARG GO_VERSION=\\).*$:\\1${_GO_VERSION}:\" -i Dockerfile",
+      "sed -e \"s:^\\(ARG DBMATE_VERSION=\\).*$:\\1${_DBMATE_VERSION}:\" -i Dockerfile",
       "sed -e \"s/\\(go-version: \\).*$/\\1\\\"${_GO_VERSION}\\\"/\" -i .github/workflows/golangci-lint.yml"
     ]
   }


### PR DESCRIPTION
In order to support migrations in a container, we need access to the dbmate application. Include the application in the final Docker image; Also include the db migrations and configure dbmate to find them using an environment variable.