### PR TITLE
fix(cmd): Fix Segmentation fault when shutting down

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -45,7 +45,11 @@ func New() *cli.Command {
 		Usage:   "Nix Binary Cache Proxy Service",
 		Version: Version,
 		After: func(ctx context.Context, _ *cli.Command) error {
-			return otelShutdown(ctx)
+			if otelShutdown != nil {
+				return otelShutdown(ctx)
+			}
+
+			return nil
 		},
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
 			var err error


### PR DESCRIPTION
This segmentation fault is thrown if the serve command did not initialize fully such as in the case of running `ncps serve --help`

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104ef6798]

goroutine 1 [running]:
github.com/kalbasit/ncps/cmd.New.func1({0x10533ca68?, 0x14000277a10?}, 0x1400025bac8?)
        /Users/wnasreddine/code/repositories/github.com/kalbasit/ncps/cmd/cmd.go:48 +0x28
github.com/urfave/cli/v3.(*Command).Run.func1()
        /Users/wnasreddine/.cache/go/path/pkg/mod/github.com/urfave/cli/v3@v3.1.1/command_run.go:207 +0x48
github.com/urfave/cli/v3.(*Command).Run(0x140001f6c88, {0x10533ca68, 0x14000277a10}, {0x140001b0090, 0x3, 0x3})
        /Users/wnasreddine/.cache/go/path/pkg/mod/github.com/urfave/cli/v3@v3.1.1/command_run.go:265 +0x1604
main.realMain()
        /Users/wnasreddine/code/repositories/github.com/kalbasit/ncps/main.go:18 +0x48
main.main()
        /Users/wnasreddine/code/repositories/github.com/kalbasit/ncps/main.go:12 +0x1c
exit status 2
```