### PR TITLE
fix: Propagate download errors to callers

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -904,7 +904,7 @@ func TestGetNar(t *testing.T) {
 	t.Run("nar does not exist upstream", func(t *testing.T) {
 		nu := nar.URL{Hash: "doesnotexist", Compression: nar.CompressionTypeXz}
 		_, _, err := c.GetNar(context.Background(), nu)
-		assert.ErrorIs(t, err, storage.ErrNotFound)
+		assert.ErrorIs(t, err, upstream.ErrNotFound)
 	})
 
 	t.Run("nar exists upstream", func(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -19,6 +19,7 @@ import (
 	otelchimetric "github.com/riandyrn/otelchi/metric"
 
 	"github.com/kalbasit/ncps/pkg/cache"
+	"github.com/kalbasit/ncps/pkg/cache/upstream"
 	"github.com/kalbasit/ncps/pkg/nar"
 	"github.com/kalbasit/ncps/pkg/storage"
 )
@@ -408,7 +409,7 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 
 		size, reader, err := s.cache.GetNar(r.Context(), nu)
 		if err != nil {
-			if errors.Is(err, storage.ErrNotFound) {
+			if errors.Is(err, storage.ErrNotFound) || errors.Is(err, upstream.ErrNotFound) {
 				http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 
 				return


### PR DESCRIPTION
### TL;DR

Properly propagate download errors from background goroutines to callers in the cache package.

### What changed?

- Added a `downloadError` field to the `downloadState` struct to store errors that occur during downloads
- Modified the `pullNarIntoStore` and `pullNarInfo` functions to store errors in the `downloadState`
- Updated `GetNar` and `GetNarInfo` to check for and return these errors to callers
- Fixed error handling in the server to properly handle both `storage.ErrNotFound` and `upstream.ErrNotFound`
- Updated a test case to expect the correct error type

### How to test?

1. Test error scenarios where NAR downloads fail
2. Verify that the correct error is propagated to the caller
3. Confirm that the server returns appropriate HTTP status codes when errors occur

### Why make this change?

Previously, errors that occurred during background NAR downloads were logged but not properly propagated to callers. This could lead to misleading error messages and incorrect behavior. This change ensures that download errors are properly captured and returned, improving error handling and making debugging easier.