### PR TITLE
fix: update go-nix to fix parsing narinfo with unknown deriver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-chi/chi/v5 v5.2.0
 	github.com/klauspost/compress v1.17.11
 	github.com/mattn/go-sqlite3 v1.14.24
-	github.com/nix-community/go-nix v0.0.0-20241231094847-b5eacc9958cd
+	github.com/nix-community/go-nix v0.0.0-20250101154619-4bdde671e0a1
 	github.com/riandyrn/otelchi v0.11.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/zerolog v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
 github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
-github.com/nix-community/go-nix v0.0.0-20241231094847-b5eacc9958cd h1:SHwu+Di8uuowbCkuYJeRon3ciXAl5pAme1xItHkIf30=
-github.com/nix-community/go-nix v0.0.0-20241231094847-b5eacc9958cd/go.mod h1:qgCw4bBKZX8qMgGeEZzGFVT3notl42dBjNqO2jut0M0=
+github.com/nix-community/go-nix v0.0.0-20250101154619-4bdde671e0a1 h1:kpt9ZfKcm+EDG4s40hMwE//d5SBgDjUOrITReV2u4aA=
+github.com/nix-community/go-nix v0.0.0-20250101154619-4bdde671e0a1/go.mod h1:qgCw4bBKZX8qMgGeEZzGFVT3notl42dBjNqO2jut0M0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/nix/packages/ncps.nix
+++ b/nix/packages/ncps.nix
@@ -38,7 +38,7 @@
 
           subPackages = [ "." ];
 
-          vendorHash = "sha256-3ovcjYcb4H79JSO/3WioOEiK8KqD/xdbzqER3HlF1ZY=";
+          vendorHash = "sha256-xPrWofNyDFrUPQ42AYDs2x2gGoQ2w3tRrMIsu3SVyHA=";
 
           doCheck = true;
 

--- a/testdata/entries.go
+++ b/testdata/entries.go
@@ -7,4 +7,5 @@ var Entries = []Entry{
 	Nar3,
 	Nar4,
 	Nar5,
+	Nar6,
 }

--- a/testdata/nar6.go
+++ b/testdata/nar6.go
@@ -1,0 +1,33 @@
+package testdata
+
+import (
+	"path/filepath"
+
+	"github.com/kalbasit/ncps/pkg/helper"
+	"github.com/kalbasit/ncps/pkg/nar"
+)
+
+// Nar6 is the nar representing hello from release-22.04 with its Deriver made
+// into unknown-deriver.
+//
+//nolint:gochecknoglobals,lll
+var Nar6 = Entry{
+	NarInfoHash: "6lwdzpbig6zz8678blcqr5f5q1caxjw2",
+	NarInfoPath: filepath.Join("6", "6l", "6lwdzpbig6zz8678blcqr5f5q1caxjw2.narinfo"),
+	NarInfoText: `StorePath: /nix/store/6lwdzpbig6zz8678blcqr5f5q1caxjw2-hello-2.12
+URL: nar/1z2a10f88f36n0iqkl831drchx3f04cs96kypjyrj0rrbcpww28n.nar.xz
+Compression: xz
+FileHash: sha256:1z2a10f88f36n0iqkl831drchx3f04cs96kypjyrj0rrbcpww28n
+FileSize: 43624
+NarHash: sha256:08n38jlm2m2wlsskaav1mcvsgp42nm7cv8x9yga84l9rgnxsz8lz
+NarSize: 181368
+References: 6lwdzpbig6zz8678blcqr5f5q1caxjw2-hello-2.12 b2hc0i92l22ir2kavnjn3z5z6mzabbvm-glibc-2.34-210
+Deriver: unknown-deriver
+Sig: cache.nixos.org-1:J3pwQAMB5Pzi4PpxyTPOugN8sl8cVbU/XjC1WVj5MKwZDIVdUHTV3IwLido9XMHe3xL6sWVdlk76hhQwaMVNDg==
+Sig: nix-cache.cluster.nasreddine.com:B+Ceczbz+qLqCqTPbb8PKOyCMaOOA4jEv5VNU0d5RzPxdCLlr5vg8sgqdfAyib/itoRXrW8CSzwHjwHQBnHOBw==`,
+
+	NarHash:        "1z2a10f88f36n0iqkl831drchx3f04cs96kypjyrj0rrbcpww28n",
+	NarCompression: nar.CompressionTypeXz,
+	NarPath:        filepath.Join("1", "1z", "1z2a10f88f36n0iqkl831drchx3f04cs96kypjyrj0rrbcpww28n.nar.xz"),
+	NarText:        helper.MustRandString(43624, nil),
+}


### PR DESCRIPTION
Update go-nix to handle unknown derivers

Added test case for narinfo with unknown-deriver and updated go-nix dependency to handle this scenario correctly.

closes #171