### PR TITLE
fix: Ensure run.sh executes from project root directory

### DIFF
--- a/dev-scripts/run.sh
+++ b/dev-scripts/run.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+# Ensure the script runs in the context of the root directory
+readonly root_dir="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root_dir"
+
 # S3/MinIO configuration (matches the settings from nix/process-compose/flake-module.nix)
 S3_BUCKET="test-bucket"
 S3_ENDPOINT="127.0.0.1:9000"


### PR DESCRIPTION
Added a safeguard to ensure the `run.sh` script always executes from the project root directory. This change prevents potential path-related issues when the script is invoked from different locations by determining the absolute path to the project root and changing to that directory before executing the rest of the script.