### PR TITLE
refactor: use http.Method constants instead of string literals

### DIFF
--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -124,7 +124,7 @@ func (c Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, e
 		Logger().
 		WithContext(ctx)
 
-	r, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	r, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating a new request: %w", err)
 	}
@@ -199,7 +199,7 @@ func (c Cache) GetNar(ctx context.Context, narURL nar.URL, mutators ...func(*htt
 			Logger(),
 	).WithContext(ctx)
 
-	r, err := http.NewRequestWithContext(ctx, "GET", u, nil)
+	r, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error creating a new request: %w", err)
 	}
@@ -244,7 +244,7 @@ func (c Cache) parsePriority(ctx context.Context) (uint64, error) {
 	ctx, cancelFn := context.WithTimeout(ctx, 3*time.Second)
 	defer cancelFn()
 
-	r, err := http.NewRequestWithContext(ctx, "GET", c.url.JoinPath("/nix-cache-info").String(), nil)
+	r, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url.JoinPath("/nix-cache-info").String(), nil)
 	if err != nil {
 		return 0, fmt.Errorf("error creating a new request: %w", err)
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -68,7 +68,7 @@ func TestServeHTTP(t *testing.T) {
 			t.Run("narInfo", func(t *testing.T) {
 				url := ts.URL + "/" + testdata.Nar1.NarInfoHash + ".narinfo"
 
-				r, err := http.NewRequestWithContext(newContext(), "DELETE", url, nil)
+				r, err := http.NewRequestWithContext(newContext(), http.MethodDelete, url, nil)
 				require.NoError(t, err)
 
 				resp, err := ts.Client().Do(r)
@@ -80,7 +80,7 @@ func TestServeHTTP(t *testing.T) {
 			t.Run("nar", func(t *testing.T) {
 				url := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar.xz"
 
-				r, err := http.NewRequestWithContext(newContext(), "DELETE", url, nil)
+				r, err := http.NewRequestWithContext(newContext(), http.MethodDelete, url, nil)
 				require.NoError(t, err)
 
 				resp, err := ts.Client().Do(r)
@@ -114,7 +114,7 @@ func TestServeHTTP(t *testing.T) {
 				t.Run("DELETE returns no error", func(t *testing.T) {
 					url := ts.URL + "/" + testdata.Nar1.NarInfoHash + ".narinfo"
 
-					r, err := http.NewRequestWithContext(newContext(), "DELETE", url, nil)
+					r, err := http.NewRequestWithContext(newContext(), http.MethodDelete, url, nil)
 					require.NoError(t, err)
 
 					resp, err := ts.Client().Do(r)
@@ -146,7 +146,7 @@ func TestServeHTTP(t *testing.T) {
 				t.Run("DELETE returns no error", func(t *testing.T) {
 					url := ts.URL + "/nar/" + testdata.Nar2.NarHash + ".nar.xz"
 
-					r, err := http.NewRequestWithContext(newContext(), "DELETE", url, nil)
+					r, err := http.NewRequestWithContext(newContext(), http.MethodDelete, url, nil)
 					require.NoError(t, err)
 
 					resp, err := ts.Client().Do(r)
@@ -186,7 +186,7 @@ func TestServeHTTP(t *testing.T) {
 
 		t.Run("narinfo", func(t *testing.T) {
 			t.Run("narinfo does not exist upstream", func(t *testing.T) {
-				r := httptest.NewRequest("GET", "/doesnotexist.narinfo", nil)
+				r := httptest.NewRequest(http.MethodGet, "/doesnotexist.narinfo", nil)
 				w := httptest.NewRecorder()
 
 				s.ServeHTTP(w, r)
@@ -195,7 +195,7 @@ func TestServeHTTP(t *testing.T) {
 			})
 
 			t.Run("narinfo exists upstream", func(t *testing.T) {
-				r := httptest.NewRequest("GET", helper.NarInfoURLPath(testdata.Nar1.NarInfoHash), nil)
+				r := httptest.NewRequest(http.MethodGet, helper.NarInfoURLPath(testdata.Nar1.NarInfoHash), nil)
 				w := httptest.NewRecorder()
 
 				s.ServeHTTP(w, r)
@@ -215,7 +215,7 @@ func TestServeHTTP(t *testing.T) {
 
 		t.Run("nar", func(t *testing.T) {
 			t.Run("nar does not exist upstream", func(t *testing.T) {
-				r := httptest.NewRequest("GET", "/nar/doesnotexist.nar", nil)
+				r := httptest.NewRequest(http.MethodGet, "/nar/doesnotexist.nar", nil)
 				w := httptest.NewRecorder()
 
 				s.ServeHTTP(w, r)
@@ -228,7 +228,7 @@ func TestServeHTTP(t *testing.T) {
 				require.NoError(t, err)
 
 				nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
-				r := httptest.NewRequest("GET", nu.JoinURL(u).String(), nil)
+				r := httptest.NewRequest(http.MethodGet, nu.JoinURL(u).String(), nil)
 				w := httptest.NewRecorder()
 
 				s.ServeHTTP(w, r)
@@ -255,7 +255,7 @@ func TestServeHTTP(t *testing.T) {
 
 				nu := nar.URL{Hash: testdata.Nar2.NarHash, Compression: nar.CompressionTypeXz, Query: q}
 
-				r := httptest.NewRequest("GET", nu.JoinURL(u).String(), nil)
+				r := httptest.NewRequest(http.MethodGet, nu.JoinURL(u).String(), nil)
 				w := httptest.NewRecorder()
 
 				s.ServeHTTP(w, r)
@@ -305,7 +305,7 @@ func TestServeHTTP(t *testing.T) {
 			t.Run("narInfo", func(t *testing.T) {
 				p := ts.URL + "/" + testdata.Nar1.NarInfoHash + ".narinfo"
 
-				r, err := http.NewRequestWithContext(newContext(), "PUT", p, strings.NewReader(testdata.Nar1.NarInfoText))
+				r, err := http.NewRequestWithContext(newContext(), http.MethodPut, p, strings.NewReader(testdata.Nar1.NarInfoText))
 				require.NoError(t, err)
 
 				resp, err := ts.Client().Do(r)
@@ -318,7 +318,7 @@ func TestServeHTTP(t *testing.T) {
 				t.Run("without compression", func(t *testing.T) {
 					p := ts.URL + "/nar/" + testdata.Nar1.NarInfoHash + ".nar"
 
-					r, err := http.NewRequestWithContext(newContext(), "PUT", p, strings.NewReader(testdata.Nar1.NarText))
+					r, err := http.NewRequestWithContext(newContext(), http.MethodPut, p, strings.NewReader(testdata.Nar1.NarText))
 					require.NoError(t, err)
 
 					resp, err := ts.Client().Do(r)
@@ -330,7 +330,7 @@ func TestServeHTTP(t *testing.T) {
 				t.Run("with compression", func(t *testing.T) {
 					p := ts.URL + "/nar/" + testdata.Nar1.NarInfoHash + ".nar.xz"
 
-					r, err := http.NewRequestWithContext(newContext(), "PUT", p, strings.NewReader(testdata.Nar1.NarText))
+					r, err := http.NewRequestWithContext(newContext(), http.MethodPut, p, strings.NewReader(testdata.Nar1.NarText))
 					require.NoError(t, err)
 
 					resp, err := ts.Client().Do(r)
@@ -358,7 +358,7 @@ func TestServeHTTP(t *testing.T) {
 				t.Run("putNarInfo does not return an error", func(t *testing.T) {
 					p := ts.URL + "/" + testdata.Nar1.NarInfoHash + ".narinfo"
 
-					r, err := http.NewRequestWithContext(newContext(), "PUT", p, strings.NewReader(testdata.Nar1.NarInfoText))
+					r, err := http.NewRequestWithContext(newContext(), http.MethodPut, p, strings.NewReader(testdata.Nar1.NarInfoText))
 					require.NoError(t, err)
 
 					resp, err := ts.Client().Do(r)
@@ -405,7 +405,7 @@ func TestServeHTTP(t *testing.T) {
 			t.Run("putNar does not return an error", func(t *testing.T) {
 				p := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar.xz"
 
-				r, err := http.NewRequestWithContext(newContext(), "PUT", p, strings.NewReader(testdata.Nar1.NarText))
+				r, err := http.NewRequestWithContext(newContext(), http.MethodPut, p, strings.NewReader(testdata.Nar1.NarText))
 				require.NoError(t, err)
 
 				resp, err := ts.Client().Do(r)

--- a/testdata/server_test.go
+++ b/testdata/server_test.go
@@ -23,7 +23,7 @@ func TestNewTestServer(t *testing.T) {
 
 	u := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar.xz"
 
-	r, err := http.NewRequestWithContext(context.Background(), "GET", u, nil)
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodGet, u, nil)
 	require.NoError(t, err)
 
 	resp, err := http.DefaultClient.Do(r)
@@ -56,7 +56,7 @@ func TestNewTestServerWithZSTD(t *testing.T) {
 
 	u := ts.URL + "/nar/" + testdata.Nar1.NarHash + ".nar"
 
-	r, err := http.NewRequestWithContext(context.Background(), "GET", u, nil)
+	r, err := http.NewRequestWithContext(context.Background(), http.MethodGet, u, nil)
 	require.NoError(t, err)
 
 	r.Header.Set("Accept-Encoding", "zstd")


### PR DESCRIPTION
### TL;DR
Replaced hardcoded HTTP method strings with standard `http.Method*` constants

### What changed?
- Replaced string literals like "GET", "PUT", and "DELETE" with their corresponding `http.Method*` constants
- Updated HTTP method references in cache operations, server tests, and test data files

### How to test?
1. Run the existing test suite
2. Verify all HTTP requests continue to function as expected
3. Confirm no changes in behavior for GET, PUT, and DELETE operations

### Why make this change?
Using standard HTTP method constants from the `http` package:
- Prevents typos in method strings
- Provides better IDE support and code completion
- Makes the code more maintainable and consistent with Go best practices
- Reduces the risk of errors from mistyped HTTP method strings