### PR TITLE
feat(cmd): enhance OpenTelemetry resource detection

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -198,8 +198,10 @@ func newResource(ctx context.Context, cmd *cli.Command) (*resource.Resource, err
 	return resource.New(
 		ctx,
 
-		// Set the Schema URL
-		// Add Custom attributes.
+		// Set the Schema URL.
+		// NOTE: This will fail if the semconv version being used within the
+		// deterctors is different and it's a check to ensure I am using the
+		// correct semconv version.
 		resource.WithSchemaURL(semconv.SchemaURL),
 
 		// Add Custom attributes.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -27,7 +27,7 @@ import (
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 
 	"github.com/kalbasit/ncps/pkg/otelzerolog"
 )

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -156,10 +156,10 @@ func setupOTelSDK(ctx context.Context, cmd *cli.Command) (func(context.Context) 
 	prop := newPropagator()
 	otel.SetTextMapPropagator(prop)
 
-	res := resource.NewWithAttributes(
-		semconv.SchemaURL,
-		semconv.ServiceName(cmd.Root().Name),
-	)
+	res, err := newResource(ctx, cmd)
+	if err != nil {
+		return shutdown, handleErr(err)
+	}
 
 	colURL := cmd.String("otel-grpc-url")
 	enabled := cmd.Bool("otel-enabled")
@@ -192,6 +192,47 @@ func setupOTelSDK(ctx context.Context, cmd *cli.Command) (func(context.Context) 
 	global.SetLoggerProvider(loggerProvider)
 
 	return shutdown, nil
+}
+
+func newResource(ctx context.Context, cmd *cli.Command) (*resource.Resource, error) {
+	return resource.New(
+		ctx,
+
+		// Set the Schema URL
+		// Add Custom attributes.
+		resource.WithSchemaURL(semconv.SchemaURL),
+
+		// Add Custom attributes.
+		resource.WithAttributes(
+			semconv.ServiceName(cmd.Root().Name),
+			semconv.ServiceVersionKey.String(Version),
+		),
+
+		// Discover and provide command-line information.
+		resource.WithProcessCommandArgs(),
+
+		// Discover and provide runtime information.
+		resource.WithProcessRuntimeVersion(),
+
+		// Discover and provide attributes from OTEL_RESOURCE_ATTRIBUTES and
+		// OTEL_SERVICE_NAME environment variables.
+		resource.WithFromEnv(),
+
+		// Discover and provide information about the OpenTelemetry SDK used.
+		resource.WithTelemetrySDK(),
+
+		// Discover and provide process information.
+		resource.WithProcess(),
+
+		// Discover and provide OS information.
+		resource.WithOS(),
+
+		// Discover and provide container information.
+		resource.WithContainer(),
+
+		// Discover and provide host information.
+		resource.WithHost(),
+	)
 }
 
 func newPropagator() propagation.TextMapPropagator {

--- a/nix/packages/docker.nix
+++ b/nix/packages/docker.nix
@@ -13,7 +13,7 @@
             etc-passwd = pkgs.writeTextFile {
               name = "passwd";
               text = ''
-                root:x:0:0:Super User:/root:/dev/null
+                root:x:0:0:Super User:/homeless-shelter:/dev/null
               '';
               destination = "/etc/passwd";
             };

--- a/nix/packages/docker.nix
+++ b/nix/packages/docker.nix
@@ -8,19 +8,41 @@
     {
       packages.docker = pkgs.dockerTools.buildLayeredImage {
         name = "kalbasit/ncps";
-        contents = [
-          # required for TLS certificate validation
-          pkgs.cacert
+        contents =
+          let
+            etc-passwd = pkgs.writeTextFile {
+              name = "passwd";
+              text = ''
+                root:x:0:0:Super User:/root:/dev/null
+              '';
+              destination = "/etc/passwd";
+            };
 
-          # required for working with timezones
-          pkgs.tzdata
+            etc-group = pkgs.writeTextFile {
+              name = "group";
+              text = ''
+                root:x:0:
+              '';
+              destination = "/etc/group";
+            };
+          in
+          [
+            # required for TLS certificate validation
+            pkgs.cacert
 
-          # required for migrating the database
-          pkgs.dbmate
+            # required for working with timezones
+            pkgs.tzdata
 
-          # the ncps package
-          config.packages.ncps
-        ];
+            # required for migrating the database
+            pkgs.dbmate
+
+            # the ncps package
+            config.packages.ncps
+
+            # required for Open-Telemetry auto-detection of process information
+            etc-passwd
+            etc-group
+          ];
         config = {
           Cmd = [ "/bin/ncps" ];
           Env = [

--- a/nix/packages/docker.nix
+++ b/nix/packages/docker.nix
@@ -27,6 +27,10 @@
             };
           in
           [
+            # required for Open-Telemetry auto-detection of process information
+            etc-passwd
+            etc-group
+
             # required for TLS certificate validation
             pkgs.cacert
 
@@ -38,10 +42,6 @@
 
             # the ncps package
             config.packages.ncps
-
-            # required for Open-Telemetry auto-detection of process information
-            etc-passwd
-            etc-group
           ];
         config = {
           Cmd = [ "/bin/ncps" ];


### PR DESCRIPTION
Enrich OpenTelemetry resources with additional attributes

- Downgrade semconv from v1.27.0 to v1.26.0 to resolve version conflicts
- Add comprehensive resource detection including:
  - Service version
  - Process command args
  - Runtime information
  - Environment variables
  - SDK details
  - Process information
  - OS information
  - Container metadata
  - Host details