### PR TITLE
fix(pkg/cache): Increase the wait time around asynchronous logic

### DIFF
--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -238,7 +238,20 @@ func TestRunLRU(t *testing.T) {
 
 	for _, narEntry := range allEntries {
 		nu := nar.URL{Hash: narEntry.NarHash, Compression: narEntry.NarCompression}
-		assert.True(t, c.narStore.HasNar(newContext(), nu), "confirm all nars are in the store")
+
+		var found bool
+
+		for i := 1; i < 100; i++ {
+			// NOTE: I tried runtime.Gosched() but it makes the test flaky
+			time.Sleep(time.Duration(i) * time.Millisecond)
+
+			found = c.narStore.HasNar(newContext(), nu)
+			if found {
+				break
+			}
+		}
+
+		assert.True(t, found, nu.String()+" should exist in the store")
 	}
 
 	// ensure time has moved by one sec for the last_accessed_at work

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -446,9 +446,9 @@ func TestGetNarInfo(t *testing.T) {
 			// Try at least 10 times before announcing an error
 			var err error
 
-			for i := 0; i < 9; i++ {
+			for i := 1; i < 100; i++ {
 				// NOTE: I tried runtime.Gosched() but it makes the test flaky
-				time.Sleep(time.Millisecond)
+				time.Sleep(time.Duration(i) * time.Millisecond)
 
 				_, err = os.Stat(filepath.Join(dir, "store", "nar", testdata.Nar2.NarPath))
 				if err == nil {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -973,8 +973,6 @@ func TestGetNar(t *testing.T) {
 		})
 
 		t.Run("it should now exist in the store", func(t *testing.T) {
-			// Force the other goroutine to run so it actually download the file
-			// Try at least 10 times before announcing an error
 			var err error
 
 			for i := 1; i < 100; i++ {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -939,8 +939,23 @@ func TestGetNar(t *testing.T) {
 		})
 
 		nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
-		size, r, err := c.GetNar(context.Background(), nu)
-		require.NoError(t, err)
+
+		var size int64
+
+		var r io.ReadCloser
+
+		for i := 1; i < 100; i++ {
+			// NOTE: I tried runtime.Gosched() but it makes the test flaky
+			time.Sleep(time.Duration(i) * time.Millisecond)
+
+			var err error
+			size, r, err = c.GetNar(context.Background(), nu)
+			require.NoError(t, err)
+
+			if size > 0 {
+				break
+			}
+		}
 
 		defer r.Close()
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -612,9 +612,9 @@ func TestGetNarInfo(t *testing.T) {
 				// Try at least 10 times before announcing an error
 				var err error
 
-				for i := 0; i < 9; i++ {
+				for i := 1; i < 100; i++ {
 					// NOTE: I tried runtime.Gosched() but it makes the test flaky
-					time.Sleep(time.Millisecond)
+					time.Sleep(time.Duration(i) * time.Millisecond)
 
 					_, err = os.Stat(narFile)
 					if err == nil {
@@ -958,7 +958,21 @@ func TestGetNar(t *testing.T) {
 		})
 
 		t.Run("it should now exist in the store", func(t *testing.T) {
-			assert.FileExists(t, filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath))
+			// Force the other goroutine to run so it actually download the file
+			// Try at least 10 times before announcing an error
+			var err error
+
+			for i := 1; i < 100; i++ {
+				// NOTE: I tried runtime.Gosched() but it makes the test flaky
+				time.Sleep(time.Duration(i) * time.Millisecond)
+
+				_, err = os.Stat(filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath))
+				if err == nil {
+					break
+				}
+			}
+
+			assert.NoError(t, err)
 		})
 
 		t.Run("getting the narinfo so the record in the database now exists", func(t *testing.T) {


### PR DESCRIPTION
These tests depends on other factors (such as CPU speed, system loadavg, etc..) and assume a very quick runtime. Wait a total of ~5s in increasingly small increments to allow for the test to finish quicly while waiting for a slow system to finish.

fixes #314 