### PR TITLE
pkg/cache/upstream: Fix the cache with no signatures

### DIFF
--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -114,9 +114,11 @@ func (c Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, e
 		return ni, fmt.Errorf("error while checking the narInfo: %w", err)
 	}
 
+	// if len(c.publicKeys) > 0 {
 	if !signature.VerifyFirst(ni.Fingerprint(), ni.Signatures, c.publicKeys) {
 		return ni, ErrSignatureValidationFailed
 	}
+	// }
 
 	return ni, nil
 }

--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -114,11 +114,11 @@ func (c Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, e
 		return ni, fmt.Errorf("error while checking the narInfo: %w", err)
 	}
 
-	// if len(c.publicKeys) > 0 {
-	if !signature.VerifyFirst(ni.Fingerprint(), ni.Signatures, c.publicKeys) {
-		return ni, ErrSignatureValidationFailed
+	if len(c.publicKeys) > 0 {
+		if !signature.VerifyFirst(ni.Fingerprint(), ni.Signatures, c.publicKeys) {
+			return ni, ErrSignatureValidationFailed
+		}
 	}
-	// }
 
 	return ni, nil
 }

--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -83,10 +83,17 @@ func TestNew(t *testing.T) {
 }
 
 func TestGetNarInfo(t *testing.T) {
+	t.Parallel()
+
 	testFn := func(withKeys bool) func(*testing.T) {
 		return func(t *testing.T) {
-			var c upstream.Cache
-			var err error
+			t.Parallel()
+
+			var (
+				c upstream.Cache
+
+				err error
+			)
 
 			if withKeys {
 				c, err = upstream.New(
@@ -168,7 +175,10 @@ func TestGetNarInfo(t *testing.T) {
 		}
 	}
 
+	//nolint:paralleltest
 	t.Run("upstream without public keys", testFn(false))
+
+	//nolint:paralleltest
 	t.Run("upstream with public keys", testFn(true))
 }
 

--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -83,74 +83,93 @@ func TestNew(t *testing.T) {
 }
 
 func TestGetNarInfo(t *testing.T) {
-	c, err := upstream.New(
-		logger,
-		"cache.nixos.org",
-		testdata.PublicKeys(),
-	)
-	require.NoError(t, err)
+	testFn := func(withKeys bool) func(*testing.T) {
+		return func(t *testing.T) {
+			var c upstream.Cache
+			var err error
 
-	t.Run("hash not found", func(t *testing.T) {
-		t.Parallel()
+			if withKeys {
+				c, err = upstream.New(
+					logger,
+					"cache.nixos.org",
+					testdata.PublicKeys(),
+				)
+			} else {
+				c, err = upstream.New(
+					logger,
+					"cache.nixos.org",
+					nil,
+				)
+			}
 
-		_, err := c.GetNarInfo(context.Background(), "abc123")
-		assert.ErrorIs(t, err, upstream.ErrNotFound)
-	})
-
-	t.Run("hash is found", func(t *testing.T) {
-		t.Parallel()
-
-		ni, err := c.GetNarInfo(context.Background(), testdata.Nar1.NarInfoHash)
-		require.NoError(t, err)
-
-		assert.Equal(t, "/nix/store/n5glp21rsz314qssw9fbvfswgy3kc68f-hello-2.12.1", ni.StorePath)
-	})
-
-	t.Run("check has failed", func(t *testing.T) {
-		t.Parallel()
-
-		hash := "broken-" + testdata.Nar1.NarInfoHash
-
-		ts := testdata.HTTPTestServer(t, 40)
-		defer ts.Close()
-
-		tu, err := url.Parse(ts.URL)
-		require.NoError(t, err)
-
-		c, err := upstream.New(
-			logger,
-			tu.Host,
-			testdata.PublicKeys(),
-		)
-		require.NoError(t, err)
-
-		_, err = c.GetNarInfo(context.Background(), hash)
-		assert.ErrorContains(t, err, "error while checking the narInfo: invalid Reference[0]: notfound-path")
-	})
-
-	for _, entry := range testdata.Entries {
-		t.Run("check does not fail", func(t *testing.T) {
-			t.Parallel()
-
-			hash := entry.NarInfoHash
-
-			ts := testdata.HTTPTestServer(t, 40)
-			defer ts.Close()
-
-			tu, err := url.Parse(ts.URL)
 			require.NoError(t, err)
 
-			c, err := upstream.New(
-				logger,
-				tu.Host,
-				testdata.PublicKeys(),
-			)
-			require.NoError(t, err)
+			t.Run("hash not found", func(t *testing.T) {
+				t.Parallel()
 
-			_, err = c.GetNarInfo(context.Background(), hash)
-			assert.NoError(t, err)
-		})
+				_, err := c.GetNarInfo(context.Background(), "abc123")
+				assert.ErrorIs(t, err, upstream.ErrNotFound)
+			})
+
+			t.Run("hash is found", func(t *testing.T) {
+				t.Parallel()
+
+				ni, err := c.GetNarInfo(context.Background(), testdata.Nar1.NarInfoHash)
+				require.NoError(t, err)
+
+				assert.Equal(t, "/nix/store/n5glp21rsz314qssw9fbvfswgy3kc68f-hello-2.12.1", ni.StorePath)
+			})
+
+			t.Run("check has failed", func(t *testing.T) {
+				t.Parallel()
+
+				hash := "broken-" + testdata.Nar1.NarInfoHash
+
+				ts := testdata.HTTPTestServer(t, 40)
+				defer ts.Close()
+
+				tu, err := url.Parse(ts.URL)
+				require.NoError(t, err)
+
+				c, err := upstream.New(
+					logger,
+					tu.Host,
+					testdata.PublicKeys(),
+				)
+				require.NoError(t, err)
+
+				_, err = c.GetNarInfo(context.Background(), hash)
+				assert.ErrorContains(t, err, "error while checking the narInfo: invalid Reference[0]: notfound-path")
+			})
+
+			for _, entry := range testdata.Entries {
+				t.Run("check does not fail", func(t *testing.T) {
+					t.Parallel()
+
+					hash := entry.NarInfoHash
+
+					ts := testdata.HTTPTestServer(t, 40)
+					defer ts.Close()
+
+					tu, err := url.Parse(ts.URL)
+					require.NoError(t, err)
+
+					c, err := upstream.New(
+						logger,
+						tu.Host,
+						testdata.PublicKeys(),
+					)
+					require.NoError(t, err)
+
+					_, err = c.GetNarInfo(context.Background(), hash)
+					assert.NoError(t, err)
+				})
+			}
+		}
 	}
+
+	t.Run("upstream without public keys", testFn(false))
+	t.Run("upstream with public keys", testFn(true))
 }
 
 func TestGetNar(t *testing.T) {


### PR DESCRIPTION
The cache was failing if no public signatures were given; Fix it.