### PR TITLE
pkg/server: capture and trickle down URL Query

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -269,7 +269,7 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 		hash := chi.URLParam(r, "hash")
 		compression := chi.URLParam(r, "compression")
 
-		nu := nar.URL{Hash: hash, Compression: compression}
+		nu := nar.URL{Hash: hash, Compression: compression, Query: r.URL.Query()}
 
 		log := nu.NewLogger(s.logger)
 
@@ -323,7 +323,7 @@ func (s *Server) putNar(w http.ResponseWriter, r *http.Request) {
 	hash := chi.URLParam(r, "hash")
 	compression := chi.URLParam(r, "compression")
 
-	nu := nar.URL{Hash: hash, Compression: compression}
+	nu := nar.URL{Hash: hash, Compression: compression, Query: r.URL.Query()}
 
 	log := nu.NewLogger(s.logger)
 
@@ -355,7 +355,7 @@ func (s *Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 	hash := chi.URLParam(r, "hash")
 	compression := chi.URLParam(r, "compression")
 
-	nu := nar.URL{Hash: hash, Compression: compression}
+	nu := nar.URL{Hash: hash, Compression: compression, Query: r.URL.Query()}
 
 	log := nu.NewLogger(s.logger)
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -237,6 +237,33 @@ func TestServeHTTP(t *testing.T) {
 					assert.Equal(t, testdata.Nar1.NarText, string(body))
 				}
 			})
+
+			t.Run("nar exists upstream with query", func(t *testing.T) {
+				u, err := url.Parse("http://example.com")
+				require.NoError(t, err)
+
+				q, err := url.ParseQuery("fakesize=123")
+				require.NoError(t, err)
+
+				nu := nar.URL{Hash: testdata.Nar2.NarHash, Compression: "xz", Query: q}
+
+				r := httptest.NewRequest("GET", nu.JoinURL(u).String(), nil)
+				w := httptest.NewRecorder()
+
+				s.ServeHTTP(w, r)
+
+				assert.Equal(t, http.StatusOK, w.Code)
+
+				resp := w.Result()
+				defer resp.Body.Close()
+
+				body, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+
+				if assert.Len(t, string(body), 123) {
+					assert.Equal(t, strings.Repeat("a", 123), string(body))
+				}
+			})
 		})
 	})
 

--- a/testdata/server.go
+++ b/testdata/server.go
@@ -54,6 +54,19 @@ func HTTPTestServer(t *testing.T, priority int) *httptest.Server {
 			}
 
 			if len(bs) > 0 {
+				if s := r.URL.Query().Get("fakesize"); s != "" {
+					size, err := strconv.Atoi(s)
+					if !requireNoError(w, err) {
+						return
+					}
+
+					w.Header().Add("Content-Length", s)
+					_, err = w.Write([]byte(strings.Repeat("a", size)))
+					requireNoError(w, err)
+
+					return
+				}
+
 				w.Header().Add("Content-Length", strconv.Itoa(len(bs)))
 
 				_, err := w.Write(bs)


### PR DESCRIPTION
# Add support for query parameters in NAR URLs

Adds support for query parameters in NAR URLs by:

1. Adding a test case that verifies query parameters are properly handled when requesting NARs
2. Extending the `nar.URL` struct to include query parameters from requests
3. Updating NAR handlers to pass query parameters through to upstream servers

This allows clients to pass additional parameters when requesting NARs, which can be useful for features like content negotiation or custom behavior flags.