### PR TITLE
pkg/cache/upstream: GetNar should return http.Response

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -372,6 +372,7 @@ func (c *Cache) getNarFromUpstream(log log15.Logger, narURL nar.URL) (*http.Resp
 	return nil, ErrNotFound
 }
 
+//nolint:unparam
 func (c *Cache) putNarInStore(_ log15.Logger, narURL nar.URL, r io.ReadCloser) (int64, error) {
 	pattern := narURL.Hash + "-*.nar"
 	if narURL.Compression != "" {

--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -191,6 +191,6 @@ func TestGetNar(t *testing.T) {
 			resp.Body.Close()
 		}()
 
-		assert.EqualValues(t, 50160, resp.Header.Get("Content-Length"))
+		assert.Equal(t, "50160", resp.Header.Get("Content-Length"))
 	})
 }

--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -175,22 +175,22 @@ func TestGetNar(t *testing.T) {
 	//nolint:paralleltest
 	t.Run("not found", func(t *testing.T) {
 		nu := nar.URL{Hash: "abc123", Compression: "xz"}
-		_, _, err := c.GetNar(context.Background(), nu)
+		_, err := c.GetNar(context.Background(), nu)
 		assert.ErrorIs(t, err, upstream.ErrNotFound)
 	})
 
 	//nolint:paralleltest
 	t.Run("hash is found", func(t *testing.T) {
 		nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: "xz"}
-		cl, body, err := c.GetNar(context.Background(), nu)
+		resp, err := c.GetNar(context.Background(), nu)
 		require.NoError(t, err)
 
 		defer func() {
 			//nolint:errcheck
-			io.Copy(io.Discard, body)
-			body.Close()
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
 		}()
 
-		assert.EqualValues(t, 50160, cl)
+		assert.EqualValues(t, 50160, resp.Header.Get("Content-Length"))
 	})
 }


### PR DESCRIPTION
### TL;DR
Improved NAR download handling by returning the full HTTP response instead of separate content length and body.

### What changed?
- Modified `getNarFromUpstream` to return the complete HTTP response instead of splitting content length and body
- Removed content length validation in the cache pull process
- Updated the response handling to properly clean up resources using deferred functions
- Simplified error handling and response processing in upstream cache operations

### How to test?
1. Download a NAR file from an upstream cache
2. Verify the download completes successfully
3. Confirm proper cleanup of resources after download
4. Test error scenarios (not found, unexpected status codes)

### Why make this change?
The previous implementation separately handled content length and body, which was unnecessary since this information is already available in the HTTP response. This change simplifies the code, reduces potential errors in content length parsing, and ensures better resource cleanup through proper response handling.