### PR TITLE
feat: Add script for running multiple ncps instances in HA mode

### DIFF
--- a/dev-scripts/run-ha.sh
+++ b/dev-scripts/run-ha.sh
@@ -40,8 +40,13 @@ cleanup() {
     fi
   done
 
-  # Wait for processes to terminate
-  sleep 1
+  # Wait up to 5 seconds for processes to terminate
+  for _ in {1..5}; do
+    if ! kill -0 "${INSTANCE_PIDS[@]}" 2>/dev/null; then
+      break # All processes terminated
+    fi
+    sleep 1
+  done
 
   # Force kill if still running
   for pid in "${INSTANCE_PIDS[@]}"; do


### PR DESCRIPTION
# Add dev-scripts/run-ha.sh for High Availability Testing

This PR adds a new development script `run-ha.sh` that simplifies testing NCPS in a high-availability configuration. The script:

- Launches multiple NCPS instances (default: 3) that share the same PostgreSQL, S3/MinIO, and Redis infrastructure
- Configures each instance with distributed locking via Redis
- Sets up hot-reloading for all instances using watchexec
- Provides clear terminal output with color-coded instance logs
- Includes dependency checks to ensure PostgreSQL, MinIO, and Redis are running
- Offers helpful usage information and testing commands

The script is designed to work with the existing development dependencies that can be started with `nix run .#deps`.