### PR TITLE
feat(server): add OpenTelemetry middleware and metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -42,6 +43,7 @@ require (
 	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/riandyrn/otelchi v0.11.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/klauspost/compress v1.17.11
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/nix-community/go-nix v0.0.0-20241220082528-4ad2fe83d684
+	github.com/riandyrn/otelchi v0.11.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/zerolog v1.33.0
 	github.com/stretchr/testify v1.10.0
@@ -43,7 +44,6 @@ require (
 	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/riandyrn/otelchi v0.11.0 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyY
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
+github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-chi/chi/v5 v5.2.0 h1:Aj1EtB0qR2Rdo2dG4O94RIU35w2lvQSj6BRA4+qwFL0=
 github.com/go-chi/chi/v5 v5.2.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -50,6 +52,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
+github.com/riandyrn/otelchi v0.11.0 h1:x9MFoTgHcwCC2DdWkTEEZ2ZQFkbl6z7GXLQtTANN6Gk=
+github.com/riandyrn/otelchi v0.11.0/go.mod h1:FlBYmG9fBQu0jFRvZZrATP4mDvLX2H5gwELfpZvNlxY=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=

--- a/nix/packages/ncps.nix
+++ b/nix/packages/ncps.nix
@@ -38,7 +38,7 @@
 
           subPackages = [ "." ];
 
-          vendorHash = "sha256-uchlV7mRNfNpKRRaWCbHBhYwA3KhtK+1mwz43AcCZUU=";
+          vendorHash = "sha256-FkAtf0fJL1ERMoGXcs+nbQVt3V8OzfUZ0Ls5RIEHdUo=";
 
           doCheck = true;
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -39,7 +39,7 @@ const (
 WantMassQuery: 1
 Priority: 10`
 
-	serverName = "github.com/kalbasit/ncps/pkg/server"
+	tracerName = "github.com/kalbasit/ncps/pkg/server"
 )
 
 // Server represents the main HTTP server.
@@ -73,13 +73,13 @@ func (s *Server) createRouter() {
 	s.router = chi.NewRouter()
 
 	mp := otel.GetMeterProvider()
-	baseCfg := otelchimetric.NewBaseConfig(serverName, otelchimetric.WithMeterProvider(mp))
+	baseCfg := otelchimetric.NewBaseConfig(tracerName, otelchimetric.WithMeterProvider(mp))
 
 	s.router.Use(middleware.Heartbeat("/healthz"))
 	s.router.Use(middleware.RealIP)
 	s.router.Use(middleware.Recoverer)
 	s.router.Use(
-		otelchi.Middleware(serverName, otelchi.WithChiRoutes(s.router)),
+		otelchi.Middleware(tracerName, otelchi.WithChiRoutes(s.router)),
 		otelchimetric.NewRequestDurationMillis(baseCfg),
 		otelchimetric.NewRequestInFlight(baseCfg),
 		otelchimetric.NewResponseSizeBytes(baseCfg),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -37,6 +37,8 @@ const (
 	nixCacheInfo = `StoreDir: /nix/store
 WantMassQuery: 1
 Priority: 10`
+
+	serverName = "github.com/kalbasit/ncps/pkg/server"
 )
 
 // Server represents the main HTTP server.
@@ -70,14 +72,14 @@ func (s *Server) createRouter() {
 	s.router = chi.NewRouter()
 
 	mp := otel.GetMeterProvider()
-	baseCfg := otelchimetric.NewBaseConfig("ncps", otelchimetric.WithMeterProvider(mp))
+	baseCfg := otelchimetric.NewBaseConfig(serverName, otelchimetric.WithMeterProvider(mp))
 
 	s.router.Use(middleware.Heartbeat("/healthz"))
 	s.router.Use(middleware.RealIP)
 	s.router.Use(middleware.Recoverer)
 	s.router.Use(requestLogger)
 	s.router.Use(
-		otelchi.Middleware("ncps", otelchi.WithChiRoutes(s.router)),
+		otelchi.Middleware(serverName, otelchi.WithChiRoutes(s.router)),
 		otelchimetric.NewRequestDurationMillis(baseCfg),
 		otelchimetric.NewRequestInFlight(baseCfg),
 		otelchimetric.NewResponseSizeBytes(baseCfg),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -47,18 +47,13 @@ type Server struct {
 	cache  *cache.Cache
 	router *chi.Mux
 
-	tracer trace.Tracer
-
 	deletePermitted bool
 	putPermitted    bool
 }
 
 // New returns a new server.
 func New(cache *cache.Cache) *Server {
-	s := &Server{
-		cache:  cache,
-		tracer: otel.Tracer(serverName),
-	}
+	s := &Server{cache: cache}
 
 	s.createRouter()
 
@@ -89,7 +84,7 @@ func (s *Server) createRouter() {
 		otelchimetric.NewRequestInFlight(baseCfg),
 		otelchimetric.NewResponseSizeBytes(baseCfg),
 	)
-	s.router.Use(s.requestLogger)
+	s.router.Use(requestLogger)
 
 	s.router.Get(routeIndex, s.getIndex)
 
@@ -111,7 +106,7 @@ func (s *Server) createRouter() {
 	s.router.Delete(routeNar, s.deleteNar)
 }
 
-func (s *Server) requestLogger(next http.Handler) http.Handler {
+func requestLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		startedAt := time.Now()
 


### PR DESCRIPTION
Add OpenTelemetry instrumentation to chi router

Adds OpenTelemetry middleware to the chi router to collect:
- Request duration metrics
- In-flight request counts
- Response size metrics
- Distributed tracing

The instrumentation uses the otelchi package to automatically capture routes and metrics using the configured OpenTelemetry meter provider.