### PR TITLE
fix(pkg/nar): handle empty compression type

### DIFF
--- a/pkg/nar/compression_type.go
+++ b/pkg/nar/compression_type.go
@@ -49,6 +49,8 @@ func CompressionTypeFromExtension(ext string) (CompressionType, error) {
 // ToFileExtension returns the file extensions associated with the compression type.
 func (ct CompressionType) ToFileExtension() string {
 	switch ct {
+	case CompressionType(""):
+		fallthrough
 	case CompressionTypeNone:
 		return ""
 	case CompressionTypeBzip2:

--- a/pkg/nar/url_test.go
+++ b/pkg/nar/url_test.go
@@ -315,6 +315,12 @@ func TestString(t *testing.T) {
 	}{
 		{
 			narURL: nar.URL{
+				Hash: "abc123",
+			},
+			string: "nar/abc123.nar",
+		},
+		{
+			narURL: nar.URL{
 				Hash:        "abc123",
 				Compression: nar.CompressionTypeNone,
 			},


### PR DESCRIPTION
### TL;DR
Added support for empty compression type handling and improved test coverage for NAR URLs.

### What changed?
- Added fallthrough case for empty compression type strings in `ToFileExtension()`
- Added new test case for NAR URLs without compression type specified

### How to test?
1. Verify NAR URL generation with empty compression type returns correct extension
2. Run test suite: `go test ./pkg/nar/...`
3. Verify new test case passes for URL without compression type

### Why make this change?
To handle edge cases where compression type is not specified, ensuring the system gracefully defaults to no compression and generates correct NAR file extensions. This prevents potential errors when processing NAR URLs without explicit compression settings.