### PR TITLE
feat(pkg/storage/local): add OpenTelemetry tracing

### DIFF
--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -70,7 +70,7 @@ func (s *Store) GetSecretKey(ctx context.Context) (signature.SecretKey, error) {
 
 	_, span := s.tracer.Start(
 		ctx,
-		"GetSecretKey",
+		"local.GetSecretKey",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("secret_key_path", skPath),
@@ -96,7 +96,7 @@ func (s *Store) PutSecretKey(ctx context.Context, sk signature.SecretKey) error 
 
 	_, span := s.tracer.Start(
 		ctx,
-		"PutSecretKey",
+		"local.PutSecretKey",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("secret_key_path", skPath),
@@ -117,7 +117,7 @@ func (s *Store) DeleteSecretKey(ctx context.Context) error {
 
 	_, span := s.tracer.Start(
 		ctx,
-		"DeleteSecretKey",
+		"local.DeleteSecretKey",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("secret_key_path", skPath),
@@ -138,7 +138,7 @@ func (s *Store) HasNarInfo(ctx context.Context, hash string) bool {
 
 	_, span := s.tracer.Start(
 		ctx,
-		"HasNarInfo",
+		"local.HasNarInfo",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("narinfo_hash", hash),
@@ -158,7 +158,7 @@ func (s *Store) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, 
 
 	_, span := s.tracer.Start(
 		ctx,
-		"GetNarInfo",
+		"local.GetNarInfo",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("narinfo_hash", hash),
@@ -187,7 +187,7 @@ func (s *Store) PutNarInfo(ctx context.Context, hash string, narInfo *narinfo.Na
 
 	_, span := s.tracer.Start(
 		ctx,
-		"PutNarInfo",
+		"local.PutNarInfo",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("narinfo_hash", hash),
@@ -224,7 +224,7 @@ func (s *Store) DeleteNarInfo(ctx context.Context, hash string) error {
 
 	_, span := s.tracer.Start(
 		ctx,
-		"DeleteNarInfo",
+		"local.DeleteNarInfo",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("narinfo_hash", hash),
@@ -250,7 +250,7 @@ func (s *Store) HasNar(ctx context.Context, narURL nar.URL) bool {
 
 	_, span := s.tracer.Start(
 		ctx,
-		"HasNar",
+		"local.HasNar",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("nar_url", narURL.String()),
@@ -271,7 +271,7 @@ func (s *Store) GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadClose
 
 	_, span := s.tracer.Start(
 		ctx,
-		"GetNar",
+		"local.GetNar",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("nar_url", narURL.String()),
@@ -303,7 +303,7 @@ func (s *Store) PutNar(ctx context.Context, narURL nar.URL, body io.Reader) (int
 
 	_, span := s.tracer.Start(
 		ctx,
-		"PutNar",
+		"local.PutNar",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("nar_url", narURL.String()),
@@ -355,7 +355,7 @@ func (s *Store) DeleteNar(ctx context.Context, narURL nar.URL) error {
 
 	_, span := s.tracer.Start(
 		ctx,
-		"DeleteNar",
+		"local.DeleteNar",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("nar_url", narURL.String()),

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -134,17 +134,18 @@ func (s *Store) DeleteSecretKey(ctx context.Context) error {
 
 // HasNarInfo returns true if the store has the narinfo.
 func (s *Store) HasNarInfo(ctx context.Context, hash string) bool {
+	narInfoPath := filepath.Join(s.storeNarInfoPath(), helper.NarInfoFilePath(hash))
+
 	_, span := s.tracer.Start(
 		ctx,
 		"HasNarInfo",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("narinfo_hash", hash),
+			attribute.String("narinfo_path", narInfoPath),
 		),
 	)
 	defer span.End()
-
-	narInfoPath := filepath.Join(s.storeNarInfoPath(), helper.NarInfoFilePath(hash))
 
 	_, err := os.Stat(narInfoPath)
 
@@ -253,7 +254,7 @@ func (s *Store) HasNar(ctx context.Context, narURL nar.URL) bool {
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("nar_url", narURL.String()),
-			attribute.String("nar", narPath),
+			attribute.String("nar_path", narPath),
 		),
 	)
 	defer span.End()
@@ -274,7 +275,7 @@ func (s *Store) GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadClose
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("nar_url", narURL.String()),
-			attribute.String("nar", narPath),
+			attribute.String("nar_path", narPath),
 		),
 	)
 	defer span.End()
@@ -306,7 +307,7 @@ func (s *Store) PutNar(ctx context.Context, narURL nar.URL, body io.Reader) (int
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("nar_url", narURL.String()),
-			attribute.String("nar", narPath),
+			attribute.String("nar_path", narPath),
 		),
 	)
 	defer span.End()
@@ -358,7 +359,7 @@ func (s *Store) DeleteNar(ctx context.Context, narURL nar.URL) error {
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("nar_url", narURL.String()),
-			attribute.String("nar", narPath),
+			attribute.String("nar_path", narPath),
 		),
 	)
 	defer span.End()


### PR DESCRIPTION
### TL;DR

Added OpenTelemetry tracing support to the local storage implementation.

### What changed?

- Added OpenTelemetry tracer initialization in the local storage Store struct
- Implemented tracing spans for all storage operations including:
  - Secret key operations (Get/Put/Delete)
  - NarInfo operations (Has/Get/Put/Delete)
  - Nar file operations (Has/Get/Put/Delete)
- Each span includes relevant attributes like file paths and hash values

### How to test?

1. Configure OpenTelemetry tracing in your application
2. Perform storage operations using the local storage implementation
3. Verify spans are being created with appropriate:
   - Operation names
   - Internal span kind
   - Attributes containing paths and identifiers
4. Confirm traces are being collected by your configured tracing backend

### Why make this change?

Adding tracing support enables better observability of storage operations, helping to:
- Debug performance issues
- Track operation latencies
- Monitor storage access patterns
- Troubleshoot failures in production environments