### PR TITLE
feat(cmd): add OpenTelemetry logging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ ncps addresses these issues by acting as a central cache on your local network.
 - **Secure caching:** ncps signs cached paths with its own key, ensuring integrity and authenticity.
 - **Cache size management:** Configure a maximum cache size and a cron schedule to automatically remove least recently used (LRU) store paths, preventing the cache from growing indefinitely.
 - **Zstandard compression support:** ncps supports storing NAR files compressed with Zstandard (zstd) as provided by upstream caches like [Harmonia](https://github.com/nix-community/harmonia). It adjusts the `narinfo` metadata accordingly to reflect the correct filesize and compression method.
+- **OpenTelemetry logging:** Forward logs to an OpenTelemetry collector for centralized logging and monitoring.
 
 ## Installation
 
@@ -180,9 +181,16 @@ spec:
 
 </details>
 
-## Configuration
+## Global Options
 
-ncps can be configured using the following flags:
+These options can be used with any `ncps` command:
+
+- `--log-level`: Set the log level (default: "info"). Possible values: "debug", "info", "warn", "error". (Environment variable: `$LOG_LEVEL`)
+- `--log-otel-grpc-endpoint`: Forward logs to an OpenTelemetry gRPC endpoint. (Environment variable: `$LOG_OTEL_GRPC_ENDPOINT`)
+
+## Serve Command Options
+
+These options are specific to the `ncps serve` command:
 
 - `--allow-delete`: Whether to allow the DELETE verb to delete `narinfo` and `nar` files from the cache (default: false). (Environment variable: `$ALLOW_DELETE_VERB`)
 - `--allow-put`: Whether to allow the PUT verb to push `narinfo` and `nar` files directly to the cache (default: false). (Environment variable: `$ALLOW_PUT_VERB`)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"time"
 
@@ -20,11 +21,48 @@ import (
 var Version = "dev"
 
 func New() *cli.Command {
+	var otelWriter *otelzerolog.OtelWriter
+
 	return &cli.Command{
 		Name:    "ncps",
 		Usage:   "Nix Binary Cache Proxy Service",
 		Version: Version,
-		Before:  beforeFunc,
+		After: func(ctx context.Context, _ *cli.Command) error {
+			if otelWriter != nil {
+				return otelWriter.Close(ctx)
+			}
+
+			return nil
+		},
+		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+			logLvl := cmd.String("log-level")
+
+			lvl, err := zerolog.ParseLevel(logLvl)
+			if err != nil {
+				return ctx, fmt.Errorf("error parsing the log-level %q: %w", logLvl, err)
+			}
+
+			var output io.Writer = os.Stdout
+
+			if colURL := cmd.String("log-otel-grpc-endpoint"); colURL != "" {
+				otelWriter, err = otelzerolog.NewOtelWriter(ctx, colURL, "ncps")
+				if err != nil {
+					return ctx, err
+				}
+
+				output = zerolog.MultiLevelWriter(os.Stdout, otelWriter)
+			}
+
+			if term.IsTerminal(int(os.Stdout.Fd())) {
+				output = zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+			}
+
+			log := zerolog.New(output).Level(lvl)
+
+			log.Info().Str("log-level", lvl.String()).Msg("logger created")
+
+			return log.WithContext(ctx), nil
+		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "log-level",
@@ -42,8 +80,8 @@ func New() *cli.Command {
 				Usage:   "Forward logs to an OpenTelemetry gRPC endpoint",
 				Sources: cli.EnvVars("LOG_OTEL_GRPC_ENDPOINT"),
 				Value:   "",
-				Validator: func(lvl string) error {
-					_, err := zerolog.ParseLevel(lvl)
+				Validator: func(colURL string) error {
+					_, err := url.Parse(colURL)
 
 					return err
 				},
@@ -53,31 +91,4 @@ func New() *cli.Command {
 			serveCommand(),
 		},
 	}
-}
-
-func beforeFunc(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-	logLvl := cmd.String("log-level")
-
-	lvl, err := zerolog.ParseLevel(logLvl)
-	if err != nil {
-		return ctx, fmt.Errorf("error parsing the log-level %q: %w", logLvl, err)
-	}
-
-	// Create the OpenTelemetry writer
-	otelWriter, err := otelzerolog.NewOtelWriter(ctx, "localhost:14317", "ncps")
-	if err != nil {
-		return ctx, err
-	}
-
-	var output io.Writer = zerolog.MultiLevelWriter(os.Stdout, otelWriter)
-
-	if term.IsTerminal(int(os.Stdout.Fd())) {
-		output = zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
-	}
-
-	log := zerolog.New(output).Level(lvl)
-
-	log.Info().Str("log-level", lvl.String()).Msg("logger created")
-
-	return log.WithContext(ctx), nil
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -37,6 +37,17 @@ func New() *cli.Command {
 					return err
 				},
 			},
+			&cli.StringFlag{
+				Name:    "log-otel-grpc-endpoint",
+				Usage:   "Forward logs to an OpenTelemetry gRPC endpoint",
+				Sources: cli.EnvVars("LOG_OTEL_GRPC_ENDPOINT"),
+				Value:   "",
+				Validator: func(lvl string) error {
+					_, err := zerolog.ParseLevel(lvl)
+
+					return err
+				},
+			},
 		},
 		Commands: []*cli.Command{
 			serveCommand(),

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -44,7 +44,8 @@ func New() *cli.Command {
 
 			var output io.Writer = os.Stdout
 
-			if colURL := cmd.String("log-otel-grpc-endpoint"); colURL != "" {
+			colURL := cmd.String("log-otel-grpc-endpoint")
+			if colURL != "" {
 				otelWriter, err = otelzerolog.NewOtelWriter(ctx, colURL, "ncps")
 				if err != nil {
 					return ctx, err
@@ -59,7 +60,11 @@ func New() *cli.Command {
 
 			log := zerolog.New(output).Level(lvl)
 
-			log.Info().Str("log-level", lvl.String()).Msg("logger created")
+			log.
+				Info().
+				Str("log-otel-grpc-endpoint", colURL).
+				Str("log-level", lvl.String()).
+				Msg("logger created")
 
 			return log.WithContext(ctx), nil
 		},


### PR DESCRIPTION
send zerolog to opentelemetry

Adds support for forwarding zerolog output to an OpenTelemetry gRPC endpoint via the `--log-otel-grpc-endpoint` flag. The OtelWriter is properly closed when the application exits.