### PR TITLE
pkg/nar: offer String() function

### DIFF
--- a/pkg/nar/url.go
+++ b/pkg/nar/url.go
@@ -59,6 +59,17 @@ func (u URL) NewLogger(log log15.Logger) log15.Logger {
 	)
 }
 
+// String returns the URL as a string.
+func (u URL) String() string {
+	p := u.pathWithCompression()
+
+	if q := u.Query.Encode(); q != "" {
+		p += "?" + q
+	}
+
+	return p
+}
+
 // ToFilePath returns the filepath in the store for a given nar URL.
 func (u URL) ToFilePath() string {
 	// TODO: bring it out of the helper
@@ -67,13 +78,7 @@ func (u URL) ToFilePath() string {
 
 // JoinURL returns a new URL combined with the given URL.
 func (u URL) JoinURL(uri *url.URL) *url.URL {
-	p := "/nar/" + u.Hash + ".nar"
-
-	if u.Compression != "" {
-		p += "." + u.Compression
-	}
-
-	uri = uri.JoinPath(p)
+	uri = uri.JoinPath("/" + u.pathWithCompression())
 
 	if q := u.Query.Encode(); q != "" {
 		if uri.RawQuery != "" {
@@ -84,4 +89,14 @@ func (u URL) JoinURL(uri *url.URL) *url.URL {
 	}
 
 	return uri
+}
+
+func (u URL) pathWithCompression() string {
+	p := "nar/" + u.Hash + ".nar"
+
+	if u.Compression != "" {
+		p += "." + u.Compression
+	}
+
+	return p
 }

--- a/pkg/nar/url.go
+++ b/pkg/nar/url.go
@@ -59,6 +59,21 @@ func (u URL) NewLogger(log log15.Logger) log15.Logger {
 	)
 }
 
+// JoinURL returns a new URL combined with the given URL.
+func (u URL) JoinURL(uri *url.URL) *url.URL {
+	uri = uri.JoinPath("/" + u.pathWithCompression())
+
+	if q := u.Query.Encode(); q != "" {
+		if uri.RawQuery != "" {
+			uri.RawQuery += "&"
+		}
+
+		uri.RawQuery += q
+	}
+
+	return uri
+}
+
 // String returns the URL as a string.
 func (u URL) String() string {
 	p := u.pathWithCompression()
@@ -74,21 +89,6 @@ func (u URL) String() string {
 func (u URL) ToFilePath() string {
 	// TODO: bring it out of the helper
 	return helper.NarFilePath(u.Hash, u.Compression)
-}
-
-// JoinURL returns a new URL combined with the given URL.
-func (u URL) JoinURL(uri *url.URL) *url.URL {
-	uri = uri.JoinPath("/" + u.pathWithCompression())
-
-	if q := u.Query.Encode(); q != "" {
-		if uri.RawQuery != "" {
-			uri.RawQuery += "&"
-		}
-
-		uri.RawQuery += q
-	}
-
-	return uri
 }
 
 func (u URL) pathWithCompression() string {

--- a/pkg/nar/url_test.go
+++ b/pkg/nar/url_test.go
@@ -82,10 +82,13 @@ func TestJoinURL(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
+		// params
 		hash        string
 		compression string
-		url         string
 		query       string
+
+		// result
+		url string
 	}{
 		{hash: "", compression: "", url: "http://example.com/nar/.nar"}, // not really valid but it is what it is
 		{hash: "abc123", compression: "", url: "http://example.com/nar/abc123.nar"},
@@ -113,6 +116,45 @@ func TestJoinURL(t *testing.T) {
 			}
 
 			assert.Equal(t, test.url, nu.JoinURL(u).String())
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		// params
+		hash        string
+		compression string
+		query       string
+
+		// result
+		string string
+	}{
+		{hash: "", compression: "", string: "nar/.nar"}, // not really valid but it is what it is
+		{hash: "abc123", compression: "", string: "nar/abc123.nar"},
+		{hash: "def456", compression: "xz", string: "nar/def456.nar.xz"},
+
+		{hash: "abc123", compression: "", query: "hash=123", string: "nar/abc123.nar?hash=123"},
+		{hash: "def456", compression: "xz", query: "hash=123", string: "nar/def456.nar.xz?hash=123"},
+	}
+
+	for _, test := range tests {
+		tname := fmt.Sprintf("URL(%q, %q, %q).String() -> %q", test.hash, test.compression, test.query, test.string)
+		t.Run(tname, func(t *testing.T) {
+			t.Parallel()
+
+			q, err := url.ParseQuery(test.query)
+			require.NoError(t, err)
+
+			nu := nar.URL{
+				Hash:        test.hash,
+				Compression: test.compression,
+				Query:       q,
+			}
+
+			assert.Equal(t, test.string, nu.String())
 		})
 	}
 }


### PR DESCRIPTION
pkg/nar: add String() function for URL type

Adds a String() method to the URL type to generate a string representation of NAR URLs. Refactors common path generation logic into a private pathWithCompression() helper function used by both String() and JoinURL().

Includes comprehensive test coverage for the new String() method.