### PR TITLE
ci: Restrict vendor hash workflow to only run on PRs targeting main branch

### DIFF
--- a/.github/workflows/auto-update-vendorhash.yaml
+++ b/.github/workflows/auto-update-vendorhash.yaml
@@ -1,6 +1,8 @@
 name: Auto Update Vendor Hash
 on:
   pull_request:
+    branches:
+      - main
     paths:
       - "go.mod"
       - "go.sum"


### PR DESCRIPTION
Restrict auto-update vendor hash workflow to only run on PRs targeting the main branch. This change ensures the workflow is only triggered when necessary, reducing unnecessary workflow runs on PRs targeting other branches.