### PR TITLE
fix: Change release job dependency from flake-check to docker

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -26,7 +26,7 @@ jobs:
       password: ${{ secrets.DOCKERHUB_TOKEN }}
   release:
     runs-on: ubuntu-24.04
-    needs: flake-check
+    needs: docker
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
### TL;DR

Updated the dependency chain in GitHub Actions workflow to ensure proper release sequence.

### What changed?

Modified the `.github/workflows/releases.yml` file to change the dependency of the `release` job from `flake-check` to `docker`. This ensures that the release process now waits for the Docker build to complete before proceeding, rather than waiting for the flake check.

### How to test?

1. Trigger a new release workflow
2. Verify that the release job starts only after the Docker job completes
3. Confirm the entire workflow completes successfully with the proper sequencing

### Why make this change?

The previous dependency chain was incorrect, as releases should depend on successful Docker image builds rather than just code quality checks. This change ensures that releases only proceed after Docker images are properly built and published, maintaining the correct order of operations in the CI/CD pipeline.