### PR TITLE
feat(cmd): add timestamp to logger output

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -77,7 +77,12 @@ func New() *cli.Command {
 				output = zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
 			}
 
-			ctx = zerolog.New(output).Level(lvl).WithContext(ctx)
+			ctx = zerolog.New(output).
+				Level(lvl).
+				With().
+				Timestamp().
+				Logger().
+				WithContext(ctx)
 
 			(zerolog.Ctx(ctx)).
 				Info().


### PR DESCRIPTION
### TL;DR
Added timestamp logging to the zerolog configuration

### What changed?
Enhanced the zerolog initialization by adding timestamp information to log entries using the `Timestamp()` method in the logging chain.

### How to test?
1. Run any command that produces logs
2. Verify that log entries now include a timestamp field
3. Confirm the timestamp format matches RFC3339 specification

### Why make this change?
Including timestamps in log entries is crucial for debugging and monitoring as it allows for better tracking of when events occur and helps with log analysis and troubleshooting.