### PR TITLE
nix/devshells: Remove references to Dockerfile

### DIFF
--- a/nix/devshells/flake-module.nix
+++ b/nix/devshells/flake-module.nix
@@ -22,8 +22,6 @@
           ${config.pre-commit.installationScript}
 
           ${pkgs.gnused}/bin/sed -e "s:^\(go \)[0-9.]*$:\1''${_GO_VERSION}:" -i go.mod
-          ${pkgs.gnused}/bin/sed -e "s:^\(ARG GO_VERSION=\).*$:\1''${_GO_VERSION}:" -i Dockerfile
-          ${pkgs.gnused}/bin/sed -e "s:^\(ARG DBMATE_VERSION=\).*$:\1''${_DBMATE_VERSION}:" -i Dockerfile
         '';
       };
     };


### PR DESCRIPTION
### TL;DR
Removed automatic version updates for GO_VERSION and DBMATE_VERSION in Dockerfile

### What changed?
Removed two `sed` commands that were automatically updating the GO_VERSION and DBMATE_VERSION arguments in the Dockerfile. The go.mod version update remains unchanged.

### How to test?
1. Enter the development shell
2. Verify that go.mod version is still being updated
3. Confirm no warnings are shown about missing Dockerfile

### Why make this change?
Dockerfile was removed in #94 but I seem to have forgotten to remove these sed commands, and they are now broken generating non-fatal errors.