### PR TITLE
GitHub: Pin runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 jobs:
   flake-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       id-token: "write"
       contents: "read"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/docker

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -5,7 +5,7 @@ on:
       - "v*.*.*"
 jobs:
   flake-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       id-token: "write"
       contents: "read"
@@ -16,7 +16,7 @@ jobs:
       - uses: DeterminateSystems/flake-checker-action@main
       - run: nix flake check
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: flake-check
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: flake-check
     permissions:
       contents: write


### PR DESCRIPTION
`ubuntu-latest` is currently pointing to `ubuntu-22.04` and will soon be pointing to `ubuntu-24.04` (see https://github.com/actions/runner-images/issues/10636). Pin to the latest version now, in a controlled fashion.