### PR TITLE
feat: Add configuration file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ ncps solves these issues by acting as a **centralized cache** on your local netw
 
 ## ✨ Key Features
 
-| Feature                 | Description                                        |
+| Feature | Description |
 | ----------------------- | -------------------------------------------------- |
-| 🚀 **Easy Setup**       | Simple configuration and deployment                |
-| 🔄 **Multi-Upstream**   | Support for multiple upstream caches with failover |
-| 💾 **Smart Caching**    | LRU cache management with configurable size limits |
-| 🔐 **Secure Signing**   | Signs cached paths with private keys for integrity |
-| 📊 **Monitoring**       | OpenTelemetry support for centralized logging      |
-| 🗜️ **Compression**      | Harmonia's transparent zstd compression support    |
-| 💾 **Embedded Storage** | Built-in SQLite database for easy deployment       |
+| 🚀 **Easy Setup** | Simple configuration and deployment |
+| 🔄 **Multi-Upstream** | Support for multiple upstream caches with failover |
+| 💾 **Smart Caching** | LRU cache management with configurable size limits |
+| 🔐 **Secure Signing** | Signs cached paths with private keys for integrity |
+| 📊 **Monitoring** | OpenTelemetry support for centralized logging |
+| 🗜️ **Compression** | Harmonia's transparent zstd compression support |
+| 💾 **Embedded Storage** | Built-in SQLite database for easy deployment |
 
 ## ⚙️ How It Works
 
@@ -434,49 +434,49 @@ go build .
 
 ### Global Options
 
-| Option                 | Description                                       | Environment Variable | Default                              |
+| Option | Description | Environment Variable | Default |
 | ---------------------- | ------------------------------------------------- | -------------------- | ------------------------------------ |
-| `--config`             | Path to the configuration file (toml, yaml, json) | `NCPS_CONFIG_FILE`   | `$XDG_CONFIG_HOME//ncps/config.yaml` |
-| `--otel-enabled`       | Enable OpenTelemetry logs, metrics, and tracing   | `OTEL_ENABLED`       | `false`                              |
-| `--prometheus-enabled` | Enable Prometheus metrics endpoint at /metrics    | `PROMETHEUS_ENABLED` | `false`                              |
-| `--log-level`          | Set log level: debug, info, warn, error           | `LOG_LEVEL`          | `info`                               |
-| `--otel-grpc-url`      | OpenTelemetry gRPC URL (omit for stdout)          | `OTEL_GRPC_URL`      | -                                    |
+| `--config` | Path to the configuration file (toml, yaml, json) | `NCPS_CONFIG_FILE` | `$XDG_CONFIG_HOME//ncps/config.yaml` |
+| `--otel-enabled` | Enable OpenTelemetry logs, metrics, and tracing | `OTEL_ENABLED` | `false` |
+| `--prometheus-enabled` | Enable Prometheus metrics endpoint at /metrics | `PROMETHEUS_ENABLED` | `false` |
+| `--log-level` | Set log level: debug, info, warn, error | `LOG_LEVEL` | `info` |
+| `--otel-grpc-url` | OpenTelemetry gRPC URL (omit for stdout) | `OTEL_GRPC_URL` | - |
 
 ### Server Configuration
 
 #### 🔧 Essential Options
 
-| Option                  | Description                           | Environment Variable   | Required |
+| Option | Description | Environment Variable | Required |
 | ----------------------- | ------------------------------------- | ---------------------- | -------- |
-| `--cache-hostname`      | **Cache hostname for key generation** | `CACHE_HOSTNAME`       | ✅       |
-| `--cache-data-path`     | Local storage directory               | `CACHE_DATA_PATH`      | ✅       |
-| `--upstream-cache`      | Upstream cache URL (repeatable)       | `UPSTREAM_CACHES`      | ✅       |
-| `--upstream-public-key` | Upstream public key (repeatable)      | `UPSTREAM_PUBLIC_KEYS` | ✅       |
+| `--cache-hostname` | **Cache hostname for key generation** | `CACHE_HOSTNAME` | ✅ |
+| `--cache-data-path` | Local storage directory | `CACHE_DATA_PATH` | ✅ |
+| `--upstream-cache` | Upstream cache URL (repeatable) | `UPSTREAM_CACHES` | ✅ |
+| `--upstream-public-key` | Upstream public key (repeatable) | `UPSTREAM_PUBLIC_KEYS` | ✅ |
 
 #### 📊 Storage & Performance
 
-| Option                 | Description                    | Environment Variable | Default         |
+| Option | Description | Environment Variable | Default |
 | ---------------------- | ------------------------------ | -------------------- | --------------- |
-| `--cache-database-url` | Database URL (SQLite only)     | `CACHE_DATABASE_URL` | embedded SQLite |
-| `--cache-max-size`     | Max cache size (5K, 10G, etc.) | `CACHE_MAX_SIZE`     | unlimited       |
-| `--cache-lru-schedule` | Cleanup cron schedule          | `CACHE_LRU_SCHEDULE` | -               |
-| `--cache-temp-path`    | Temporary download directory   | `CACHE_TEMP_PATH`    | system temp     |
+| `--cache-database-url` | Database URL (SQLite only) | `CACHE_DATABASE_URL` | embedded SQLite |
+| `--cache-max-size` | Max cache size (5K, 10G, etc.) | `CACHE_MAX_SIZE` | unlimited |
+| `--cache-lru-schedule` | Cleanup cron schedule | `CACHE_LRU_SCHEDULE` | - |
+| `--cache-temp-path` | Temporary download directory | `CACHE_TEMP_PATH` | system temp |
 
 #### 🔐 Security & Signing
 
-| Option                      | Description                          | Environment Variable      | Default        |
+| Option | Description | Environment Variable | Default |
 | --------------------------- | ------------------------------------ | ------------------------- | -------------- |
-| `--cache-sign-narinfo`      | Sign narInfo files                   | `CACHE_SIGN_NARINFO`      | `true`         |
-| `--cache-secret-key-path`   | Path to signing key                  | `CACHE_SECRET_KEY_PATH`   | auto-generated |
-| `--cache-allow-put-verb`    | Allow PUT uploads                    | `CACHE_ALLOW_PUT_VERB`    | `false`        |
-| `--cache-allow-delete-verb` | Allow DELETE operations              | `CACHE_ALLOW_DELETE_VERB` | `false`        |
-| `--netrc-file`              | Path to netrc file for upstream auth | `NETRC_FILE`              | `~/.netrc`     |
+| `--cache-sign-narinfo` | Sign narInfo files | `CACHE_SIGN_NARINFO` | `true` |
+| `--cache-secret-key-path` | Path to signing key | `CACHE_SECRET_KEY_PATH` | auto-generated |
+| `--cache-allow-put-verb` | Allow PUT uploads | `CACHE_ALLOW_PUT_VERB` | `false` |
+| `--cache-allow-delete-verb` | Allow DELETE operations | `CACHE_ALLOW_DELETE_VERB` | `false` |
+| `--netrc-file` | Path to netrc file for upstream auth | `NETRC_FILE` | `~/.netrc` |
 
 #### 🌐 Network
 
-| Option          | Description             | Environment Variable | Default |
+| Option | Description | Environment Variable | Default |
 | --------------- | ----------------------- | -------------------- | ------- |
-| `--server-addr` | Listen address and port | `SERVER_ADDR`        | `:8501` |
+| `--server-addr` | Listen address and port | `SERVER_ADDR` | `:8501` |
 
 ## 🔧 Client Setup
 
@@ -626,13 +626,13 @@ Contributions are welcome! Here's how to get started:
 - 💬 Start a [discussion](https://github.com/kalbasit/ncps/discussions)
 - 📧 Contact maintainers
 
----
+______________________________________________________________________
 
 ## 📄 License
 
 This project is licensed under the **MIT License** - see the [LICENSE](/LICENSE) file for details.
 
----
+______________________________________________________________________
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -437,8 +437,8 @@ All the flags can be set using the configuration file. See config.example.yaml f
 ### Global Options
 
 | Option | Description | Environment Variable | Default |
-| ---------------------- | ------------------------------------------------- | -------------------- | ------------------------------------ |
-| `--config` | Path to the configuration file (toml, yaml, json) | `NCPS_CONFIG_FILE` | `$XDG_CONFIG_HOME//ncps/config.yaml` |
+| ---------------------- | ------------------------------------------------- | -------------------- | ----------------------------------- |
+| `--config` | Path to the configuration file (json, yaml, toml) | `NCPS_CONFIG_FILE` | `$XDG_CONFIG_HOME/ncps/config.yaml` |
 | `--otel-enabled` | Enable OpenTelemetry logs, metrics, and tracing | `OTEL_ENABLED` | `false` |
 | `--prometheus-enabled` | Enable Prometheus metrics endpoint at /metrics | `PROMETHEUS_ENABLED` | `false` |
 | `--log-level` | Set log level: debug, info, warn, error | `LOG_LEVEL` | `info` |

--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ ncps solves these issues by acting as a **centralized cache** on your local netw
 
 ## ✨ Key Features
 
-| Feature | Description |
+| Feature                 | Description                                        |
 | ----------------------- | -------------------------------------------------- |
-| 🚀 **Easy Setup** | Simple configuration and deployment |
-| 🔄 **Multi-Upstream** | Support for multiple upstream caches with failover |
-| 💾 **Smart Caching** | LRU cache management with configurable size limits |
-| 🔐 **Secure Signing** | Signs cached paths with private keys for integrity |
-| 📊 **Monitoring** | OpenTelemetry support for centralized logging |
-| 🗜️ **Compression** | Harmonia's transparent zstd compression support |
-| 💾 **Embedded Storage** | Built-in SQLite database for easy deployment |
+| 🚀 **Easy Setup**       | Simple configuration and deployment                |
+| 🔄 **Multi-Upstream**   | Support for multiple upstream caches with failover |
+| 💾 **Smart Caching**    | LRU cache management with configurable size limits |
+| 🔐 **Secure Signing**   | Signs cached paths with private keys for integrity |
+| 📊 **Monitoring**       | OpenTelemetry support for centralized logging      |
+| 🗜️ **Compression**      | Harmonia's transparent zstd compression support    |
+| 💾 **Embedded Storage** | Built-in SQLite database for easy deployment       |
 
 ## ⚙️ How It Works
 
@@ -434,48 +434,49 @@ go build .
 
 ### Global Options
 
-| Option | Description | Environment Variable | Default |
-| ---------------------- | ----------------------------------------------- | -------------------- | ------- |
-| `--otel-enabled` | Enable OpenTelemetry logs, metrics, and tracing | `OTEL_ENABLED` | `false` |
-| `--prometheus-enabled` | Enable Prometheus metrics endpoint at /metrics | `PROMETHEUS_ENABLED` | `false` |
-| `--log-level` | Set log level: debug, info, warn, error | `LOG_LEVEL` | `info` |
-| `--otel-grpc-url` | OpenTelemetry gRPC URL (omit for stdout) | `OTEL_GRPC_URL` | - |
+| Option                 | Description                                       | Environment Variable | Default                              |
+| ---------------------- | ------------------------------------------------- | -------------------- | ------------------------------------ |
+| `--config`             | Path to the configuration file (toml, yaml, json) | `NCPS_CONFIG_FILE`   | `$XDG_CONFIG_HOME//ncps/config.yaml` |
+| `--otel-enabled`       | Enable OpenTelemetry logs, metrics, and tracing   | `OTEL_ENABLED`       | `false`                              |
+| `--prometheus-enabled` | Enable Prometheus metrics endpoint at /metrics    | `PROMETHEUS_ENABLED` | `false`                              |
+| `--log-level`          | Set log level: debug, info, warn, error           | `LOG_LEVEL`          | `info`                               |
+| `--otel-grpc-url`      | OpenTelemetry gRPC URL (omit for stdout)          | `OTEL_GRPC_URL`      | -                                    |
 
 ### Server Configuration
 
 #### 🔧 Essential Options
 
-| Option | Description | Environment Variable | Required |
+| Option                  | Description                           | Environment Variable   | Required |
 | ----------------------- | ------------------------------------- | ---------------------- | -------- |
-| `--cache-hostname` | **Cache hostname for key generation** | `CACHE_HOSTNAME` | ✅ |
-| `--cache-data-path` | Local storage directory | `CACHE_DATA_PATH` | ✅ |
-| `--upstream-cache` | Upstream cache URL (repeatable) | `UPSTREAM_CACHES` | ✅ |
-| `--upstream-public-key` | Upstream public key (repeatable) | `UPSTREAM_PUBLIC_KEYS` | ✅ |
+| `--cache-hostname`      | **Cache hostname for key generation** | `CACHE_HOSTNAME`       | ✅       |
+| `--cache-data-path`     | Local storage directory               | `CACHE_DATA_PATH`      | ✅       |
+| `--upstream-cache`      | Upstream cache URL (repeatable)       | `UPSTREAM_CACHES`      | ✅       |
+| `--upstream-public-key` | Upstream public key (repeatable)      | `UPSTREAM_PUBLIC_KEYS` | ✅       |
 
 #### 📊 Storage & Performance
 
-| Option | Description | Environment Variable | Default |
+| Option                 | Description                    | Environment Variable | Default         |
 | ---------------------- | ------------------------------ | -------------------- | --------------- |
-| `--cache-database-url` | Database URL (SQLite only) | `CACHE_DATABASE_URL` | embedded SQLite |
-| `--cache-max-size` | Max cache size (5K, 10G, etc.) | `CACHE_MAX_SIZE` | unlimited |
-| `--cache-lru-schedule` | Cleanup cron schedule | `CACHE_LRU_SCHEDULE` | - |
-| `--cache-temp-path` | Temporary download directory | `CACHE_TEMP_PATH` | system temp |
+| `--cache-database-url` | Database URL (SQLite only)     | `CACHE_DATABASE_URL` | embedded SQLite |
+| `--cache-max-size`     | Max cache size (5K, 10G, etc.) | `CACHE_MAX_SIZE`     | unlimited       |
+| `--cache-lru-schedule` | Cleanup cron schedule          | `CACHE_LRU_SCHEDULE` | -               |
+| `--cache-temp-path`    | Temporary download directory   | `CACHE_TEMP_PATH`    | system temp     |
 
 #### 🔐 Security & Signing
 
-| Option | Description | Environment Variable | Default |
+| Option                      | Description                          | Environment Variable      | Default        |
 | --------------------------- | ------------------------------------ | ------------------------- | -------------- |
-| `--cache-sign-narinfo` | Sign narInfo files | `CACHE_SIGN_NARINFO` | `true` |
-| `--cache-secret-key-path` | Path to signing key | `CACHE_SECRET_KEY_PATH` | auto-generated |
-| `--cache-allow-put-verb` | Allow PUT uploads | `CACHE_ALLOW_PUT_VERB` | `false` |
-| `--cache-allow-delete-verb` | Allow DELETE operations | `CACHE_ALLOW_DELETE_VERB` | `false` |
-| `--netrc-file` | Path to netrc file for upstream auth | `NETRC_FILE` | `~/.netrc` |
+| `--cache-sign-narinfo`      | Sign narInfo files                   | `CACHE_SIGN_NARINFO`      | `true`         |
+| `--cache-secret-key-path`   | Path to signing key                  | `CACHE_SECRET_KEY_PATH`   | auto-generated |
+| `--cache-allow-put-verb`    | Allow PUT uploads                    | `CACHE_ALLOW_PUT_VERB`    | `false`        |
+| `--cache-allow-delete-verb` | Allow DELETE operations              | `CACHE_ALLOW_DELETE_VERB` | `false`        |
+| `--netrc-file`              | Path to netrc file for upstream auth | `NETRC_FILE`              | `~/.netrc`     |
 
 #### 🌐 Network
 
-| Option | Description | Environment Variable | Default |
+| Option          | Description             | Environment Variable | Default |
 | --------------- | ----------------------- | -------------------- | ------- |
-| `--server-addr` | Listen address and port | `SERVER_ADDR` | `:8501` |
+| `--server-addr` | Listen address and port | `SERVER_ADDR`        | `:8501` |
 
 ## 🔧 Client Setup
 
@@ -625,13 +626,13 @@ Contributions are welcome! Here's how to get started:
 - 💬 Start a [discussion](https://github.com/kalbasit/ncps/discussions)
 - 📧 Contact maintainers
 
-______________________________________________________________________
+---
 
 ## 📄 License
 
 This project is licensed under the **MIT License** - see the [LICENSE](/LICENSE) file for details.
 
-______________________________________________________________________
+---
 
 <div align="center">
 

--- a/README.md
+++ b/README.md
@@ -432,6 +432,8 @@ go build .
 
 ## ⚙️ Configuration
 
+All the flags can be set using the configuration file. See config.example.yaml for reference.
+
 ### Global Options
 
 | Option | Description | Environment Variable | Default |

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ All the flags can be set using the configuration file. See config.example.yaml f
 
 | Option | Description | Environment Variable | Default |
 | ---------------------- | ------------------------------------------------- | -------------------- | ----------------------------------- |
-| `--config` | Path to the configuration file (json, yaml, toml) | `NCPS_CONFIG_FILE` | `$XDG_CONFIG_HOME/ncps/config.yaml` |
+| `--config` | Path to the configuration file (json, toml, yaml) | `NCPS_CONFIG_FILE` | `$XDG_CONFIG_HOME/ncps/config.yaml` |
 | `--otel-enabled` | Enable OpenTelemetry logs, metrics, and tracing | `OTEL_ENABLED` | `false` |
 | `--prometheus-enabled` | Enable Prometheus metrics endpoint at /metrics | `PROMETHEUS_ENABLED` | `false` |
 | `--log-level` | Set log level: debug, info, warn, error | `LOG_LEVEL` | `info` |

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -118,12 +118,12 @@ func New() *cli.Command {
 			&cli.BoolFlag{
 				Name:    "otel-enabled",
 				Usage:   "Enable Open-Telemetry logs, metrics and tracing.",
-				Sources: flagSources("global.otel.enabled", "OTEL_ENABLED"),
+				Sources: flagSources("opentelemetry.enabled", "OTEL_ENABLED"),
 			},
 			&cli.StringFlag{
 				Name:    "log-level",
 				Usage:   "Set the log level",
-				Sources: flagSources("global.log.level", "LOG_LEVEL"),
+				Sources: flagSources("log.level", "LOG_LEVEL"),
 				Value:   "info",
 				Validator: func(lvl string) error {
 					_, err := zerolog.ParseLevel(lvl)
@@ -135,7 +135,7 @@ func New() *cli.Command {
 				Name: "otel-grpc-url",
 				Usage: "Configure OpenTelemetry gRPC URL; Missing or https " +
 					"scheme enable secure gRPC, insecure otherwize. Omit to emit Telemetry to stdout.",
-				Sources: flagSources("global.otel.grpc-url", "OTEL_GRPC_URL"),
+				Sources: flagSources("opentelemetry.grpc-url", "OTEL_GRPC_URL"),
 				Value:   "",
 				Validator: func(colURL string) error {
 					_, err := url.Parse(colURL)
@@ -152,7 +152,7 @@ func New() *cli.Command {
 			&cli.BoolFlag{
 				Name:    "prometheus-enabled",
 				Usage:   "Enable Prometheus metrics endpoint at /metrics",
-				Sources: flagSources("global.prometheus.enabled", "PROMETHEUS_ENABLED"),
+				Sources: flagSources("prometheus.enabled", "PROMETHEUS_ENABLED"),
 			},
 		},
 		Commands: []*cli.Command{

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -145,7 +145,7 @@ func New() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:        "config",
-				Usage:       "Path to the configuration file (json, yaml, toml)",
+				Usage:       "Path to the configuration file (json, toml, yaml)",
 				Sources:     cli.EnvVars("NCPS_CONFIG_FILE"),
 				Value:       getDefaultConfigPath(),
 				Destination: &configPath,

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -42,6 +42,8 @@ import (
 //nolint:gochecknoglobals
 var Version = "dev"
 
+type flagSourcesFn func(configFileKey, envVar string) cli.ValueSourceChain
+
 func New() *cli.Command {
 	var otelShutdown func(context.Context) error
 
@@ -116,12 +118,12 @@ func New() *cli.Command {
 			&cli.BoolFlag{
 				Name:    "otel-enabled",
 				Usage:   "Enable Open-Telemetry logs, metrics and tracing.",
-				Sources: cli.EnvVars("OTEL_ENABLED"),
+				Sources: flagSources("global.otel.enabled", "OTEL_ENABLED"),
 			},
 			&cli.StringFlag{
 				Name:    "log-level",
 				Usage:   "Set the log level",
-				Sources: cli.EnvVars("LOG_LEVEL"),
+				Sources: flagSources("global.log.level", "LOG_LEVEL"),
 				Value:   "info",
 				Validator: func(lvl string) error {
 					_, err := zerolog.ParseLevel(lvl)
@@ -133,7 +135,7 @@ func New() *cli.Command {
 				Name: "otel-grpc-url",
 				Usage: "Configure OpenTelemetry gRPC URL; Missing or https " +
 					"scheme enable secure gRPC, insecure otherwize. Omit to emit Telemetry to stdout.",
-				Sources: cli.EnvVars("OTEL_GRPC_URL"),
+				Sources: flagSources("global.otel.grpc-url", "OTEL_GRPC_URL"),
 				Value:   "",
 				Validator: func(colURL string) error {
 					_, err := url.Parse(colURL)
@@ -150,11 +152,11 @@ func New() *cli.Command {
 			&cli.BoolFlag{
 				Name:    "prometheus-enabled",
 				Usage:   "Enable Prometheus metrics endpoint at /metrics",
-				Sources: flagSources("prometheus.enabled", "PROMETHEUS_ENABLED"),
+				Sources: flagSources("global.prometheus.enabled", "PROMETHEUS_ENABLED"),
 			},
 		},
 		Commands: []*cli.Command{
-			serveCommand(),
+			serveCommand(flagSources),
 		},
 	}
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -145,7 +145,7 @@ func New() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:        "config",
-				Usage:       "Path to the configuration file (toml, yaml, json)",
+				Usage:       "Path to the configuration file (json, yaml, toml)",
 				Sources:     cli.EnvVars("NCPS_CONFIG_FILE"),
 				Value:       getDefaultConfigPath(),
 				Destination: &configPath,

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -146,6 +146,7 @@ func New() *cli.Command {
 			&cli.StringFlag{
 				Name:        "config",
 				Usage:       "Path to the configuration file (toml, yaml, json)",
+				Sources:     cli.EnvVars("NCPS_CONFIG_FILE"),
 				Value:       getDefaultConfigPath(),
 				Destination: &configPath,
 			},

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -66,36 +66,36 @@ func serveCommand(flagSources flagSourcesFn) *cli.Command {
 			&cli.BoolFlag{
 				Name:    "cache-allow-delete-verb",
 				Usage:   "Whether to allow the DELETE verb to delete narInfo and nar files",
-				Sources: flagSources("serve.cache.allow-delete-verb", "CACHE_ALLOW_DELETE_VERB"),
+				Sources: flagSources("cache.allow-delete-verb", "CACHE_ALLOW_DELETE_VERB"),
 			},
 			&cli.BoolFlag{
 				Name:    "cache-allow-put-verb",
 				Usage:   "Whether to allow the PUT verb to push narInfo and nar files directly",
-				Sources: flagSources("serve.cache.allow-put-verb", "CACHE_ALLOW_PUT_VERB"),
+				Sources: flagSources("cache.allow-put-verb", "CACHE_ALLOW_PUT_VERB"),
 			},
 			&cli.StringFlag{
 				Name:     "cache-hostname",
 				Usage:    "The hostname of the cache server",
-				Sources:  flagSources("serve.cache.hostname", "CACHE_HOSTNAME"),
+				Sources:  flagSources("cache.hostname", "CACHE_HOSTNAME"),
 				Required: true,
 			},
 			&cli.StringFlag{
 				Name:     "cache-data-path",
 				Usage:    "The local data path used for configuration and cache storage",
-				Sources:  flagSources("serve.cache.data-path", "CACHE_DATA_PATH"),
+				Sources:  flagSources("cache.data-path", "CACHE_DATA_PATH"),
 				Required: true,
 			},
 			&cli.StringFlag{
 				Name:     "cache-database-url",
 				Usage:    "The URL of the database",
-				Sources:  flagSources("serve.cache.database-url", "CACHE_DATABASE_URL"),
+				Sources:  flagSources("cache.database-url", "CACHE_DATABASE_URL"),
 				Required: true,
 			},
 			&cli.StringFlag{
 				Name: "cache-max-size",
 				//nolint:lll
 				Usage:   "The maximum size of the store. It can be given with units such as 5K, 10G etc. Supported units: B, K, M, G, T",
-				Sources: flagSources("serve.cache.max-size", "CACHE_MAX_SIZE"),
+				Sources: flagSources("cache.max-size", "CACHE_MAX_SIZE"),
 				Validator: func(s string) error {
 					_, err := helper.ParseSize(s)
 
@@ -106,7 +106,7 @@ func serveCommand(flagSources flagSourcesFn) *cli.Command {
 				Name: "cache-lru-schedule",
 				//nolint:lll
 				Usage:   "The cron spec for cleaning the store. Refer to https://pkg.go.dev/github.com/robfig/cron/v3#hdr-Usage for documentation",
-				Sources: flagSources("serve.cache.lru.schedule", "CACHE_LRU_SCHEDULE"),
+				Sources: flagSources("cache.lru.schedule", "CACHE_LRU_SCHEDULE"),
 				Validator: func(s string) error {
 					_, err := cron.ParseStandard(s)
 
@@ -116,48 +116,48 @@ func serveCommand(flagSources flagSourcesFn) *cli.Command {
 			&cli.StringFlag{
 				Name:    "cache-lru-schedule-timezone",
 				Usage:   "The name of the timezone to use for the cron",
-				Sources: flagSources("serve.cache.lru.timezone", "CACHE_LRU_SCHEDULE_TZ"),
+				Sources: flagSources("cache.lru.timezone", "CACHE_LRU_SCHEDULE_TZ"),
 				Value:   "Local",
 			},
 			&cli.StringFlag{
 				Name:    "cache-secret-key-path",
 				Usage:   "The path to the secret key used for signing cached paths",
-				Sources: flagSources("serve.cache.secret-key-path", "CACHE_SECRET_KEY_PATH"),
+				Sources: flagSources("cache.secret-key-path", "CACHE_SECRET_KEY_PATH"),
 			},
 			&cli.BoolFlag{
 				Name:    "cache-sign-narinfo",
 				Usage:   "Whether to sign narInfo files or passthru as-is from upstream",
-				Sources: flagSources("serve.cache.sign-narinfo", "CACHE_SIGN_NARINFO"),
+				Sources: flagSources("cache.sign-narinfo", "CACHE_SIGN_NARINFO"),
 				Value:   true,
 			},
 			&cli.StringFlag{
 				Name:    "cache-temp-path",
 				Usage:   "The path to the temporary directory that is used by the cache to download NAR files",
-				Sources: flagSources("serve.cache.temp-path", "CACHE_TEMP_PATH"),
+				Sources: flagSources("cache.temp-path", "CACHE_TEMP_PATH"),
 				Value:   os.TempDir(),
 			},
 			&cli.StringFlag{
 				Name:    "netrc-file",
 				Usage:   "Path to netrc file for upstream authentication",
-				Sources: flagSources("serve.cache.netrc-file", "NETRC_FILE"),
+				Sources: flagSources("cache.netrc-file", "NETRC_FILE"),
 				Value:   getDefaultNetrcPath(),
 			},
 			&cli.StringFlag{
 				Name:    "server-addr",
 				Usage:   "The address of the server",
-				Sources: flagSources("serve.server.addr", "SERVER_ADDR"),
+				Sources: flagSources("server.addr", "SERVER_ADDR"),
 				Value:   ":8501",
 			},
 			&cli.StringSliceFlag{
 				Name:     "upstream-cache",
 				Usage:    "Set to URL (with scheme) for each upstream cache",
-				Sources:  flagSources("serve.upstream-caches", "UPSTREAM_CACHES"),
+				Sources:  flagSources("cache.upstream.caches", "UPSTREAM_CACHES"),
 				Required: true,
 			},
 			&cli.StringSliceFlag{
 				Name:    "upstream-public-key",
 				Usage:   "Set to host:public-key for each upstream cache",
-				Sources: flagSources("serve.upstream-public-keys", "UPSTREAM_PUBLIC_KEYS"),
+				Sources: flagSources("cache.upstream.public-keys", "UPSTREAM_PUBLIC_KEYS"),
 			},
 		},
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -56,7 +56,7 @@ func parseNetrcFile(netrcPath string) (*netrc.Netrc, error) {
 	return n, nil
 }
 
-func serveCommand() *cli.Command {
+func serveCommand(flagSources flagSourcesFn) *cli.Command {
 	return &cli.Command{
 		Name:    "serve",
 		Aliases: []string{"s"},
@@ -66,36 +66,36 @@ func serveCommand() *cli.Command {
 			&cli.BoolFlag{
 				Name:    "cache-allow-delete-verb",
 				Usage:   "Whether to allow the DELETE verb to delete narInfo and nar files",
-				Sources: cli.EnvVars("CACHE_ALLOW_DELETE_VERB"),
+				Sources: flagSources("serve.cache.allow-delete-verb", "CACHE_ALLOW_DELETE_VERB"),
 			},
 			&cli.BoolFlag{
 				Name:    "cache-allow-put-verb",
 				Usage:   "Whether to allow the PUT verb to push narInfo and nar files directly",
-				Sources: cli.EnvVars("CACHE_ALLOW_PUT_VERB"),
+				Sources: flagSources("serve.cache.allow-put-verb", "CACHE_ALLOW_PUT_VERB"),
 			},
 			&cli.StringFlag{
 				Name:     "cache-hostname",
 				Usage:    "The hostname of the cache server",
-				Sources:  cli.EnvVars("CACHE_HOSTNAME"),
+				Sources:  flagSources("serve.cache.hostname", "CACHE_HOSTNAME"),
 				Required: true,
 			},
 			&cli.StringFlag{
 				Name:     "cache-data-path",
 				Usage:    "The local data path used for configuration and cache storage",
-				Sources:  cli.EnvVars("CACHE_DATA_PATH"),
+				Sources:  flagSources("serve.cache.data-path", "CACHE_DATA_PATH"),
 				Required: true,
 			},
 			&cli.StringFlag{
 				Name:     "cache-database-url",
 				Usage:    "The URL of the database",
-				Sources:  cli.EnvVars("CACHE_DATABASE_URL"),
+				Sources:  flagSources("serve.cache.database-url", "CACHE_DATABASE_URL"),
 				Required: true,
 			},
 			&cli.StringFlag{
 				Name: "cache-max-size",
 				//nolint:lll
 				Usage:   "The maximum size of the store. It can be given with units such as 5K, 10G etc. Supported units: B, K, M, G, T",
-				Sources: cli.EnvVars("CACHE_MAX_SIZE"),
+				Sources: flagSources("serve.cache.max-size", "CACHE_MAX_SIZE"),
 				Validator: func(s string) error {
 					_, err := helper.ParseSize(s)
 
@@ -106,7 +106,7 @@ func serveCommand() *cli.Command {
 				Name: "cache-lru-schedule",
 				//nolint:lll
 				Usage:   "The cron spec for cleaning the store. Refer to https://pkg.go.dev/github.com/robfig/cron/v3#hdr-Usage for documentation",
-				Sources: cli.EnvVars("CACHE_LRU_SCHEDULE"),
+				Sources: flagSources("serve.cache.lru.schedule", "CACHE_LRU_SCHEDULE"),
 				Validator: func(s string) error {
 					_, err := cron.ParseStandard(s)
 
@@ -116,48 +116,48 @@ func serveCommand() *cli.Command {
 			&cli.StringFlag{
 				Name:    "cache-lru-schedule-timezone",
 				Usage:   "The name of the timezone to use for the cron",
-				Sources: cli.EnvVars("CACHE_LRU_SCHEDULE_TZ"),
+				Sources: flagSources("serve.cache.lru.timezone", "CACHE_LRU_SCHEDULE_TZ"),
 				Value:   "Local",
 			},
 			&cli.StringFlag{
 				Name:    "cache-secret-key-path",
 				Usage:   "The path to the secret key used for signing cached paths",
-				Sources: cli.EnvVars("CACHE_SECRET_KEY_PATH"),
+				Sources: flagSources("serve.cache.secret-key-path", "CACHE_SECRET_KEY_PATH"),
 			},
 			&cli.BoolFlag{
 				Name:    "cache-sign-narinfo",
 				Usage:   "Whether to sign narInfo files or passthru as-is from upstream",
-				Sources: cli.EnvVars("CACHE_SIGN_NARINFO"),
+				Sources: flagSources("serve.cache.sign-narinfo", "CACHE_SIGN_NARINFO"),
 				Value:   true,
 			},
 			&cli.StringFlag{
 				Name:    "cache-temp-path",
 				Usage:   "The path to the temporary directory that is used by the cache to download NAR files",
-				Sources: cli.EnvVars("CACHE_TEMP_PATH"),
+				Sources: flagSources("serve.cache.temp-path", "CACHE_TEMP_PATH"),
 				Value:   os.TempDir(),
 			},
 			&cli.StringFlag{
 				Name:    "netrc-file",
 				Usage:   "Path to netrc file for upstream authentication",
-				Sources: cli.EnvVars("NETRC_FILE"),
+				Sources: flagSources("serve.cache.netrc-file", "NETRC_FILE"),
 				Value:   getDefaultNetrcPath(),
 			},
 			&cli.StringFlag{
 				Name:    "server-addr",
 				Usage:   "The address of the server",
-				Sources: cli.EnvVars("SERVER_ADDR"),
+				Sources: flagSources("serve.server.addr", "SERVER_ADDR"),
 				Value:   ":8501",
 			},
 			&cli.StringSliceFlag{
 				Name:     "upstream-cache",
 				Usage:    "Set to URL (with scheme) for each upstream cache",
-				Sources:  cli.EnvVars("UPSTREAM_CACHES"),
+				Sources:  flagSources("serve.upstream-caches", "UPSTREAM_CACHES"),
 				Required: true,
 			},
 			&cli.StringSliceFlag{
 				Name:    "upstream-public-key",
 				Usage:   "Set to host:public-key for each upstream cache",
-				Sources: cli.EnvVars("UPSTREAM_PUBLIC_KEYS"),
+				Sources: flagSources("serve.upstream-public-keys", "UPSTREAM_PUBLIC_KEYS"),
 			},
 		},
 	}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,67 @@
+log:
+  # Set the log level. Supported levels:
+  #
+  # - trace
+  # - debug
+  # - info
+  # - warn
+  # - error
+  # - fatal
+  # - panic
+  #
+  level: "error"
+# OpenTelemetry support.
+opentelemetry:
+  enabled: true
+  # Configure open telemetry to connect to a collector with the grpc URL. If
+  # not set, ncps will simply print telemetry to stdout which is not very
+  # useful but can be helpful for debugging.
+  grpc-url: "http://otelcol-collector.monitoring.svc:4317"
+# Prometheus metrics exposed at /metrics on the same port as ncps
+prometheus:
+  enabled: true
+# Configure the cache functionality.
+cache:
+  # Whether to allow the DELETE verb to delete narInfo and nar files
+  allow-delete-verb: true
+  # Whether to allow the PUT verb to push narInfo and nar files directly
+  allow-put-verb: true
+  # The hostname of the cache server
+  hostname: "ncps.mycompany.tld"
+  # The local data path used for configuration and cache storage
+  data-path: "/tmp/data-folder"
+  # The URL of the database
+  database-url: "that-database-url"
+  # The maximum size of the store. It can be given with units such as 5K, 10G
+  # etc. Supported units: B, K, M, G, T
+  max-size: 100G
+  # Configure the LRU to clean the store and purge least used nars. No nars are
+  # removed unless the size approaches max-size.
+  lru:
+    # The cron spec for cleaning the store. Refer to
+    # https://pkg.go.dev/github.com/robfig/cron/v3#hdr-Usage for documentation
+    schedule: "0 0 * * *"
+    # The name of the timezone to use for the cron
+    timezone: America/Los_Angeles
+  # The path to the secret key used for signing cached paths
+  secret-key-path: "/path/to/secret.key"
+  # Whether to sign narInfo files or passthru as-is from upstream
+  sign-narinfo: true
+  # The path to the temporary directory that is used by the cache to download NAR files
+  temp-path: "/path/to/temp"
+  # Path to netrc file for upstream authentication
+  netrc-file: "/path/to/netrc-file"
+  # Configure upstream caches
+  upstream:
+    # Set to URL (with scheme) for each upstream cache
+    caches:
+      - https://cache.nixos.org
+      - https://nix-community.cachix.org
+    # Set to host:public-key for each upstream cache
+    public-keys:
+      - cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+      - nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
+# Configure the main server
+server:
+  # The address of the server
+  addr: ":8501"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -44,7 +44,8 @@ cache:
     # The name of the timezone to use for the cron
     timezone: America/Los_Angeles
   # The path to the secret key used for signing cached paths
-  secret-key-path: "/path/to/secret.key"
+  # XXX: Only set this if you intend to store the key yourself instead of having ncps store it in its config store.
+  secret-key-path: ""
   # Whether to sign narInfo files or passthru as-is from upstream
   sign-narinfo: true
   # The path to the temporary directory that is used by the cache to download NAR files

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -29,9 +29,9 @@ cache:
   # The hostname of the cache server
   hostname: "ncps.mycompany.tld"
   # The local data path used for configuration and cache storage
-  data-path: "/tmp/data-folder"
+  data-path: "/var/lib/ncps"
   # The URL of the database
-  database-url: "that-database-url"
+  database-url: "sqlite:/var/lib/ncps/db/db.sqlite"
   # The maximum size of the store. It can be given with units such as 5K, 10G
   # etc. Supported units: B, K, M, G, T
   max-size: 100G
@@ -49,9 +49,9 @@ cache:
   # Whether to sign narInfo files or passthru as-is from upstream
   sign-narinfo: true
   # The path to the temporary directory that is used by the cache to download NAR files
-  temp-path: "/path/to/temp"
+  temp-path: "/tmp"
   # Path to netrc file for upstream authentication
-  netrc-file: "/path/to/netrc-file"
+  netrc-file: "/etc/ncps/netrc"
   # Configure upstream caches
   upstream:
     # Set to URL (with scheme) for each upstream cache

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
 	github.com/sysbot/go-netrc v0.0.0-20231214061310-8bb3fde9e2d4
+	github.com/urfave/cli-altsrc/v3 v3.0.1
 	github.com/urfave/cli/v3 v3.4.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.38.0
@@ -36,6 +37,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module github.com/kalbasit/ncps
 
 go 1.24.6
 
+// TODO: Remove this once the bug is fixed upstream
+// https://github.com/urfave/cli-altsrc/issues/24
+replace github.com/urfave/cli-altsrc/v3 v3.0.1 => github.com/kalbasit/cli-altsrc/v3 v3.0.0-20250925041744-510029350cc6
+
 require (
 	github.com/XSAM/otelsql v0.40.0
 	github.com/go-chi/chi/v5 v5.2.3

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/XSAM/otelsql v0.40.0 h1:8jaiQ6KcoEXF46fBmPEqb+pp29w2xjWfuXjZXTXBjaA=
 github.com/XSAM/otelsql v0.40.0/go.mod h1:/7F+1XKt3/sTlYtwKtkHQ5Gzoom+EerXmD1VdnTqfB4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -76,6 +78,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/sysbot/go-netrc v0.0.0-20231214061310-8bb3fde9e2d4 h1:VsedlThweu7x40/FG3zkk8KCVrgySDGI2YoGpkR1jpI=
 github.com/sysbot/go-netrc v0.0.0-20231214061310-8bb3fde9e2d4/go.mod h1:DQBGBc3K3ueGX4QWNQRL8w3QupJeCNNN4ICyIPBzJ4s=
+github.com/urfave/cli-altsrc/v3 v3.0.1 h1:v+gHk59syLk8ao9rYybZs43+D5ut/gzj0omqQ1XYl8k=
+github.com/urfave/cli-altsrc/v3 v3.0.1/go.mod h1:8UtsKKcxFVzvaoySFPfvQOk413T+IXJhaCWyyoPW3yM=
 github.com/urfave/cli/v3 v3.4.1 h1:1M9UOCy5bLmGnuu1yn3t3CB4rG79Rtoxuv1sPhnm6qM=
 github.com/urfave/cli/v3 v3.4.1/go.mod h1:FJSKtM/9AiiTOJL4fJ6TbMUkxBXn7GO9guZqoZtpYpo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 h1:8Tjv8EJ+pM1xP8mK6egEbD1OgnVTyacbefKhmbLhIhU=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2/go.mod h1:pkJQ2tZHJ0aFOVEEot6oZmaVEZcRme73eIFmhiVuRWs=
+github.com/kalbasit/cli-altsrc/v3 v3.0.0-20250925041744-510029350cc6 h1:zdWb1IjTnu7PkzqiurAOfwlIzTRLzAIiPf8aAqU7COU=
+github.com/kalbasit/cli-altsrc/v3 v3.0.0-20250925041744-510029350cc6/go.mod h1:8UtsKKcxFVzvaoySFPfvQOk413T+IXJhaCWyyoPW3yM=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -78,8 +80,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/sysbot/go-netrc v0.0.0-20231214061310-8bb3fde9e2d4 h1:VsedlThweu7x40/FG3zkk8KCVrgySDGI2YoGpkR1jpI=
 github.com/sysbot/go-netrc v0.0.0-20231214061310-8bb3fde9e2d4/go.mod h1:DQBGBc3K3ueGX4QWNQRL8w3QupJeCNNN4ICyIPBzJ4s=
-github.com/urfave/cli-altsrc/v3 v3.0.1 h1:v+gHk59syLk8ao9rYybZs43+D5ut/gzj0omqQ1XYl8k=
-github.com/urfave/cli-altsrc/v3 v3.0.1/go.mod h1:8UtsKKcxFVzvaoySFPfvQOk413T+IXJhaCWyyoPW3yM=
 github.com/urfave/cli/v3 v3.4.1 h1:1M9UOCy5bLmGnuu1yn3t3CB4rG79Rtoxuv1sPhnm6qM=
 github.com/urfave/cli/v3 v3.4.1/go.mod h1:FJSKtM/9AiiTOJL4fJ6TbMUkxBXn7GO9guZqoZtpYpo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/nix/packages/ncps.nix
+++ b/nix/packages/ncps.nix
@@ -36,7 +36,7 @@
             "-X github.com/kalbasit/ncps/cmd.Version=${version}"
           ];
 
-          vendorHash = "sha256-tfcl3z44qWW8rv5x1hWzrUTqx9h+FkwXvF+lxaE2J4M=";
+          vendorHash = "sha256-00w655DZuIHMgeBH91IHF8U8evtB5gXSc1G0fj8Hm0Y=";
 
           doCheck = true;
           checkFlags = [ "-race" ];

--- a/nix/packages/ncps.nix
+++ b/nix/packages/ncps.nix
@@ -36,7 +36,7 @@
             "-X github.com/kalbasit/ncps/cmd.Version=${version}"
           ];
 
-          vendorHash = "sha256-00w655DZuIHMgeBH91IHF8U8evtB5gXSc1G0fj8Hm0Y=";
+          vendorHash = "sha256-GqhphqGZRoNxf8HyOwCTOPkVGhecooff5cEzi83jeE0=";
 
           doCheck = true;
           checkFlags = [ "-race" ];


### PR DESCRIPTION
# Add configuration file support

This PR adds support for loading configuration from TOML, YAML, or JSON files. The configuration file path can be specified with the `--config` flag, defaulting to the user's config directory at `$XDG_CONFIG_HOME/ncps/config.yaml`.

All existing environment variables are still supported, but now have corresponding configuration file entries. For example, `CACHE_HOSTNAME` can now be set via `cache.hostname` in the config file.

An example configuration file (`config.example.yaml`) is included to demonstrate the available options and their structure.

closes #324