### PR TITLE
test(pkg/nar): Fuzz the Parse and JoinURL funcs

### DIFF
--- a/pkg/nar/url.go
+++ b/pkg/nar/url.go
@@ -29,27 +29,25 @@ type URL struct {
 
 // ParseURL parses a nar URL (as present in narinfo) and returns its components.
 func ParseURL(u string) (URL, error) {
-	var nu URL
-
 	if u == "" || !strings.HasPrefix(u, "nar/") {
-		return nu, ErrInvalidURL
+		return URL{}, ErrInvalidURL
 	}
 
 	sm := narRegexp.FindStringSubmatch(u)
 	if len(sm) != 6 {
-		return nu, ErrInvalidURL
+		return URL{}, ErrInvalidURL
 	}
 
-	nu.Hash = sm[1]
+	nu := URL{Hash: sm[1]}
 
 	var err error
 
 	if nu.Compression, err = CompressionTypeFromExtension(sm[3]); err != nil {
-		return nu, fmt.Errorf("error computing the compression type: %w", err)
+		return URL{}, fmt.Errorf("error computing the compression type: %w", err)
 	}
 
 	if nu.Query, err = url.ParseQuery(sm[5]); err != nil {
-		return nu, fmt.Errorf("error parsing the RawQuery as url.Values: %w", err)
+		return URL{}, fmt.Errorf("error parsing the RawQuery as url.Values: %w", err)
 	}
 
 	return nu, nil

--- a/pkg/nar/url_test.go
+++ b/pkg/nar/url_test.go
@@ -11,6 +11,39 @@ import (
 	"github.com/kalbasit/ncps/pkg/nar"
 )
 
+func FuzzParseURL(f *testing.F) {
+	tests := []string{
+		"",
+		"helloworld",
+		"nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar",
+		"nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.bz2",
+		"nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.zst",
+		"nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.lzip",
+		"nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.lz4",
+		"nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.br",
+		"nar/1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.xz",
+		"nar/1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac.nar?hash=1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl",
+		"nar/1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac.nar.zst?hash=1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl",
+		"nar/1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac.nar.xz?hash=1q8w6gl1ll0mwfkqc3c2yx005s6wwfrl",
+	}
+
+	for _, tc := range tests {
+		f.Add(tc)
+	}
+
+	f.Fuzz(func(t *testing.T, url string) {
+		narURL, err := nar.ParseURL(url)
+		if err != nil {
+			assert.Equal(t, "", narURL.Hash)
+			assert.Equal(t, "", string(narURL.Compression))
+			assert.Equal(t, "", narURL.Query.Encode())
+		} else {
+			assert.NotEmpty(t, narURL.Hash)
+			assert.NotEmpty(t, string(narURL.Compression))
+		}
+	})
+}
+
 func TestParseURL(t *testing.T) {
 	tests := []struct {
 		url    string
@@ -130,6 +163,64 @@ func TestParseURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func FuzzJoinURL(f *testing.F) {
+	hashes := []string{
+		"1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+		"1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+		"1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+		"1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+		"1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+		"1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+		"1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+		"1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac",
+		"1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac",
+		"1bn7c3bf5z32cdgylhbp9nzhh6ydib5ngsm6mdhsvf233g0nh1ac",
+	}
+
+	queries := []string{
+		"",
+		"a=1",
+		"a=1&b=2",
+	}
+
+	urls := []string{
+		"http://example.com",
+		"example.com",
+	}
+
+	for _, uri := range urls {
+		for _, hash := range hashes {
+			for _, query := range queries {
+				f.Add(uri, hash, query)
+			}
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, uri, hash, query string) {
+		q, err := url.ParseQuery(query)
+		if err != nil {
+			t.Skip()
+		}
+
+		u1, err := url.Parse(uri)
+		if err != nil {
+			t.Skip()
+		}
+
+		narURL := nar.URL{
+			Hash:        hash,
+			Compression: "xz",
+			Query:       q,
+		}
+
+		u2 := narURL.JoinURL(u1)
+
+		assert.Equal(t, u1.Scheme, u2.Scheme)
+		assert.Equal(t, u1.Host, u2.Host)
+		assert.Equal(t, u1.JoinPath("/nar/"+hash+".nar.xz").Path, u2.Path)
+	})
 }
 
 func TestJoinURL(t *testing.T) {


### PR DESCRIPTION
### TL;DR
Added fuzzing tests for URL parsing and joining functionality in the NAR package.

### What changed?
- Added `FuzzParseURL` to test the URL parsing functionality with various input combinations
- Added `FuzzJoinURL` to test URL joining functionality with different hashes, queries, and base URLs
- Optimized `ParseURL` function to return early on errors and initialize the URL struct more efficiently

### How to test?
Run the fuzzing tests:
```bash
go test -fuzz=FuzzParseURL ./pkg/nar
go test -fuzz=FuzzJoinURL ./pkg/nar
```

### Why make this change?
Fuzzing tests help identify edge cases and potential vulnerabilities in URL parsing and joining operations by testing with randomly generated inputs. This improves the robustness and security of the NAR package's URL handling capabilities.