### PR TITLE
treewide: only main/test should call log15.New()

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -184,7 +184,7 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadClose
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	log := narURL.NewLogger(log15.New())
+	log := narURL.NewLogger(c.logger)
 
 	if c.hasNarInStore(log, narURL) {
 		return c.getNarFromStore(ctx, log, narURL)


### PR DESCRIPTION
### TL;DR
Updated the logger initialization in cache operations to use the cache instance's logger instead of creating a new one.

### What changed?
Modified the `GetNar` function to use the cache instance's logger (`c.logger`) rather than instantiating a new logger with `log15.New()`.

### How to test?
1. Execute cache operations that trigger the `GetNar` function
2. Verify that logging output is consistent with the cache instance's logger configuration
3. Confirm that log messages are properly propagated through the existing logger chain

### Why make this change?
Using the cache instance's logger ensures consistent logging configuration across all cache operations and prevents the creation of unnecessary logger instances. This maintains logging context and allows for better log aggregation and filtering based on the parent logger's settings. I was also seeing logs when running tests which should not have been possible.