### PR TITLE
feat(ci): add logging flags to nix commands

### DIFF
--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -41,7 +41,7 @@ runs:
       env:
         RELEASE_VERSION: ${{ github.ref_name }}
       run: |
-        nix build --impure .#push-docker-image
+        nix build -L --impure .#push-docker-image
     - name: Push the docker image
       if: ${{ inputs.push }}
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v16
       - uses: DeterminateSystems/magic-nix-cache-action@v8
       - uses: DeterminateSystems/flake-checker-action@main
-      - run: nix flake check
+      - run: nix flake check -L --all-systems
   docker:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v16
       - uses: DeterminateSystems/magic-nix-cache-action@v8
       - uses: DeterminateSystems/flake-checker-action@main
-      - run: nix flake check
+      - run: nix flake check -L --all-systems
   docker:
     runs-on: ubuntu-24.04
     needs: flake-check

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v16
       - uses: DeterminateSystems/magic-nix-cache-action@v8
       - uses: DeterminateSystems/flake-checker-action@main
-      - run: nix flake check
+      - run: nix flake check -L --all-systems
   docker:
     runs-on: ubuntu-24.04
     needs: flake-check


### PR DESCRIPTION
### TL;DR

Added verbose logging and multi-system checks to Nix commands in GitHub Actions workflows.

### What changed?

- Added `-L` flag to `nix build` command in Docker action for verbose logging
- Updated `nix flake check` commands to include `-L` and `--all-systems` flags across CI, Docker, and Release workflows

### How to test?

1. Run a GitHub Action workflow
2. Verify that Nix commands now show more detailed output during execution
3. Confirm that flake checks are running against all supported systems

### Why make this change?

The addition of verbose logging (`-L`) improves debugging capabilities by providing more detailed output during builds and checks. The `--all-systems` flag ensures that flake checks are comprehensive across all supported systems, helping catch system-specific issues earlier in the development process.