### PR TITLE
fix: Improve NAR size test to use relative comparison instead of absolute difference

### DIFF
--- a/pkg/database/mysql_integration_test.go
+++ b/pkg/database/mysql_integration_test.go
@@ -283,9 +283,6 @@ func TestMySQL_GetNarTotalSize(t *testing.T) {
 			return
 		}
 
-		initialSize, err := db.GetNarTotalSize(context.Background())
-		require.NoError(t, err)
-
 		// Create multiple nars
 		var narIDs []int64
 
@@ -338,10 +335,10 @@ func TestMySQL_GetNarTotalSize(t *testing.T) {
 			}
 		})
 
-		finalSize, err := db.GetNarTotalSize(context.Background())
+		size, err := db.GetNarTotalSize(context.Background())
 		require.NoError(t, err)
 		//nolint:gosec
-		assert.Equal(t, int64(totalSize), finalSize-initialSize)
+		assert.LessOrEqual(t, totalSize, uint64(size)) // Should be at least our nars
 	})
 }
 


### PR DESCRIPTION
Fix NAR size test to avoid race conditions

This PR modifies the `TestMySQL_GetNarTotalSize` test to prevent race conditions when running tests in parallel. Instead of comparing the difference between initial and final sizes, which could be affected by other concurrent tests, the test now simply verifies that the total NAR size is at least as large as the size of the NARs created within the test.