### PR TITLE
refactor: Handle errors gracefully instead of panicking

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -63,14 +63,12 @@ func New() (*cli.Command, error) {
 		)
 	}
 
-	commands := make([]*cli.Command, 0)
-
 	srvCmd, err := serveCommand(flagSources)
 	if err != nil {
 		return nil, fmt.Errorf("error creating the serve command: %w", err)
 	}
 
-	commands = append(commands, srvCmd)
+	commands := []*cli.Command{srvCmd}
 
 	c := &cli.Command{
 		Name:    "ncps",

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -46,13 +46,8 @@ func parseNetrcFile(netrcPath string) (*netrc.Netrc, error) {
 	return n, nil
 }
 
-func serveCommand(flagSources flagSourcesFn) (*cli.Command, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("unable to determine user home directory: %w", err)
-	}
-
-	c := &cli.Command{
+func serveCommand(userDirs userDirectories, flagSources flagSourcesFn) *cli.Command {
+	return &cli.Command{
 		Name:    "serve",
 		Aliases: []string{"s"},
 		Usage:   "serve the nix binary cache over http",
@@ -135,7 +130,7 @@ func serveCommand(flagSources flagSourcesFn) (*cli.Command, error) {
 				Name:    "netrc-file",
 				Usage:   "Path to netrc file for upstream authentication",
 				Sources: flagSources("cache.netrc-file", "NETRC_FILE"),
-				Value:   filepath.Join(homeDir, ".netrc"),
+				Value:   filepath.Join(userDirs.homeDir, ".netrc"),
 			},
 			&cli.StringFlag{
 				Name:    "server-addr",
@@ -156,8 +151,6 @@ func serveCommand(flagSources flagSourcesFn) (*cli.Command, error) {
 			},
 		},
 	}
-
-	return c, nil
 }
 
 func serveAction() cli.ActionFunc {

--- a/main.go
+++ b/main.go
@@ -13,7 +13,12 @@ func main() {
 }
 
 func realMain() int {
-	c := cmd.New()
+	c, err := cmd.New()
+	if err != nil {
+		log.Printf("error creating the application: %s", err)
+
+		return 1
+	}
 
 	if err := c.Run(context.Background(), os.Args); err != nil {
 		log.Printf("error running the application: %s", err)


### PR DESCRIPTION
### TL;DR

Improved error handling in the CLI initialization process by returning errors instead of panicking.

### What changed?

- Modified `cmd.New()` to return an error instead of just a command
- Created a `userDirectories` struct to hold config and home directories
- Added `getUserDirs()` function that properly returns errors instead of panicking
- Refactored `serveCommand()` to accept the user directories as a parameter
- Removed `getDefaultConfigPath()` and `getDefaultNetrcPath()` functions in favor of using the directories from the new struct
- Updated the main function to handle potential errors from `cmd.New()`

### How to test?

1. Run the application in an environment where user directories cannot be determined (e.g., with restricted permissions)
2. Verify that the application exits with a proper error message instead of panicking
3. Test normal operation to ensure the application still works as expected with valid user directories

### Why make this change?

This change improves the robustness of the application by properly handling errors during initialization instead of panicking. This provides a better user experience when the application encounters issues with user directories, allowing for graceful failure with meaningful error messages rather than abrupt termination.