### PR TITLE
feat(pkg/cache/upstream): add OpenTelemetry tracing

### DIFF
--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -106,7 +106,7 @@ func (c Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, e
 
 	ctx, span := c.tracer.Start(
 		ctx,
-		"GetNarInfo",
+		"upstream.GetNarInfo",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("narinfo_hash", hash),
@@ -182,7 +182,7 @@ func (c Cache) GetNar(ctx context.Context, narURL nar.URL, mutators ...func(*htt
 
 	ctx, span := c.tracer.Start(
 		ctx,
-		"GetNar",
+		"upstream.GetNar",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("nar_url", u),

--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -106,7 +106,11 @@ func (c Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, e
 		Logger().
 		WithContext(ctx)
 
-	r, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	// create a new context not associated with any request because we don't want
+	// downstream HTTP request to cancel this.
+	detachedCtx := zerolog.Ctx(ctx).WithContext(context.Background())
+
+	r, err := http.NewRequestWithContext(detachedCtx, "GET", u, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating a new request: %w", err)
 	}
@@ -170,7 +174,11 @@ func (c Cache) GetNar(ctx context.Context, narURL nar.URL, mutators ...func(*htt
 			Logger(),
 	).WithContext(ctx)
 
-	r, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	// create a new context not associated with any request because we don't want
+	// pulling from upstream to be associated with a user request.
+	detachedCtx := zerolog.Ctx(ctx).WithContext(context.Background())
+
+	r, err := http.NewRequestWithContext(detachedCtx, "GET", u, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating a new request: %w", err)
 	}


### PR DESCRIPTION
### TL;DR

Added OpenTelemetry tracing to upstream cache operations

### What changed?

- Integrated OpenTelemetry tracing into the upstream cache package
- Added tracing spans for `GetNarInfo` and `GetNar` operations
- Included relevant attributes in spans such as narinfo hash, URLs, and upstream information
- Initialized a new tracer in the Cache constructor

### How to test?

1. Configure an OpenTelemetry collector in your environment
2. Make requests that trigger `GetNarInfo` or `GetNar` operations
3. Verify that traces appear in your collector with the following spans:
   - `GetNarInfo` with attributes: narinfo_hash, narinfo_url, upstream_url
   - `GetNar` with attributes: nar_url, upstream_url

### Why make this change?

Adding tracing capabilities enables better observability of cache operations, making it easier to:
- Debug performance issues
- Track request flows
- Monitor cache behavior in production environments
- Analyze cache operation patterns and dependencies