### PR TITLE
feat: Add GitHub domain to Claude WebFetch permissions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,8 @@
       "Bash(export NCPS_TEST_S3_ACCESS_KEY_ID=\"test-access-key\")",
       "Bash(export NCPS_TEST_S3_SECRET_ACCESS_KEY=\"test-secret-key\")",
       "Bash(nix flake check:*)",
-      "Bash(nix fmt:*)"
+      "Bash(nix fmt:*)",
+      "WebFetch(domain:github.com)"
     ]
   }
 }


### PR DESCRIPTION
Added WebFetch capability with github.com domain to the Claude settings file, allowing Claude to fetch content from GitHub when needed.