### PR TITLE
pkg/storage: Add interface defining the storage

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -47,7 +47,7 @@ type NarStore interface {
 	GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadCloser, error)
 
 	// PutNar puts the nar in the store.
-	PutNar(ctx context.Context, narURL nar.URL, body io.ReadCloser) (int64, error)
+	PutNar(ctx context.Context, narURL nar.URL, body io.Reader) (int64, error)
 
 	// DeleteNar deletes the nar from the store.
 	DeleteNar(ctx context.Context, narURL nar.URL) error

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1,0 +1,55 @@
+package storage
+
+import (
+	"context"
+	"io"
+
+	"github.com/nix-community/go-nix/pkg/narinfo"
+	"github.com/nix-community/go-nix/pkg/narinfo/signature"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+)
+
+// ConfigStore represents a store for the ncps to use for storing
+// configurations.
+type ConfigStore interface {
+	// GetSecretKey returns secret key from the store.
+	GetSecretKey(ctx context.Context) (signature.SecretKey, error)
+
+	// PutSecretKey stores the secret key in the store.
+	PutSecretKey(ctx context.Context, sk signature.SecretKey) error
+
+	// DeleteSecretKey deletes the secret key in the store.
+	DeleteSecretKey(ctx context.Context) error
+}
+
+// NarInfoStore represents a store capable of storing narinfos.
+type NarInfoStore interface {
+	// GetNarInfo returns narinfo from the store.
+	GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, error)
+
+	// PutNarInfo puts the narinfo in the store.
+	PutNarInfo(ctx context.Context, hash string, narInfo *narinfo.NarInfo) error
+
+	// DeleteNarInfo deletes the narinfo from the store.
+	DeleteNarInfo(ctx context.Context, hash string) error
+}
+
+// NarStore represents a store capable of storing nars.
+type NarStore interface {
+	// GetNar returns nar from the store.
+	GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadCloser, error)
+
+	// PutNar puts the nar in the store.
+	PutNar(ctx context.Context, narURL nar.URL, body io.ReadCloser) error
+
+	// DeleteNar deletes the nar from the store.
+	DeleteNar(ctx context.Context, narURL nar.URL) error
+}
+
+// Store represents a store capable of storing narinfos and nars.
+type Store struct {
+	ConfigStore
+	NarInfoStore
+	NarStore
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -47,7 +47,7 @@ type NarStore interface {
 	GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadCloser, error)
 
 	// PutNar puts the nar in the store.
-	PutNar(ctx context.Context, narURL nar.URL, body io.ReadCloser) error
+	PutNar(ctx context.Context, narURL nar.URL, body io.ReadCloser) (int64, error)
 
 	// DeleteNar deletes the nar from the store.
 	DeleteNar(ctx context.Context, narURL nar.URL) error

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -25,6 +25,9 @@ type ConfigStore interface {
 
 // NarInfoStore represents a store capable of storing narinfos.
 type NarInfoStore interface {
+	// HasNarInfo returns true if the store has the narinfo.
+	HasNarInfo(ctx context.Context, hash string) bool
+
 	// GetNarInfo returns narinfo from the store.
 	GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, error)
 
@@ -37,6 +40,9 @@ type NarInfoStore interface {
 
 // NarStore represents a store capable of storing nars.
 type NarStore interface {
+	// HasNar returns true if the store has the nar.
+	HasNar(ctx context.Context, narURL nar.URL) bool
+
 	// GetNar returns nar from the store.
 	GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadCloser, error)
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -44,6 +44,7 @@ type NarStore interface {
 	HasNar(ctx context.Context, narURL nar.URL) bool
 
 	// GetNar returns nar from the store.
+	// NOTE: The caller must close the returned io.ReadCloser!
 	GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadCloser, error)
 
 	// PutNar puts the nar in the store.


### PR DESCRIPTION
### TL;DR

Introduces new storage interfaces for managing configurations, NAR files, and NAR information in the Nix ecosystem.

### What changed?

Created three new interfaces and a composite Store type:
- `ConfigStore`: Manages secret keys with get, put, and delete operations
- `NarInfoStore`: Handles NAR information storage with get, put, and delete operations
- `NarStore`: Manages NAR file storage with get, put, and delete operations
- `Store`: Combines all three interfaces into a single type

### How to test?

1. Implement each interface with a concrete storage backend
2. Test each method:
   - Secret key operations (get/put/delete)
   - NAR info operations with valid hash values
   - NAR file operations with valid NAR URLs
3. Verify error handling for non-existent items

### Why make this change?

This change establishes a clear contract for storage implementations in the NCPS system, allowing for:
- Flexible storage backend implementations
- Consistent handling of Nix-related data
- Clear separation of concerns between different storage types
- Easy testing through interface mocking