### PR TITLE
refactor(pkg/cache): use context logger instead of struct logger

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1073,7 +1073,7 @@ func (c *Cache) runLRU(ctx context.Context) func() {
 			if _, err := c.db.WithTx(tx).DeleteNarByHash(ctx, narRecord.Hash); err != nil {
 				log.Error().
 					Err(err).
-					Str("hash", narRecord.Hash).
+					Str("nar-hash", narRecord.Hash).
 					Msg("error removing nar from database")
 			}
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -190,6 +190,10 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadClose
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
+	ctx = narURL.
+		NewLogger(*zerolog.Ctx(ctx)).
+		WithContext(ctx)
+
 	if c.narStore.HasNar(ctx, narURL) {
 		return c.getNarFromStore(ctx, &narURL)
 	}
@@ -209,6 +213,10 @@ func (c *Cache) PutNar(ctx context.Context, narURL nar.URL, r io.ReadCloser) err
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
+	ctx = narURL.
+		NewLogger(*zerolog.Ctx(ctx)).
+		WithContext(ctx)
+
 	defer func() {
 		//nolint:errcheck
 		io.Copy(io.Discard, r)
@@ -225,6 +233,10 @@ func (c *Cache) PutNar(ctx context.Context, narURL nar.URL, r io.ReadCloser) err
 func (c *Cache) DeleteNar(ctx context.Context, narURL nar.URL) error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+
+	ctx = narURL.
+		NewLogger(*zerolog.Ctx(ctx)).
+		WithContext(ctx)
 
 	return c.narStore.DeleteNar(ctx, narURL)
 }
@@ -418,6 +430,12 @@ func (c *Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, 
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
+	ctx = zerolog.Ctx(ctx).
+		With().
+		Str("narinfo-hash", hash).
+		Logger().
+		WithContext(ctx)
+
 	var (
 		narInfo *narinfo.NarInfo
 		err     error
@@ -532,6 +550,12 @@ func (c *Cache) PutNarInfo(ctx context.Context, hash string, r io.ReadCloser) er
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
+	ctx = zerolog.Ctx(ctx).
+		With().
+		Str("narinfo-hash", hash).
+		Logger().
+		WithContext(ctx)
+
 	defer func() {
 		//nolint:errcheck
 		io.Copy(io.Discard, r)
@@ -559,6 +583,12 @@ func (c *Cache) PutNarInfo(ctx context.Context, hash string, r io.ReadCloser) er
 func (c *Cache) DeleteNarInfo(ctx context.Context, hash string) error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
+
+	ctx = zerolog.Ctx(ctx).
+		With().
+		Str("narinfo-hash", hash).
+		Logger().
+		WithContext(ctx)
 
 	return c.deleteNarInfoFromStore(ctx, hash)
 }

--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -75,7 +75,7 @@ func TestAddUpstreamCaches(t *testing.T) {
 		c, err := New(ctx, cacheName, db, localStore, localStore, localStore)
 		require.NoError(t, err)
 
-		c.AddUpstreamCaches(ucs...)
+		c.AddUpstreamCaches(ctx, ucs...)
 
 		for idx, uc := range c.upstreamCaches {
 			//nolint:gosec
@@ -131,7 +131,7 @@ func TestAddUpstreamCaches(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, uc := range ucs {
-			c.AddUpstreamCaches(uc)
+			c.AddUpstreamCaches(ctx, uc)
 		}
 
 		for idx, uc := range c.upstreamCaches {
@@ -169,7 +169,7 @@ func TestRunLRU(t *testing.T) {
 	uc, err := upstream.New(logger, testhelper.MustParseURL(t, ts.URL), nil)
 	require.NoError(t, err)
 
-	c.AddUpstreamCaches(uc)
+	c.AddUpstreamCaches(ctx, uc)
 	c.SetRecordAgeIgnoreTouch(0)
 
 	// NOTE: For this test, any nar that's explicitly testing the zstd

--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -255,7 +255,7 @@ func TestRunLRU(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	c.runLRU()
+	c.runLRU(ctx)()
 
 	// confirm all narinfos except the last one are in the store
 	for _, nar := range entries {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -190,7 +190,7 @@ func TestGetNarInfo(t *testing.T) {
 	c, err := cache.New(ctx, cacheName, db, localStore, localStore, localStore)
 	require.NoError(t, err)
 
-	c.AddUpstreamCaches(uc)
+	c.AddUpstreamCaches(ctx, uc)
 	c.SetRecordAgeIgnoreTouch(0)
 
 	t.Run("narinfo does not exist upstream", func(t *testing.T) {
@@ -785,7 +785,7 @@ func TestGetNar(t *testing.T) {
 	c, err := cache.New(ctx, cacheName, db, localStore, localStore, localStore)
 	require.NoError(t, err)
 
-	c.AddUpstreamCaches(uc)
+	c.AddUpstreamCaches(ctx, uc)
 	c.SetRecordAgeIgnoreTouch(0)
 
 	t.Run("nar does not exist upstream", func(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -60,7 +60,7 @@ func TestServeHTTP(t *testing.T) {
 		c, err := cache.New(ctx, cacheName, db, localStore, localStore, localStore)
 		require.NoError(t, err)
 
-		c.AddUpstreamCaches(uc)
+		c.AddUpstreamCaches(ctx, uc)
 		c.SetRecordAgeIgnoreTouch(0)
 
 		t.Run("DELETE is not permitted", func(t *testing.T) {
@@ -73,7 +73,7 @@ func TestServeHTTP(t *testing.T) {
 			t.Run("narInfo", func(t *testing.T) {
 				url := ts.URL + "/" + testdata.Nar1.NarInfoHash + ".narinfo"
 
-				r, err := http.NewRequestWithContext(context.Background(), "DELETE", url, nil)
+				r, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
 				require.NoError(t, err)
 
 				resp, err := ts.Client().Do(r)
@@ -85,7 +85,7 @@ func TestServeHTTP(t *testing.T) {
 			t.Run("nar", func(t *testing.T) {
 				url := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar.xz"
 
-				r, err := http.NewRequestWithContext(context.Background(), "DELETE", url, nil)
+				r, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
 				require.NoError(t, err)
 
 				resp, err := ts.Client().Do(r)
@@ -109,7 +109,7 @@ func TestServeHTTP(t *testing.T) {
 					assert.NoFileExists(t, storePath)
 				})
 
-				_, err := c.GetNarInfo(context.Background(), testdata.Nar1.NarInfoHash)
+				_, err := c.GetNarInfo(ctx, testdata.Nar1.NarInfoHash)
 				require.NoError(t, err)
 
 				t.Run("narinfo does exist in storage", func(t *testing.T) {
@@ -119,7 +119,7 @@ func TestServeHTTP(t *testing.T) {
 				t.Run("DELETE returns no error", func(t *testing.T) {
 					url := ts.URL + "/" + testdata.Nar1.NarInfoHash + ".narinfo"
 
-					r, err := http.NewRequestWithContext(context.Background(), "DELETE", url, nil)
+					r, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
 					require.NoError(t, err)
 
 					resp, err := ts.Client().Do(r)
@@ -141,7 +141,7 @@ func TestServeHTTP(t *testing.T) {
 				})
 
 				nu := nar.URL{Hash: testdata.Nar2.NarHash, Compression: nar.CompressionTypeXz}
-				_, _, err := c.GetNar(context.Background(), nu)
+				_, _, err := c.GetNar(ctx, nu)
 				require.NoError(t, err)
 
 				t.Run("nar does exist in storage", func(t *testing.T) {
@@ -151,7 +151,7 @@ func TestServeHTTP(t *testing.T) {
 				t.Run("DELETE returns no error", func(t *testing.T) {
 					url := ts.URL + "/nar/" + testdata.Nar2.NarHash + ".nar.xz"
 
-					r, err := http.NewRequestWithContext(context.Background(), "DELETE", url, nil)
+					r, err := http.NewRequestWithContext(ctx, "DELETE", url, nil)
 					require.NoError(t, err)
 
 					resp, err := ts.Client().Do(r)
@@ -186,7 +186,7 @@ func TestServeHTTP(t *testing.T) {
 		c, err := cache.New(ctx, cacheName, db, localStore, localStore, localStore)
 		require.NoError(t, err)
 
-		c.AddUpstreamCaches(uc)
+		c.AddUpstreamCaches(ctx, uc)
 		c.SetRecordAgeIgnoreTouch(0)
 
 		s := server.New(c)
@@ -301,7 +301,7 @@ func TestServeHTTP(t *testing.T) {
 		c, err := cache.New(ctx, cacheName, db, localStore, localStore, localStore)
 		require.NoError(t, err)
 
-		c.AddUpstreamCaches(uc)
+		c.AddUpstreamCaches(ctx, uc)
 		c.SetRecordAgeIgnoreTouch(0)
 
 		t.Run("PUT is not permitted", func(t *testing.T) {
@@ -314,7 +314,7 @@ func TestServeHTTP(t *testing.T) {
 			t.Run("narInfo", func(t *testing.T) {
 				p := ts.URL + "/" + testdata.Nar1.NarInfoHash + ".narinfo"
 
-				r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(testdata.Nar1.NarInfoText))
+				r, err := http.NewRequestWithContext(ctx, "PUT", p, strings.NewReader(testdata.Nar1.NarInfoText))
 				require.NoError(t, err)
 
 				resp, err := ts.Client().Do(r)
@@ -327,7 +327,7 @@ func TestServeHTTP(t *testing.T) {
 				t.Run("without compression", func(t *testing.T) {
 					p := ts.URL + "/nar/" + testdata.Nar1.NarInfoHash + ".nar"
 
-					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(testdata.Nar1.NarText))
+					r, err := http.NewRequestWithContext(ctx, "PUT", p, strings.NewReader(testdata.Nar1.NarText))
 					require.NoError(t, err)
 
 					resp, err := ts.Client().Do(r)
@@ -339,7 +339,7 @@ func TestServeHTTP(t *testing.T) {
 				t.Run("with compression", func(t *testing.T) {
 					p := ts.URL + "/nar/" + testdata.Nar1.NarInfoHash + ".nar.xz"
 
-					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(testdata.Nar1.NarText))
+					r, err := http.NewRequestWithContext(ctx, "PUT", p, strings.NewReader(testdata.Nar1.NarText))
 					require.NoError(t, err)
 
 					resp, err := ts.Client().Do(r)
@@ -367,7 +367,7 @@ func TestServeHTTP(t *testing.T) {
 				t.Run("putNarInfo does not return an error", func(t *testing.T) {
 					p := ts.URL + "/" + testdata.Nar1.NarInfoHash + ".narinfo"
 
-					r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(testdata.Nar1.NarInfoText))
+					r, err := http.NewRequestWithContext(ctx, "PUT", p, strings.NewReader(testdata.Nar1.NarInfoText))
 					require.NoError(t, err)
 
 					resp, err := ts.Client().Do(r)
@@ -414,7 +414,7 @@ func TestServeHTTP(t *testing.T) {
 			t.Run("putNar does not return an error", func(t *testing.T) {
 				p := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar.xz"
 
-				r, err := http.NewRequestWithContext(context.Background(), "PUT", p, strings.NewReader(testdata.Nar1.NarText))
+				r, err := http.NewRequestWithContext(ctx, "PUT", p, strings.NewReader(testdata.Nar1.NarText))
 				require.NoError(t, err)
 
 				resp, err := ts.Client().Do(r)


### PR DESCRIPTION
# Remove global logger in favor of context-based logging

The cache package now uses context-based logging instead of maintaining a global logger instance. This change:

- Removes the global logger field from the Cache struct
- Passes logger through context in all methods
- Updates method signatures to use context-based logging
- Ensures consistent logging patterns across the codebase
- Maintains proper logging context and correlation

The change improves logging consistency and makes it easier to trace operations through the system by using context-based logging throughout the cache package.