### PR TITLE
feat(cmd): add cache-secret-key-path flag for custom signing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ These options are specific to the `ncps serve` command:
 - `--cache-max-size`: The maximum size of the store. It can be given with units such as 5K, 10G etc. Supported units: B, K, M, G, T (Environment variable: `$CACHE_MAX_SIZE`)
 - `--cache-lru-schedule`: The cron spec for cleaning the store to keep it under `--cache-max-size`. Refer to https://pkg.go.dev/github.com/robfig/cron/v3#hdr-Usage for documentation (Environment variable: `$CACHE_LRU_SCHEDULE`)
 - `--cache-lru-schedule-timezone`: The name of the timezone to use for the cron schedule (default: "Local"). (Environment variable: `$CACHE_LRU_SCHEDULE_TZ`)
+- `--cache-secret-key-path`: The path to the secret key used for signing cached paths. (Environment variable: `$CACHE_SECRET_KEY_PATH`)
 - `--server-addr`: The address and port the server listens on (default: ":8501"). (Environment variable: `$SERVER_ADDR`)
 - `--upstream-cache`: The URL of an upstream binary cache (e.g., `https://cache.nixos.org`). This flag can be used multiple times to specify multiple upstream caches. (Environment variable: `$UPSTREAM_CACHES`)
 - `--upstream-public-key`: The public key of an upstream cache in the format `host:public-key`. This flag is used to verify the signatures of store paths downloaded from upstream caches. This flag can be used multiple times, once for each upstream cache. (Environment variable: `$UPSTREAM_PUBLIC_KEYS`)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -91,7 +91,7 @@ func serveCommand() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:    "cache-secret-key-path",
-				Usage:   "The path to the secret Key",
+				Usage:   "The path to the secret key used for signing cached paths",
 				Sources: cli.EnvVars("CACHE_SECRET_KEY_PATH"),
 			},
 			&cli.StringFlag{

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -90,6 +90,11 @@ func serveCommand() *cli.Command {
 				Value:   "Local",
 			},
 			&cli.StringFlag{
+				Name:    "cache-secret-key-path",
+				Usage:   "The path to the secret Key",
+				Sources: cli.EnvVars("CACHE_SECRET_KEY_PATH"),
+			},
+			&cli.StringFlag{
 				Name:    "server-addr",
 				Usage:   "The address of the server",
 				Sources: cli.EnvVars("SERVER_ADDR"),
@@ -225,6 +230,7 @@ func createCache(
 		localStore,
 		localStore,
 		localStore,
+		cmd.String("cache-secret-key-path"),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating a new cache: %w", err)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1178,7 +1178,7 @@ func (c *Cache) setupSecretKey(ctx context.Context, secretKeyPath string) error 
 
 		c.secretKey, err = signature.LoadSecretKey(string(skc))
 		if err != nil {
-			return fmt.Errorf("error reading the given secret key located at %q: %w", secretKeyPath, err)
+			return fmt.Errorf("error loading the given secret key located at %q: %w", secretKeyPath, err)
 		}
 
 		return nil

--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -67,7 +67,7 @@ func TestAddUpstreamCaches(t *testing.T) {
 		localStore, err := local.New(newContext(), dir)
 		require.NoError(t, err)
 
-		c, err := New(newContext(), cacheName, db, localStore, localStore, localStore)
+		c, err := New(newContext(), cacheName, db, localStore, localStore, localStore, "")
 		require.NoError(t, err)
 
 		c.AddUpstreamCaches(newContext(), ucs...)
@@ -120,7 +120,7 @@ func TestAddUpstreamCaches(t *testing.T) {
 		localStore, err := local.New(newContext(), dir)
 		require.NoError(t, err)
 
-		c, err := New(newContext(), cacheName, db, localStore, localStore, localStore)
+		c, err := New(newContext(), cacheName, db, localStore, localStore, localStore, "")
 		require.NoError(t, err)
 
 		for _, uc := range ucs {
@@ -151,7 +151,7 @@ func TestRunLRU(t *testing.T) {
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := New(newContext(), cacheName, db, localStore, localStore, localStore)
+	c, err := New(newContext(), cacheName, db, localStore, localStore, localStore, "")
 	require.NoError(t, err)
 
 	ts := testdata.NewTestServer(t, 40)

--- a/pkg/server/server_internal_test.go
+++ b/pkg/server/server_internal_test.go
@@ -33,7 +33,7 @@ func TestSetDeletePermitted(t *testing.T) {
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := cache.New(newContext(), cacheName, db, localStore, localStore, localStore)
+	c, err := cache.New(newContext(), cacheName, db, localStore, localStore, localStore, "")
 	require.NoError(t, err)
 
 	t.Run("false", func(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -52,7 +52,7 @@ func TestServeHTTP(t *testing.T) {
 		localStore, err := local.New(newContext(), dir)
 		require.NoError(t, err)
 
-		c, err := cache.New(newContext(), cacheName, db, localStore, localStore, localStore)
+		c, err := cache.New(newContext(), cacheName, db, localStore, localStore, localStore, "")
 		require.NoError(t, err)
 
 		c.AddUpstreamCaches(newContext(), uc)
@@ -176,7 +176,7 @@ func TestServeHTTP(t *testing.T) {
 		localStore, err := local.New(newContext(), dir)
 		require.NoError(t, err)
 
-		c, err := cache.New(newContext(), cacheName, db, localStore, localStore, localStore)
+		c, err := cache.New(newContext(), cacheName, db, localStore, localStore, localStore, "")
 		require.NoError(t, err)
 
 		c.AddUpstreamCaches(newContext(), uc)
@@ -289,7 +289,7 @@ func TestServeHTTP(t *testing.T) {
 		localStore, err := local.New(newContext(), dir)
 		require.NoError(t, err)
 
-		c, err := cache.New(newContext(), cacheName, db, localStore, localStore, localStore)
+		c, err := cache.New(newContext(), cacheName, db, localStore, localStore, localStore, "")
 		require.NoError(t, err)
 
 		c.AddUpstreamCaches(newContext(), uc)


### PR DESCRIPTION
Add support for providing a secret key file.

The `--cache-secret-key-path` flag allows specifying a file containing a secret key for signing cached paths. When provided, this key will be used instead of generating and storing a new one.

Added documentation for the new flag in the README.