### PR TITLE
Ensure pull requests are conventional

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,0 +1,18 @@
+name: "Lint PR"
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+permissions:
+  pull-requests: read
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -9,7 +9,7 @@ on:
 permissions:
   pull-requests: read
 jobs:
-  main:
+  validate-pr-title:
     name: Validate PR title
     runs-on: ubuntu-24.04
     steps:

--- a/nix/pre-commit/flake-module.nix
+++ b/nix/pre-commit/flake-module.nix
@@ -9,7 +9,6 @@
     pre-commit.check.enable = false;
     pre-commit.settings.hooks = {
       check-merge-conflicts.enable = true;
-      commitizen.enable = true;
       deadnix.enable = true;
       gofmt.enable = true;
       golangci-lint.enable = true;


### PR DESCRIPTION
Pull requests are squashed so individual commits are pointless which makes the `commitizen` pre-commit hook completely useless. Integrate [this action](https://github.com/amannn/action-semantic-pull-request) instead to ensure the pull request tile follow the [conventional commits](https://www.conventionalcommits.org) which becomes the commit message once merged.

- Remove commitizen pre-commit hook.
- Add semantic pull request validation workflow.