### PR TITLE
feat(pre-commit)!: enforce conventional commits

### DIFF
--- a/nix/pre-commit/flake-module.nix
+++ b/nix/pre-commit/flake-module.nix
@@ -11,6 +11,7 @@
       check-merge-conflicts.enable = true;
       commitizen.enable = true;
       deadnix.enable = true;
+      end-of-file-fixer.enable = true;
       gofmt.enable = true;
       golangci-lint.enable = true;
       no-commit-to-branch.enable = true;

--- a/nix/pre-commit/flake-module.nix
+++ b/nix/pre-commit/flake-module.nix
@@ -8,6 +8,7 @@
   perSystem = {
     pre-commit.check.enable = false;
     pre-commit.settings.hooks = {
+      check-merge-conflicts.enable = true;
       commitizen.enable = true;
       deadnix.enable = true;
       gofmt.enable = true;

--- a/nix/pre-commit/flake-module.nix
+++ b/nix/pre-commit/flake-module.nix
@@ -11,7 +11,6 @@
       check-merge-conflicts.enable = true;
       commitizen.enable = true;
       deadnix.enable = true;
-      end-of-file-fixer.enable = true;
       gofmt.enable = true;
       golangci-lint.enable = true;
       no-commit-to-branch.enable = true;

--- a/nix/pre-commit/flake-module.nix
+++ b/nix/pre-commit/flake-module.nix
@@ -8,6 +8,7 @@
   perSystem = {
     pre-commit.check.enable = false;
     pre-commit.settings.hooks = {
+      commitizen.enable = true;
       deadnix.enable = true;
       gofmt.enable = true;
       golangci-lint.enable = true;


### PR DESCRIPTION
feat(pre-commit)!: enforce conventional commits

https://commitizen-tools.github.io/commitizen/

feat(pre-commit): prevent checking merge conflicts markers

feat(pre-commit): add end-of-file-fixer

Revert "feat(pre-commit): add end-of-file-fixer"

This reverts commit 5632f4e1af1b43b0f764a604075820bc2b250965.