### PR TITLE
fix(server): logger was being overritten

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -104,7 +104,7 @@ func requestLogger(logger zerolog.Logger) func(handler http.Handler) http.Handle
 			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 
 			defer func() {
-				logger.With().
+				log := logger.With().
 					Str("method", r.Method).
 					Str("request-uri", r.RequestURI).
 					Int("status", ww.Status()).
@@ -115,12 +115,12 @@ func requestLogger(logger zerolog.Logger) func(handler http.Handler) http.Handle
 
 				switch r.Method {
 				case http.MethodHead, http.MethodGet:
-					logger = logger.With().Int("bytes", ww.BytesWritten()).Logger()
+					log = logger.With().Int("bytes", ww.BytesWritten()).Logger()
 				case http.MethodPost, http.MethodPut, http.MethodPatch:
-					logger = logger.With().Int64("bytes", r.ContentLength).Logger()
+					log = logger.With().Int64("bytes", r.ContentLength).Logger()
 				}
 
-				logger.Info().Msg("handled request")
+				log.Info().Msg("handled request")
 			}()
 
 			next.ServeHTTP(ww, r)


### PR DESCRIPTION
### TL;DR

Fixed request logger to properly chain logging context in HTTP middleware.

### What changed?

Modified the request logger middleware to store the logger context in a local variable instead of reassigning the logger parameter. This ensures all logging context is properly captured when handling HTTP requests.

### How to test?

1. Start the server
2. Send various HTTP requests (GET, POST, PUT, PATCH, HEAD)
3. Verify that the logs contain all expected fields:
   - method
   - request-uri
   - status
   - duration
   - bytes/content-length (depending on request type)

### Why make this change?

The previous implementation was reassigning the logger parameter instead of building up the context in a local variable. This could lead to inconsistent or missing log fields since each assignment created a new logger instance rather than chaining the context properly.

closes #129