### PR TITLE
testdata: add a way to customize Server handler from tests

### DIFF
--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"math/rand/v2"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,10 +33,10 @@ func TestAddUpstreamCaches(t *testing.T) {
 	t.Run("upstream caches added at once", func(t *testing.T) {
 		t.Parallel()
 
-		testServers := make(map[int]*httptest.Server)
+		testServers := make(map[int]*testdata.Server)
 
 		for i := 1; i < 10; i++ {
-			ts := testdata.HTTPTestServer(t, i)
+			ts := testdata.NewTestServer(t, i)
 			defer ts.Close()
 			testServers[i] = ts
 		}
@@ -81,10 +80,10 @@ func TestAddUpstreamCaches(t *testing.T) {
 	t.Run("upstream caches added one by one", func(t *testing.T) {
 		t.Parallel()
 
-		testServers := make(map[int]*httptest.Server)
+		testServers := make(map[int]*testdata.Server)
 
 		for i := 1; i < 10; i++ {
-			ts := testdata.HTTPTestServer(t, i)
+			ts := testdata.NewTestServer(t, i)
 			defer ts.Close()
 			testServers[i] = ts
 		}
@@ -140,7 +139,7 @@ func TestRunLRU(t *testing.T) {
 	c, err := New(logger, "cache.example.com", dir)
 	require.NoError(t, err)
 
-	ts := testdata.HTTPTestServer(t, 40)
+	ts := testdata.NewTestServer(t, 40)
 	defer ts.Close()
 
 	uc, err := upstream.New(logger, testhelper.MustParseURL(t, ts.URL), nil)

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -177,7 +177,7 @@ func TestPublicKey(t *testing.T) {
 
 //nolint:paralleltest
 func TestGetNarInfo(t *testing.T) {
-	ts := testdata.HTTPTestServer(t, 40)
+	ts := testdata.NewTestServer(t, 40)
 	defer ts.Close()
 
 	dir, err := os.MkdirTemp("", "cache-path-")
@@ -702,7 +702,7 @@ func TestDeleteNarInfo(t *testing.T) {
 
 //nolint:paralleltest
 func TestGetNar(t *testing.T) {
-	ts := testdata.HTTPTestServer(t, 40)
+	ts := testdata.NewTestServer(t, 40)
 	defer ts.Close()
 
 	dir, err := os.MkdirTemp("", "cache-path-")

--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -29,7 +29,7 @@ func init() {
 func TestNew(t *testing.T) {
 	t.Parallel()
 
-	ts := testdata.HTTPTestServer(t, 40)
+	ts := testdata.NewTestServer(t, 40)
 	defer ts.Close()
 
 	//nolint:paralleltest
@@ -105,24 +105,7 @@ func TestGetNarInfo(t *testing.T) {
 				err error
 			)
 
-			ts := testdata.HTTPTestServer(t, 40, func(w http.ResponseWriter, r *http.Request) bool {
-				for _, entry := range testdata.Entries {
-					if r.URL.Path == "/broken-"+entry.NarInfoHash+".narinfo" {
-						// mutate the inside
-						b := entry.NarInfoText
-						b = strings.Replace(b, "References:", "References: notfound-path", -1)
-
-						_, err := w.Write([]byte(b))
-						if err != nil {
-							http.Error(w, err.Error(), http.StatusInternalServerError)
-						}
-
-						return true
-					}
-				}
-
-				return false
-			})
+			ts := testdata.NewTestServer(t, 40)
 			defer ts.Close()
 
 			if withKeys {
@@ -154,6 +137,27 @@ func TestGetNarInfo(t *testing.T) {
 			})
 
 			t.Run("check has failed", func(t *testing.T) {
+				idx := ts.AddMaybeHandler(func(w http.ResponseWriter, r *http.Request) bool {
+					for _, entry := range testdata.Entries {
+						if r.URL.Path == "/broken-"+entry.NarInfoHash+".narinfo" {
+							// mutate the inside
+							b := entry.NarInfoText
+							b = strings.Replace(b, "References:", "References: notfound-path", -1)
+
+							_, err := w.Write([]byte(b))
+							if err != nil {
+								http.Error(w, err.Error(), http.StatusInternalServerError)
+							}
+
+							return true
+						}
+					}
+
+					return false
+				})
+
+				defer ts.RemoveMaybeHandler(idx)
+
 				hash := "broken-" + testdata.Nar1.NarInfoHash
 
 				_, err = c.GetNarInfo(context.Background(), hash)
@@ -181,7 +185,7 @@ func TestGetNarInfo(t *testing.T) {
 func TestGetNar(t *testing.T) {
 	t.Parallel()
 
-	ts := testdata.HTTPTestServer(t, 40)
+	ts := testdata.NewTestServer(t, 40)
 	defer ts.Close()
 
 	c, err := upstream.New(
@@ -217,7 +221,7 @@ func TestGetNar(t *testing.T) {
 func TestGetNarCanMutate(t *testing.T) {
 	t.Parallel()
 
-	ts := testdata.HTTPTestServer(t, 40)
+	ts := testdata.NewTestServer(t, 40)
 	defer ts.Close()
 
 	c, err := upstream.New(

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -36,7 +36,7 @@ func init() {
 
 //nolint:paralleltest
 func TestServeHTTP(t *testing.T) {
-	hts := testdata.HTTPTestServer(t, 40)
+	hts := testdata.NewTestServer(t, 40)
 	defer hts.Close()
 
 	uc, err := upstream.New(logger, testhelper.MustParseURL(t, hts.URL), testdata.PublicKeys())

--- a/testdata/server.go
+++ b/testdata/server.go
@@ -20,14 +20,9 @@ type Server struct {
 	mu            sync.RWMutex
 	maybeHandlers map[string]MaybeHandlerFunc
 	priority      int
-	publicKeys    []string
 }
 
 type MaybeHandlerFunc func(http.ResponseWriter, *http.Request) bool
-
-func PublicKeys() []string {
-	return []string{"cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="}
-}
 
 func NewTestServer(t *testing.T, priority int) *Server {
 	t.Helper()
@@ -40,13 +35,6 @@ func NewTestServer(t *testing.T, priority int) *Server {
 	s.Server = httptest.NewServer(compressMiddleware(s.handler()))
 
 	return s
-}
-
-func (s *Server) AddPublicKey(pk string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.publicKeys = append(s.publicKeys, pk)
 }
 
 func (s *Server) AddMaybeHandler(maybeHandler MaybeHandlerFunc) string {

--- a/testdata/server_test.go
+++ b/testdata/server_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/kalbasit/ncps/testdata"
 )
 
-func TestHTTPTestServer(t *testing.T) {
+func TestNewTestServer(t *testing.T) {
 	t.Parallel()
 
 	priority := 40
 
-	ts := testdata.HTTPTestServer(t, priority)
+	ts := testdata.NewTestServer(t, priority)
 	defer ts.Close()
 
 	u := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar.xz"
@@ -46,12 +46,12 @@ func TestHTTPTestServer(t *testing.T) {
 	}
 }
 
-func TestHTTPTestServerWithZSTD(t *testing.T) {
+func TestNewTestServerWithZSTD(t *testing.T) {
 	t.Parallel()
 
 	priority := 40
 
-	ts := testdata.HTTPTestServer(t, priority)
+	ts := testdata.NewTestServer(t, priority)
 	defer ts.Close()
 
 	u := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar"

--- a/testdata/upstream_public_keys.go
+++ b/testdata/upstream_public_keys.go
@@ -1,0 +1,5 @@
+package testdata
+
+func PublicKeys() []string {
+	return []string{"cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="}
+}


### PR DESCRIPTION
# Add dynamic handlers to test server

Refactors the test server to allow adding custom request handlers at runtime. This enables more flexible testing scenarios by allowing tests to inject custom behavior without modifying the server implementation.

The changes include:
- Added `AddMaybeHandler()` and `RemoveMaybeHandler()` methods to dynamically manage handlers
- Moved the broken narinfo logic into a custom handler in the test
- Extracted public keys into a separate file for better organization
- Renamed `HTTPTestServer` to `NewTestServer` for clarity

This makes the test infrastructure more maintainable and allows for better test isolation.