### PR TITLE
pkg/storage/local: Implement local storage

### DIFF
--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -143,7 +143,17 @@ func (s *Store) PutNarInfo(ctx context.Context, hash string, narInfo *narinfo.Na
 
 // DeleteNarInfo deletes the narinfo from the store.
 func (s *Store) DeleteNarInfo(ctx context.Context, hash string) error {
-	return errors.New("not implemented")
+	narInfoPath := filepath.Join(s.storeNarInfoPath(), helper.NarInfoFilePath(hash))
+
+	if err := os.Remove(narInfoPath); err != nil {
+		if os.IsNotExist(err) {
+			return storage.ErrNotFound
+		}
+
+		return fmt.Errorf("error deleting narinfo %q from store: %w", narInfoPath, err)
+	}
+
+	return nil
 }
 
 // GetNar returns nar from the store.

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -89,7 +89,13 @@ func (s *Store) PutSecretKey(ctx context.Context, sk signature.SecretKey) error 
 
 // DeleteSecretKey deletes the secret key in the store.
 func (s *Store) DeleteSecretKey(ctx context.Context) error {
-	return errors.New("not implemented")
+	skPath := s.secretKeyPath()
+
+	if _, err := os.Stat(skPath); os.IsNotExist(err) {
+		return ErrNoSecretKey
+	}
+
+	return os.Remove(skPath)
 }
 
 // GetNarInfo returns narinfo from the store.

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -157,8 +157,8 @@ func (s *Store) DeleteNarInfo(ctx context.Context, hash string) error {
 }
 
 // GetNar returns nar from the store.
-func (s *Store) GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadCloser, error) {
-	return 0, nil, errors.New("not implemented")
+func (s *Store) GetNar(ctx context.Context, narURL nar.URL) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
 }
 
 // PutNar puts the nar in the store.

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -33,9 +33,6 @@ var (
 
 	// ErrNoSecretKey is returned if no secret key is present.
 	ErrNoSecretKey = errors.New("no secret key was found")
-
-	// ErrSecretKeyAlreadyExists is returned if a secret key already exists in the store.
-	ErrSecretKeyAlreadyExists = errors.New("secret key already exists")
 )
 
 const (
@@ -83,7 +80,7 @@ func (s *Store) PutSecretKey(ctx context.Context, sk signature.SecretKey) error 
 	skPath := s.secretKeyPath()
 
 	if _, err := os.Stat(skPath); err == nil {
-		return ErrSecretKeyAlreadyExists
+		return storage.ErrAlreadyExists
 	}
 
 	return os.WriteFile(skPath, []byte(sk.String()), secretKeyFileMode)

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -97,6 +97,15 @@ func (s *Store) DeleteSecretKey(_ context.Context) error {
 	return os.Remove(skPath)
 }
 
+// HasNarInfo returns true if the store has the narinfo.
+func (s *Store) HasNarInfo(_ context.Context, hash string) bool {
+	narInfoPath := filepath.Join(s.storeNarInfoPath(), helper.NarInfoFilePath(hash))
+
+	_, err := os.Stat(narInfoPath)
+
+	return err == nil
+}
+
 // GetNarInfo returns narinfo from the store.
 func (s *Store) GetNarInfo(_ context.Context, hash string) (*narinfo.NarInfo, error) {
 	narInfoPath := filepath.Join(s.storeNarInfoPath(), helper.NarInfoFilePath(hash))
@@ -154,6 +163,15 @@ func (s *Store) DeleteNarInfo(_ context.Context, hash string) error {
 	}
 
 	return nil
+}
+
+// HasNar returns true if the store has the nar.
+func (s *Store) HasNar(_ context.Context, narURL nar.URL) bool {
+	narPath := filepath.Join(s.storeNarPath(), narURL.ToFilePath())
+
+	_, err := os.Stat(narPath)
+
+	return err == nil
 }
 
 // GetNar returns nar from the store.

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -30,9 +30,6 @@ var (
 
 	// ErrPathMustBeWritable is returned if the given path to New is not writable.
 	ErrPathMustBeWritable = errors.New("path must be writable")
-
-	// ErrNoSecretKey is returned if no secret key is present.
-	ErrNoSecretKey = errors.New("no secret key was found")
 )
 
 const (
@@ -64,7 +61,7 @@ func (s *Store) GetSecretKey(_ context.Context) (signature.SecretKey, error) {
 	skPath := s.secretKeyPath()
 
 	if _, err := os.Stat(skPath); os.IsNotExist(err) {
-		return signature.SecretKey{}, ErrNoSecretKey
+		return signature.SecretKey{}, storage.ErrNotFound
 	}
 
 	skc, err := os.ReadFile(skPath)
@@ -91,7 +88,7 @@ func (s *Store) DeleteSecretKey(_ context.Context) error {
 	skPath := s.secretKeyPath()
 
 	if _, err := os.Stat(skPath); os.IsNotExist(err) {
-		return ErrNoSecretKey
+		return storage.ErrNotFound
 	}
 
 	return os.Remove(skPath)

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -114,7 +114,7 @@ func (s *Store) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, 
 }
 
 // PutNarInfo puts the narinfo in the store.
-func (s *Store) PutNarInfo(ctx context.Context, hash string, narInfo *narinfo.NarInfo) error {
+func (s *Store) PutNarInfo(ctx context.Context, narInfo *narinfo.NarInfo) error {
 	return errors.New("not implemented")
 }
 

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -199,6 +199,10 @@ func (s *Store) PutNar(_ context.Context, narURL nar.URL, body io.Reader) (int64
 		return 0, storage.ErrAlreadyExists
 	}
 
+	if err := os.MkdirAll(filepath.Dir(narPath), dirMode); err != nil {
+		return 0, fmt.Errorf("error creating the directories for %q: %w", narPath, err)
+	}
+
 	pattern := narURL.Hash + "-*.nar"
 	if cext := narURL.Compression.String(); cext != "" {
 		pattern += "." + cext
@@ -219,10 +223,6 @@ func (s *Store) PutNar(_ context.Context, narURL nar.URL, body io.Reader) (int64
 
 	if err := f.Close(); err != nil {
 		return 0, fmt.Errorf("error closing the temporary file: %w", err)
-	}
-
-	if err := os.MkdirAll(filepath.Dir(narPath), dirMode); err != nil {
-		return 0, fmt.Errorf("error creating the directories for %q: %w", narPath, err)
 	}
 
 	if err := os.Rename(f.Name(), narPath); err != nil {

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -158,7 +158,18 @@ func (s *Store) DeleteNarInfo(ctx context.Context, hash string) error {
 
 // GetNar returns nar from the store.
 func (s *Store) GetNar(ctx context.Context, narURL nar.URL) (io.ReadCloser, error) {
-	return nil, errors.New("not implemented")
+	narPath := filepath.Join(s.storeNarPath(), narURL.ToFilePath())
+
+	nf, err := os.Open(narPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, storage.ErrNotFound
+		}
+
+		return nil, fmt.Errorf("error opening the nar file %q: %w", narPath, err)
+	}
+
+	return nf, nil
 }
 
 // PutNar puts the nar in the store.

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -13,7 +13,9 @@ import (
 	"github.com/nix-community/go-nix/pkg/narinfo/signature"
 	"github.com/rs/zerolog"
 
+	"github.com/kalbasit/ncps/pkg/helper"
 	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
 )
 
 var (
@@ -100,7 +102,16 @@ func (s *Store) DeleteSecretKey(ctx context.Context) error {
 
 // GetNarInfo returns narinfo from the store.
 func (s *Store) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, error) {
-	return nil, errors.New("not implemented")
+	nif, err := os.Open(filepath.Join(s.storeNarInfoPath(), helper.NarInfoFilePath(hash)))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, storage.ErrNotFound
+		}
+
+		return nil, fmt.Errorf("error opening the narinfo: %w", err)
+	}
+
+	return narinfo.Parse(nif)
 }
 
 // PutNarInfo puts the narinfo in the store.

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -3,11 +3,31 @@ package local
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
 
-	"github.com/kalbasit/ncps/pkg/nar"
 	"github.com/nix-community/go-nix/pkg/narinfo"
 	"github.com/nix-community/go-nix/pkg/narinfo/signature"
+	"github.com/rs/zerolog"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+)
+
+var (
+	// ErrPathMustBeAbsolute is returned if the given path to New was not absolute.
+	ErrPathMustBeAbsolute = errors.New("path must be absolute")
+
+	// ErrPathMustExist is returned if the given path to New did not exist.
+	ErrPathMustExist = errors.New("path must exist")
+
+	// ErrPathMustBeADirectory is returned if the given path to New is not a directory.
+	ErrPathMustBeADirectory = errors.New("path must be a directory")
+
+	// ErrPathMustBeWritable is returned if the given path to New is not writable.
+	ErrPathMustBeWritable = errors.New("path must be writable")
 )
 
 // Store represents a local store and implements storage.Store.
@@ -15,8 +35,18 @@ type Store struct {
 	path string
 }
 
-func New(path string) (*Store, error) {
-	return nil, errors.New("not implemented")
+func New(ctx context.Context, path string) (*Store, error) {
+	if err := validatePath(ctx, path); err != nil {
+		return nil, err
+	}
+
+	s := &Store{path: path}
+
+	if err := s.setupDirs(); err != nil {
+		return nil, fmt.Errorf("error setting up the store directory: %w", err)
+	}
+
+	return s, nil
 }
 
 // GetSecretKey returns secret key from the store.
@@ -62,4 +92,80 @@ func (s *Store) PutNar(ctx context.Context, narURL nar.URL, body io.ReadCloser) 
 // DeleteNar deletes the nar from the store.
 func (s *Store) DeleteNar(ctx context.Context, narURL nar.URL) error {
 	return errors.New("not implemented")
+}
+
+func (s *Store) configPath() string       { return filepath.Join(s.path, "config") }
+func (s *Store) secretKeyPath() string    { return filepath.Join(s.configPath(), "cache.key") }
+func (s *Store) storePath() string        { return filepath.Join(s.path, "store") }
+func (s *Store) storeNarInfoPath() string { return filepath.Join(s.storePath(), "narinfo") }
+func (s *Store) storeNarPath() string     { return filepath.Join(s.storePath(), "nar") }
+func (s *Store) storeTMPPath() string     { return filepath.Join(s.storePath(), "tmp") }
+
+func (s *Store) setupDirs() error {
+	if err := os.RemoveAll(s.storeTMPPath()); err != nil {
+		return fmt.Errorf("error removing the temporary download directory: %w", err)
+	}
+
+	allPaths := []string{
+		s.configPath(),
+		s.storePath(),
+		s.storeNarInfoPath(),
+		s.storeNarPath(),
+		s.storeTMPPath(),
+	}
+
+	for _, p := range allPaths {
+		if err := os.MkdirAll(p, 0o700); err != nil {
+			return fmt.Errorf("error creating the directory %q: %w", p, err)
+		}
+	}
+
+	return nil
+}
+
+func validatePath(ctx context.Context, path string) error {
+	log := zerolog.Ctx(ctx)
+
+	if !filepath.IsAbs(path) {
+		log.Error().Str("path", path).Msg("path is not absolute")
+
+		return ErrPathMustBeAbsolute
+	}
+
+	info, err := os.Stat(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		log.Error().Str("path", path).Msg("path does not exist")
+
+		return ErrPathMustExist
+	}
+
+	if !info.IsDir() {
+		log.Error().Str("path", path).Msg("path is not a directory")
+
+		return ErrPathMustBeADirectory
+	}
+
+	if !isWritable(ctx, path) {
+		return ErrPathMustBeWritable
+	}
+
+	return nil
+}
+
+func isWritable(ctx context.Context, path string) bool {
+	log := zerolog.Ctx(ctx)
+	tmpFile, err := os.CreateTemp(path, "write_test")
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("path", path).
+			Msg("error writing a temp file in the path")
+
+		return false
+	}
+
+	defer os.Remove(tmpFile.Name())
+	defer tmpFile.Close()
+
+	return true
 }

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -173,7 +173,7 @@ func (s *Store) GetNar(ctx context.Context, narURL nar.URL) (io.ReadCloser, erro
 }
 
 // PutNar puts the nar in the store.
-func (s *Store) PutNar(ctx context.Context, narURL nar.URL, body io.ReadCloser) error {
+func (s *Store) PutNar(ctx context.Context, narURL nar.URL, body io.Reader) error {
 	return errors.New("not implemented")
 }
 

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -214,7 +214,17 @@ func (s *Store) PutNar(ctx context.Context, narURL nar.URL, body io.Reader) erro
 
 // DeleteNar deletes the nar from the store.
 func (s *Store) DeleteNar(ctx context.Context, narURL nar.URL) error {
-	return errors.New("not implemented")
+	narPath := filepath.Join(s.storeNarPath(), narURL.ToFilePath())
+
+	if err := os.Remove(narPath); err != nil {
+		if os.IsNotExist(err) {
+			return storage.ErrNotFound
+		}
+
+		return fmt.Errorf("error deleting nar %q from store: %w", narPath, err)
+	}
+
+	return nil
 }
 
 func (s *Store) configPath() string       { return filepath.Join(s.path, "config") }

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -170,6 +170,7 @@ func (s *Store) HasNar(_ context.Context, narURL nar.URL) bool {
 }
 
 // GetNar returns nar from the store.
+// NOTE: The caller must close the returned io.ReadCloser!
 func (s *Store) GetNar(_ context.Context, narURL nar.URL) (int64, io.ReadCloser, error) {
 	narPath := filepath.Join(s.storeNarPath(), narURL.ToFilePath())
 

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -114,7 +114,7 @@ func (s *Store) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, 
 }
 
 // PutNarInfo puts the narinfo in the store.
-func (s *Store) PutNarInfo(ctx context.Context, narInfo *narinfo.NarInfo) error {
+func (s *Store) PutNarInfo(ctx context.Context, hash string, narInfo *narinfo.NarInfo) error {
 	return errors.New("not implemented")
 }
 

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -108,6 +108,8 @@ func (s *Store) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, 
 		return nil, fmt.Errorf("error opening the narinfo: %w", err)
 	}
 
+	defer nif.Close()
+
 	return narinfo.Parse(nif)
 }
 

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -60,7 +60,7 @@ func New(ctx context.Context, path string) (*Store, error) {
 }
 
 // GetSecretKey returns secret key from the store.
-func (s *Store) GetSecretKey(ctx context.Context) (signature.SecretKey, error) {
+func (s *Store) GetSecretKey(_ context.Context) (signature.SecretKey, error) {
 	skPath := s.secretKeyPath()
 
 	if _, err := os.Stat(skPath); os.IsNotExist(err) {
@@ -76,7 +76,7 @@ func (s *Store) GetSecretKey(ctx context.Context) (signature.SecretKey, error) {
 }
 
 // PutSecretKey stores the secret key in the store.
-func (s *Store) PutSecretKey(ctx context.Context, sk signature.SecretKey) error {
+func (s *Store) PutSecretKey(_ context.Context, sk signature.SecretKey) error {
 	skPath := s.secretKeyPath()
 
 	if _, err := os.Stat(skPath); err == nil {
@@ -87,7 +87,7 @@ func (s *Store) PutSecretKey(ctx context.Context, sk signature.SecretKey) error 
 }
 
 // DeleteSecretKey deletes the secret key in the store.
-func (s *Store) DeleteSecretKey(ctx context.Context) error {
+func (s *Store) DeleteSecretKey(_ context.Context) error {
 	skPath := s.secretKeyPath()
 
 	if _, err := os.Stat(skPath); os.IsNotExist(err) {
@@ -98,7 +98,7 @@ func (s *Store) DeleteSecretKey(ctx context.Context) error {
 }
 
 // GetNarInfo returns narinfo from the store.
-func (s *Store) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, error) {
+func (s *Store) GetNarInfo(_ context.Context, hash string) (*narinfo.NarInfo, error) {
 	narInfoPath := filepath.Join(s.storeNarInfoPath(), helper.NarInfoFilePath(hash))
 
 	nif, err := os.Open(narInfoPath)
@@ -116,7 +116,7 @@ func (s *Store) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, 
 }
 
 // PutNarInfo puts the narinfo in the store.
-func (s *Store) PutNarInfo(ctx context.Context, hash string, narInfo *narinfo.NarInfo) error {
+func (s *Store) PutNarInfo(_ context.Context, hash string, narInfo *narinfo.NarInfo) error {
 	narInfoPath := filepath.Join(s.storeNarInfoPath(), helper.NarInfoFilePath(hash))
 
 	if err := os.MkdirAll(filepath.Dir(narInfoPath), dirMode); err != nil {
@@ -135,14 +135,14 @@ func (s *Store) PutNarInfo(ctx context.Context, hash string, narInfo *narinfo.Na
 	defer nif.Close()
 
 	if _, err := nif.WriteString(narInfo.String()); err != nil {
-		return fmt.Errorf("error writing the narinfo to %q: %s", narInfoPath, err)
+		return fmt.Errorf("error writing the narinfo to %q: %w", narInfoPath, err)
 	}
 
 	return nil
 }
 
 // DeleteNarInfo deletes the narinfo from the store.
-func (s *Store) DeleteNarInfo(ctx context.Context, hash string) error {
+func (s *Store) DeleteNarInfo(_ context.Context, hash string) error {
 	narInfoPath := filepath.Join(s.storeNarInfoPath(), helper.NarInfoFilePath(hash))
 
 	if err := os.Remove(narInfoPath); err != nil {
@@ -157,7 +157,7 @@ func (s *Store) DeleteNarInfo(ctx context.Context, hash string) error {
 }
 
 // GetNar returns nar from the store.
-func (s *Store) GetNar(ctx context.Context, narURL nar.URL) (io.ReadCloser, error) {
+func (s *Store) GetNar(_ context.Context, narURL nar.URL) (io.ReadCloser, error) {
 	narPath := filepath.Join(s.storeNarPath(), narURL.ToFilePath())
 
 	nf, err := os.Open(narPath)
@@ -173,7 +173,7 @@ func (s *Store) GetNar(ctx context.Context, narURL nar.URL) (io.ReadCloser, erro
 }
 
 // PutNar puts the nar in the store.
-func (s *Store) PutNar(ctx context.Context, narURL nar.URL, body io.Reader) error {
+func (s *Store) PutNar(_ context.Context, narURL nar.URL, body io.Reader) error {
 	narPath := filepath.Join(s.storeNarPath(), narURL.ToFilePath())
 
 	if _, err := os.Stat(narPath); err == nil {
@@ -213,7 +213,7 @@ func (s *Store) PutNar(ctx context.Context, narURL nar.URL, body io.Reader) erro
 }
 
 // DeleteNar deletes the nar from the store.
-func (s *Store) DeleteNar(ctx context.Context, narURL nar.URL) error {
+func (s *Store) DeleteNar(_ context.Context, narURL nar.URL) error {
 	narPath := filepath.Join(s.storeNarPath(), narURL.ToFilePath())
 
 	if err := os.Remove(narPath); err != nil {
@@ -287,6 +287,7 @@ func validatePath(ctx context.Context, path string) error {
 
 func isWritable(ctx context.Context, path string) bool {
 	log := zerolog.Ctx(ctx)
+
 	tmpFile, err := os.CreateTemp(path, "write_test")
 	if err != nil {
 		log.Error().

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -1,0 +1,65 @@
+package local
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/nix-community/go-nix/pkg/narinfo"
+	"github.com/nix-community/go-nix/pkg/narinfo/signature"
+)
+
+// Store represents a local store and implements storage.Store.
+type Store struct {
+	path string
+}
+
+func New(path string) (*Store, error) {
+	return nil, errors.New("not implemented")
+}
+
+// GetSecretKey returns secret key from the store.
+func (s *Store) GetSecretKey(ctx context.Context) (signature.SecretKey, error) {
+	return signature.SecretKey{}, errors.New("not implemented")
+}
+
+// PutSecretKey stores the secret key in the store.
+func (s *Store) PutSecretKey(ctx context.Context, sk signature.SecretKey) error {
+	return errors.New("not implemented")
+}
+
+// DeleteSecretKey deletes the secret key in the store.
+func (s *Store) DeleteSecretKey(ctx context.Context) error {
+	return errors.New("not implemented")
+}
+
+// GetNarInfo returns narinfo from the store.
+func (s *Store) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, error) {
+	return nil, errors.New("not implemented")
+}
+
+// PutNarInfo puts the narinfo in the store.
+func (s *Store) PutNarInfo(ctx context.Context, hash string, narInfo *narinfo.NarInfo) error {
+	return errors.New("not implemented")
+}
+
+// DeleteNarInfo deletes the narinfo from the store.
+func (s *Store) DeleteNarInfo(ctx context.Context, hash string) error {
+	return errors.New("not implemented")
+}
+
+// GetNar returns nar from the store.
+func (s *Store) GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadCloser, error) {
+	return 0, nil, errors.New("not implemented")
+}
+
+// PutNar puts the nar in the store.
+func (s *Store) PutNar(ctx context.Context, narURL nar.URL, body io.ReadCloser) error {
+	return errors.New("not implemented")
+}
+
+// DeleteNar deletes the nar from the store.
+func (s *Store) DeleteNar(ctx context.Context, narURL nar.URL) error {
+	return errors.New("not implemented")
+}

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -38,9 +38,7 @@ const (
 )
 
 // Store represents a local store and implements storage.Store.
-type Store struct {
-	path string
-}
+type Store struct{ path string }
 
 func New(ctx context.Context, path string) (*Store, error) {
 	if err := validatePath(ctx, path); err != nil {

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -487,7 +487,7 @@ func TestGetNar(t *testing.T) {
 		narPath := filepath.Join(
 			dir,
 			"store",
-			"narinfo",
+			"nar",
 			testdata.Nar1.NarPath,
 		)
 
@@ -515,6 +515,132 @@ func TestGetNar(t *testing.T) {
 		}
 	})
 }
+
+// func TestPutNar(t *testing.T) {
+// 	t.Parallel()
+//
+// 	t.Run("no narfile exists in the store", func(t *testing.T) {
+// 		t.Parallel()
+//
+// 		dir, err := os.MkdirTemp("", "cache-path-")
+// 		require.NoError(t, err)
+// 		defer os.RemoveAll(dir) // clean up
+//
+// 		ctx := newContext()
+//
+// 		s, err := local.New(ctx, dir)
+// 		require.NoError(t, err)
+//
+// 		ni1, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarText))
+// 		require.NoError(t, err)
+//
+// 		require.NoError(t, s.PutNar(ctx, testdata.Nar1.NarHash, ni1))
+//
+// 		narPath := filepath.Join(
+// 			dir,
+// 			"store",
+// 			"narinfo",
+// 			helper.NarFilePath(testdata.Nar1.NarHash),
+// 		)
+//
+// 		require.FileExists(t, narPath)
+//
+// 		ni2c, err := os.Open(narPath)
+// 		require.NoError(t, err)
+//
+// 		defer ni2c.Close()
+//
+// 		ni2, err := narinfo.Parse(ni2c)
+// 		require.NoError(t, err)
+//
+// 		assert.Equal(t,
+// 			strings.TrimSpace(ni1.String()),
+// 			strings.TrimSpace(ni2.String()),
+// 		)
+// 	})
+//
+// 	t.Run("narfile exists in the store", func(t *testing.T) {
+// 		t.Parallel()
+//
+// 		dir, err := os.MkdirTemp("", "cache-path-")
+// 		require.NoError(t, err)
+// 		defer os.RemoveAll(dir) // clean up
+//
+// 		ctx := newContext()
+//
+// 		s, err := local.New(ctx, dir)
+// 		require.NoError(t, err)
+//
+// 		narPath := filepath.Join(
+// 			dir,
+// 			"store",
+// 			"narinfo",
+// 			helper.NarFilePath(testdata.Nar1.NarHash),
+// 		)
+//
+// 		require.NoError(t, os.MkdirAll(filepath.Dir(narPath), 0o700))
+//
+// 		err = os.WriteFile(narPath, []byte(testdata.Nar1.NarText), 0o400)
+// 		require.NoError(t, err)
+//
+// 		ni, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarText))
+// 		require.NoError(t, err)
+//
+// 		err = s.PutNar(ctx, testdata.Nar1.NarHash, ni)
+// 		assert.ErrorIs(t, err, storage.ErrAlreadyExists)
+// 	})
+// }
+//
+// func TestDeleteNar(t *testing.T) {
+// 	t.Parallel()
+//
+// 	t.Run("no nar exists in the store", func(t *testing.T) {
+// 		t.Parallel()
+//
+// 		dir, err := os.MkdirTemp("", "cache-path-")
+// 		require.NoError(t, err)
+// 		defer os.RemoveAll(dir) // clean up
+//
+// 		ctx := newContext()
+//
+// 		s, err := local.New(ctx, dir)
+// 		require.NoError(t, err)
+//
+// 		assert.ErrorIs(t,
+// 			s.DeleteNar(ctx, testdata.Nar1.NarHash),
+// 			storage.ErrNotFound,
+// 		)
+// 	})
+//
+// 	t.Run("narfile exists in the store", func(t *testing.T) {
+// 		t.Parallel()
+//
+// 		dir, err := os.MkdirTemp("", "cache-path-")
+// 		require.NoError(t, err)
+// 		defer os.RemoveAll(dir) // clean up
+//
+// 		ctx := newContext()
+//
+// 		s, err := local.New(ctx, dir)
+// 		require.NoError(t, err)
+//
+// 		narPath := filepath.Join(
+// 			dir,
+// 			"store",
+// 			"narinfo",
+// 			helper.NarFilePath(testdata.Nar1.NarHash),
+// 		)
+//
+// 		require.NoError(t, os.MkdirAll(filepath.Dir(narPath), 0o700))
+//
+// 		err = os.WriteFile(narPath, []byte(testdata.Nar1.NarText), 0o400)
+// 		require.NoError(t, err)
+//
+// 		require.NoError(t, s.DeleteNar(ctx, testdata.Nar1.NarHash))
+//
+// 		assert.NoFileExists(t, narPath)
+// 	})
+// }
 
 func newContext() context.Context {
 	return zerolog.

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -135,7 +135,7 @@ func TestGetSecretKey(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = s.GetSecretKey(newContext())
-		assert.ErrorIs(t, err, local.ErrNoSecretKey)
+		assert.ErrorIs(t, err, storage.ErrNotFound)
 	})
 
 	t.Run("secret key is present", func(t *testing.T) {
@@ -241,7 +241,7 @@ func TestDeleteSecretKey(t *testing.T) {
 		require.NoError(t, err)
 
 		err = s.DeleteSecretKey(newContext())
-		assert.ErrorIs(t, err, local.ErrNoSecretKey)
+		assert.ErrorIs(t, err, storage.ErrNotFound)
 	})
 
 	t.Run("secret key does exist", func(t *testing.T) {

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -452,7 +452,7 @@ func TestDeleteNarInfo(t *testing.T) {
 func TestGetNar(t *testing.T) {
 	t.Parallel()
 
-	t.Run("no narfile exists in the store", func(t *testing.T) {
+	t.Run("no nar exists in the store", func(t *testing.T) {
 		t.Parallel()
 
 		dir, err := os.MkdirTemp("", "cache-path-")
@@ -472,7 +472,7 @@ func TestGetNar(t *testing.T) {
 		assert.ErrorIs(t, err, storage.ErrNotFound)
 	})
 
-	t.Run("narfile exists in the store", func(t *testing.T) {
+	t.Run("nar exists in the store", func(t *testing.T) {
 		t.Parallel()
 
 		dir, err := os.MkdirTemp("", "cache-path-")
@@ -558,7 +558,7 @@ func TestPutNar(t *testing.T) {
 		}
 	})
 
-	t.Run("narfile exists in the store", func(t *testing.T) {
+	t.Run("nar exists in the store", func(t *testing.T) {
 		t.Parallel()
 
 		dir, err := os.MkdirTemp("", "cache-path-")
@@ -592,56 +592,66 @@ func TestPutNar(t *testing.T) {
 	})
 }
 
-// func TestDeleteNar(t *testing.T) {
-// 	t.Parallel()
-//
-// 	t.Run("no nar exists in the store", func(t *testing.T) {
-// 		t.Parallel()
-//
-// 		dir, err := os.MkdirTemp("", "cache-path-")
-// 		require.NoError(t, err)
-// 		defer os.RemoveAll(dir) // clean up
-//
-// 		ctx := newContext()
-//
-// 		s, err := local.New(ctx, dir)
-// 		require.NoError(t, err)
-//
-// 		assert.ErrorIs(t,
-// 			s.DeleteNar(ctx, testdata.Nar1.NarHash),
-// 			storage.ErrNotFound,
-// 		)
-// 	})
-//
-// 	t.Run("narfile exists in the store", func(t *testing.T) {
-// 		t.Parallel()
-//
-// 		dir, err := os.MkdirTemp("", "cache-path-")
-// 		require.NoError(t, err)
-// 		defer os.RemoveAll(dir) // clean up
-//
-// 		ctx := newContext()
-//
-// 		s, err := local.New(ctx, dir)
-// 		require.NoError(t, err)
-//
-// 		narPath := filepath.Join(
-// 			dir,
-// 			"store",
-// 			"narinfo",
-// 			helper.NarFilePath(testdata.Nar1.NarHash),
-// 		)
-//
-// 		require.NoError(t, os.MkdirAll(filepath.Dir(narPath), 0o700))
-//
-// 		err = os.WriteFile(narPath, []byte(testdata.Nar1.NarText), 0o400)
-// 		require.NoError(t, err)
-//
-// 		require.NoError(t, s.DeleteNar(ctx, testdata.Nar1.NarHash))
-//
-// 		assert.NoFileExists(t, narPath)
-// 	})
-// }
+func TestDeleteNar(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no nar exists in the store", func(t *testing.T) {
+		t.Parallel()
+
+		dir, err := os.MkdirTemp("", "cache-path-")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir) // clean up
+
+		ctx := newContext()
+
+		s, err := local.New(ctx, dir)
+		require.NoError(t, err)
+
+		narURL := nar.URL{
+			Hash:        testdata.Nar1.NarHash,
+			Compression: testdata.Nar1.NarCompression,
+		}
+
+		assert.ErrorIs(t,
+			s.DeleteNar(ctx, narURL),
+			storage.ErrNotFound,
+		)
+	})
+
+	t.Run("nar exists in the store", func(t *testing.T) {
+		t.Parallel()
+
+		dir, err := os.MkdirTemp("", "cache-path-")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir) // clean up
+
+		ctx := newContext()
+
+		s, err := local.New(ctx, dir)
+		require.NoError(t, err)
+
+		narPath := filepath.Join(
+			dir,
+			"store",
+			"nar",
+			testdata.Nar1.NarPath,
+		)
+
+		require.NoError(t, os.MkdirAll(filepath.Dir(narPath), 0o700))
+
+		err = os.WriteFile(narPath, []byte(testdata.Nar1.NarText), 0o400)
+		require.NoError(t, err)
+
+		narURL := nar.URL{
+			Hash:        testdata.Nar1.NarHash,
+			Compression: testdata.Nar1.NarCompression,
+		}
+
+		require.NoError(t, s.DeleteNar(ctx, narURL))
+
+		assert.NoFileExists(t, narPath)
+	})
+}
 
 func newContext() context.Context {
 	return zerolog.

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -465,7 +465,7 @@ func TestGetNar(t *testing.T) {
 		s, err := local.New(ctx, dir)
 		require.NoError(t, err)
 
-		_, err = s.GetNar(ctx, nar.URL{
+		_, _, err = s.GetNar(ctx, nar.URL{
 			Hash:        testdata.Nar1.NarHash,
 			Compression: testdata.Nar1.NarCompression,
 		})
@@ -502,11 +502,13 @@ func TestGetNar(t *testing.T) {
 			Compression: testdata.Nar1.NarCompression,
 		}
 
-		r, err := s.GetNar(ctx, narURL)
+		size, r, err := s.GetNar(ctx, narURL)
 		require.NoError(t, err)
 
 		nt, err := io.ReadAll(r)
 		require.NoError(t, err)
+
+		assert.EqualValues(t, len(testdata.Nar1.NarText), size)
 
 		if assert.Equal(t, len(testdata.Nar1.NarText), len(nt)) {
 			assert.Equal(t,

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -1,0 +1,154 @@
+package local_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/storage/local"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("path is required", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := local.New(newContext(), "")
+		assert.ErrorIs(t, err, local.ErrPathMustBeAbsolute)
+	})
+
+	t.Run("path is not absolute", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := local.New(newContext(), "somedir")
+		assert.ErrorIs(t, err, local.ErrPathMustBeAbsolute)
+	})
+
+	t.Run("path must exist", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := local.New(newContext(), "/non-existing")
+		assert.ErrorIs(t, err, local.ErrPathMustExist)
+	})
+
+	t.Run("path must be a directory", func(t *testing.T) {
+		t.Parallel()
+
+		f, err := os.CreateTemp("", "somefile")
+		require.NoError(t, err)
+		defer os.Remove(f.Name())
+
+		_, err = local.New(newContext(), f.Name())
+		assert.ErrorIs(t, err, local.ErrPathMustBeADirectory)
+	})
+
+	t.Run("path must be writable", func(t *testing.T) {
+		t.Parallel()
+
+		dir, err := os.MkdirTemp("", "cache-path-")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir) // clean up
+
+		require.NoError(t, os.Chmod(dir, 0o500))
+
+		_, err = local.New(newContext(), dir)
+		assert.ErrorIs(t, err, local.ErrPathMustBeWritable)
+	})
+
+	t.Run("valid path must return no error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := local.New(newContext(), os.TempDir())
+		assert.NoError(t, err)
+	})
+
+	t.Run("should create directories", func(t *testing.T) {
+		t.Parallel()
+
+		dir, err := os.MkdirTemp("", "cache-path-")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir) // clean up
+
+		dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+		testhelper.CreateMigrateDatabase(t, dbFile)
+
+		_, err = local.New(newContext(), dir)
+		require.NoError(t, err)
+
+		dirs := []string{
+			"config",
+			"store",
+			filepath.Join("store", "narinfo"),
+			filepath.Join("store", "nar"),
+			filepath.Join("store", "tmp"),
+			filepath.Join("var", "ncps", "db"),
+		}
+
+		for _, p := range dirs {
+			t.Run("Checking that "+p+" exists", func(t *testing.T) {
+				assert.DirExists(t, filepath.Join(dir, p))
+			})
+		}
+	})
+
+	t.Run("store/tmp is removed on boot", func(t *testing.T) {
+		t.Parallel()
+
+		dir, err := os.MkdirTemp("", "cache-path-")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir) // clean up
+
+		// create the directory tmp and add a file inside of it
+		err = os.MkdirAll(filepath.Join(dir, "store", "tmp"), 0o700)
+		require.NoError(t, err)
+
+		f, err := os.CreateTemp(filepath.Join(dir, "store", "tmp"), "hello")
+		require.NoError(t, err)
+
+		_, err = local.New(newContext(), dir)
+		require.NoError(t, err)
+
+		assert.NoFileExists(t, f.Name())
+	})
+}
+
+func TestGetSecretKey(t *testing.T) {
+}
+
+func TestPutSecretKey(t *testing.T) {
+}
+
+func TestDeleteSecretKey(t *testing.T) {
+}
+
+func TestGetNarInfo(t *testing.T) {
+}
+
+func TestPutNarInfo(t *testing.T) {
+}
+
+func TestDeleteNarInfo(t *testing.T) {
+}
+
+func TestGetNar(t *testing.T) {
+}
+
+func TestPutNar(t *testing.T) {
+}
+
+func TestDeleteNar(t *testing.T) {
+}
+
+func newContext() context.Context {
+	return zerolog.
+		New(io.Discard).
+		WithContext(context.Background())
+}

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -643,7 +643,10 @@ func TestPutNar(t *testing.T) {
 			Compression: testdata.Nar1.NarCompression,
 		}
 
-		require.NoError(t, s.PutNar(ctx, narURL, strings.NewReader(testdata.Nar1.NarText)))
+		written, err := s.PutNar(ctx, narURL, strings.NewReader(testdata.Nar1.NarText))
+		require.NoError(t, err)
+
+		require.EqualValues(t, len([]byte(testdata.Nar1.NarText)), written)
 
 		narPath := filepath.Join(
 			dir,
@@ -694,7 +697,7 @@ func TestPutNar(t *testing.T) {
 			Compression: testdata.Nar1.NarCompression,
 		}
 
-		err = s.PutNar(ctx, narURL, strings.NewReader(testdata.Nar1.NarText))
+		_, err = s.PutNar(ctx, narURL, strings.NewReader(testdata.Nar1.NarText))
 		assert.ErrorIs(t, err, storage.ErrAlreadyExists)
 	})
 }

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -516,81 +516,82 @@ func TestGetNar(t *testing.T) {
 	})
 }
 
-// func TestPutNar(t *testing.T) {
-// 	t.Parallel()
-//
-// 	t.Run("no narfile exists in the store", func(t *testing.T) {
-// 		t.Parallel()
-//
-// 		dir, err := os.MkdirTemp("", "cache-path-")
-// 		require.NoError(t, err)
-// 		defer os.RemoveAll(dir) // clean up
-//
-// 		ctx := newContext()
-//
-// 		s, err := local.New(ctx, dir)
-// 		require.NoError(t, err)
-//
-// 		ni1, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarText))
-// 		require.NoError(t, err)
-//
-// 		require.NoError(t, s.PutNar(ctx, testdata.Nar1.NarHash, ni1))
-//
-// 		narPath := filepath.Join(
-// 			dir,
-// 			"store",
-// 			"narinfo",
-// 			helper.NarFilePath(testdata.Nar1.NarHash),
-// 		)
-//
-// 		require.FileExists(t, narPath)
-//
-// 		ni2c, err := os.Open(narPath)
-// 		require.NoError(t, err)
-//
-// 		defer ni2c.Close()
-//
-// 		ni2, err := narinfo.Parse(ni2c)
-// 		require.NoError(t, err)
-//
-// 		assert.Equal(t,
-// 			strings.TrimSpace(ni1.String()),
-// 			strings.TrimSpace(ni2.String()),
-// 		)
-// 	})
-//
-// 	t.Run("narfile exists in the store", func(t *testing.T) {
-// 		t.Parallel()
-//
-// 		dir, err := os.MkdirTemp("", "cache-path-")
-// 		require.NoError(t, err)
-// 		defer os.RemoveAll(dir) // clean up
-//
-// 		ctx := newContext()
-//
-// 		s, err := local.New(ctx, dir)
-// 		require.NoError(t, err)
-//
-// 		narPath := filepath.Join(
-// 			dir,
-// 			"store",
-// 			"narinfo",
-// 			helper.NarFilePath(testdata.Nar1.NarHash),
-// 		)
-//
-// 		require.NoError(t, os.MkdirAll(filepath.Dir(narPath), 0o700))
-//
-// 		err = os.WriteFile(narPath, []byte(testdata.Nar1.NarText), 0o400)
-// 		require.NoError(t, err)
-//
-// 		ni, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarText))
-// 		require.NoError(t, err)
-//
-// 		err = s.PutNar(ctx, testdata.Nar1.NarHash, ni)
-// 		assert.ErrorIs(t, err, storage.ErrAlreadyExists)
-// 	})
-// }
-//
+func TestPutNar(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no nar exists in the store", func(t *testing.T) {
+		t.Parallel()
+
+		dir, err := os.MkdirTemp("", "cache-path-")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir) // clean up
+
+		ctx := newContext()
+
+		s, err := local.New(ctx, dir)
+		require.NoError(t, err)
+
+		narURL := nar.URL{
+			Hash:        testdata.Nar1.NarHash,
+			Compression: testdata.Nar1.NarCompression,
+		}
+
+		require.NoError(t, s.PutNar(ctx, narURL, strings.NewReader(testdata.Nar1.NarText)))
+
+		narPath := filepath.Join(
+			dir,
+			"store",
+			"narinfo",
+			testdata.Nar1.NarPath,
+		)
+
+		require.FileExists(t, narPath)
+
+		cs, err := os.ReadFile(narPath)
+		require.NoError(t, err)
+
+		if assert.Equal(t, len(testdata.Nar1.NarText), len(string(cs))) {
+			assert.Equal(t,
+				strings.TrimSpace(testdata.Nar1.NarText),
+				strings.TrimSpace(string(cs)),
+			)
+		}
+	})
+
+	t.Run("narfile exists in the store", func(t *testing.T) {
+		t.Parallel()
+
+		dir, err := os.MkdirTemp("", "cache-path-")
+		require.NoError(t, err)
+		defer os.RemoveAll(dir) // clean up
+
+		ctx := newContext()
+
+		s, err := local.New(ctx, dir)
+		require.NoError(t, err)
+
+		narPath := filepath.Join(
+			dir,
+			"store",
+			"narinfo",
+			testdata.Nar1.NarPath,
+		)
+
+		require.NoError(t, os.MkdirAll(filepath.Dir(narPath), 0o700))
+
+		err = os.WriteFile(narPath, []byte(testdata.Nar1.NarText), 0o400)
+		require.NoError(t, err)
+
+		narURL := nar.URL{
+			Hash:        testdata.Nar1.NarHash,
+			Compression: testdata.Nar1.NarCompression,
+		}
+
+		err = s.PutNar(ctx, narURL, strings.NewReader(testdata.Nar1.NarText))
+		assert.ErrorIs(t, err, storage.ErrAlreadyExists)
+	})
+}
+
 // func TestDeleteNar(t *testing.T) {
 // 	t.Parallel()
 //

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/kalbasit/ncps/pkg/helper"
 	"github.com/kalbasit/ncps/pkg/storage"
 	"github.com/kalbasit/ncps/pkg/storage/local"
 	"github.com/kalbasit/ncps/testdata"
@@ -306,7 +305,7 @@ func TestGetNarInfo(t *testing.T) {
 			dir,
 			"store",
 			"narinfo",
-			helper.NarInfoFilePath(testdata.Nar1.NarInfoHash),
+			testdata.Nar1.NarInfoPath,
 		)
 
 		require.NoError(t, os.MkdirAll(filepath.Dir(narInfoPath), 0o700))
@@ -348,7 +347,7 @@ func TestPutNarInfo(t *testing.T) {
 			dir,
 			"store",
 			"narinfo",
-			helper.NarInfoFilePath(testdata.Nar1.NarInfoHash),
+			testdata.Nar1.NarInfoPath,
 		)
 
 		require.FileExists(t, narInfoPath)
@@ -383,7 +382,7 @@ func TestPutNarInfo(t *testing.T) {
 			dir,
 			"store",
 			"narinfo",
-			helper.NarInfoFilePath(testdata.Nar1.NarInfoHash),
+			testdata.Nar1.NarInfoPath,
 		)
 
 		require.NoError(t, os.MkdirAll(filepath.Dir(narInfoPath), 0o700))
@@ -436,7 +435,7 @@ func TestDeleteNarInfo(t *testing.T) {
 			dir,
 			"store",
 			"narinfo",
-			helper.NarInfoFilePath(testdata.Nar1.NarInfoHash),
+			testdata.Nar1.NarInfoPath,
 		)
 
 		require.NoError(t, os.MkdirAll(filepath.Dir(narInfoPath), 0o700))

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -222,7 +222,7 @@ func TestPutSecretKey(t *testing.T) {
 		require.NoError(t, err)
 
 		err = s.PutSecretKey(ctx, sk2)
-		assert.ErrorIs(t, err, local.ErrSecretKeyAlreadyExists)
+		assert.ErrorIs(t, err, storage.ErrAlreadyExists)
 	})
 }
 

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -342,7 +342,7 @@ func TestPutNarInfo(t *testing.T) {
 		ni1, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
 		require.NoError(t, err)
 
-		require.NoError(t, s.PutNarInfo(ctx, ni1))
+		require.NoError(t, s.PutNarInfo(ctx, testdata.Nar1.NarInfoHash, ni1))
 
 		narInfoPath := filepath.Join(
 			dir,
@@ -394,7 +394,7 @@ func TestPutNarInfo(t *testing.T) {
 		ni, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
 		require.NoError(t, err)
 
-		err = s.PutNarInfo(ctx, ni)
+		err = s.PutNarInfo(ctx, testdata.Nar1.NarInfoHash, ni)
 		assert.ErrorIs(t, err, storage.ErrAlreadyExists)
 	})
 }

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -449,6 +449,7 @@ func TestDeleteNarInfo(t *testing.T) {
 		assert.NoFileExists(t, narInfoPath)
 	})
 }
+
 func TestGetNar(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -541,7 +541,7 @@ func TestPutNar(t *testing.T) {
 		narPath := filepath.Join(
 			dir,
 			"store",
-			"narinfo",
+			"nar",
 			testdata.Nar1.NarPath,
 		)
 
@@ -573,7 +573,7 @@ func TestPutNar(t *testing.T) {
 		narPath := filepath.Join(
 			dir,
 			"store",
-			"narinfo",
+			"nar",
 			testdata.Nar1.NarPath,
 		)
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -42,7 +42,7 @@ type NarInfoStore interface {
 	GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, error)
 
 	// PutNarInfo puts the narinfo in the store.
-	PutNarInfo(ctx context.Context, narInfo *narinfo.NarInfo) error
+	PutNarInfo(ctx context.Context, hash string, narInfo *narinfo.NarInfo) error
 
 	// DeleteNarInfo deletes the narinfo from the store.
 	DeleteNarInfo(ctx context.Context, hash string) error

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -14,6 +14,10 @@ import (
 var (
 	// ErrNotFound is returned if the nar or narinfo were not found.
 	ErrNotFound = errors.New("not found")
+
+	// ErrAlreadyExists is returned the store already has a file with the
+	// same name.
+	ErrAlreadyExists = errors.New("secret key already exists")
 )
 
 // ConfigStore represents a store for the ncps to use for storing

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -42,7 +42,7 @@ type NarInfoStore interface {
 	GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, error)
 
 	// PutNarInfo puts the narinfo in the store.
-	PutNarInfo(ctx context.Context, hash string, narInfo *narinfo.NarInfo) error
+	PutNarInfo(ctx context.Context, narInfo *narinfo.NarInfo) error
 
 	// DeleteNarInfo deletes the narinfo from the store.
 	DeleteNarInfo(ctx context.Context, hash string) error

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2,12 +2,18 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/nix-community/go-nix/pkg/narinfo"
 	"github.com/nix-community/go-nix/pkg/narinfo/signature"
 
 	"github.com/kalbasit/ncps/pkg/nar"
+)
+
+var (
+	// ErrNotFound is returned if the nar or narinfo were not found.
+	ErrNotFound = errors.New("not found")
 )
 
 // ConfigStore represents a store for the ncps to use for storing

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -17,7 +17,7 @@ var (
 
 	// ErrAlreadyExists is returned the store already has a file with the
 	// same name.
-	ErrAlreadyExists = errors.New("secret key already exists")
+	ErrAlreadyExists = errors.New("file already exists")
 )
 
 // ConfigStore represents a store for the ncps to use for storing


### PR DESCRIPTION
Implements a local storage backend for storing nars and narinfos

- Adds local storage implementation with support for:
  - Secret key management (get/put/delete)
  - NarInfo management (get/put/delete) 
  - Nar file management (get/put/delete)

- Includes comprehensive test coverage for all operations
- Adds validation for storage paths and permissions
- Implements proper file modes and directory structure
- Handles temporary file cleanup on initialization
- Adds error types for common failure cases

The local storage backend provides a complete implementation of the Store interface while maintaining proper file permissions and directory structure.