### PR TITLE
fix(nix): fix invocation with nix run github:kalbasit/ncps

### DIFF
--- a/nix/packages/ncps.nix
+++ b/nix/packages/ncps.nix
@@ -55,6 +55,7 @@
             description = "Nix binary cache proxy service";
             homepage = "https://github.com/kalbasit/ncps";
             license = lib.licenses.mit;
+            mainProgram = "ncps";
             maintainers = [ lib.maintainers.kalbasit ];
           };
         };


### PR DESCRIPTION
### TL;DR

Added `mainProgram` attribute to NCPS package metadata

### What changed?

Added the `mainProgram = "ncps";` attribute to the package metadata in `nix/packages/ncps.nix`

### How to test?

1. Verify that the command `nix run` runs `ncps`.

### Why make this change?

This addition helps Nix better identify the primary executable for the package, improving the user experience when using commands like `nix run` and ensuring proper program discovery in the Nix ecosystem.

closes #174