### PR TITLE
fix(CI): Do not run the docker-manifest if push is disabled

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,9 +94,15 @@ jobs:
         run: |
           ./result
   docker-manifest:
+    if: inputs.push_images
     runs-on: ubuntu-24.04
     needs: [docker-meta, docker-images]
     steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ inputs.username }}
+          password: ${{ secrets.password }}
       - name: Create a multi-architecture manifest
         env:
           DOCKER_IMAGE_TAGS: ${{ needs.docker-meta.outputs.tags }}
@@ -111,14 +117,7 @@ jobs:
 
             docker manifest create $tag ${imgs[*]}
           done
-      - name: Login to Docker Hub
-        if: inputs.push_images
-        uses: docker/login-action@v3
-        with:
-          username: ${{ inputs.username }}
-          password: ${{ secrets.password }}
       - name: Push the docker image
-        if: inputs.push_images
         env:
           DOCKER_IMAGE_TAGS: ${{ needs.docker-meta.outputs.tags }}
         shell: bash


### PR DESCRIPTION
Since we are not pushing images, the docker-manifest will always fail so just skip it.