### PR TITLE
cmd/serve: --upstream-public-key should not be required

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -91,10 +91,9 @@ func serveCommand(logger log15.Logger) *cli.Command {
 				Required: true,
 			},
 			&cli.StringSliceFlag{
-				Name:     "upstream-public-key",
-				Usage:    "Set to host:public-key for each upstream cache",
-				Sources:  cli.EnvVars("UPSTREAM_PUBLIC_KEYS"),
-				Required: true,
+				Name:    "upstream-public-key",
+				Usage:   "Set to host:public-key for each upstream cache",
+				Sources: cli.EnvVars("UPSTREAM_PUBLIC_KEYS"),
 			},
 		},
 	}


### PR DESCRIPTION
The `--upstream-public-key` should not be required because, for example, Harmonia does not sign packages by default.