### PR TITLE
fix(server): properly fix the logging

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -115,9 +115,9 @@ func requestLogger(logger zerolog.Logger) func(handler http.Handler) http.Handle
 
 				switch r.Method {
 				case http.MethodHead, http.MethodGet:
-					log = logger.With().Int("bytes", ww.BytesWritten()).Logger()
+					log = log.With().Int("bytes", ww.BytesWritten()).Logger()
 				case http.MethodPost, http.MethodPut, http.MethodPatch:
-					log = logger.With().Int64("bytes", r.ContentLength).Logger()
+					log = log.With().Int64("bytes", r.ContentLength).Logger()
 				}
 
 				log.Info().Msg("handled request")


### PR DESCRIPTION
In #130 I attempted to fix the logger, but I used the wrong logger instance when adding the bytes effectively erasing all the other fields.