### PR TITLE
feat: Enable WebSearch capability in local settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,8 @@
       "Bash(nix fmt:*)",
       "Bash(sqlc generate:*)",
       "Bash(sqlfluff:*)",
-      "WebFetch(domain:github.com)"
+      "WebFetch(domain:github.com)",
+      "WebSearch"
     ]
   }
 }


### PR DESCRIPTION
Added WebSearch to the list of allowed tools in the Claude settings file. This enables the WebSearch capability alongside the existing tools like Bash commands and GitHub web fetching.