### PR TITLE
feat: Add metrics for NAR file serving

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -174,7 +174,7 @@ func setupOTelSDK(ctx context.Context, cmd *cli.Command) (func(context.Context) 
 	enabled := cmd.Bool("otel-enabled")
 
 	// Set up trace provider.
-	tracerProvider, err := newTraceProvider(ctx, false, colURL, res)
+	tracerProvider, err := newTraceProvider(ctx, enabled, colURL, res)
 	if err != nil {
 		return shutdown, handleErr(err)
 	}
@@ -192,7 +192,7 @@ func setupOTelSDK(ctx context.Context, cmd *cli.Command) (func(context.Context) 
 	otel.SetMeterProvider(meterProvider)
 
 	// Set up logger provider.
-	loggerProvider, err := newLoggerProvider(ctx, false, colURL, res)
+	loggerProvider, err := newLoggerProvider(ctx, enabled, colURL, res)
 	if err != nil {
 		return shutdown, handleErr(err)
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -174,7 +174,7 @@ func setupOTelSDK(ctx context.Context, cmd *cli.Command) (func(context.Context) 
 	enabled := cmd.Bool("otel-enabled")
 
 	// Set up trace provider.
-	tracerProvider, err := newTraceProvider(ctx, enabled, colURL, res)
+	tracerProvider, err := newTraceProvider(ctx, false, colURL, res)
 	if err != nil {
 		return shutdown, handleErr(err)
 	}
@@ -192,7 +192,7 @@ func setupOTelSDK(ctx context.Context, cmd *cli.Command) (func(context.Context) 
 	otel.SetMeterProvider(meterProvider)
 
 	// Set up logger provider.
-	loggerProvider, err := newLoggerProvider(ctx, enabled, colURL, res)
+	loggerProvider, err := newLoggerProvider(ctx, false, colURL, res)
 	if err != nil {
 		return shutdown, handleErr(err)
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/kalbasit/ncps/pkg/cache/healthcheck"
@@ -52,11 +53,13 @@ var (
 	errNarInfoPurged = errors.New("the narinfo was purged")
 
 	//nolint:gochecknoglobals
+	meter  metric.Meter
 	tracer trace.Tracer
 )
 
 //nolint:gochecknoinits
 func init() {
+	meter = otel.Meter(otelPackageName)
 	tracer = otel.Tracer(otelPackageName)
 }
 
@@ -73,7 +76,6 @@ type Cache struct {
 
 	// tempDir is used to store nar files temporarily.
 	tempDir string
-
 	// stores
 	configStore  storage.ConfigStore
 	narInfoStore storage.NarInfoStore


### PR DESCRIPTION
# Add NAR Serving Metrics

This PR:

1. Adds metrics for NAR file serving:
    - Creates a new `narServedCount` metric counter to track NAR files served
    - Adds attributes to track hit/miss status and success/error outcomes
    - Implements proper metric recording in the `GetNar` function
2. Fixes an error message that incorrectly referred to "narinfo" instead of "nar"

closes #206