### PR TITLE
refactor: Move MinIO initialization script to separate file

### DIFF
--- a/nix/process-compose/flake-module.nix
+++ b/nix/process-compose/flake-module.nix
@@ -32,79 +32,19 @@
               };
             };
             create-buckets = {
-              command = ''
-                set -e
-                # 1. Setup Admin Alias (Strictly use 127.0.0.1)
-                ${pkgs.minio-client}/bin/mc alias set local http://127.0.0.1:9000 admin password
-                # 2. Setup Resources
-                ${pkgs.minio-client}/bin/mc mb local/test-bucket || true
-                ${pkgs.minio-client}/bin/mc admin user svcacct add \
-                  --access-key "test-access-key" \
-                  --secret-key "test-secret-key" \
-                  local admin || true
-                echo "This is secret data!" | ${pkgs.minio-client}/bin/mc pipe --quiet local/test-bucket/message.txt
-                echo "---------------------------------------------------"
-                echo "🔍 VERIFICATION CHECKS:"
-                # Check A: Keys (mc handles signing internally)
-                echo -n "1. Access Keys... "
-                ${pkgs.minio-client}/bin/mc alias set tester http://127.0.0.1:9000 test-access-key test-secret-key > /dev/null
-                if ${pkgs.minio-client}/bin/mc ls tester/test-bucket/message.txt > /dev/null; then
-                  echo "✅ Success"
-                else
-                  echo "❌ Failed"
-                fi
-                # Check B: Public Access (Anonymous)
-                echo -n "2. Public Access (Expect 403)... "
-                HTTP_CODE=$(curl -o /dev/null --silent --head --write-out '%{http_code}\n' "http://127.0.0.1:9000/test-bucket/message.txt")
-                if [ "$HTTP_CODE" -eq "403" ]; then
-                   echo "✅ Success"
-                else
-                   echo "❌ Failed (Got $HTTP_CODE)"
-                fi
-                # Check C: Signed URL
-                echo -n "3. Signed Access... "
-                # Generate presigned URL using mc
-                SIGNED_URL=$(${pkgs.minio-client}/bin/mc share download --expire 1h --json tester/test-bucket/message.txt | ${pkgs.jq}/bin/jq -r '.share')
-
-                # Test the signed URL as-is (no Host header manipulation)
-                if curl --output /dev/null --silent --fail "$SIGNED_URL"; then
-                  echo "✅ Success"
-                  # Verify content
-                  CONTENT=$(curl --silent "$SIGNED_URL")
-                  if [ "$CONTENT" = "This is secret data!" ]; then
-                    echo "   Content verified: ✅"
-                  else
-                    echo "   Content mismatch: ❌"
-                  fi
-                else
-                  echo "❌ Failed"
-                  echo "Debug URL: $SIGNED_URL"
-                  echo "Testing with verbose output:"
-                  curl -v "$SIGNED_URL" 2>&1 | tail -20
-                fi
-                echo "---------------------------------------------------"
-                echo ""
-                echo "╔═══════════════════════════════════════════════════════════╗"
-                echo "║           NCPS MINIO CONFIGURATION                        ║"
-                echo "╚═══════════════════════════════════════════════════════════╝"
-                echo ""
-                echo "📦 S3-Compatible Storage Configuration:"
-                echo ""
-                echo "  Endpoint:     http://127.0.0.1:9000"
-                echo "  Region:       us-east-1"
-                echo "  Bucket:       test-bucket"
-                echo "  Access Key:   test-access-key"
-                echo "  Secret Key:   test-secret-key"
-                echo "  Use SSL:      false"
-                echo ""
-                echo "🌐 Console UI:"
-                echo "  URL:          http://127.0.0.1:9001"
-                echo "  Username:     admin"
-                echo "  Password:     password"
-                echo ""
-                echo "---------------------------------------------------"
-                sleep infinity
-              '';
+              command =
+                let
+                  initMinio = pkgs.writeShellApplication {
+                    name = "init-minio";
+                    runtimeInputs = [
+                      pkgs.minio-client
+                      pkgs.curl
+                      pkgs.jq
+                    ];
+                    text = builtins.readFile ./init-minio.sh;
+                  };
+                in
+                "${initMinio}/bin/init-minio";
               depends_on.minio-server.condition = "process_healthy";
             };
           };

--- a/nix/process-compose/init-minio.sh
+++ b/nix/process-compose/init-minio.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -e
+# 1. Setup Admin Alias (Strictly use 127.0.0.1)
+mc alias set local http://127.0.0.1:9000 admin password
+# 2. Setup Resources
+mc mb local/test-bucket || true
+mc admin user svcacct add \
+  --access-key "test-access-key" \
+  --secret-key "test-secret-key" \
+  local admin || true
+echo "This is secret data!" | mc pipe --quiet local/test-bucket/message.txt
+echo "---------------------------------------------------"
+echo "🔍 VERIFICATION CHECKS:"
+# Check A: Keys (mc handles signing internally)
+echo -n "1. Access Keys... "
+mc alias set tester http://127.0.0.1:9000 test-access-key test-secret-key > /dev/null
+if mc ls tester/test-bucket/message.txt > /dev/null; then
+  echo "✅ Success"
+else
+  echo "❌ Failed"
+fi
+# Check B: Public Access (Anonymous)
+echo -n "2. Public Access (Expect 403)... "
+HTTP_CODE=$(curl -o /dev/null --silent --head --write-out '%{http_code}\n' "http://127.0.0.1:9000/test-bucket/message.txt")
+if [ "$HTTP_CODE" -eq "403" ]; then
+   echo "✅ Success"
+else
+   echo "❌ Failed (Got $HTTP_CODE)"
+fi
+# Check C: Signed URL
+echo -n "3. Signed Access... "
+# Generate presigned URL using mc
+SIGNED_URL=$(mc share download --expire 1h --json tester/test-bucket/message.txt | jq -r '.share')
+
+# Test the signed URL as-is (no Host header manipulation)
+if curl --output /dev/null --silent --fail "$SIGNED_URL"; then
+  echo "✅ Success"
+  # Verify content
+  CONTENT=$(curl --silent "$SIGNED_URL")
+  if [ "$CONTENT" = "This is secret data!" ]; then
+    echo "   Content verified: ✅"
+  else
+    echo "   Content mismatch: ❌"
+  fi
+else
+  echo "❌ Failed"
+  echo "Debug URL: $SIGNED_URL"
+  echo "Testing with verbose output:"
+  curl -v "$SIGNED_URL" 2>&1 | tail -20
+fi
+echo "---------------------------------------------------"
+echo ""
+echo "╔═══════════════════════════════════════════════════════════╗"
+echo "║           NCPS MINIO CONFIGURATION                        ║"
+echo "╚═══════════════════════════════════════════════════════════╝"
+echo ""
+echo "📦 S3-Compatible Storage Configuration:"
+echo ""
+echo "  Endpoint:     http://127.0.0.1:9000"
+echo "  Region:       us-east-1"
+echo "  Bucket:       test-bucket"
+echo "  Access Key:   test-access-key"
+echo "  Secret Key:   test-secret-key"
+echo "  Use SSL:      false"
+echo ""
+echo "🌐 Console UI:"
+echo "  URL:          http://127.0.0.1:9001"
+echo "  Username:     admin"
+echo "  Password:     password"
+echo ""
+echo "---------------------------------------------------"
+sleep infinity


### PR DESCRIPTION
### TL;DR

Extracted MinIO initialization script to a separate file for better maintainability.

### What changed?

- Moved the MinIO initialization script from an inline command in `flake-module.nix` to a dedicated file `init-minio.sh`
- Created a proper shell application using `pkgs.writeShellApplication` to execute the script
- Maintained all the original functionality including bucket creation, access key setup, and verification checks

### How to test?

1. Run the development environment with `nix develop` or equivalent
2. Verify that MinIO initializes correctly with the test bucket and credentials
3. Check that all verification steps pass:
   - Access key authentication
   - Public access restriction (403 expected)
   - Signed URL access

### Why make this change?

This refactoring improves code organization by separating the MinIO initialization logic from the Nix configuration. The change makes the script easier to maintain, edit, and version control as a standalone file rather than as a large string embedded in the Nix configuration.

part of #291