### PR TITLE
fix(pkg/cache): correct log messages for nar operations

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -316,7 +316,7 @@ func (c *Cache) pullNar(
 		zerolog.Ctx(ctx).
 			Error().
 			Err(err).
-			Msg("error getting the narInfo from upstream caches")
+			Msg("error getting the nar from upstream caches")
 
 		done()
 

--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -206,7 +206,7 @@ func (c Cache) HasNarInfo(ctx context.Context, hash string) (bool, error) {
 
 	zerolog.Ctx(ctx).
 		Info().
-		Msg("download the narinfo from upstream")
+		Msg("heading the narinfo from upstream")
 
 	resp, err := c.httpClient.Do(r)
 	if err != nil {
@@ -318,7 +318,7 @@ func (c Cache) HasNar(ctx context.Context, narURL nar.URL, mutators ...func(*htt
 
 	zerolog.Ctx(ctx).
 		Info().
-		Msg("download the nar from upstream")
+		Msg("heading the nar from upstream")
 
 	resp, err := c.httpClient.Do(r)
 	if err != nil {


### PR DESCRIPTION
### TL;DR
Updated log messages to accurately reflect HTTP operations in cache interactions

### What changed?
- Fixed error message when getting nar from upstream caches
- Changed "download" to "heading" in narinfo and nar upstream log messages to better reflect the HTTP HEAD operation being performed

### How to test?
1. Enable debug logging
2. Perform cache operations that interact with upstream caches
3. Verify log messages accurately describe the HEAD operations
4. Verify error messages are clear when nar retrieval fails

### Why make this change?
The log messages were misleading, suggesting downloads were occurring when the code was actually performing HEAD requests to check for resource existence. This change improves observability by making the logs more accurate and clearer for debugging purposes.