### PR TITLE
fix(GitHub): The Docker build on aarch64-linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   docker:
     uses: ./.github/workflows/docker.yml
     with:
-      systems: "['x86_64-linux', 'aarch64-linux']"
+      systems: "['x86_64-linux']"
       images: kalbasit/ncps
       username: ${{ vars.DOCKERHUB_USERNAME }}
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   docker:
     uses: ./.github/workflows/docker.yml
     with:
-      systems: "['x86_64-linux']"
+      systems: "['x86_64-linux', 'aarch64-linux']"
       images: kalbasit/ncps
       username: ${{ vars.DOCKERHUB_USERNAME }}
     secrets:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,7 +54,9 @@ jobs:
     steps:
       - name: Install required cross-system tool
         if: "${{ matrix.system != 'x86_64-linux' }}"
-        run: sudo apt-get install -y qemu-user-static
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
         shell: bash
       - uses: DeterminateSystems/nix-installer-action@v20
         with:


### PR DESCRIPTION
The Docker build is failing on aarch64-linux because it fails to install `qemu-user-static` due to the stale Debian lists. I fixed it by simply running `apt-get update` first.