### PR TITLE
feat(pkg/cache): optimize upstream narinfo selection

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -976,6 +976,15 @@ func (c *Cache) selectNarInfoUpstream(
 	hash string,
 	ucs []upstream.Cache,
 ) (*upstream.Cache, error) {
+	if len(ucs) == 0 {
+		//nolint:nilnil
+		return nil, nil
+	}
+
+	if len(ucs) == 1 {
+		return &ucs[0], nil
+	}
+
 	ch := make(chan *upstream.Cache)
 	errC := make(chan error)
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1027,7 +1027,9 @@ func (c *Cache) selectNarInfoUpstream(
 
 			return uc, errs
 		case err := <-errC:
-			errs = errors.Join(errs, err)
+			if !errors.Is(err, context.Canceled) {
+				errs = errors.Join(errs, err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
# Optimize narinfo upstream selection

- Add `selectNarInfoUpstream` function to efficiently select the first available upstream cache containing the narinfo
- Short-circuit when no upstreams exist or only one is configured
- Parallelize upstream availability checks when multiple upstreams exist
- Update `getNarInfoFromUpstream` to use the new selection logic