### PR TITLE
pkg/nar: Add proprer compressionType handling

### DIFF
--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -170,7 +170,7 @@ func TestRunLRU(t *testing.T) {
 		_, err := c.GetNarInfo(context.Background(), narEntry.NarInfoHash)
 		require.NoErrorf(t, err, "unable to get narinfo for idx %d", i)
 
-		nu := nar.URL{Hash: narEntry.NarHash, Compression: "xz"}
+		nu := nar.URL{Hash: narEntry.NarHash, Compression: nar.CompressionTypeXz}
 		size, _, err := c.GetNar(context.Background(), nu)
 		require.NoError(t, err, "unable to get nar for idx %d", i)
 
@@ -183,7 +183,7 @@ func TestRunLRU(t *testing.T) {
 	assert.Equal(t, expectedSize, sizePulled, "size pulled is less than maxSize by exactly the last one")
 
 	for _, narEntry := range allEntries {
-		nu := nar.URL{Hash: narEntry.NarHash, Compression: "xz"}
+		nu := nar.URL{Hash: narEntry.NarHash, Compression: nar.CompressionTypeXz}
 		assert.True(t, c.hasNarInStore(logger, nu), "confirm all nars are in the store")
 	}
 
@@ -197,7 +197,7 @@ func TestRunLRU(t *testing.T) {
 		_, err := c.GetNarInfo(context.Background(), narEntry.NarInfoHash)
 		require.NoError(t, err)
 
-		nu := nar.URL{Hash: narEntry.NarHash, Compression: "xz"}
+		nu := nar.URL{Hash: narEntry.NarHash, Compression: nar.CompressionTypeXz}
 		size, _, err := c.GetNar(context.Background(), nu)
 		require.NoError(t, err)
 
@@ -230,11 +230,11 @@ func TestRunLRU(t *testing.T) {
 
 	// confirm all nars except the last one are in the store
 	for _, narEntry := range entries {
-		nu := nar.URL{Hash: narEntry.NarHash, Compression: "xz"}
+		nu := nar.URL{Hash: narEntry.NarHash, Compression: nar.CompressionTypeXz}
 		assert.True(t, c.hasNarInStore(logger, nu))
 	}
 
-	nu := nar.URL{Hash: lastEntry.NarHash, Compression: "xz"}
+	nu := nar.URL{Hash: lastEntry.NarHash, Compression: nar.CompressionTypeXz}
 	assert.False(t, c.hasNarInStore(logger, nu))
 
 	// all narinfo records except the last one are in the database

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -683,7 +683,7 @@ func TestGetNar(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("nar does not exist upstream", func(t *testing.T) {
-		nu := nar.URL{Hash: "doesnotexist", Compression: "xz"}
+		nu := nar.URL{Hash: "doesnotexist", Compression: nar.CompressionTypeXz}
 		_, _, err := c.GetNar(context.Background(), nu)
 		assert.ErrorIs(t, err, cache.ErrNotFound)
 	})
@@ -717,7 +717,7 @@ func TestGetNar(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
-		nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: "xz"}
+		nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
 		size, r, err := c.GetNar(context.Background(), nu)
 		require.NoError(t, err)
 
@@ -785,7 +785,7 @@ func TestGetNar(t *testing.T) {
 				c.SetRecordAgeIgnoreTouch(0)
 			}()
 
-			nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: "xz"}
+			nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
 
 			_, r, err := c.GetNar(context.Background(), nu)
 			require.NoError(t, err)
@@ -826,7 +826,7 @@ func TestGetNar(t *testing.T) {
 		t.Run("pulling it another time should update last_accessed_at", func(t *testing.T) {
 			time.Sleep(time.Second)
 
-			nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: "xz"}
+			nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
 
 			_, r, err := c.GetNar(context.Background(), nu)
 			require.NoError(t, err)
@@ -889,7 +889,7 @@ func TestPutNar(t *testing.T) {
 	t.Run("putNar does not return an error", func(t *testing.T) {
 		r := io.NopCloser(strings.NewReader(testdata.Nar1.NarText))
 
-		nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: "xz"}
+		nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
 		err := c.PutNar(context.Background(), nu, r)
 		assert.NoError(t, err)
 	})
@@ -927,7 +927,7 @@ func TestDeleteNar(t *testing.T) {
 		})
 
 		t.Run("DeleteNar does return an error", func(t *testing.T) {
-			nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: "xz"}
+			nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
 			err := c.DeleteNar(context.Background(), nu)
 			assert.ErrorIs(t, err, cache.ErrNotFound)
 		})
@@ -953,7 +953,7 @@ func TestDeleteNar(t *testing.T) {
 		})
 
 		t.Run("deleteNar does not return an error", func(t *testing.T) {
-			nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: "xz"}
+			nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
 			err := c.DeleteNar(context.Background(), nu)
 			assert.NoError(t, err)
 		})

--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -176,14 +176,14 @@ func TestGetNar(t *testing.T) {
 
 	//nolint:paralleltest
 	t.Run("not found", func(t *testing.T) {
-		nu := nar.URL{Hash: "abc123", Compression: "xz"}
+		nu := nar.URL{Hash: "abc123", Compression: nar.CompressionTypeXz}
 		_, err := c.GetNar(context.Background(), nu)
 		assert.ErrorIs(t, err, upstream.ErrNotFound)
 	})
 
 	//nolint:paralleltest
 	t.Run("hash is found", func(t *testing.T) {
-		nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: "xz"}
+		nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
 		resp, err := c.GetNar(context.Background(), nu)
 		require.NoError(t, err)
 
@@ -216,7 +216,7 @@ func TestGetNarCanMutate(t *testing.T) {
 		r.Header.Set("ping", pingV)
 	}
 
-	nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: "xz"}
+	nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
 	resp, err := c.GetNar(context.Background(), nu, mutator)
 	require.NoError(t, err)
 

--- a/pkg/database/query_test.go
+++ b/pkg/database/query_test.go
@@ -388,7 +388,7 @@ func TestGetNarByHash(t *testing.T) {
 		ni1, err := db.CreateNar(context.Background(), database.CreateNarParams{
 			NarInfoID:   narInfo.ID,
 			Hash:        narHash,
-			Compression: "xz",
+			Compression: nar.CompressionTypeXz.String(),
 			Query:       "hash=123&key=value",
 			FileSize:    123,
 		})
@@ -765,17 +765,17 @@ func TestNarTotalSize(t *testing.T) {
 	require.NoError(t, err)
 
 	var expectedSize uint64
-	for _, nar := range testdata.Entries {
-		expectedSize += uint64(len(nar.NarText))
+	for _, narEntry := range testdata.Entries {
+		expectedSize += uint64(len(narEntry.NarText))
 
-		narInfo, err := db.CreateNarInfo(context.Background(), nar.NarInfoHash)
+		narInfo, err := db.CreateNarInfo(context.Background(), narEntry.NarInfoHash)
 		require.NoError(t, err)
 
 		_, err = db.CreateNar(context.Background(), database.CreateNarParams{
 			NarInfoID:   narInfo.ID,
-			Hash:        nar.NarHash,
-			Compression: "xz",
-			FileSize:    uint64(len(nar.NarText)),
+			Hash:        narEntry.NarHash,
+			Compression: nar.CompressionTypeXz.String(),
+			FileSize:    uint64(len(narEntry.NarText)),
 		})
 		require.NoError(t, err)
 	}
@@ -802,25 +802,25 @@ func TestGetLeastAccessedNars(t *testing.T) {
 	require.NoError(t, err)
 
 	var totalSize uint64
-	for _, nar := range testdata.Entries {
-		totalSize += uint64(len(nar.NarText))
+	for _, narEntry := range testdata.Entries {
+		totalSize += uint64(len(narEntry.NarText))
 
-		narInfo, err := db.CreateNarInfo(context.Background(), nar.NarInfoHash)
+		narInfo, err := db.CreateNarInfo(context.Background(), narEntry.NarInfoHash)
 		require.NoError(t, err)
 
 		_, err = db.CreateNar(context.Background(), database.CreateNarParams{
 			NarInfoID:   narInfo.ID,
-			Hash:        nar.NarHash,
-			Compression: "xz",
-			FileSize:    uint64(len(nar.NarText)),
+			Hash:        narEntry.NarHash,
+			Compression: nar.CompressionTypeXz.String(),
+			FileSize:    uint64(len(narEntry.NarText)),
 		})
 		require.NoError(t, err)
 	}
 
 	time.Sleep(time.Second)
 
-	for _, nar := range testdata.Entries[:len(testdata.Entries)-1] {
-		_, err := db.TouchNar(context.Background(), nar.NarHash)
+	for _, narEntry := range testdata.Entries[:len(testdata.Entries)-1] {
+		_, err := db.TouchNar(context.Background(), narEntry.NarHash)
 		require.NoError(t, err)
 	}
 

--- a/pkg/database/query_test.go
+++ b/pkg/database/query_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/kalbasit/ncps/pkg/database"
 	"github.com/kalbasit/ncps/pkg/helper"
+	"github.com/kalbasit/ncps/pkg/nar"
 	"github.com/kalbasit/ncps/testdata"
 	"github.com/kalbasit/ncps/testhelper"
 )
@@ -422,7 +423,17 @@ func TestInsertNar(t *testing.T) {
 	narInfo, err := db.CreateNarInfo(context.Background(), hash)
 	require.NoError(t, err)
 
-	for _, compression := range []string{"", "xz", "tar.gz"} {
+	allCompressions := []nar.CompressionType{
+		nar.CompressionTypeNoCompression,
+		nar.CompressionTypeBzip2,
+		nar.CompressionTypeZstd,
+		nar.CompressionTypeLzip,
+		nar.CompressionTypeLz4,
+		nar.CompressionTypeBr,
+		nar.CompressionTypeXz,
+	}
+
+	for _, compression := range allCompressions {
 		t.Run(fmt.Sprintf("compression=%q", compression), func(t *testing.T) {
 			_, err := db.DB().Exec("DELETE FROM nars")
 			require.NoError(t, err)
@@ -434,7 +445,7 @@ func TestInsertNar(t *testing.T) {
 				nar, err := db.CreateNar(context.Background(), database.CreateNarParams{
 					NarInfoID:   narInfo.ID,
 					Hash:        hash,
-					Compression: compression,
+					Compression: compression.String(),
 					FileSize:    123,
 				})
 				require.NoError(t, err)
@@ -475,7 +486,7 @@ func TestInsertNar(t *testing.T) {
 					assert.Equal(t, nar.ID, nims[0].ID)
 					assert.Equal(t, narInfo.ID, nims[0].NarInfoID)
 					assert.Equal(t, hash, nims[0].Hash)
-					assert.Equal(t, compression, nims[0].Compression)
+					assert.Equal(t, compression.String(), nims[0].Compression)
 					assert.EqualValues(t, 123, nims[0].FileSize)
 					assert.Less(t, time.Since(nims[0].CreatedAt), 3*time.Second)
 					assert.False(t, nims[0].UpdatedAt.Valid)

--- a/pkg/database/query_test.go
+++ b/pkg/database/query_test.go
@@ -424,7 +424,7 @@ func TestInsertNar(t *testing.T) {
 	require.NoError(t, err)
 
 	allCompressions := []nar.CompressionType{
-		nar.CompressionTypeNoCompression,
+		nar.CompressionTypeNone,
 		nar.CompressionTypeBzip2,
 		nar.CompressionTypeZstd,
 		nar.CompressionTypeLzip,

--- a/pkg/nar/compression_type.go
+++ b/pkg/nar/compression_type.go
@@ -13,20 +13,22 @@ var ErrUnknownFileExtension = errors.New("file extension is not known")
 type CompressionType string
 
 const (
-	CompressionTypeNoCompression CompressionType = ""
-	CompressionTypeBzip2         CompressionType = "bzip2"
-	CompressionTypeZstd          CompressionType = "zstd"
-	CompressionTypeLzip          CompressionType = "lzip"
-	CompressionTypeLz4           CompressionType = "lz4"
-	CompressionTypeBr            CompressionType = "br"
-	CompressionTypeXz            CompressionType = "xz"
+	CompressionTypeNone  CompressionType = "none"
+	CompressionTypeBzip2 CompressionType = "bzip2"
+	CompressionTypeZstd  CompressionType = "zstd"
+	CompressionTypeLzip  CompressionType = "lzip"
+	CompressionTypeLz4   CompressionType = "lz4"
+	CompressionTypeBr    CompressionType = "br"
+	CompressionTypeXz    CompressionType = "xz"
 )
 
 // CompressionTypeFromExtension returns the compression type given an extension.
 func CompressionTypeFromExtension(ext string) (CompressionType, error) {
 	switch ext {
 	case "":
-		return CompressionTypeNoCompression, nil
+		fallthrough
+	case "none":
+		return CompressionTypeNone, nil
 	case "bz2":
 		return CompressionTypeBzip2, nil
 	case "zst":
@@ -47,7 +49,7 @@ func CompressionTypeFromExtension(ext string) (CompressionType, error) {
 // ToFileExtension returns the file extensions associated with the compression type.
 func (ct CompressionType) ToFileExtension() string {
 	switch ct {
-	case CompressionTypeNoCompression:
+	case CompressionTypeNone:
 		return ""
 	case CompressionTypeBzip2:
 		return "bz2"

--- a/pkg/nar/compression_type.go
+++ b/pkg/nar/compression_type.go
@@ -1,0 +1,73 @@
+package nar
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrUnknownFileExtension is returned if the file extension is not known.
+var ErrUnknownFileExtension = errors.New("file extension is not known")
+
+// CompressionType represents the compression types supported by Nix. See:
+// https://github.com/NixOS/nix/blob/f1187cb696584739884687d788a6fbb4dd36c61c/src/libstore/binary-cache-store.cc#L166
+type CompressionType string
+
+const (
+	CompressionTypeNoCompression CompressionType = ""
+	CompressionTypeBzip2         CompressionType = "bzip2"
+	CompressionTypeZstd          CompressionType = "zstd"
+	CompressionTypeLzip          CompressionType = "lzip"
+	CompressionTypeLz4           CompressionType = "lz4"
+	CompressionTypeBr            CompressionType = "br"
+	CompressionTypeXz            CompressionType = "xz"
+)
+
+// CompressionTypeFromExtension returns the compression type given an extension.
+func CompressionTypeFromExtension(ext string) (CompressionType, error) {
+	switch ext {
+	case "":
+		return CompressionTypeNoCompression, nil
+	case "bz2":
+		return CompressionTypeBzip2, nil
+	case "zst":
+		return CompressionTypeZstd, nil
+	case "lzip":
+		return CompressionTypeLzip, nil
+	case "lz4":
+		return CompressionTypeLz4, nil
+	case "br":
+		return CompressionTypeBr, nil
+	case "xz":
+		return CompressionTypeXz, nil
+	default:
+		return CompressionType(""), ErrUnknownFileExtension
+	}
+}
+
+// ToFileExtension returns the file extensions associated with the compression type.
+func (ct CompressionType) ToFileExtension() string {
+	switch ct {
+	case CompressionTypeNoCompression:
+		return ""
+	case CompressionTypeBzip2:
+		return "bz2"
+	case CompressionTypeZstd:
+		return "zst"
+	case CompressionTypeLzip:
+		return "lzip"
+	case CompressionTypeLz4:
+		return "lz4"
+	case CompressionTypeBr:
+		return "br"
+	case CompressionTypeXz:
+		return "xz"
+	default:
+		panic(fmt.Sprintf("The compression type %s is not known", ct))
+	}
+}
+
+// CompressionTypeFromString returns the string compression type as CompressionType.
+func CompressionTypeFromString(ct string) CompressionType { return CompressionType(ct) }
+
+// String returns the CompressionType as a string.
+func (ct CompressionType) String() string { return string(ct) }

--- a/pkg/nar/url.go
+++ b/pkg/nar/url.go
@@ -2,6 +2,7 @@ package nar
 
 import (
 	"errors"
+	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
@@ -22,7 +23,7 @@ var (
 // URL represents a nar URL.
 type URL struct {
 	Hash        string
-	Compression string
+	Compression CompressionType
 	Query       url.Values
 }
 
@@ -41,16 +42,14 @@ func ParseURL(u string) (URL, error) {
 
 	nu.Hash = sm[1]
 
-	switch sm[3] {
-	case "zst":
-		nu.Compression = "zstd"
-	default:
-		nu.Compression = sm[3]
+	var err error
+
+	if nu.Compression, err = CompressionTypeFromExtension(sm[3]); err != nil {
+		return nu, fmt.Errorf("error computing the compression type: %w", err)
 	}
 
-	var err error
 	if nu.Query, err = url.ParseQuery(sm[5]); err != nil {
-		return nu, err
+		return nu, fmt.Errorf("error parsing the RawQuery as url.Values: %w", err)
 	}
 
 	return nu, nil
@@ -94,19 +93,14 @@ func (u URL) String() string {
 // ToFilePath returns the filepath in the store for a given nar URL.
 func (u URL) ToFilePath() string {
 	// TODO: bring it out of the helper
-	return helper.NarFilePath(u.Hash, u.Compression)
+	return helper.NarFilePath(u.Hash, u.Compression.ToFileExtension())
 }
 
 func (u URL) pathWithCompression() string {
 	p := "nar/" + u.Hash + ".nar"
 
-	if u.Compression != "" {
-		switch u.Compression {
-		case "zstd":
-			p += ".zst"
-		default:
-			p += "." + u.Compression
-		}
+	if e := u.Compression.ToFileExtension(); e != "" {
+		p += "." + e
 	}
 
 	return p

--- a/pkg/nar/url.go
+++ b/pkg/nar/url.go
@@ -40,7 +40,13 @@ func ParseURL(u string) (URL, error) {
 	}
 
 	nu.Hash = sm[1]
-	nu.Compression = sm[3]
+
+	switch sm[3] {
+	case "zst":
+		nu.Compression = "zstd"
+	default:
+		nu.Compression = sm[3]
+	}
 
 	var err error
 	if nu.Query, err = url.ParseQuery(sm[5]); err != nil {
@@ -95,7 +101,12 @@ func (u URL) pathWithCompression() string {
 	p := "nar/" + u.Hash + ".nar"
 
 	if u.Compression != "" {
-		p += "." + u.Compression
+		switch u.Compression {
+		case "zstd":
+			p += ".zst"
+		default:
+			p += "." + u.Compression
+		}
 	}
 
 	return p

--- a/pkg/nar/url_test.go
+++ b/pkg/nar/url_test.go
@@ -29,16 +29,16 @@ func TestParseURL(t *testing.T) {
 			url: "nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar",
 			narURL: nar.URL{
 				Hash:        "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
-				Compression: "",
+				Compression: nar.CompressionTypeNoCompression,
 				Query:       url.Values{},
 			},
 			err: nil,
 		},
 		{
-			url: "nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.xz",
+			url: "nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.bz2",
 			narURL: nar.URL{
 				Hash:        "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
-				Compression: "xz",
+				Compression: nar.CompressionTypeBzip2,
 				Query:       url.Values{},
 			},
 			err: nil,
@@ -47,7 +47,43 @@ func TestParseURL(t *testing.T) {
 			url: "nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.zst",
 			narURL: nar.URL{
 				Hash:        "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
-				Compression: "zstd",
+				Compression: nar.CompressionTypeZstd,
+				Query:       url.Values{},
+			},
+			err: nil,
+		},
+		{
+			url: "nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.lzip",
+			narURL: nar.URL{
+				Hash:        "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+				Compression: nar.CompressionTypeLzip,
+				Query:       url.Values{},
+			},
+			err: nil,
+		},
+		{
+			url: "nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.lz4",
+			narURL: nar.URL{
+				Hash:        "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+				Compression: nar.CompressionTypeLz4,
+				Query:       url.Values{},
+			},
+			err: nil,
+		},
+		{
+			url: "nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.br",
+			narURL: nar.URL{
+				Hash:        "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+				Compression: nar.CompressionTypeBr,
+				Query:       url.Values{},
+			},
+			err: nil,
+		},
+		{
+			url: "nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.xz",
+			narURL: nar.URL{
+				Hash:        "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+				Compression: nar.CompressionTypeXz,
 				Query:       url.Values{},
 			},
 			err: nil,
@@ -56,16 +92,7 @@ func TestParseURL(t *testing.T) {
 			url: "nar/1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac.nar?hash=1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl",
 			narURL: nar.URL{
 				Hash:        "1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac",
-				Compression: "",
-				Query:       url.Values(map[string][]string{"hash": {"1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl"}}),
-			},
-			err: nil,
-		},
-		{
-			url: "nar/1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac.nar.xz?hash=1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl",
-			narURL: nar.URL{
-				Hash:        "1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac",
-				Compression: "xz",
+				Compression: nar.CompressionTypeNoCompression,
 				Query:       url.Values(map[string][]string{"hash": {"1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl"}}),
 			},
 			err: nil,
@@ -74,7 +101,16 @@ func TestParseURL(t *testing.T) {
 			url: "nar/1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac.nar.zst?hash=1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl",
 			narURL: nar.URL{
 				Hash:        "1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac",
-				Compression: "zstd",
+				Compression: nar.CompressionTypeZstd,
+				Query:       url.Values(map[string][]string{"hash": {"1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl"}}),
+			},
+			err: nil,
+		},
+		{
+			url: "nar/1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac.nar.xz?hash=1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl",
+			narURL: nar.URL{
+				Hash:        "1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac",
+				Compression: nar.CompressionTypeXz,
 				Query:       url.Values(map[string][]string{"hash": {"1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl"}}),
 			},
 			err: nil,
@@ -100,42 +136,80 @@ func TestJoinURL(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		// params
-		hash        string
-		compression string
-		query       string
+		narURL nar.URL
 
-		// result
 		url string
 	}{
-		{hash: "", compression: "", url: "http://example.com/nar/.nar"}, // not really valid but it is what it is
-		{hash: "abc123", compression: "", url: "http://example.com/nar/abc123.nar"},
-		{hash: "def456", compression: "xz", url: "http://example.com/nar/def456.nar.xz"},
-		{hash: "def456", compression: "zstd", url: "http://example.com/nar/def456.nar.zst"},
-
-		{hash: "abc123", compression: "", query: "hash=123", url: "http://example.com/nar/abc123.nar?hash=123"},
-		{hash: "def456", compression: "xz", query: "hash=123", url: "http://example.com/nar/def456.nar.xz?hash=123"},
-		{hash: "def456", compression: "zstd", query: "hash=123", url: "http://example.com/nar/def456.nar.zst?hash=123"},
+		{
+			narURL: nar.URL{
+				Hash:        "abc123",
+				Compression: nar.CompressionTypeNoCompression,
+			},
+			url: "http://example.com/nar/abc123.nar",
+		},
+		{
+			narURL: nar.URL{
+				Hash:        "def456",
+				Compression: nar.CompressionTypeBzip2,
+			},
+			url: "http://example.com/nar/def456.nar.bz2",
+		},
+		{
+			narURL: nar.URL{
+				Hash:        "def456",
+				Compression: nar.CompressionTypeZstd,
+			},
+			url: "http://example.com/nar/def456.nar.zst",
+		},
+		{
+			narURL: nar.URL{
+				Hash:        "def456",
+				Compression: nar.CompressionTypeXz,
+			},
+			url: "http://example.com/nar/def456.nar.xz",
+		},
+		{
+			narURL: nar.URL{
+				Hash:        "abc123",
+				Compression: nar.CompressionTypeNoCompression,
+				Query:       url.Values(map[string][]string{"hash": {"123"}}),
+			},
+			url: "http://example.com/nar/abc123.nar?hash=123",
+		},
+		{
+			narURL: nar.URL{
+				Hash:        "def456",
+				Compression: nar.CompressionTypeZstd,
+				Query:       url.Values(map[string][]string{"hash": {"123"}}),
+			},
+			url: "http://example.com/nar/def456.nar.zst?hash=123",
+		},
+		{
+			narURL: nar.URL{
+				Hash:        "def456",
+				Compression: nar.CompressionTypeXz,
+				Query:       url.Values(map[string][]string{"hash": {"123"}}),
+			},
+			url: "http://example.com/nar/def456.nar.xz?hash=123",
+		},
 	}
 
 	for _, test := range tests {
-		tname := fmt.Sprintf("URL(%q, %q, %q).ToFilePath() -> %q", test.hash, test.compression, test.query, test.url)
+		tname := fmt.Sprintf(
+			"URL(%q, %q, %q).ToFilePath() -> %q",
+			test.narURL.Hash,
+			test.narURL.Compression,
+			test.narURL.Query.Encode(),
+			test.url,
+		)
+
 		t.Run(tname, func(t *testing.T) {
 			t.Parallel()
 
 			u, err := url.Parse("http://example.com")
 			require.NoError(t, err)
 
-			q, err := url.ParseQuery(test.query)
-			require.NoError(t, err)
-
-			nu := nar.URL{
-				Hash:        test.hash,
-				Compression: test.compression,
-				Query:       q,
-			}
-
-			assert.Equal(t, test.url, nu.JoinURL(u).String())
+			assert.Equal(t, test.url, test.narURL.JoinURL(u).String())
 		})
 	}
 }
@@ -144,39 +218,76 @@ func TestString(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		// params
-		hash        string
-		compression string
-		query       string
+		narURL nar.URL
 
-		// result
 		string string
 	}{
-		{hash: "", compression: "", string: "nar/.nar"}, // not really valid but it is what it is
-		{hash: "abc123", compression: "", string: "nar/abc123.nar"},
-		{hash: "def456", compression: "xz", string: "nar/def456.nar.xz"},
-		{hash: "def456", compression: "zstd", string: "nar/def456.nar.zst"},
-
-		{hash: "abc123", compression: "", query: "hash=123", string: "nar/abc123.nar?hash=123"},
-		{hash: "def456", compression: "xz", query: "hash=123", string: "nar/def456.nar.xz?hash=123"},
-		{hash: "def456", compression: "zstd", query: "hash=123", string: "nar/def456.nar.zst?hash=123"},
+		{
+			narURL: nar.URL{
+				Hash:        "abc123",
+				Compression: nar.CompressionTypeNoCompression,
+			},
+			string: "nar/abc123.nar",
+		},
+		{
+			narURL: nar.URL{
+				Hash:        "def456",
+				Compression: nar.CompressionTypeBzip2,
+			},
+			string: "nar/def456.nar.bz2",
+		},
+		{
+			narURL: nar.URL{
+				Hash:        "def456",
+				Compression: nar.CompressionTypeZstd,
+			},
+			string: "nar/def456.nar.zst",
+		},
+		{
+			narURL: nar.URL{
+				Hash:        "def456",
+				Compression: nar.CompressionTypeXz,
+			},
+			string: "nar/def456.nar.xz",
+		},
+		{
+			narURL: nar.URL{
+				Hash:        "abc123",
+				Compression: nar.CompressionTypeNoCompression,
+				Query:       url.Values(map[string][]string{"hash": {"123"}}),
+			},
+			string: "nar/abc123.nar?hash=123",
+		},
+		{
+			narURL: nar.URL{
+				Hash:        "def456",
+				Compression: nar.CompressionTypeZstd,
+				Query:       url.Values(map[string][]string{"hash": {"123"}}),
+			},
+			string: "nar/def456.nar.zst?hash=123",
+		},
+		{
+			narURL: nar.URL{
+				Hash:        "def456",
+				Compression: nar.CompressionTypeXz,
+				Query:       url.Values(map[string][]string{"hash": {"123"}}),
+			},
+			string: "nar/def456.nar.xz?hash=123",
+		},
 	}
 
 	for _, test := range tests {
-		tname := fmt.Sprintf("URL(%q, %q, %q).String() -> %q", test.hash, test.compression, test.query, test.string)
+		tname := fmt.Sprintf(
+			"URL(%q, %q, %q).String() -> %q",
+			test.narURL.Hash,
+			test.narURL.Compression,
+			test.narURL.Query.Encode(),
+			test.string,
+		)
 		t.Run(tname, func(t *testing.T) {
 			t.Parallel()
 
-			q, err := url.ParseQuery(test.query)
-			require.NoError(t, err)
-
-			nu := nar.URL{
-				Hash:        test.hash,
-				Compression: test.compression,
-				Query:       q,
-			}
-
-			assert.Equal(t, test.string, nu.String())
+			assert.Equal(t, test.string, test.narURL.String())
 		})
 	}
 }

--- a/pkg/nar/url_test.go
+++ b/pkg/nar/url_test.go
@@ -44,6 +44,15 @@ func TestParseURL(t *testing.T) {
 			err: nil,
 		},
 		{
+			url: "nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.zst",
+			narURL: nar.URL{
+				Hash:        "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+				Compression: "zstd",
+				Query:       url.Values{},
+			},
+			err: nil,
+		},
+		{
 			url: "nar/1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac.nar?hash=1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl",
 			narURL: nar.URL{
 				Hash:        "1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac",
@@ -57,6 +66,15 @@ func TestParseURL(t *testing.T) {
 			narURL: nar.URL{
 				Hash:        "1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac",
 				Compression: "xz",
+				Query:       url.Values(map[string][]string{"hash": {"1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl"}}),
+			},
+			err: nil,
+		},
+		{
+			url: "nar/1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac.nar.zst?hash=1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl",
+			narURL: nar.URL{
+				Hash:        "1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac",
+				Compression: "zstd",
 				Query:       url.Values(map[string][]string{"hash": {"1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl"}}),
 			},
 			err: nil,
@@ -93,9 +111,11 @@ func TestJoinURL(t *testing.T) {
 		{hash: "", compression: "", url: "http://example.com/nar/.nar"}, // not really valid but it is what it is
 		{hash: "abc123", compression: "", url: "http://example.com/nar/abc123.nar"},
 		{hash: "def456", compression: "xz", url: "http://example.com/nar/def456.nar.xz"},
+		{hash: "def456", compression: "zstd", url: "http://example.com/nar/def456.nar.zst"},
 
 		{hash: "abc123", compression: "", query: "hash=123", url: "http://example.com/nar/abc123.nar?hash=123"},
 		{hash: "def456", compression: "xz", query: "hash=123", url: "http://example.com/nar/def456.nar.xz?hash=123"},
+		{hash: "def456", compression: "zstd", query: "hash=123", url: "http://example.com/nar/def456.nar.zst?hash=123"},
 	}
 
 	for _, test := range tests {
@@ -135,9 +155,11 @@ func TestString(t *testing.T) {
 		{hash: "", compression: "", string: "nar/.nar"}, // not really valid but it is what it is
 		{hash: "abc123", compression: "", string: "nar/abc123.nar"},
 		{hash: "def456", compression: "xz", string: "nar/def456.nar.xz"},
+		{hash: "def456", compression: "zstd", string: "nar/def456.nar.zst"},
 
 		{hash: "abc123", compression: "", query: "hash=123", string: "nar/abc123.nar?hash=123"},
 		{hash: "def456", compression: "xz", query: "hash=123", string: "nar/def456.nar.xz?hash=123"},
+		{hash: "def456", compression: "zstd", query: "hash=123", string: "nar/def456.nar.zst?hash=123"},
 	}
 
 	for _, test := range tests {

--- a/pkg/nar/url_test.go
+++ b/pkg/nar/url_test.go
@@ -29,7 +29,7 @@ func TestParseURL(t *testing.T) {
 			url: "nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar",
 			narURL: nar.URL{
 				Hash:        "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
-				Compression: nar.CompressionTypeNoCompression,
+				Compression: nar.CompressionTypeNone,
 				Query:       url.Values{},
 			},
 			err: nil,
@@ -92,7 +92,7 @@ func TestParseURL(t *testing.T) {
 			url: "nar/1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac.nar?hash=1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl",
 			narURL: nar.URL{
 				Hash:        "1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac",
-				Compression: nar.CompressionTypeNoCompression,
+				Compression: nar.CompressionTypeNone,
 				Query:       url.Values(map[string][]string{"hash": {"1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl"}}),
 			},
 			err: nil,
@@ -143,7 +143,7 @@ func TestJoinURL(t *testing.T) {
 		{
 			narURL: nar.URL{
 				Hash:        "abc123",
-				Compression: nar.CompressionTypeNoCompression,
+				Compression: nar.CompressionTypeNone,
 			},
 			url: "http://example.com/nar/abc123.nar",
 		},
@@ -171,7 +171,7 @@ func TestJoinURL(t *testing.T) {
 		{
 			narURL: nar.URL{
 				Hash:        "abc123",
-				Compression: nar.CompressionTypeNoCompression,
+				Compression: nar.CompressionTypeNone,
 				Query:       url.Values(map[string][]string{"hash": {"123"}}),
 			},
 			url: "http://example.com/nar/abc123.nar?hash=123",
@@ -225,7 +225,7 @@ func TestString(t *testing.T) {
 		{
 			narURL: nar.URL{
 				Hash:        "abc123",
-				Compression: nar.CompressionTypeNoCompression,
+				Compression: nar.CompressionTypeNone,
 			},
 			string: "nar/abc123.nar",
 		},
@@ -253,7 +253,7 @@ func TestString(t *testing.T) {
 		{
 			narURL: nar.URL{
 				Hash:        "abc123",
-				Compression: nar.CompressionTypeNoCompression,
+				Compression: nar.CompressionTypeNone,
 				Query:       url.Values(map[string][]string{"hash": {"123"}}),
 			},
 			string: "nar/abc123.nar?hash=123",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -285,7 +285,7 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 			return
 		}
 
-		log = nu.NewLogger(log)
+		log = nu.NewLogger(s.logger) // re-create the logger to avoid dups
 
 		size, reader, err := s.cache.GetNar(r.Context(), nu)
 		if err != nil {
@@ -353,7 +353,7 @@ func (s *Server) putNar(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log = nu.NewLogger(log)
+	log = nu.NewLogger(s.logger) // re-create the logger to avoid dups
 
 	if !s.putPermitted {
 		w.WriteHeader(http.StatusMethodNotAllowed)
@@ -399,7 +399,7 @@ func (s *Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log = nu.NewLogger(log)
+	log = nu.NewLogger(s.logger) // re-create the logger to avoid dups
 
 	if !s.deletePermitted {
 		w.WriteHeader(http.StatusMethodNotAllowed)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -267,11 +267,25 @@ func (s *Server) deleteNarInfo(w http.ResponseWriter, r *http.Request) {
 func (s *Server) getNar(withBody bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		hash := chi.URLParam(r, "hash")
-		compression := chi.URLParam(r, "compression")
 
-		nu := nar.URL{Hash: hash, Compression: compression, Query: r.URL.Query()}
+		nu := nar.URL{Hash: hash, Query: r.URL.Query()}
 
 		log := nu.NewLogger(s.logger)
+
+		var err error
+
+		nu.Compression, err = nar.CompressionTypeFromExtension(chi.URLParam(r, "compression"))
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+
+			if _, err := w.Write([]byte(http.StatusText(http.StatusBadRequest))); err != nil {
+				log.Error("error computing the compression", "error", err)
+			}
+
+			return
+		}
+
+		log = nu.NewLogger(log)
 
 		size, reader, err := s.cache.GetNar(r.Context(), nu)
 		if err != nil {
@@ -321,11 +335,25 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 
 func (s *Server) putNar(w http.ResponseWriter, r *http.Request) {
 	hash := chi.URLParam(r, "hash")
-	compression := chi.URLParam(r, "compression")
 
-	nu := nar.URL{Hash: hash, Compression: compression, Query: r.URL.Query()}
+	nu := nar.URL{Hash: hash, Query: r.URL.Query()}
 
 	log := nu.NewLogger(s.logger)
+
+	var err error
+
+	nu.Compression, err = nar.CompressionTypeFromExtension(chi.URLParam(r, "compression"))
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+
+		if _, err := w.Write([]byte(http.StatusText(http.StatusBadRequest))); err != nil {
+			log.Error("error computing the compression", "error", err)
+		}
+
+		return
+	}
+
+	log = nu.NewLogger(log)
 
 	if !s.putPermitted {
 		w.WriteHeader(http.StatusMethodNotAllowed)
@@ -353,11 +381,25 @@ func (s *Server) putNar(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 	hash := chi.URLParam(r, "hash")
-	compression := chi.URLParam(r, "compression")
 
-	nu := nar.URL{Hash: hash, Compression: compression, Query: r.URL.Query()}
+	nu := nar.URL{Hash: hash, Query: r.URL.Query()}
 
 	log := nu.NewLogger(s.logger)
+
+	var err error
+
+	nu.Compression, err = nar.CompressionTypeFromExtension(chi.URLParam(r, "compression"))
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+
+		if _, err := w.Write([]byte(http.StatusText(http.StatusBadRequest))); err != nil {
+			log.Error("error computing the compression", "error", err)
+		}
+
+		return
+	}
+
+	log = nu.NewLogger(log)
 
 	if !s.deletePermitted {
 		w.WriteHeader(http.StatusMethodNotAllowed)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -133,7 +133,7 @@ func TestServeHTTP(t *testing.T) {
 					assert.NoFileExists(t, storePath)
 				})
 
-				nu := nar.URL{Hash: testdata.Nar2.NarHash, Compression: "xz"}
+				nu := nar.URL{Hash: testdata.Nar2.NarHash, Compression: nar.CompressionTypeXz}
 				_, _, err := c.GetNar(context.Background(), nu)
 				require.NoError(t, err)
 
@@ -219,7 +219,7 @@ func TestServeHTTP(t *testing.T) {
 				u, err := url.Parse("http://example.com")
 				require.NoError(t, err)
 
-				nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: "xz"}
+				nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
 				r := httptest.NewRequest("GET", nu.JoinURL(u).String(), nil)
 				w := httptest.NewRecorder()
 
@@ -245,7 +245,7 @@ func TestServeHTTP(t *testing.T) {
 				q, err := url.ParseQuery("fakesize=123")
 				require.NoError(t, err)
 
-				nu := nar.URL{Hash: testdata.Nar2.NarHash, Compression: "xz", Query: q}
+				nu := nar.URL{Hash: testdata.Nar2.NarHash, Compression: nar.CompressionTypeXz, Query: q}
 
 				r := httptest.NewRequest("GET", nu.JoinURL(u).String(), nil)
 				w := httptest.NewRecorder()


### PR DESCRIPTION
Introduce compression type enum to standardize compression handling

- Replace string-based compression with strongly typed CompressionType enum
- Add support for all [Nix compression types](https://github.com/NixOS/nix/blob/f1187cb696584739884687d788a6fbb4dd36c61c/src/libstore/binary-cache-store.cc#L166): none, bzip2, zstd, lzip, lz4, br, xz
- Replace manual compression string handling with type-safe methods
- Add validation and error handling for unknown compression types
- Update all code paths to use new CompressionType enum
- Avoid duplicate logging when handling compression errors

The changes standardize how compression is handled throughout the codebase while adding support for all compression types supported by Nix. This makes the code more maintainable and type-safe.