### PR TITLE
fix: Add cleanup trap to ensure background processes are killed when tests fail

### DIFF
--- a/nix/packages/ncps.nix
+++ b/nix/packages/ncps.nix
@@ -291,17 +291,19 @@
           ];
 
           # pre and post checks
-          preCheck = builtins.concatStringsSep "\n" [
-            minioPreCheck
-            postgresPreCheck
-            mysqlPreCheck
-          ];
+          preCheck = ''
+            # Set up cleanup trap to ensure background processes are killed even if tests fail
+            cleanup() {
+              ${mysqlPostCheck}
+              ${postgresPostCheck}
+              ${minioPostCheck}
+            }
+            trap cleanup EXIT
 
-          postCheck = builtins.concatStringsSep "\n" [
-            mysqlPostCheck
-            postgresPostCheck
-            minioPostCheck
-          ];
+            ${minioPreCheck}
+            ${postgresPreCheck}
+            ${mysqlPreCheck}
+          '';
 
           postInstall = ''
             mkdir -p $out/share/ncps


### PR DESCRIPTION
Added a cleanup trap in preCheck to ensure background processes are killed even if tests fail. The trap executes the MySQL, PostgreSQL, and MinIO post-check cleanup operations when the script exits, regardless of whether tests succeed or fail. This prevents orphaned processes when tests don't complete successfully.