### PR TITLE
feat: Releases job should allow pre-releases

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -36,3 +36,4 @@ jobs:
         with:
           generate_release_notes: true
           make_latest: "true"
+          prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') || contains(github.ref, 'rc') }}


### PR DESCRIPTION
If the tag contains one of the following, the release will be marked as a pre-release:
- alpha
- beta
- rc

For example the following are all pre-releases:
- `v0.3.0-alpha1`
- `v0.3.0-rc1`