### PR TITLE
nix/formatters: exclude files that have no formatter

### DIFF
--- a/nix/formatter/flake-module.nix
+++ b/nix/formatter/flake-module.nix
@@ -7,7 +7,12 @@
       # Used to find the project root
       projectRootFile = ".git/config";
 
-      settings.global.excludes = [ ".envrc" ];
+      settings.global.excludes = [
+        ".env"
+        ".envrc"
+        "LICENSE"
+        "renovate.json"
+      ];
 
       programs = {
         deadnix.enable = true;


### PR DESCRIPTION
Get rid of the following warnings:

```bash
$ nix fmt
[...]
WARN no formatter for path: .env
WARN no formatter for path: LICENSE
WARN no formatter for path: renovate.json
[...]
```