### PR TITLE
refactor: Use concatStringsSep for cleaner preCheck and postCheck concatenation

### DIFF
--- a/nix/packages/ncps.nix
+++ b/nix/packages/ncps.nix
@@ -291,8 +291,17 @@
           ];
 
           # pre and post checks
-          preCheck = minioPreCheck + "\n" + postgresPreCheck + "\n" + mysqlPreCheck;
-          postCheck = mysqlPostCheck + "\n" + postgresPostCheck + "\n" + minioPostCheck;
+          preCheck = builtins.concatStringsSep "\n" [
+            minioPreCheck
+            postgresPreCheck
+            mysqlPreCheck
+          ];
+
+          postCheck = builtins.concatStringsSep "\n" [
+            mysqlPostCheck
+            postgresPostCheck
+            minioPostCheck
+          ];
 
           postInstall = ''
             mkdir -p $out/share/ncps


### PR DESCRIPTION
Refactored pre/post check string concatenation in ncps.nix to use `builtins.concatStringsSep` instead of direct string addition. This improves readability and maintainability by clearly showing each component on its own line in a list structure.