### PR TITLE
refactor(pkg/storage): Remove unused Store struct

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -63,10 +63,3 @@ type NarStore interface {
 	// DeleteNar deletes the nar from the store.
 	DeleteNar(ctx context.Context, narURL nar.URL) error
 }
-
-// Store represents a store capable of storing narinfos and nars.
-type Store struct {
-	ConfigStore
-	NarInfoStore
-	NarStore
-}


### PR DESCRIPTION
Removed the `Store` struct from `pkg/storage/store.go` which was a composition of `ConfigStore`, `NarInfoStore`, and `NarStore` interfaces. This change simplifies the storage package by eliminating an unnecessary abstraction layer, allowing consumers to work directly with the individual store interfaces.