### PR TITLE
pkg/database: Do not auto-create the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ spec:
         tier: proxy
     spec:
       initContainers:
+        - image: alpine:latest
+          name: create-directories
+          args:
+            - /bin/sh
+            - -c
+            - "mkdir -m 0755 -p /storage/var && mkdir -m 0700 -p /storage/var/ncps && mkdir -m 0700 -p /storage/var/ncps/db"
+          volumeMounts:
+            - name: nix-cache-persistent-storage
+              mountPath: /storage
         - image: kalbasit/ncps:latest # NOTE: It's recommended to use a tag here!
           name: migrate-database
           args:

--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
 	"github.com/kalbasit/ncps/pkg/database"
 	"github.com/kalbasit/ncps/testdata"
+	"github.com/kalbasit/ncps/testhelper"
 )
 
 //nolint:gochecknoglobals
@@ -56,9 +58,14 @@ func TestAddUpstreamCaches(t *testing.T) {
 			ucs = append(ucs, uc)
 		}
 
-		cachePath := os.TempDir()
+		dir, err := os.MkdirTemp("", "cache-path-")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir) // clean up
 
-		c, err := New(logger, "cache.example.com", cachePath)
+		dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+		testhelper.CreateMigrateDatabase(t, dbFile)
+
+		c, err := New(logger, "cache.example.com", dir)
 		require.NoError(t, err)
 
 		c.AddUpstreamCaches(ucs...)
@@ -101,9 +108,14 @@ func TestAddUpstreamCaches(t *testing.T) {
 			ucs = append(ucs, uc)
 		}
 
-		cachePath := os.TempDir()
+		dir, err := os.MkdirTemp("", "cache-path-")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir) // clean up
 
-		c, err := New(logger, "cache.example.com", cachePath)
+		dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+		testhelper.CreateMigrateDatabase(t, dbFile)
+
+		c, err := New(logger, "cache.example.com", dir)
 		require.NoError(t, err)
 
 		for _, uc := range ucs {
@@ -124,6 +136,9 @@ func TestRunLRU(t *testing.T) {
 	dir, err := os.MkdirTemp("", "cache-path-")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir) // clean up
+
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
 
 	c, err := New(logger, "cache.example.com", dir)
 	require.NoError(t, err)

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
 	"github.com/kalbasit/ncps/pkg/database"
 	"github.com/kalbasit/ncps/testdata"
+	"github.com/kalbasit/ncps/testhelper"
 
 	// Import the SQLite driver.
 	_ "github.com/mattn/go-sqlite3"
@@ -75,6 +76,9 @@ func TestNew(t *testing.T) {
 			require.NoError(t, err)
 			defer os.RemoveAll(dir) // clean up
 
+			dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+			testhelper.CreateMigrateDatabase(t, dbFile)
+
 			_, err = cache.New(logger, "cache.example.com", dir)
 			require.NoError(t, err)
 
@@ -110,17 +114,6 @@ func TestNew(t *testing.T) {
 			require.NoError(t, err)
 
 			assert.NoFileExists(t, f.Name())
-		})
-
-		t.Run("should create sqlite3 database", func(t *testing.T) {
-			dir, err := os.MkdirTemp("", "cache-path-")
-			require.NoError(t, err)
-			defer os.RemoveAll(dir) // clean up
-
-			_, err = cache.New(logger, "cache.example.com", dir)
-			require.NoError(t, err)
-
-			assert.FileExists(t, filepath.Join(dir, "var", "ncps", "db", "db.sqlite"))
 		})
 	})
 
@@ -188,13 +181,16 @@ func TestGetNarInfo(t *testing.T) {
 	uc, err := upstream.New(logger, tu.Host, testdata.PublicKeys())
 	require.NoError(t, err)
 
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
 	c, err := cache.New(logger, "cache.example.com", dir)
 	require.NoError(t, err)
 
 	c.AddUpstreamCaches(uc)
 	c.SetRecordAgeIgnoreTouch(0)
 
-	db, err := sql.Open("sqlite3", filepath.Join(dir, "var", "ncps", "db", "db.sqlite"))
+	db, err := sql.Open("sqlite3", dbFile)
 	require.NoError(t, err)
 
 	t.Run("narinfo does not exist upstream", func(t *testing.T) {
@@ -470,12 +466,15 @@ func TestPutNarInfo(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir) // clean up
 
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
 	c, err := cache.New(logger, "cache.example.com", dir)
 	require.NoError(t, err)
 
 	c.SetRecordAgeIgnoreTouch(0)
 
-	db, err := sql.Open("sqlite3", filepath.Join(dir, "var", "ncps", "db", "db.sqlite"))
+	db, err := sql.Open("sqlite3", dbFile)
 	require.NoError(t, err)
 
 	storePath := filepath.Join(dir, "store", "narinfo", testdata.Nar1.NarInfoPath)
@@ -604,6 +603,9 @@ func TestDeleteNarInfo(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir) // clean up
 
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
 	c, err := cache.New(logger, "cache.example.com", dir)
 	require.NoError(t, err)
 
@@ -668,13 +670,16 @@ func TestGetNar(t *testing.T) {
 	uc, err := upstream.New(logger, tu.Host, testdata.PublicKeys())
 	require.NoError(t, err)
 
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
 	c, err := cache.New(logger, "cache.example.com", dir)
 	require.NoError(t, err)
 
 	c.AddUpstreamCaches(uc)
 	c.SetRecordAgeIgnoreTouch(0)
 
-	db, err := sql.Open("sqlite3", filepath.Join(dir, "var", "ncps", "db", "db.sqlite"))
+	db, err := sql.Open("sqlite3", dbFile)
 	require.NoError(t, err)
 
 	t.Run("nar does not exist upstream", func(t *testing.T) {
@@ -861,6 +866,9 @@ func TestPutNar(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir) // clean up
 
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
 	c, err := cache.New(logger, "cache.example.com", dir)
 	require.NoError(t, err)
 
@@ -895,6 +903,9 @@ func TestDeleteNar(t *testing.T) {
 	dir, err := os.MkdirTemp("", "cache-path-")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir) // clean up
+
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
 
 	c, err := cache.New(logger, "cache.example.com", dir)
 	require.NoError(t, err)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kalbasit/ncps/pkg/helper"
 	"github.com/kalbasit/ncps/pkg/server"
 	"github.com/kalbasit/ncps/testdata"
+	"github.com/kalbasit/ncps/testhelper"
 )
 
 //nolint:gochecknoglobals
@@ -187,6 +188,9 @@ func TestServeHTTP(t *testing.T) {
 		uc, err := upstream.New(logger, uu.Host, testdata.PublicKeys())
 		require.NoError(t, err)
 
+		dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+		testhelper.CreateMigrateDatabase(t, dbFile)
+
 		c, err := cache.New(logger, "cache.example.com", dir)
 		require.NoError(t, err)
 
@@ -258,6 +262,9 @@ func TestServeHTTP(t *testing.T) {
 		dir, err := os.MkdirTemp("", "cache-path-")
 		require.NoError(t, err)
 		defer os.RemoveAll(dir) // clean up
+
+		dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+		testhelper.CreateMigrateDatabase(t, dbFile)
 
 		c, err := cache.New(logger, "cache.example.com", dir)
 		require.NoError(t, err)

--- a/testhelper/sqlite.go
+++ b/testhelper/sqlite.go
@@ -1,0 +1,44 @@
+package testhelper
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	_, b, _, _ = runtime.Caller(0)
+	basePath   = filepath.Dir(b)
+)
+
+func CreateMigrateDatabase(t *testing.T, dbFile string) {
+	t.Helper()
+
+	require.NoError(t, os.MkdirAll(filepath.Dir(dbFile), 0o700))
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+
+	dbMigrationsDir := filepath.Join(
+		filepath.Dir(filepath.Dir(thisFile)),
+		"db",
+		"migrations",
+	)
+
+	cmd := exec.Command(
+		"dbmate",
+		"--url=sqlite:"+dbFile,
+		"--migrations-dir="+dbMigrationsDir,
+		"migrate",
+		"up",
+	)
+
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "Running %q has failed", cmd.String())
+
+	t.Logf("%s: %s", cmd.String(), output)
+}

--- a/testhelper/sqlite.go
+++ b/testhelper/sqlite.go
@@ -10,11 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	_, b, _, _ = runtime.Caller(0)
-	basePath   = filepath.Dir(b)
-)
-
+// CreateMigrateDatabase will create all necessary directories, and will create
+// the sqlite3 database (if necessary) and migrate it.
 func CreateMigrateDatabase(t *testing.T, dbFile string) {
 	t.Helper()
 
@@ -29,11 +26,11 @@ func CreateMigrateDatabase(t *testing.T, dbFile string) {
 		"migrations",
 	)
 
+	//nolint:gosec
 	cmd := exec.Command(
 		"dbmate",
 		"--url=sqlite:"+dbFile,
 		"--migrations-dir="+dbMigrationsDir,
-		"migrate",
 		"up",
 	)
 


### PR DESCRIPTION
`dbmate` is now in charge of creating and migrating the database, so remove pkg/database's ability of creating the database.