### PR TITLE
Direnv: use flake instead of devbox

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,9 +1,1 @@
-#!/bin/bash
-
-# Automatically sets up your devbox environment whenever you cd into this
-# directory via our direnv integration:
-
-eval "$(devbox generate direnv --print-envrc)"
-
-# check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
-# for more details
+use_flake

--- a/.gitignore
+++ b/.gitignore
@@ -21,12 +21,13 @@
 go.work
 go.work.sum
 
-# env file
+# env file used by dbmate
 .env
 
-# Go and Nix build result
+# Go and Nix-related build result
 /ncps
 /result
+/.direnv
 
 # SQLite database
 /db/database.sqlite3


### PR DESCRIPTION
Make use of `nix develop` instead of Devbox.