### PR TITLE
fix(pkg/server): use hostname for OpenTelemetry tracer name

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -79,13 +79,13 @@ func (s *Server) createRouter() {
 	s.router = chi.NewRouter()
 
 	mp := otel.GetMeterProvider()
-	baseCfg := otelchimetric.NewBaseConfig(tracerName, otelchimetric.WithMeterProvider(mp))
+	baseCfg := otelchimetric.NewBaseConfig(s.cache.GetHostname(), otelchimetric.WithMeterProvider(mp))
 
 	s.router.Use(middleware.Heartbeat("/healthz"))
 	s.router.Use(middleware.RealIP)
 	s.router.Use(middleware.Recoverer)
 	s.router.Use(
-		otelchi.Middleware(tracerName, otelchi.WithChiRoutes(s.router)),
+		otelchi.Middleware(s.cache.GetHostname(), otelchi.WithChiRoutes(s.router)),
 		otelchimetric.NewRequestDurationMillis(baseCfg),
 		otelchimetric.NewRequestInFlight(baseCfg),
 		otelchimetric.NewResponseSizeBytes(baseCfg),


### PR DESCRIPTION
### TL;DR

Updated OpenTelemetry middleware configuration to use dynamic hostname instead of static tracer name

### What changed?

Replaced the static `tracerName` with `s.cache.GetHostname()` in both the OpenTelemetry Chi middleware and metrics base configuration. This change ensures that telemetry data is properly tagged with the actual host identifier.

### How to test?

1. Deploy the application
2. Check OpenTelemetry traces and metrics
3. Verify that the service name in traces and metrics matches the host's hostname
4. Confirm that all middleware functions (heartbeat, RealIP, Recoverer) continue to work as expected

### Why make this change?

Using the actual hostname instead of a static tracer name provides better observability by allowing proper identification of the source of telemetry data in distributed environments. This makes it easier to track and debug issues across multiple instances of the service.