### PR TITLE
pkg/upstream/cache: GetNar accept request mutators

### DIFF
--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -130,7 +130,7 @@ func (c Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, e
 
 // GetNar returns the NAR archive from the cache server.
 // NOTE: It's the caller responsibility to close the body.
-func (c Cache) GetNar(ctx context.Context, narURL nar.URL) (*http.Response, error) {
+func (c Cache) GetNar(ctx context.Context, narURL nar.URL, mutators ...func(*http.Request)) (*http.Response, error) {
 	u := narURL.JoinURL(c.url).String()
 
 	log := narURL.NewLogger(c.logger.New("nar-url", u))
@@ -140,6 +140,10 @@ func (c Cache) GetNar(ctx context.Context, narURL nar.URL) (*http.Response, erro
 	r, err := http.NewRequestWithContext(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating a new request: %w", err)
+	}
+
+	for _, mutator := range mutators {
+		mutator(r)
 	}
 
 	resp, err := http.DefaultClient.Do(r)

--- a/testdata/server.go
+++ b/testdata/server.go
@@ -29,6 +29,10 @@ func HTTPTestServer(t *testing.T, priority int) *httptest.Server {
 	t.Helper()
 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if p := r.Header.Get("ping"); p != "" {
+			w.Header().Add("pong", p)
+		}
+
 		if r.URL.Path == "/nix-cache-info" {
 			_, err := w.Write([]byte(NixStoreInfo(priority)))
 			requireNoError(w, err)


### PR DESCRIPTION
Add mutators concept to GetNar

Adds the ability to mutate HTTP requests before they are sent to the upstream cache server by introducing optional request mutator functions to `GetNar`. Includes a test demonstrating the functionality using a ping/pong header exchange.