### PR TITLE
cmd: open sqlite database and create cache with it

### DIFF
--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
+	"github.com/kalbasit/ncps/pkg/database"
 	"github.com/kalbasit/ncps/pkg/nar"
 	"github.com/kalbasit/ncps/testdata"
 	"github.com/kalbasit/ncps/testhelper"
@@ -60,7 +61,10 @@ func TestAddUpstreamCaches(t *testing.T) {
 		dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 		testhelper.CreateMigrateDatabase(t, dbFile)
 
-		c, err := New(logger, "cache.example.com", dir)
+		db, err := database.Open("sqlite:" + dbFile)
+		require.NoError(t, err)
+
+		c, err := New(logger, "cache.example.com", dir, db)
 		require.NoError(t, err)
 
 		c.AddUpstreamCaches(ucs...)
@@ -107,7 +111,10 @@ func TestAddUpstreamCaches(t *testing.T) {
 		dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 		testhelper.CreateMigrateDatabase(t, dbFile)
 
-		c, err := New(logger, "cache.example.com", dir)
+		db, err := database.Open("sqlite:" + dbFile)
+		require.NoError(t, err)
+
+		c, err := New(logger, "cache.example.com", dir, db)
 		require.NoError(t, err)
 
 		for _, uc := range ucs {
@@ -132,7 +139,10 @@ func TestRunLRU(t *testing.T) {
 	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 	testhelper.CreateMigrateDatabase(t, dbFile)
 
-	c, err := New(logger, "cache.example.com", dir)
+	db, err := database.Open("sqlite:" + dbFile)
+	require.NoError(t, err)
+
+	c, err := New(logger, "cache.example.com", dir, db)
 	require.NoError(t, err)
 
 	ts := testdata.NewTestServer(t, 40)

--- a/pkg/database/query_test.go
+++ b/pkg/database/query_test.go
@@ -35,7 +35,7 @@ func TestGetNarInfoByHash(t *testing.T) {
 		dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 		testhelper.CreateMigrateDatabase(t, dbFile)
 
-		db, err := database.Open(dbFile)
+		db, err := database.Open("sqlite:" + dbFile)
 		require.NoError(t, err)
 
 		hash, err := helper.RandString(32, nil)
@@ -55,7 +55,7 @@ func TestGetNarInfoByHash(t *testing.T) {
 		dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 		testhelper.CreateMigrateDatabase(t, dbFile)
 
-		db, err := database.Open(dbFile)
+		db, err := database.Open("sqlite:" + dbFile)
 		require.NoError(t, err)
 
 		hash, err := helper.RandString(32, nil)
@@ -80,7 +80,7 @@ func TestInsertNarInfo(t *testing.T) {
 	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 	testhelper.CreateMigrateDatabase(t, dbFile)
 
-	db, err := database.Open(dbFile)
+	db, err := database.Open("sqlite:" + dbFile)
 	require.NoError(t, err)
 
 	t.Run("inserting one record", func(t *testing.T) {
@@ -182,7 +182,7 @@ func TestTouchNarInfo(t *testing.T) {
 	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 	testhelper.CreateMigrateDatabase(t, dbFile)
 
-	db, err := database.Open(dbFile)
+	db, err := database.Open("sqlite:" + dbFile)
 	require.NoError(t, err)
 
 	t.Run("narinfo not existing", func(t *testing.T) {
@@ -272,7 +272,7 @@ func TestDeleteNarInfo(t *testing.T) {
 	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 	testhelper.CreateMigrateDatabase(t, dbFile)
 
-	db, err := database.Open(dbFile)
+	db, err := database.Open("sqlite:" + dbFile)
 	require.NoError(t, err)
 
 	t.Run("narinfo not existing", func(t *testing.T) {
@@ -339,7 +339,7 @@ func TestGetNarByHash(t *testing.T) {
 		dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 		testhelper.CreateMigrateDatabase(t, dbFile)
 
-		db, err := database.Open(dbFile)
+		db, err := database.Open("sqlite:" + dbFile)
 		require.NoError(t, err)
 
 		narInfoHash, err := helper.RandString(32, nil)
@@ -365,7 +365,7 @@ func TestGetNarByHash(t *testing.T) {
 		dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 		testhelper.CreateMigrateDatabase(t, dbFile)
 
-		db, err := database.Open(dbFile)
+		db, err := database.Open("sqlite:" + dbFile)
 		require.NoError(t, err)
 
 		narInfoHash, err := helper.RandString(32, nil)
@@ -405,7 +405,7 @@ func TestInsertNar(t *testing.T) {
 	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 	testhelper.CreateMigrateDatabase(t, dbFile)
 
-	db, err := database.Open(dbFile)
+	db, err := database.Open("sqlite:" + dbFile)
 	require.NoError(t, err)
 
 	// create a narinfo
@@ -520,7 +520,7 @@ func TestTouchNar(t *testing.T) {
 	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 	testhelper.CreateMigrateDatabase(t, dbFile)
 
-	db, err := database.Open(dbFile)
+	db, err := database.Open("sqlite:" + dbFile)
 	require.NoError(t, err)
 
 	t.Run("nar not existing", func(t *testing.T) {
@@ -659,7 +659,7 @@ func TestDeleteNar(t *testing.T) {
 	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 	testhelper.CreateMigrateDatabase(t, dbFile)
 
-	db, err := database.Open(dbFile)
+	db, err := database.Open("sqlite:" + dbFile)
 	require.NoError(t, err)
 
 	t.Run("nar not existing", func(t *testing.T) {
@@ -753,7 +753,7 @@ func TestNarTotalSize(t *testing.T) {
 	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 	testhelper.CreateMigrateDatabase(t, dbFile)
 
-	db, err := database.Open(dbFile)
+	db, err := database.Open("sqlite:" + dbFile)
 	require.NoError(t, err)
 
 	var expectedSize uint64
@@ -790,7 +790,7 @@ func TestGetLeastAccessedNars(t *testing.T) {
 	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 	testhelper.CreateMigrateDatabase(t, dbFile)
 
-	db, err := database.Open(dbFile)
+	db, err := database.Open("sqlite:" + dbFile)
 	require.NoError(t, err)
 
 	// NOTE: For this test, any nar that's explicitly testing the zstd

--- a/pkg/server/server_internal_test.go
+++ b/pkg/server/server_internal_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -10,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kalbasit/ncps/pkg/cache"
+	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/testhelper"
 )
 
 //nolint:gochecknoglobals
@@ -20,7 +23,13 @@ func TestSetDeletePermitted(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir) // clean up
 
-	c, err := cache.New(logger, "cache.example.com", dir)
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
+	db, err := database.Open("sqlite:" + dbFile)
+	require.NoError(t, err)
+
+	c, err := cache.New(logger, "cache.example.com", dir, db)
 	require.NoError(t, err)
 
 	t.Run("false", func(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -19,12 +19,15 @@ import (
 
 	"github.com/kalbasit/ncps/pkg/cache"
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
+	"github.com/kalbasit/ncps/pkg/database"
 	"github.com/kalbasit/ncps/pkg/helper"
 	"github.com/kalbasit/ncps/pkg/nar"
 	"github.com/kalbasit/ncps/pkg/server"
 	"github.com/kalbasit/ncps/testdata"
 	"github.com/kalbasit/ncps/testhelper"
 )
+
+const cacheName = "cache.example.com"
 
 //nolint:gochecknoglobals
 var logger = zerolog.New(io.Discard)
@@ -45,7 +48,10 @@ func TestServeHTTP(t *testing.T) {
 		dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 		testhelper.CreateMigrateDatabase(t, dbFile)
 
-		c, err := cache.New(logger, "cache.example.com", dir)
+		db, err := database.Open("sqlite:" + dbFile)
+		require.NoError(t, err)
+
+		c, err := cache.New(logger, cacheName, dir, db)
 		require.NoError(t, err)
 
 		c.AddUpstreamCaches(uc)
@@ -163,7 +169,10 @@ func TestServeHTTP(t *testing.T) {
 		dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 		testhelper.CreateMigrateDatabase(t, dbFile)
 
-		c, err := cache.New(logger, "cache.example.com", dir)
+		db, err := database.Open("sqlite:" + dbFile)
+		require.NoError(t, err)
+
+		c, err := cache.New(logger, cacheName, dir, db)
 		require.NoError(t, err)
 
 		c.AddUpstreamCaches(uc)
@@ -270,7 +279,10 @@ func TestServeHTTP(t *testing.T) {
 		dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 		testhelper.CreateMigrateDatabase(t, dbFile)
 
-		c, err := cache.New(logger, "cache.example.com", dir)
+		db, err := database.Open("sqlite:" + dbFile)
+		require.NoError(t, err)
+
+		c, err := cache.New(logger, cacheName, dir, db)
 		require.NoError(t, err)
 
 		c.AddUpstreamCaches(uc)
@@ -364,7 +376,7 @@ func TestServeHTTP(t *testing.T) {
 
 					var sig signature.Signature
 					for _, sig = range ni.Signatures {
-						if sig.Name == "cache.example.com" {
+						if sig.Name == cacheName {
 							found = true
 
 							break


### PR DESCRIPTION
### TL;DR

Refactored database initialization to accept a database URL instead of creating the database connection within the cache.

### What changed?

- Modified `database.Open()` to accept a URL-style connection string (e.g., "sqlite:/path/to/db")
- Moved database initialization out of the cache package and into the calling code
- Added new `cache-database-url` CLI flag and environment variable
- Updated cache constructor to accept database connection as parameter
- Removed database path/file management from cache package
- Updated all tests to handle external database initialization

### How to test?

1. Run the service with the new required `--cache-database-url` flag:
```bash
ncps serve --cache-database-url="sqlite:/path/to/database.sqlite"
```

2. Verify database operations work as expected through the API endpoints
3. Run the test suite to ensure database operations function correctly

### Why make this change?

This change improves separation of concerns by moving database connection management outside the cache package. It also provides more flexibility for database configuration and makes it easier to support different database backends in the future through the URL-style connection string.