### PR TITLE
refactor(cmd)!: rename allow-delete/put flags to cache-allow-delete/put-verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ These options can be used with any `ncps` command:
 
 These options are specific to the `ncps serve` command:
 
-- `--allow-delete`: Whether to allow the DELETE verb to delete `narinfo` and `nar` files from the cache (default: false). (Environment variable: `$ALLOW_DELETE_VERB`)
-- `--allow-put`: Whether to allow the PUT verb to push `narinfo` and `nar` files directly to the cache (default: false). (Environment variable: `$ALLOW_PUT_VERB`)
+- `--cache-allow-delete-verb`: Whether to allow the DELETE verb to delete `narinfo` and `nar` files from the cache (default: false). (Environment variable: `$CACHE_ALLOW_DELETE_VERB`)
+- `--cache-allow-put-verb`: Whether to allow the PUT verb to push `narinfo` and `nar` files directly to the cache (default: false). (Environment variable: `$CACHE_ALLOW_PUT_VERB`)
 - `--cache-hostname`: The hostname of the cache server. **This is used to generate the private key used for signing store paths (.narinfo).** (Environment variable: `$CACHE_HOSTNAME`)
 - `--cache-data-path`: The local directory for storing configuration and cached store paths. (Environment variable: `$CACHE_DATA_PATH`)
 - `--cache-database-url`: The URL of the database (defaults to an embedded SQLite database). (Environment variable: `$CACHE_DATABASE_URL`)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -34,14 +34,14 @@ func serveCommand() *cli.Command {
 		Action:  serveAction(),
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
-				Name:    "allow-delete",
+				Name:    "cache-allow-delete-verb",
 				Usage:   "Whether to allow the DELETE verb to delete narInfo and nar files",
-				Sources: cli.EnvVars("ALLOW_DELETE_VERB"),
+				Sources: cli.EnvVars("CACHE_ALLOW_DELETE_VERB"),
 			},
 			&cli.BoolFlag{
-				Name:    "allow-put",
+				Name:    "cache-allow-put-verb",
 				Usage:   "Whether to allow the PUT verb to push narInfo and nar files directly",
-				Sources: cli.EnvVars("ALLOW_PUT_VERB"),
+				Sources: cli.EnvVars("CACHE_ALLOW_PUT_VERB"),
 			},
 			&cli.StringFlag{
 				Name:     "cache-hostname",
@@ -145,8 +145,8 @@ func serveAction() cli.ActionFunc {
 		}
 
 		srv := server.New(cache)
-		srv.SetDeletePermitted(cmd.Bool("allow-delete"))
-		srv.SetPutPermitted(cmd.Bool("allow-put"))
+		srv.SetDeletePermitted(cmd.Bool("cache-allow-delete-verb"))
+		srv.SetPutPermitted(cmd.Bool("cache-allow-put-verb"))
 
 		server := &http.Server{
 			BaseContext:       func(net.Listener) context.Context { return ctx },


### PR DESCRIPTION
consistency: rename environment variables and flags for HTTP verbs

- rename `--allow-delete` to `--cache-allow-delete-verb`
- rename `--allow-put` to `--cache-allow-put-verb`
- rename `$ALLOW_DELETE_VERB` to `$CACHE_ALLOW_DELETE_VERB`
- rename `$ALLOW_PUT_VERB` to `$CACHE_ALLOW_PUT_VERB`

update readme to reflect new flag and environment variable names