### PR TITLE
pkg/cache/upstream: Set URL.RawQuery to original query in nar URL

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -752,6 +752,7 @@ func (c *Cache) storeInDatabase(log log15.Logger, hash string, narInfo *narinfo.
 		NarInfoID:   nir.ID,
 		Hash:        narURL.Hash,
 		Compression: narURL.Compression,
+		Query:       narURL.Query.Encode(),
 		FileSize:    narInfo.FileSize,
 	})
 	if err != nil {

--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -126,11 +126,11 @@ func (c Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, e
 // GetNar returns the NAR archive from the cache server.
 // NOTE: It's the caller responsibility to close the body.
 func (c Cache) GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadCloser, error) {
-	log := narURL.NewLogger(c.logger)
+	u := narURL.JoinURL(c.url).String()
 
-	u := c.url.JoinPath(narURL.ToNetURLPath()).String()
+	log := narURL.NewLogger(c.logger.New("nar-url", u))
 
-	log.Info("download the nar from upstream", "nar-url", u)
+	log.Info("download the nar from upstream")
 
 	r, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {

--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -48,7 +48,9 @@ type Cache struct {
 }
 
 func New(logger log15.Logger, u *url.URL, pubKeys []string) (Cache, error) {
-	c := Cache{logger: logger, url: u}
+	c := Cache{url: u}
+
+	c.logger = logger.New("upstream-url", u.String())
 
 	if err := c.validateURL(u); err != nil {
 		return c, err
@@ -126,7 +128,11 @@ func (c Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, e
 func (c Cache) GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadCloser, error) {
 	log := narURL.NewLogger(c.logger)
 
-	r, err := http.NewRequestWithContext(ctx, "GET", narURL.JoinURL(c.url).String(), nil)
+	u := c.url.JoinPath(narURL.ToNetURLPath()).String()
+
+	log.Info("download the nar from upstream", "nar-url", u)
+
+	r, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
 		return 0, nil, fmt.Errorf("error creating a new request: %w", err)
 	}

--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -48,7 +48,13 @@ type Cache struct {
 }
 
 func New(logger log15.Logger, u *url.URL, pubKeys []string) (Cache, error) {
-	c := Cache{url: u}
+	c := Cache{}
+
+	if u == nil {
+		return c, ErrURLRequired
+	}
+
+	c.url = u
 
 	c.logger = logger.New("upstream-url", u.String())
 

--- a/pkg/database/query_test.go
+++ b/pkg/database/query_test.go
@@ -388,6 +388,7 @@ func TestGetNarByHash(t *testing.T) {
 			NarInfoID:   narInfo.ID,
 			Hash:        narHash,
 			Compression: "xz",
+			Query:       "hash=123&key=value",
 			FileSize:    123,
 		})
 		require.NoError(t, err)


### PR DESCRIPTION
Store NAR URL query parameters in database

Adds support for storing and retrieving Nar URL query parameters in the database. This ensures query parameters are preserved when fetching Nars from upstream caches.

Additional improvements include:
- Better logging of upstream Nar URLs
- Validation of required URL in upstream cache
- Enhanced error handling for Nar downloads