### PR TITLE
feat(pkg/server): add OpenTelemetry tracing support

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -357,6 +357,19 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 
 		nu := nar.URL{Hash: hash, Query: r.URL.Query()}
 
+		r = r.WithContext(
+			nu.NewLogger(*zerolog.Ctx(r.Context())).
+				WithContext(r.Context()))
+
+		var err error
+
+		nu.Compression, err = nar.CompressionTypeFromExtension(chi.URLParam(r, "compression"))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+
+			return
+		}
+
 		ctx, span := s.tracer.Start(
 			r.Context(),
 			"getNar",
@@ -371,19 +384,6 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 		r = r.WithContext(
 			nu.NewLogger(*zerolog.Ctx(ctx)).
 				WithContext(ctx))
-
-		var err error
-
-		nu.Compression, err = nar.CompressionTypeFromExtension(chi.URLParam(r, "compression"))
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-
-			return
-		}
-
-		r = r.WithContext(
-			nu.NewLogger(*zerolog.Ctx(r.Context())).
-				WithContext(r.Context()))
 
 		size, reader, err := s.cache.GetNar(r.Context(), nu)
 		if err != nil {
@@ -438,6 +438,19 @@ func (s *Server) putNar(w http.ResponseWriter, r *http.Request) {
 
 	nu := nar.URL{Hash: hash, Query: r.URL.Query()}
 
+	r = r.WithContext(
+		nu.NewLogger(*zerolog.Ctx(r.Context())).
+			WithContext(r.Context()))
+
+	var err error
+
+	nu.Compression, err = nar.CompressionTypeFromExtension(chi.URLParam(r, "compression"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
 	ctx, span := s.tracer.Start(
 		r.Context(),
 		"putNar",
@@ -452,19 +465,6 @@ func (s *Server) putNar(w http.ResponseWriter, r *http.Request) {
 	r = r.WithContext(
 		nu.NewLogger(*zerolog.Ctx(ctx)).
 			WithContext(ctx))
-
-	var err error
-
-	nu.Compression, err = nar.CompressionTypeFromExtension(chi.URLParam(r, "compression"))
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-
-		return
-	}
-
-	r = r.WithContext(
-		nu.NewLogger(*zerolog.Ctx(r.Context())).
-			WithContext(r.Context()))
 
 	if !s.putPermitted {
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
@@ -491,6 +491,19 @@ func (s *Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 
 	nu := nar.URL{Hash: hash, Query: r.URL.Query()}
 
+	r = r.WithContext(
+		nu.NewLogger(*zerolog.Ctx(r.Context())).
+			WithContext(r.Context()))
+
+	var err error
+
+	nu.Compression, err = nar.CompressionTypeFromExtension(chi.URLParam(r, "compression"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+
+		return
+	}
+
 	ctx, span := s.tracer.Start(
 		r.Context(),
 		"deleteNar",
@@ -505,19 +518,6 @@ func (s *Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 	r = r.WithContext(
 		nu.NewLogger(*zerolog.Ctx(ctx)).
 			WithContext(ctx))
-
-	var err error
-
-	nu.Compression, err = nar.CompressionTypeFromExtension(chi.URLParam(r, "compression"))
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-
-		return
-	}
-
-	r = r.WithContext(
-		nu.NewLogger(*zerolog.Ctx(r.Context())).
-			WithContext(r.Context()))
 
 	if !s.deletePermitted {
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -188,7 +188,7 @@ func (s *Server) getIndex(w http.ResponseWriter, r *http.Request) {
 func (s *Server) getNixCacheInfo(w http.ResponseWriter, r *http.Request) {
 	_, span := s.tracer.Start(
 		r.Context(),
-		"getNixCacheInfo",
+		"server.getNixCacheInfo",
 		trace.WithSpanKind(trace.SpanKindServer),
 	)
 	defer span.End()
@@ -209,7 +209,7 @@ func (s *Server) getNarInfo(withBody bool) http.HandlerFunc {
 
 		ctx, span := s.tracer.Start(
 			r.Context(),
-			"getNarInfo",
+			"server.getNarInfo",
 			trace.WithSpanKind(trace.SpanKindServer),
 			trace.WithAttributes(
 				attribute.String("narinfo_hash", hash),
@@ -270,7 +270,7 @@ func (s *Server) putNarInfo(w http.ResponseWriter, r *http.Request) {
 
 	ctx, span := s.tracer.Start(
 		r.Context(),
-		"putNarInfo",
+		"server.putNarInfo",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
 			attribute.String("narinfo_hash", hash),
@@ -310,7 +310,7 @@ func (s *Server) deleteNarInfo(w http.ResponseWriter, r *http.Request) {
 
 	ctx, span := s.tracer.Start(
 		r.Context(),
-		"deleteNarInfo",
+		"server.deleteNarInfo",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
 			attribute.String("narinfo_hash", hash),
@@ -372,7 +372,7 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 
 		ctx, span := s.tracer.Start(
 			r.Context(),
-			"getNar",
+			"server.getNar",
 			trace.WithSpanKind(trace.SpanKindServer),
 			trace.WithAttributes(
 				attribute.String("nar_hash", hash),
@@ -453,7 +453,7 @@ func (s *Server) putNar(w http.ResponseWriter, r *http.Request) {
 
 	ctx, span := s.tracer.Start(
 		r.Context(),
-		"putNar",
+		"server.putNar",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
 			attribute.String("nar_hash", hash),
@@ -506,7 +506,7 @@ func (s *Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 
 	ctx, span := s.tracer.Start(
 		r.Context(),
-		"deleteNar",
+		"server.deleteNar",
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
 			attribute.String("nar_hash", hash),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -186,6 +186,13 @@ func (s *Server) getIndex(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getNixCacheInfo(w http.ResponseWriter, r *http.Request) {
+	_, span := s.tracer.Start(
+		r.Context(),
+		"getNixCacheInfo",
+		trace.WithSpanKind(trace.SpanKindServer),
+	)
+	defer span.End()
+
 	if _, err := w.Write([]byte(nixCacheInfo)); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
@@ -261,12 +268,22 @@ func (s *Server) getNarInfo(withBody bool) http.HandlerFunc {
 func (s *Server) putNarInfo(w http.ResponseWriter, r *http.Request) {
 	hash := chi.URLParam(r, "hash")
 
+	ctx, span := s.tracer.Start(
+		r.Context(),
+		"putNarInfo",
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(
+			attribute.String("narinfo_hash", hash),
+		),
+	)
+	defer span.End()
+
 	r = r.WithContext(
-		zerolog.Ctx(r.Context()).
+		zerolog.Ctx(ctx).
 			With().
 			Str("narinfo-hash", hash).
 			Logger().
-			WithContext(r.Context()))
+			WithContext(ctx))
 
 	if !s.putPermitted {
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
@@ -291,12 +308,22 @@ func (s *Server) putNarInfo(w http.ResponseWriter, r *http.Request) {
 func (s *Server) deleteNarInfo(w http.ResponseWriter, r *http.Request) {
 	hash := chi.URLParam(r, "hash")
 
+	ctx, span := s.tracer.Start(
+		r.Context(),
+		"deleteNarInfo",
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(
+			attribute.String("narinfo_hash", hash),
+		),
+	)
+	defer span.End()
+
 	r = r.WithContext(
-		zerolog.Ctx(r.Context()).
+		zerolog.Ctx(ctx).
 			With().
 			Str("narinfo-hash", hash).
 			Logger().
-			WithContext(r.Context()))
+			WithContext(ctx))
 
 	if !s.deletePermitted {
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
@@ -330,9 +357,20 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 
 		nu := nar.URL{Hash: hash, Query: r.URL.Query()}
 
+		ctx, span := s.tracer.Start(
+			r.Context(),
+			"getNar",
+			trace.WithSpanKind(trace.SpanKindServer),
+			trace.WithAttributes(
+				attribute.String("nar_hash", hash),
+				attribute.String("nar_url", nu.String()),
+			),
+		)
+		defer span.End()
+
 		r = r.WithContext(
-			nu.NewLogger(*zerolog.Ctx(r.Context())).
-				WithContext(r.Context()))
+			nu.NewLogger(*zerolog.Ctx(ctx)).
+				WithContext(ctx))
 
 		var err error
 
@@ -400,9 +438,20 @@ func (s *Server) putNar(w http.ResponseWriter, r *http.Request) {
 
 	nu := nar.URL{Hash: hash, Query: r.URL.Query()}
 
+	ctx, span := s.tracer.Start(
+		r.Context(),
+		"putNar",
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(
+			attribute.String("nar_hash", hash),
+			attribute.String("nar_url", nu.String()),
+		),
+	)
+	defer span.End()
+
 	r = r.WithContext(
-		nu.NewLogger(*zerolog.Ctx(r.Context())).
-			WithContext(r.Context()))
+		nu.NewLogger(*zerolog.Ctx(ctx)).
+			WithContext(ctx))
 
 	var err error
 
@@ -442,9 +491,20 @@ func (s *Server) deleteNar(w http.ResponseWriter, r *http.Request) {
 
 	nu := nar.URL{Hash: hash, Query: r.URL.Query()}
 
+	ctx, span := s.tracer.Start(
+		r.Context(),
+		"deleteNar",
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithAttributes(
+			attribute.String("nar_hash", hash),
+			attribute.String("nar_url", nu.String()),
+		),
+	)
+	defer span.End()
+
 	r = r.WithContext(
-		nu.NewLogger(*zerolog.Ctx(r.Context())).
-			WithContext(r.Context()))
+		nu.NewLogger(*zerolog.Ctx(ctx)).
+			WithContext(ctx))
 
 	var err error
 


### PR DESCRIPTION
### TL;DR

Added OpenTelemetry tracing spans to all server endpoints with relevant attributes.

### What changed?

- Added a `tracer` field to the Server struct
- Initialized the tracer in the `New` function
- Added tracing spans with appropriate attributes for:
  - `getNixCacheInfo`
  - `getNarInfo`
  - `putNarInfo`
  - `deleteNarInfo`
  - `getNar`
  - `putNar`
  - `deleteNar`

### How to test?

1. Deploy the application with OpenTelemetry collector configured
2. Make requests to various endpoints
3. Verify spans appear in your tracing backend with:
   - Correct operation names
   - Server span kind
   - Hash and URL attributes where applicable

### Why make this change?

Improved observability by adding detailed tracing information for all server operations, making it easier to:
- Debug request flows
- Monitor performance
- Track operation attributes
- Analyze request patterns