### PR TITLE
feat: Stream NAR downloads to clients while still downloading

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -450,12 +450,6 @@ func (c *Cache) pullNarIntoStore(
 
 		// Final broadcast
 		ds.cond.Broadcast()
-
-		// Wait until nothing is reading from the asset and remove it
-		go func() {
-			ds.wg.Wait()
-			os.Remove(ds.assetPath)
-		}()
 	}()
 
 	ctx, span := c.tracer.Start(

--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -220,6 +220,8 @@ func TestRunLRU(t *testing.T) {
 		size, reader, err := c.GetNar(context.Background(), nu)
 		require.NoError(t, err, "unable to get nar for idx %d", i)
 
+		// If the size is zero (likely) then the download is in progress so
+		// compute the size by reading it fully first.
 		if size < 0 {
 			var err error
 			size, err = io.Copy(io.Discard, reader)

--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -217,8 +217,14 @@ func TestRunLRU(t *testing.T) {
 		require.NoErrorf(t, err, "unable to get narinfo for idx %d", i)
 
 		nu := nar.URL{Hash: narEntry.NarHash, Compression: narEntry.NarCompression}
-		size, _, err := c.GetNar(context.Background(), nu)
+		size, reader, err := c.GetNar(context.Background(), nu)
 		require.NoError(t, err, "unable to get nar for idx %d", i)
+
+		if size < 0 {
+			var err error
+			size, err = io.Copy(io.Discard, reader)
+			require.NoError(t, err)
+		}
 
 		sizePulled += size
 	}


### PR DESCRIPTION
# Streaming NAR Downloads

This PR implements streaming NAR downloads, allowing clients to start receiving data as soon as it becomes available rather than waiting for the entire download to complete.

Key changes:

- Added a streaming mechanism using a pipe to send data to clients as it's downloaded
- Enhanced `downloadState` with mutex, condition variable, and progress tracking
- Modified the NAR download process to write in chunks and notify waiting clients
- Updated server code to handle streaming responses with unknown final size
- Fixed tests to properly handle streaming responses

The implementation uses a producer-consumer pattern where the download process writes chunks to a file while simultaneously streaming those chunks to connected clients. This improves performance by eliminating the need to wait for complete downloads before serving content.

fixes #20