### PR TITLE
ci: run flake-check before pushing docker on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,12 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v8
       - uses: DeterminateSystems/flake-checker-action@main
       - run: nix flake check
+  docker:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/docker
+        with:
+          images: kalbasit/ncps
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,8 +5,20 @@ on:
       - "main"
   pull_request:
 jobs:
+  flake-check:
+    runs-on: ubuntu-24.04
+    permissions:
+      id-token: "write"
+      contents: "read"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - uses: DeterminateSystems/flake-checker-action@main
+      - run: nix flake check
   docker:
     runs-on: ubuntu-24.04
+    needs: flake-check
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - "main"
-  pull_request:
 jobs:
   flake-check:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### TL;DR

Added Docker image build and publish workflow to CI pipeline

### What changed?

- Added Docker build job to the CI workflow for pull requests
- Modified main Docker workflow to:
  - Run only on main branch pushes
  - Add flake check as a prerequisite
  - Remove pull request trigger

### How to test?

1. Create a new pull request
2. Verify Docker image builds successfully in CI
3. Merge PR to main branch
4. Confirm Docker image is published to DockerHub under kalbasit/ncps

### Why make this change?

Ensures Docker images are pushed to Dockerhub only after all tests have passed. This prevents pushing broken images to Dockerhub.