### PR TITLE
feat(auth): Add netrc support for upstream authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,12 +464,12 @@ go build .
 #### 🔐 Security & Signing
 
 | Option | Description | Environment Variable | Default |
-| --------------------------- | ----------------------- | ------------------------- | -------------- |
+| --------------------------- | ------------------------------------ | ------------------------- | -------------- |
 | `--cache-sign-narinfo` | Sign narInfo files | `CACHE_SIGN_NARINFO` | `true` |
 | `--cache-secret-key-path` | Path to signing key | `CACHE_SECRET_KEY_PATH` | auto-generated |
-| `--netrc-file` | Path to netrc file for upstream auth | `NETRC_FILE` | `~/.netrc` |
 | `--cache-allow-put-verb` | Allow PUT uploads | `CACHE_ALLOW_PUT_VERB` | `false` |
 | `--cache-allow-delete-verb` | Allow DELETE operations | `CACHE_ALLOW_DELETE_VERB` | `false` |
+| `--netrc-file` | Path to netrc file for upstream auth | `NETRC_FILE` | `~/.netrc` |
 
 #### 🌐 Network
 

--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ go build .
 | --------------------------- | ----------------------- | ------------------------- | -------------- |
 | `--cache-sign-narinfo` | Sign narInfo files | `CACHE_SIGN_NARINFO` | `true` |
 | `--cache-secret-key-path` | Path to signing key | `CACHE_SECRET_KEY_PATH` | auto-generated |
+| `--netrc-file` | Path to netrc file for upstream auth | `NETRC_FILE` | `~/.netrc` |
 | `--cache-allow-put-verb` | Allow PUT uploads | `CACHE_ALLOW_PUT_VERB` | `false` |
 | `--cache-allow-delete-verb` | Allow DELETE operations | `CACHE_ALLOW_DELETE_VERB` | `false` |
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -8,11 +8,13 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"time"
 
 	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog"
+	"github.com/sysbot/go-netrc"
 	"github.com/urfave/cli/v3"
 	"golang.org/x/sync/errgroup"
 
@@ -27,6 +29,32 @@ import (
 
 // ErrCacheMaxSizeRequired is returned if --cache-lru-schedule was given but not --cache-max-size.
 var ErrCacheMaxSizeRequired = errors.New("--cache-max-size is required when --cache-lru-schedule is specified")
+
+// getDefaultNetrcPath returns the default path to the netrc file.
+func getDefaultNetrcPath() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ".netrc" // fallback to current directory
+	}
+
+	return filepath.Join(homeDir, ".netrc")
+}
+
+// parseNetrcFile parses the netrc file and returns the parsed netrc object.
+func parseNetrcFile(netrcPath string) (*netrc.Netrc, error) {
+	file, err := os.Open(netrcPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	n, err := netrc.Parse(file)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing netrc file: %w", err)
+	}
+
+	return n, nil
+}
 
 func serveCommand() *cli.Command {
 	return &cli.Command{
@@ -125,6 +153,12 @@ func serveCommand() *cli.Command {
 				Usage:   "Set to host:public-key for each upstream cache",
 				Sources: cli.EnvVars("UPSTREAM_PUBLIC_KEYS"),
 			},
+			&cli.StringFlag{
+				Name:    "netrc-file",
+				Usage:   "Path to netrc file for upstream authentication",
+				Sources: cli.EnvVars("NETRC_FILE"),
+				Value:   getDefaultNetrcPath(),
+			},
 		},
 	}
 }
@@ -153,7 +187,12 @@ func serveAction() cli.ActionFunc {
 			return autoMaxProcs(ctx, 30*time.Second, logger)
 		})
 
-		ucs, err := getUpstreamCaches(ctx, cmd)
+		netrcData, err := parseNetrcFile(cmd.String("netrc-file"))
+		if err != nil {
+			logger.Warn().Err(err).Msg("failed to parse netrc file, proceeding without netrc authentication")
+		}
+
+		ucs, err := getUpstreamCaches(ctx, cmd, netrcData)
 		if err != nil {
 			return fmt.Errorf("error computing the upstream caches: %w", err)
 		}
@@ -211,7 +250,7 @@ func serveAction() cli.ActionFunc {
 	}
 }
 
-func getUpstreamCaches(ctx context.Context, cmd *cli.Command) ([]*upstream.Cache, error) {
+func getUpstreamCaches(ctx context.Context, cmd *cli.Command, netrcData *netrc.Netrc) ([]*upstream.Cache, error) {
 	ucSlice := cmd.StringSlice("upstream-cache")
 
 	ucs := make([]*upstream.Cache, 0, len(ucSlice))
@@ -232,7 +271,19 @@ func getUpstreamCaches(ctx context.Context, cmd *cli.Command) ([]*upstream.Cache
 			}
 		}
 
-		uc, err := upstream.New(ctx, u, pubKeys)
+		// Get credentials for this hostname
+		var creds *upstream.NetrcCredentials
+
+		if netrcData != nil {
+			if machine := netrcData.FindMachine(u.Hostname()); machine != nil {
+				creds = &upstream.NetrcCredentials{
+					Username: machine.Login,
+					Password: machine.Password,
+				}
+			}
+		}
+
+		uc, err := upstream.New(ctx, u, pubKeys, creds)
 		if err != nil {
 			return nil, fmt.Errorf("error creating a new upstream cache: %w", err)
 		}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -137,6 +137,12 @@ func serveCommand() *cli.Command {
 				Value:   os.TempDir(),
 			},
 			&cli.StringFlag{
+				Name:    "netrc-file",
+				Usage:   "Path to netrc file for upstream authentication",
+				Sources: cli.EnvVars("NETRC_FILE"),
+				Value:   getDefaultNetrcPath(),
+			},
+			&cli.StringFlag{
 				Name:    "server-addr",
 				Usage:   "The address of the server",
 				Sources: cli.EnvVars("SERVER_ADDR"),
@@ -152,12 +158,6 @@ func serveCommand() *cli.Command {
 				Name:    "upstream-public-key",
 				Usage:   "Set to host:public-key for each upstream cache",
 				Sources: cli.EnvVars("UPSTREAM_PUBLIC_KEYS"),
-			},
-			&cli.StringFlag{
-				Name:    "netrc-file",
-				Usage:   "Path to netrc file for upstream authentication",
-				Sources: cli.EnvVars("NETRC_FILE"),
-				Value:   getDefaultNetrcPath(),
 			},
 		},
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -34,7 +34,7 @@ var ErrCacheMaxSizeRequired = errors.New("--cache-max-size is required when --ca
 func getDefaultNetrcPath() string {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return ".netrc" // fallback to current directory
+		panic(fmt.Sprintf("unable to determine user home directory: %v", err))
 	}
 
 	return filepath.Join(homeDir, ".netrc")

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/otlptranslator v0.0.2 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
+	github.com/sysbot/go-netrc v0.0.0-20231214061310-8bb3fde9e2d4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/stretchr/testify v1.11.0 h1:ib4sjIrwZKxE5u/Japgo/7SJV3PvgjGiRNAvTVGqQ
 github.com/stretchr/testify v1.11.0/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/sysbot/go-netrc v0.0.0-20231214061310-8bb3fde9e2d4 h1:VsedlThweu7x40/FG3zkk8KCVrgySDGI2YoGpkR1jpI=
+github.com/sysbot/go-netrc v0.0.0-20231214061310-8bb3fde9e2d4/go.mod h1:DQBGBc3K3ueGX4QWNQRL8w3QupJeCNNN4ICyIPBzJ4s=
 github.com/urfave/cli/v3 v3.4.1 h1:1M9UOCy5bLmGnuu1yn3t3CB4rG79Rtoxuv1sPhnm6qM=
 github.com/urfave/cli/v3 v3.4.1/go.mod h1:FJSKtM/9AiiTOJL4fJ6TbMUkxBXn7GO9guZqoZtpYpo=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/nix/packages/ncps.nix
+++ b/nix/packages/ncps.nix
@@ -36,7 +36,7 @@
             "-X github.com/kalbasit/ncps/cmd.Version=${version}"
           ];
 
-          vendorHash = "sha256-eFeGtBCDF2vOFVu2okOreJLVCJkrZVHNUvkbK9NS7Sw=";
+          vendorHash = "sha256-7bu9nXkS4Xfd2wEXIX+ANbVec1Lrh2w/zikOPeuAHzo=";
 
           doCheck = true;
           checkFlags = [ "-race" ];

--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -54,7 +54,7 @@ func TestAddUpstreamCaches(t *testing.T) {
 		for _, idx := range randomOrder {
 			ts := testServers[idx]
 
-			uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), nil)
+			uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), nil, nil)
 			require.NoError(t, err)
 
 			ucs = append(ucs, uc)
@@ -113,7 +113,7 @@ func TestAddUpstreamCaches(t *testing.T) {
 		for _, idx := range randomOrder {
 			ts := testServers[idx]
 
-			uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), nil)
+			uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), nil, nil)
 			require.NoError(t, err)
 
 			ucs = append(ucs, uc)
@@ -172,7 +172,7 @@ func TestRunLRU(t *testing.T) {
 	ts := testdata.NewTestServer(t, 40)
 	defer ts.Close()
 
-	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), nil)
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), nil, nil)
 	require.NoError(t, err)
 
 	c.AddUpstreamCaches(newContext(), uc)

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -236,7 +236,7 @@ func TestGetNarInfoWithoutSignature(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir) // clean up
 
-	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), testdata.PublicKeys())
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), testdata.PublicKeys(), nil)
 	require.NoError(t, err)
 
 	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
@@ -288,7 +288,7 @@ func TestGetNarInfo(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir) // clean up
 
-	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), testdata.PublicKeys())
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), testdata.PublicKeys(), nil)
 	require.NoError(t, err)
 
 	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
@@ -882,7 +882,7 @@ func TestGetNar(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir) // clean up
 
-	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), testdata.PublicKeys())
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), testdata.PublicKeys(), nil)
 	require.NoError(t, err)
 
 	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")

--- a/pkg/cache/healthcheck/healthcheck_test.go
+++ b/pkg/cache/healthcheck/healthcheck_test.go
@@ -31,7 +31,7 @@ func TestHealthCheck(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(dir) // clean up
 
-	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), testdata.PublicKeys())
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), testdata.PublicKeys(), nil)
 	require.NoError(t, err)
 
 	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")

--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -31,26 +31,26 @@ func TestNew(t *testing.T) {
 	t.Run("hostname must be valid with no scheme or path", func(t *testing.T) {
 		//nolint:paralleltest
 		t.Run("hostname must not be empty", func(t *testing.T) {
-			_, err := upstream.New(newContext(), nil, nil)
+			_, err := upstream.New(newContext(), nil, nil, nil)
 			assert.ErrorIs(t, err, upstream.ErrURLRequired)
 		})
 
 		//nolint:paralleltest
 		t.Run("hostname must not contain scheme", func(t *testing.T) {
-			_, err := upstream.New(newContext(), testhelper.MustParseURL(t, "cache.nixos.org"), nil)
+			_, err := upstream.New(newContext(), testhelper.MustParseURL(t, "cache.nixos.org"), nil, nil)
 			assert.ErrorIs(t, err, upstream.ErrURLMustContainScheme)
 		})
 
 		t.Run("valid url with no path must not return no error", func(t *testing.T) {
 			_, err := upstream.New(newContext(),
-				testhelper.MustParseURL(t, ts.URL), nil)
+				testhelper.MustParseURL(t, ts.URL), nil, nil)
 
 			assert.NoError(t, err)
 		})
 
 		t.Run("valid url with only / must not return no error", func(t *testing.T) {
 			_, err := upstream.New(newContext(),
-				testhelper.MustParseURL(t, ts.URL), nil)
+				testhelper.MustParseURL(t, ts.URL), nil, nil)
 
 			assert.NoError(t, err)
 		})
@@ -60,7 +60,7 @@ func TestNew(t *testing.T) {
 	t.Run("public keys", func(t *testing.T) {
 		//nolint:paralleltest
 		t.Run("invalid public keys", func(t *testing.T) {
-			_, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), []string{"invalid"})
+			_, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), []string{"invalid"}, nil)
 			assert.True(t, strings.HasPrefix(err.Error(), "error parsing the public key: public key is corrupt:"))
 		})
 
@@ -70,6 +70,7 @@ func TestNew(t *testing.T) {
 				newContext(),
 				testhelper.MustParseURL(t, ts.URL),
 				testdata.PublicKeys(),
+				nil,
 			)
 			assert.NoError(t, err)
 		})
@@ -81,6 +82,7 @@ func TestNew(t *testing.T) {
 			newContext(),
 			testhelper.MustParseURL(t, ts.URL),
 			testdata.PublicKeys(),
+			nil,
 		)
 		require.NoError(t, err)
 
@@ -93,6 +95,7 @@ func TestNew(t *testing.T) {
 			newContext(),
 			testhelper.MustParseURL(t, ts.URL+"?priority=42"),
 			testdata.PublicKeys(),
+			nil,
 		)
 		require.NoError(t, err)
 
@@ -105,6 +108,7 @@ func TestNew(t *testing.T) {
 			newContext(),
 			testhelper.MustParseURL(t, ts.URL+"?priority=0"),
 			testdata.PublicKeys(),
+			nil,
 		)
 		require.NoError(t, err)
 
@@ -117,6 +121,7 @@ func TestNew(t *testing.T) {
 			newContext(),
 			testhelper.MustParseURL(t, ts.URL+"?priority=-1"),
 			testdata.PublicKeys(),
+			nil,
 		)
 		assert.ErrorContains(t, err, "error parsing the priority from the URL")
 	})
@@ -142,11 +147,13 @@ func TestGetNarInfo(t *testing.T) {
 					newContext(),
 					testhelper.MustParseURL(t, ts.URL),
 					testdata.PublicKeys(),
+					nil,
 				)
 			} else {
 				c, err = upstream.New(
 					newContext(),
 					testhelper.MustParseURL(t, ts.URL),
+					nil,
 					nil,
 				)
 			}
@@ -223,6 +230,7 @@ func TestGetNarInfo(t *testing.T) {
 			newContext(),
 			testhelper.MustParseURL(t, slowServer.URL),
 			testdata.PublicKeys(),
+			nil,
 		)
 		require.NoError(t, err)
 
@@ -244,6 +252,7 @@ func TestHasNarInfo(t *testing.T) {
 			newContext(),
 			testhelper.MustParseURL(t, ts.URL),
 			testdata.PublicKeys(),
+			nil,
 		)
 		require.NoError(t, err)
 
@@ -264,6 +273,7 @@ func TestHasNarInfo(t *testing.T) {
 				newContext(),
 				testhelper.MustParseURL(t, ts.URL),
 				testdata.PublicKeys(),
+				nil,
 			)
 			require.NoError(t, err)
 
@@ -287,6 +297,7 @@ func TestHasNarInfo(t *testing.T) {
 			newContext(),
 			testhelper.MustParseURL(t, slowServer.URL),
 			testdata.PublicKeys(),
+			nil,
 		)
 		require.NoError(t, err)
 
@@ -305,6 +316,7 @@ func TestGetNar(t *testing.T) {
 		newContext(),
 		testhelper.MustParseURL(t, ts.URL),
 		testdata.PublicKeys(),
+		nil,
 	)
 	require.NoError(t, err)
 
@@ -343,6 +355,7 @@ func TestGetNar(t *testing.T) {
 			newContext(),
 			testhelper.MustParseURL(t, slowServer.URL),
 			testdata.PublicKeys(),
+			nil,
 		)
 		require.NoError(t, err)
 
@@ -365,6 +378,7 @@ func TestHasNar(t *testing.T) {
 			newContext(),
 			testhelper.MustParseURL(t, ts.URL),
 			testdata.PublicKeys(),
+			nil,
 		)
 		require.NoError(t, err)
 
@@ -386,6 +400,7 @@ func TestHasNar(t *testing.T) {
 				newContext(),
 				testhelper.MustParseURL(t, ts.URL),
 				testdata.PublicKeys(),
+				nil,
 			)
 			require.NoError(t, err)
 
@@ -410,6 +425,7 @@ func TestHasNar(t *testing.T) {
 			newContext(),
 			testhelper.MustParseURL(t, slowServer.URL),
 			testdata.PublicKeys(),
+			nil,
 		)
 		require.NoError(t, err)
 
@@ -429,6 +445,7 @@ func TestGetNarCanMutate(t *testing.T) {
 		newContext(),
 		testhelper.MustParseURL(t, ts.URL),
 		testdata.PublicKeys(),
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -35,7 +35,7 @@ func TestServeHTTP(t *testing.T) {
 	hts := testdata.NewTestServer(t, 40)
 	defer hts.Close()
 
-	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, hts.URL), testdata.PublicKeys())
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, hts.URL), testdata.PublicKeys(), nil)
 	require.NoError(t, err)
 
 	t.Run("GET /pubkey", func(t *testing.T) {


### PR DESCRIPTION
@kalbasit this is a proof of concept (the netrc path is still hardcoded) but seems to work. What do you think?

It works even if the netrc entry is without the `username`, exactly as nix does.

Since I'm not a go developer I got help form an LLM but I've double checked everything and it makes sense to me.

Assuming that you like what I did: how do you think that we should retrieve the netrc path? I see the following solutions:
- we add an extra CLI argument for the netrc path
- we call `nix show-config --json` (or do we parse `/etc/nix/nix.conf`?) and use the netrc file specified there

Closes #307 