### PR TITLE
feat(pkg/cache/upstream): add HasNarInfo and HasNar methods

### DIFF
--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -290,7 +290,7 @@ func (c Cache) HasNar(ctx context.Context, narURL nar.URL, mutators ...func(*htt
 
 	ctx, span := c.tracer.Start(
 		ctx,
-		"upstream.HetNar",
+		"upstream.HasNar",
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("nar_url", u),

--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -175,6 +175,7 @@ func (c Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, e
 	return ni, nil
 }
 
+// HasNarInfo returns true if the narinfo exists upstream.
 func (c Cache) HasNarInfo(ctx context.Context, hash string) (bool, error) {
 	u := c.url.JoinPath(helper.NarInfoURLPath(hash)).String()
 
@@ -281,6 +282,56 @@ func (c Cache) GetNar(ctx context.Context, narURL nar.URL, mutators ...func(*htt
 	}
 
 	return resp, nil
+}
+
+// HasNar returns true if the NAR exists upstream.
+func (c Cache) HasNar(ctx context.Context, narURL nar.URL, mutators ...func(*http.Request)) (bool, error) {
+	u := narURL.JoinURL(c.url).String()
+
+	ctx, span := c.tracer.Start(
+		ctx,
+		"upstream.HetNar",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			attribute.String("nar_url", u),
+			attribute.String("upstream_url", c.url.String()),
+		),
+	)
+	defer span.End()
+
+	ctx = narURL.NewLogger(
+		zerolog.Ctx(ctx).
+			With().
+			Str("nar_url", u).
+			Str("upstream_url", c.url.String()).
+			Logger(),
+	).WithContext(ctx)
+
+	r, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return false, fmt.Errorf("error creating a new request: %w", err)
+	}
+
+	for _, mutator := range mutators {
+		mutator(r)
+	}
+
+	zerolog.Ctx(ctx).
+		Info().
+		Msg("download the nar from upstream")
+
+	resp, err := c.httpClient.Do(r)
+	if err != nil {
+		return false, fmt.Errorf("error performing the request: %w", err)
+	}
+
+	defer func() {
+		//nolint:errcheck
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	return resp.StatusCode < http.StatusBadRequest, nil
 }
 
 // GetPriority returns the priority of this upstream cache.

--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -178,18 +178,18 @@ func TestGetNarInfo(t *testing.T) {
 func TestHasNarInfo(t *testing.T) {
 	t.Parallel()
 
-	ts := testdata.NewTestServer(t, 40)
-	defer ts.Close()
-
-	c, err := upstream.New(
-		newContext(),
-		testhelper.MustParseURL(t, ts.URL),
-		testdata.PublicKeys(),
-	)
-	require.NoError(t, err)
-
 	t.Run("narinfo exists", func(t *testing.T) {
 		t.Parallel()
+
+		ts := testdata.NewTestServer(t, 40)
+		defer ts.Close()
+
+		c, err := upstream.New(
+			newContext(),
+			testhelper.MustParseURL(t, ts.URL),
+			testdata.PublicKeys(),
+		)
+		require.NoError(t, err)
 
 		exists, err := c.HasNarInfo(context.Background(), "abc123")
 		require.NoError(t, err)
@@ -200,6 +200,16 @@ func TestHasNarInfo(t *testing.T) {
 	for i, narEntry := range testdata.Entries {
 		t.Run(fmt.Sprintf("Nar%d should exist", i+1), func(t *testing.T) {
 			t.Parallel()
+
+			ts := testdata.NewTestServer(t, 40)
+			defer ts.Close()
+
+			c, err := upstream.New(
+				newContext(),
+				testhelper.MustParseURL(t, ts.URL),
+				testdata.PublicKeys(),
+			)
+			require.NoError(t, err)
 
 			exists, err := c.HasNarInfo(context.Background(), narEntry.NarInfoHash)
 			require.NoError(t, err)

--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -175,6 +175,40 @@ func TestGetNarInfo(t *testing.T) {
 	t.Run("upstream with public keys", testFn(true))
 }
 
+func TestHasNarInfo(t *testing.T) {
+	t.Parallel()
+
+	ts := testdata.NewTestServer(t, 40)
+	defer ts.Close()
+
+	c, err := upstream.New(
+		newContext(),
+		testhelper.MustParseURL(t, ts.URL),
+		testdata.PublicKeys(),
+	)
+	require.NoError(t, err)
+
+	t.Run("narinfo exists", func(t *testing.T) {
+		t.Parallel()
+
+		exists, err := c.HasNarInfo(context.Background(), "abc123")
+		require.NoError(t, err)
+
+		assert.False(t, exists)
+	})
+
+	for i, narEntry := range testdata.Entries {
+		t.Run(fmt.Sprintf("Nar%d should exist", i+1), func(t *testing.T) {
+			t.Parallel()
+
+			exists, err := c.HasNarInfo(context.Background(), narEntry.NarInfoHash)
+			require.NoError(t, err)
+
+			assert.True(t, exists)
+		})
+	}
+}
+
 func TestGetNar(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Implement HasNarInfo and HasNar methods in upstream cache

Adds two new methods to check for the existence of narinfo and nar files in the upstream cache:

- `HasNarInfo`: Uses HEAD request to verify if a narinfo exists
- `HasNar`: Uses HEAD request to verify if a nar archive exists

Both methods return a boolean indicating existence and include appropriate tracing and logging.