### PR TITLE
feat(Docker): Add /storage as Volume in the Docker image

### DIFF
--- a/nix/packages/docker.nix
+++ b/nix/packages/docker.nix
@@ -68,6 +68,7 @@
             "org.opencontainers.image.title" = "ncps";
             "org.opencontainers.image.url" = "https://github.com/kalbasit/ncps";
           };
+          Volumes = [ "/storage" ];
         };
       };
 

--- a/nix/packages/docker.nix
+++ b/nix/packages/docker.nix
@@ -68,7 +68,9 @@
             "org.opencontainers.image.title" = "ncps";
             "org.opencontainers.image.url" = "https://github.com/kalbasit/ncps";
           };
-          Volumes = [ "/storage" ];
+          Volumes = {
+            "/storage" = { };
+          };
         };
       };
 


### PR DESCRIPTION
The README refers to `/storage` extensively but it was never declared as a volume in the docker container; By declaring it, we ensure the `/storage` becomes a volume even if no volume was explicitly mounted there.