### PR TITLE
GitHub: Update CI job to run nix flake check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,14 @@ name: CI
 on:
   pull_request:
 jobs:
-  go-test:
+  flake-check:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: "write"
+      contents: "read"
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup_devbox
-      - uses: ./.github/actions/setup_go
-      - uses: ./.github/actions/go_test
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - uses: DeterminateSystems/flake-checker-action@main
+      - run: nix flake check


### PR DESCRIPTION
The project is ready to start using `nix flake check`, so start using it on the CI.