### PR TITLE
refactor(server): improve logging and error handling

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -143,11 +144,12 @@ func serveAction() cli.ActionFunc {
 			return err
 		}
 
-		srv := server.New(logger, cache)
+		srv := server.New(cache)
 		srv.SetDeletePermitted(cmd.Bool("allow-delete"))
 		srv.SetPutPermitted(cmd.Bool("allow-put"))
 
 		server := &http.Server{
+			BaseContext:       func(net.Listener) context.Context { return ctx },
 			Addr:              cmd.String("server-addr"),
 			Handler:           srv,
 			ReadHeaderTimeout: 10 * time.Second,

--- a/pkg/nar/url.go
+++ b/pkg/nar/url.go
@@ -56,9 +56,9 @@ func ParseURL(u string) (URL, error) {
 // NewLogger returns a new logger with the right fields.
 func (u URL) NewLogger(log zerolog.Logger) zerolog.Logger {
 	return log.With().
-		Str("hash", u.Hash).
-		Str("compression", u.Compression.String()).
-		Str("query", u.Query.Encode()).
+		Str("nar-hash", u.Hash).
+		Str("nar-compression", u.Compression.String()).
+		Str("nar-query", u.Query.Encode()).
 		Logger()
 }
 

--- a/pkg/server/server_internal_test.go
+++ b/pkg/server/server_internal_test.go
@@ -2,12 +2,10 @@ package server
 
 import (
 	"context"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -18,9 +16,6 @@ import (
 )
 
 const cacheName = "cache.example.com"
-
-//nolint:gochecknoglobals
-var logger = zerolog.New(io.Discard)
 
 func TestSetDeletePermitted(t *testing.T) {
 	dir, err := os.MkdirTemp("", "cache-path-")
@@ -44,7 +39,7 @@ func TestSetDeletePermitted(t *testing.T) {
 	t.Run("false", func(t *testing.T) {
 		t.Parallel()
 
-		s := New(logger, c)
+		s := New(c)
 		s.SetDeletePermitted(false)
 
 		assert.False(t, s.deletePermitted)
@@ -53,7 +48,7 @@ func TestSetDeletePermitted(t *testing.T) {
 	t.Run("true", func(t *testing.T) {
 		t.Parallel()
 
-		s := New(logger, c)
+		s := New(c)
 		s.SetDeletePermitted(true)
 
 		assert.True(t, s.deletePermitted)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -64,7 +64,7 @@ func TestServeHTTP(t *testing.T) {
 		c.SetRecordAgeIgnoreTouch(0)
 
 		t.Run("DELETE is not permitted", func(t *testing.T) {
-			s := server.New(logger, c)
+			s := server.New(c)
 			s.SetDeletePermitted(false)
 
 			ts := httptest.NewServer(s)
@@ -96,7 +96,7 @@ func TestServeHTTP(t *testing.T) {
 		})
 
 		t.Run("DELETE is permitted", func(t *testing.T) {
-			s := server.New(logger, c)
+			s := server.New(c)
 			s.SetDeletePermitted(true)
 
 			ts := httptest.NewServer(s)
@@ -189,7 +189,7 @@ func TestServeHTTP(t *testing.T) {
 		c.AddUpstreamCaches(uc)
 		c.SetRecordAgeIgnoreTouch(0)
 
-		s := server.New(logger, c)
+		s := server.New(c)
 
 		t.Run("narinfo", func(t *testing.T) {
 			t.Run("narinfo does not exist upstream", func(t *testing.T) {
@@ -305,7 +305,7 @@ func TestServeHTTP(t *testing.T) {
 		c.SetRecordAgeIgnoreTouch(0)
 
 		t.Run("PUT is not permitted", func(t *testing.T) {
-			s := server.New(logger, c)
+			s := server.New(c)
 			s.SetPutPermitted(false)
 
 			ts := httptest.NewServer(s)
@@ -351,7 +351,7 @@ func TestServeHTTP(t *testing.T) {
 		})
 
 		t.Run("PUT is permitted", func(t *testing.T) {
-			s := server.New(logger, c)
+			s := server.New(c)
 			s.SetPutPermitted(true)
 
 			ts := httptest.NewServer(s)


### PR DESCRIPTION
### TL;DR

Improved logging context and error handling in the HTTP server implementation.

### What changed?

- Moved logging responsibility from the server to request context
- Standardized error handling using `http.Error`
- Added consistent log field prefixes (`nar-`, `narinfo-`)
- Removed logger dependency from Server struct
- Added BaseContext to HTTP server for proper context propagation
- Simplified error response writing across all handlers

### How to test?

1. Run the server with logging enabled
2. Make various HTTP requests (GET, PUT, DELETE)
3. Verify log output contains consistent field names
4. Verify error responses contain appropriate status codes and messages
5. Check that request context properly carries logging information

### Why make this change?

This change improves logging consistency and makes the codebase more maintainable by:
- Centralizing logging logic within the request context
- Making error handling more uniform across all endpoints
- Reducing coupling between components by removing logger dependency
- Ensuring proper context propagation throughout request lifecycle