### PR TITLE
fix(pkg/cache): downgrade not found errors to info level

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -324,10 +324,17 @@ func (c *Cache) pullNar(
 
 	resp, err := c.getNarFromUpstream(ctx, narURL, uc, narInfo, enableZSTD)
 	if err != nil {
-		zerolog.Ctx(ctx).
-			Error().
-			Err(err).
-			Msg("error getting the nar from upstream caches")
+		if !errors.Is(err, storage.ErrNotFound) {
+			zerolog.Ctx(ctx).
+				Error().
+				Err(err).
+				Msg("error getting the nar from upstream caches")
+		} else {
+			zerolog.Ctx(ctx).
+				Info().
+				Err(err).
+				Msg("error getting the nar from upstream caches")
+		}
 
 		done()
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -589,10 +589,17 @@ func (c *Cache) pullNarInfo(
 
 	uc, narInfo, err := c.getNarInfoFromUpstream(ctx, hash)
 	if err != nil {
-		zerolog.Ctx(ctx).
-			Error().
-			Err(err).
-			Msg("error getting the narInfo from upstream caches")
+		if !errors.Is(err, storage.ErrNotFound) {
+			zerolog.Ctx(ctx).
+				Error().
+				Err(err).
+				Msg("error getting the narInfo from upstream caches")
+		} else {
+			zerolog.Ctx(ctx).
+				Info().
+				Err(err).
+				Msg("error getting the narInfo from upstream caches")
+		}
 
 		done()
 


### PR DESCRIPTION
do not error log not found

Changes error logging to info logging when encountering storage.ErrNotFound errors during nar and narInfo retrieval from upstream caches.