### PR TITLE
Nix: Allow setting ncps version; GitHub: build Docker with version

### DIFF
--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -38,8 +38,10 @@ runs:
     - uses: DeterminateSystems/magic-nix-cache-action@v8
     - name: Build the docker image pusher
       shell: bash
+      env:
+        RELEASE_VERSION: ${{ github.ref_name }}
       run: |
-        nix build .#push-docker-image
+        nix build --impure .#push-docker-image
     - name: Push the docker image
       if: ${{ inputs.push }}
       env:


### PR DESCRIPTION
Compute the version from git tag or revision

- Add version computation logic in `ncps.nix` using either release tag or git revision
- Make docker image build impure to access environment variables
- Pass release version through environment variable during docker build