### PR TITLE
golangci-lint: remove iretrun

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,6 @@ linters:
     - goimports
     - gosec
     - importas
-    - ireturn
     - lll
     - makezero
     - misspell


### PR DESCRIPTION
### TL;DR
Removed `ireturn` from the golangci-lint configuration

### What changed?
Removed the `ireturn` linter from the enabled linters list in `.golangci.yml`

### How to test?
1. Run `golangci-lint run` to verify the linter executes without the `ireturn` check
2. Verify that interface return checks are no longer enforced

### Why make this change?
The `ireturn` linter is overly restrictive and can force unnecessary concrete type returns when interface returns would be more appropriate for the codebase design. Removing this linter allows for more flexible return types while maintaining other code quality checks.