### PR TITLE
feat: Add Docker workflow outputs for tags and labels

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,13 @@ on:
       password:
         description: "Password or personal access token used to log against the Docker registry"
         required: true
+    outputs:
+      tags:
+        description: "The generated Docker tags"
+        value: ${{ jobs.docker-meta.outputs.tags }}
+      labels:
+        description: "The generated Docker labels"
+        value: ${{ jobs.docker-meta.outputs.labels }}
 jobs:
   docker-meta:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### TL;DR

Added workflow outputs to expose Docker tags and labels from the docker.yml GitHub workflow.

### What changed?

Added `outputs` section to the workflow file that exposes the Docker tags and labels generated by the `docker-meta` job. This allows other workflows or steps to access these values when this workflow is called.

### How to test?

1. Call this workflow from another workflow using the `workflow_call` trigger
2. Reference the outputs in the calling workflow using:
3. Verify that the tags and labels are correctly passed to the calling workflow

### Why make this change?

This change enables better workflow composition by exposing the Docker metadata (tags and labels) to calling workflows. This is particularly useful for CI/CD pipelines that need to reference the same Docker tags across multiple jobs or workflows.