### PR TITLE
ci(nix): include testdata and testhelper in package-ncps checks

### DIFF
--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -16,6 +16,16 @@
         packages
         // devShells
         // {
+          package-ncps = packages."package-ncps".overrideAttrs (oa: {
+            # The testdata and testhelper packages are not used by the main
+            # package but do (could) have tests. Have the check include them to
+            # ensure they pass should they have tests.
+            subPackages = oa.subPackages ++ [
+              "testdata"
+              "testhelper"
+            ];
+          });
+
           golangci-lint = config.packages.ncps.overrideAttrs (oa: {
             name = "golangci-lint";
             src = ../../.;


### PR DESCRIPTION
### TL;DR

Added testdata and testhelper packages to the package-ncps checks.

### What changed?

Created a new package-ncps override that includes additional subpackages (testdata and testhelper) in the test suite.

### How to test?

Run the package-ncps checks to verify that tests for testdata and testhelper packages execute successfully:
```
nix build .#checks.x86_64-linux.package-ncps
```

### Why make this change?

To ensure comprehensive testing coverage by including testdata and testhelper packages in the test suite, even though they're not directly used by the main package.