### PR TITLE
feat: Add Helm chart and release workflow for ncps

### DIFF
--- a/charts/ncps/.helmignore
+++ b/charts/ncps/.helmignore
@@ -1,0 +1,30 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+# Test files
+*_test.yaml
+test-values/

--- a/charts/ncps/Chart.yaml
+++ b/charts/ncps/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: ncps
+description: A Helm chart for ncps (Nix Cache Proxy Server)
+type: application
+version: 1.0.0
+appVersion: "0.5.1"
+keywords:
+  - nix
+  - cache
+  - proxy
+  - binary-cache
+home: https://github.com/kalbasit/ncps
+sources:
+  - https://github.com/kalbasit/ncps
+maintainers:
+  - name: Wael Nasreddine
+    email: wael.nasreddine@gmail.com
+icon: https://nixos.org/logo/nixos-logo-only-hires.png

--- a/charts/ncps/README.md
+++ b/charts/ncps/README.md
@@ -1,0 +1,613 @@
+# ncps Helm Chart
+
+A Helm chart for deploying [ncps (Nix Cache Proxy Server)](https://github.com/kalbasit/ncps) on Kubernetes.
+
+## Introduction
+
+This chart bootstraps a ncps deployment on a Kubernetes cluster using the Helm package manager. ncps is a local binary cache proxy for Nix that fetches store paths from upstream caches and caches them locally, reducing download times and bandwidth usage.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.8+
+- PV provisioner support in the underlying infrastructure (for local storage with persistence)
+
+## Installation
+
+### Install from OCI Registry
+
+```bash
+# Install with default values (single instance, local storage, SQLite)
+helm install ncps oci://ghcr.io/kalbasit/helm/ncps --version <chart-version>
+
+# Install with custom values
+helm install ncps oci://ghcr.io/kalbasit/helm/ncps \
+  --version <chart-version> \
+  --set config.hostname=cache.example.com \
+  --set config.upstream.caches[0].url=https://cache.nixos.org
+```
+
+### Install from Source
+
+```bash
+git clone https://github.com/kalbasit/ncps.git
+cd ncps/charts/ncps
+helm install ncps . -f values.yaml
+```
+
+## Upgrading
+
+```bash
+# Upgrade to a new version
+helm upgrade ncps oci://ghcr.io/kalbasit/helm/ncps --version <new-chart-version>
+
+# Upgrade with new values
+helm upgrade ncps oci://ghcr.io/kalbasit/helm/ncps \
+  --version <new-chart-version> \
+  --set config.cache.maxSize=500G
+```
+
+## Uninstalling
+
+```bash
+helm uninstall ncps
+
+# To also delete PVCs (persistent volumes)
+kubectl delete pvc -l app.kubernetes.io/instance=<release-name>
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the ncps chart and their default values.
+
+### Global Settings
+
+| Parameter | Description | Default |
+| ---------------------- | ----------------------------------------------------- | --------------- |
+| `global.imageRegistry` | Global image registry override | `""` |
+| `replicaCount` | Number of replicas (1 for single instance, 2+ for HA) | `1` |
+| `mode` | Deployment mode: `deployment` or `statefulset` | `statefulset` |
+| `image.registry` | Image registry | `docker.io` |
+| `image.repository` | Image repository | `kalbasit/ncps` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `image.tag` | Image tag (defaults to chart appVersion) | `""` |
+| `imagePullSecrets` | Image pull secrets | `[]` |
+| `nameOverride` | Override chart name | `""` |
+| `fullnameOverride` | Override full name | `""` |
+
+### Service Account
+
+| Parameter | Description | Default |
+| --------------------------------------------- | ------------------------------- | ------- |
+| `serviceAccount.create` | Create service account | `true` |
+| `serviceAccount.annotations` | Service account annotations | `{}` |
+| `serviceAccount.name` | Service account name | `""` |
+| `serviceAccount.automountServiceAccountToken` | Automount service account token | `false` |
+
+### Security Context
+
+| Parameter | Description | Default |
+| ------------------------------------------ | -------------------------- | ------- |
+| `podSecurityContext.runAsNonRoot` | Run as non-root | `true` |
+| `podSecurityContext.runAsUser` | User ID | `1000` |
+| `podSecurityContext.runAsGroup` | Group ID | `1000` |
+| `podSecurityContext.fsGroup` | FS group | `1000` |
+| `securityContext.allowPrivilegeEscalation` | Allow privilege escalation | `false` |
+| `securityContext.readOnlyRootFilesystem` | Read-only root filesystem | `true` |
+
+### ncps Configuration
+
+| Parameter | Description | Default |
+| -------------------------------- | -------------------------------- | ------------------ |
+| `config.hostname` | Cache hostname (REQUIRED) | `ncps.example.com` |
+| `config.logLevel` | Logging level | `info` |
+| `config.server.addr` | Server listen address | `:8501` |
+| `config.permissions.allowPut` | Allow PUT requests | `false` |
+| `config.permissions.allowDelete` | Allow DELETE requests | `false` |
+| `config.signing.enabled` | Enable NAR signing | `true` |
+| `config.signing.secretKey` | Signing secret key | `""` |
+| `config.signing.existingSecret` | Existing secret with signing key | `""` |
+
+### Cache Management
+
+| Parameter | Description | Default |
+| -------------------------- | --------------------------------- | ----------- |
+| `config.cache.maxSize` | Maximum cache size (e.g., "100G") | `""` |
+| `config.cache.lruSchedule` | LRU cleanup cron schedule | `""` |
+| `config.cache.lruTimezone` | Timezone for cron schedule | `Local` |
+| `config.cache.tempPath` | Temporary directory path | `/tmp/ncps` |
+
+### Storage Configuration
+
+| Parameter | Description | Default |
+| --------------------------------------------------- | ----------------------------------- | ----------------- |
+| `config.storage.type` | Storage type: `local` or `s3` | `local` |
+| `config.storage.local.path` | Local storage path | `/storage` |
+| `config.storage.local.persistence.enabled` | Enable persistent storage | `true` |
+| `config.storage.local.persistence.storageClassName` | Storage class | `""` |
+| `config.storage.local.persistence.accessModes` | Access modes | `[ReadWriteOnce]` |
+| `config.storage.local.persistence.size` | PVC size | `20Gi` |
+| `config.storage.s3.bucket` | S3 bucket name | `""` |
+| `config.storage.s3.endpoint` | S3 endpoint | `""` |
+| `config.storage.s3.region` | S3 region | `us-east-1` |
+| `config.storage.s3.useSSL` | Use SSL/TLS | `true` |
+| `config.storage.s3.accessKeyId` | S3 access key ID | `""` |
+| `config.storage.s3.secretAccessKey` | S3 secret access key | `""` |
+| `config.storage.s3.existingSecret` | Existing secret with S3 credentials | `""` |
+
+### Database Configuration
+
+| Parameter | Description | Default |
+| ------------------------------------------- | ------------------------------------------------- | --------------------- |
+| `config.database.type` | Database type: `sqlite`, `postgresql`, or `mysql` | `sqlite` |
+| `config.database.sqlite.path` | SQLite database file path | `/storage/db/ncps.db` |
+| `config.database.postgresql.host` | PostgreSQL host | `""` |
+| `config.database.postgresql.port` | PostgreSQL port | `5432` |
+| `config.database.postgresql.database` | PostgreSQL database name | `ncps` |
+| `config.database.postgresql.username` | PostgreSQL username | `ncps` |
+| `config.database.postgresql.password` | PostgreSQL password | `""` |
+| `config.database.postgresql.sslMode` | PostgreSQL SSL mode | `disable` |
+| `config.database.postgresql.existingSecret` | Existing secret with PostgreSQL password | `""` |
+| `config.database.mysql.host` | MySQL host | `""` |
+| `config.database.mysql.port` | MySQL port | `3306` |
+| `config.database.mysql.database` | MySQL database name | `ncps` |
+| `config.database.mysql.username` | MySQL username | `ncps` |
+| `config.database.mysql.password` | MySQL password | `""` |
+| `config.database.mysql.existingSecret` | Existing secret with MySQL password | `""` |
+| `config.database.pool.maxOpenConns` | Maximum open connections | `0` |
+| `config.database.pool.maxIdleConns` | Maximum idle connections | `0` |
+
+### Upstream Cache Configuration
+
+| Parameter | Description | Default |
+| --------------------------------------- | ------------------------------- | --------------- |
+| `config.upstream.caches` | List of upstream caches | See values.yaml |
+| `config.upstream.dialerTimeout` | Connection timeout | `3s` |
+| `config.upstream.responseHeaderTimeout` | Response header timeout | `3s` |
+| `config.upstream.netrcFile` | Netrc file content | `""` |
+| `config.upstream.existingNetrcSecret` | Existing secret with netrc file | `""` |
+
+### Redis Configuration (HA Mode)
+
+| Parameter | Description | Default |
+| -------------------------------------- | -------------------------------------- | -------------- |
+| `config.redis.enabled` | Enable Redis (required for HA) | `false` |
+| `config.redis.addresses` | Redis server addresses | `[redis:6379]` |
+| `config.redis.username` | Redis username | `""` |
+| `config.redis.password` | Redis password | `""` |
+| `config.redis.existingSecret` | Existing secret with Redis credentials | `""` |
+| `config.redis.db` | Redis database number | `0` |
+| `config.redis.useTLS` | Use TLS | `false` |
+| `config.redis.poolSize` | Connection pool size | `10` |
+| `config.redis.keyPrefix` | Lock key prefix | `ncps:lock:` |
+| `config.redis.lock.downloadTTL` | Download lock TTL | `5m` |
+| `config.redis.lock.lruTTL` | LRU lock TTL | `30m` |
+| `config.redis.lock.retry.maxAttempts` | Maximum retry attempts | `3` |
+| `config.redis.lock.retry.initialDelay` | Initial retry delay | `100ms` |
+| `config.redis.lock.retry.maxDelay` | Maximum retry delay | `2s` |
+| `config.redis.lock.retry.jitter` | Enable retry jitter | `true` |
+| `config.redis.lock.allowDegradedMode` | Allow degraded mode | `false` |
+
+### Observability
+
+| Parameter | Description | Default |
+| -------------------------------------------- | ------------------------- | ------- |
+| `config.observability.opentelemetry.enabled` | Enable OpenTelemetry | `false` |
+| `config.observability.opentelemetry.grpcURL` | OTLP gRPC collector URL | `""` |
+| `config.observability.prometheus.enabled` | Enable Prometheus metrics | `false` |
+
+### Service Configuration
+
+| Parameter | Description | Default |
+| ------------------------- | ------------------- | ----------- |
+| `service.type` | Service type | `ClusterIP` |
+| `service.port` | Service port | `8501` |
+| `service.portName` | Port name | `http` |
+| `service.annotations` | Service annotations | `{}` |
+| `service.sessionAffinity` | Session affinity | `None` |
+
+### Ingress Configuration
+
+| Parameter | Description | Default |
+| --------------------- | ------------------------- | --------------- |
+| `ingress.enabled` | Enable Ingress | `false` |
+| `ingress.className` | Ingress class name | `nginx` |
+| `ingress.annotations` | Ingress annotations | `{}` |
+| `ingress.hosts` | Ingress hosts | See values.yaml |
+| `ingress.tls` | Ingress TLS configuration | `[]` |
+
+### Health Checks
+
+| Parameter | Description | Default |
+| ---------------- | ----------------------------- | --------------- |
+| `livenessProbe` | Liveness probe configuration | See values.yaml |
+| `readinessProbe` | Readiness probe configuration | See values.yaml |
+
+### Resources
+
+| Parameter | Description | Default |
+| --------------------------- | -------------- | ------- |
+| `resources.limits.cpu` | CPU limit | `2000m` |
+| `resources.limits.memory` | Memory limit | `2Gi` |
+| `resources.requests.cpu` | CPU request | `100m` |
+| `resources.requests.memory` | Memory request | `256Mi` |
+
+### Monitoring
+
+| Parameter | Description | Default |
+| ------------------------------ | -------------------------------- | ------- |
+| `serviceMonitor.enabled` | Enable Prometheus ServiceMonitor | `false` |
+| `serviceMonitor.namespace` | ServiceMonitor namespace | `""` |
+| `serviceMonitor.labels` | Additional labels | `{}` |
+| `serviceMonitor.interval` | Scrape interval | `30s` |
+| `serviceMonitor.scrapeTimeout` | Scrape timeout | `10s` |
+
+### Other Settings
+
+| Parameter | Description | Default |
+| ---------------------------------- | --------------------------- | ------- |
+| `podDisruptionBudget.enabled` | Enable PodDisruptionBudget | `false` |
+| `podDisruptionBudget.minAvailable` | Minimum available pods | `1` |
+| `nodeSelector` | Node selector | `{}` |
+| `tolerations` | Pod tolerations | `[]` |
+| `affinity` | Pod affinity | `{}` |
+| `extraEnvVars` | Extra environment variables | `[]` |
+| `extraVolumes` | Extra volumes | `[]` |
+| `extraVolumeMounts` | Extra volume mounts | `[]` |
+| `initContainers` | Init containers | `[]` |
+| `sidecars` | Sidecar containers | `[]` |
+| `tests.enabled` | Enable Helm tests | `false` |
+
+## Examples
+
+### Single Instance with Local Storage
+
+Default configuration - simple single-instance deployment:
+
+```yaml
+replicaCount: 1
+mode: statefulset
+config:
+  hostname: cache.example.com
+  storage:
+    type: local
+    local:
+      persistence:
+        enabled: true
+        size: 50Gi
+  database:
+    type: sqlite
+```
+
+### Single Instance with S3 and PostgreSQL
+
+Production single-instance with S3 storage and PostgreSQL:
+
+```yaml
+replicaCount: 1
+mode: statefulset
+config:
+  hostname: cache.example.com
+  storage:
+    type: s3
+    s3:
+      bucket: my-nix-cache
+      endpoint: s3.amazonaws.com
+      region: us-west-2
+      useSSL: true
+      accessKeyId: AKIA...
+      secretAccessKey: secret...
+  database:
+    type: postgresql
+    postgresql:
+      host: postgres.example.com
+      port: 5432
+      database: ncps
+      username: ncps
+      password: secretpassword
+```
+
+### High Availability with 3 Replicas
+
+HA deployment with S3, PostgreSQL, and Redis:
+
+```yaml
+replicaCount: 3
+mode: deployment
+config:
+  hostname: cache.example.com
+  storage:
+    type: s3
+    s3:
+      bucket: my-nix-cache-ha
+      endpoint: s3.amazonaws.com
+      region: us-west-2
+      useSSL: true
+      accessKeyId: AKIA...
+      secretAccessKey: secret...
+  database:
+    type: postgresql
+    postgresql:
+      host: postgres-ha.example.com
+      port: 5432
+      database: ncps
+      username: ncps
+      password: secretpassword
+  redis:
+    enabled: true
+    addresses:
+      - redis-ha:6379
+    password: redispassword
+    lock:
+      downloadTTL: 5m
+      lruTTL: 30m
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                  - ncps
+          topologyKey: kubernetes.io/hostname
+```
+
+### HA with Shared Filesystem (NFS)
+
+HA deployment using StatefulSet with NFS for storage:
+
+```yaml
+replicaCount: 3
+mode: statefulset
+config:
+  hostname: cache.example.com
+  storage:
+    type: local
+    local:
+      path: /storage
+      persistence:
+        enabled: true
+        storageClassName: nfs-client # NFS storage class
+        size: 100Gi
+        accessModes:
+          - ReadWriteMany # NFS supports multiple writers
+  database:
+    type: postgresql
+    postgresql:
+      host: postgres-ha.example.com
+      port: 5432
+      database: ncps
+      username: ncps
+      password: secretpassword
+  redis:
+    enabled: true
+    addresses:
+      - redis-ha:6379
+    password: redispassword
+```
+
+### Using Existing Secrets
+
+For better security, use existing Kubernetes secrets:
+
+```yaml
+config:
+  storage:
+    type: s3
+    s3:
+      bucket: my-nix-cache
+      endpoint: s3.amazonaws.com
+      region: us-west-2
+      existingSecret: ncps-s3-credentials
+  database:
+    type: postgresql
+    postgresql:
+      host: postgres.example.com
+      database: ncps
+      username: ncps
+      existingSecret: ncps-postgres-credentials
+  redis:
+    enabled: true
+    addresses:
+      - redis:6379
+    existingSecret: ncps-redis-credentials
+  signing:
+    existingSecret: ncps-signing-key
+```
+
+Create secrets:
+
+```bash
+# S3 credentials
+kubectl create secret generic ncps-s3-credentials \
+  --from-literal=access-key-id=AKIA... \
+  --from-literal=secret-access-key=secret...
+
+# PostgreSQL password
+kubectl create secret generic ncps-postgres-credentials \
+  --from-literal=password=secretpassword
+
+# Redis credentials
+kubectl create secret generic ncps-redis-credentials \
+  --from-literal=password=redispassword
+
+# Signing key
+kubectl create secret generic ncps-signing-key \
+  --from-literal=signing-key="ncps-1:base64encodedkey..."
+```
+
+### With Ingress and TLS
+
+Expose ncps via Ingress with Let's Encrypt TLS:
+
+```yaml
+config:
+  hostname: cache.example.com
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-body-size: "0" # Allow large uploads
+  hosts:
+    - host: cache.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: ncps-tls
+      hosts:
+        - cache.example.com
+```
+
+### With Prometheus Monitoring
+
+Enable Prometheus metrics and ServiceMonitor:
+
+```yaml
+config:
+  observability:
+    prometheus:
+      enabled: true
+
+serviceMonitor:
+  enabled: true
+  interval: 30s
+  scrapeTimeout: 10s
+  labels:
+    prometheus: kube-prometheus
+```
+
+## Testing
+
+The chart includes a connection test that verifies the service is responding on the `/healthz` endpoint.
+
+### Using Native Helm
+
+When deploying with `helm install` or `helm upgrade`, you can enable and run tests:
+
+```bash
+# Install with tests enabled
+helm install ncps oci://ghcr.io/kalbasit/helm/ncps \
+  --set tests.enabled=true
+
+# Run the test
+helm test ncps
+```
+
+### Using `helm template` (nixidy, manual templating, etc.)
+
+**IMPORTANT**: Keep `tests.enabled=false` (the default) when using `helm template`.
+
+When using `helm template` (manually or via tools like nixidy), Helm hook annotations are ignored and the test pod gets rendered as a regular resource, causing issues:
+
+- The pod runs once and completes
+- It appears as degraded/failed in your cluster
+- Updates to the pod fail (can't update completed pods)
+
+```yaml
+# values.yaml when using helm template
+tests:
+  enabled: false # Keep disabled to prevent test pod from being rendered
+```
+
+**Note for ArgoCD/Flux users**: These tools may use `helm template` internally. Check your configuration:
+
+- ArgoCD: Depends on your Application's source configuration
+- Flux: HelmRelease with `spec.install.disableHooks: true` has this issue
+
+To test your deployment when using templating, use the readiness/liveness probes or manually verify:
+
+```bash
+kubectl get pod -l app.kubernetes.io/instance=<release-name>
+kubectl port-forward svc/<release-name>-ncps 8501:8501
+curl http://localhost:8501/healthz
+```
+
+## Troubleshooting
+
+### Chart Validation Errors
+
+The chart includes validation to prevent incompatible configurations:
+
+**Error: "High availability mode requires Redis"**
+
+- Enable Redis when using multiple replicas: `config.redis.enabled=true`
+
+**Error: "High availability mode is not compatible with SQLite"**
+
+- Use PostgreSQL or MySQL: `config.database.type=postgresql`
+
+**Error: "High availability mode with Deployment requires S3 storage"**
+
+- Either use S3: `config.storage.type=s3`
+- Or switch to StatefulSet with NFS: `mode=statefulset`
+
+### Pods Not Starting
+
+Check pod events:
+
+```bash
+kubectl describe pod -l app.kubernetes.io/instance=<release-name>
+```
+
+Check logs:
+
+```bash
+kubectl logs -l app.kubernetes.io/instance=<release-name>
+```
+
+### Storage Issues
+
+Verify PVC status:
+
+```bash
+kubectl get pvc -l app.kubernetes.io/instance=<release-name>
+```
+
+For NFS issues, verify storage class supports ReadWriteMany:
+
+```bash
+kubectl get storageclass
+```
+
+### Database Connection Failures
+
+Test database connectivity:
+
+```bash
+kubectl exec -it deployment/<release-name>-ncps -- /bin/sh
+# Try connecting to database
+```
+
+Verify database credentials in secrets:
+
+```bash
+kubectl get secret <release-name>-ncps -o yaml
+```
+
+### Redis Connection Issues
+
+Verify Redis is accessible:
+
+```bash
+kubectl exec -it deployment/<release-name>-ncps -- redis-cli -h redis -p 6379 ping
+```
+
+Check Redis authentication:
+
+```bash
+kubectl get secret <release-name>-ncps -o jsonpath='{.data.redis-password}' | base64 -d
+```
+
+## Further Information
+
+- [ncps GitHub Repository](https://github.com/kalbasit/ncps)
+- [ncps Documentation](https://github.com/kalbasit/ncps/blob/main/README.md)
+- [Distributed Locking Guide](https://github.com/kalbasit/ncps/blob/main/docs/distributed-locking.md)
+- [Helm Documentation](https://helm.sh/docs/)

--- a/charts/ncps/templates/NOTES.txt
+++ b/charts/ncps/templates/NOTES.txt
@@ -1,0 +1,80 @@
+Thank you for installing {{ .Chart.Name }}!
+
+Your release is named {{ .Release.Name }}.
+
+To access ncps:
+
+{{- if .Values.ingress.enabled }}
+
+1. The application is available at:
+{{- range .Values.ingress.hosts }}
+   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ .host }}
+{{- end }}
+
+{{- else if contains "NodePort" .Values.service.type }}
+
+1. Get the application URL:
+   export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "ncps.fullname" . }})
+   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+   echo http://$NODE_IP:$NODE_PORT
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+1. Get the application URL:
+   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "ncps.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+   echo http://$SERVICE_IP:{{ .Values.service.port }}
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+1. Forward the port to your local machine:
+   kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "ncps.fullname" . }} 8501:{{ .Values.service.port }}
+
+   Then access: http://localhost:8501
+
+{{- end }}
+
+Configuration:
+  Mode: {{ if gt (int .Values.replicaCount) 1 }}High Availability ({{ .Values.replicaCount }} replicas){{ else }}Single Instance{{ end }}
+  Deployment Type: {{ .Values.mode | upper }}
+  Storage: {{ .Values.config.storage.type | upper }}
+  Database: {{ .Values.config.database.type | upper }}
+  {{- if .Values.config.redis.enabled }}
+  Redis: Enabled (distributed locking active)
+  {{- end }}
+
+Useful endpoints:
+  /               - Cache information
+  /pubkey         - Public signing key
+  /nix-cache-info - Nix cache metadata
+  /healthz        - Health check
+  {{- if .Values.config.observability.prometheus.enabled }}
+  /metrics        - Prometheus metrics
+  {{- end }}
+
+{{- if and (gt (int .Values.replicaCount) 1) (not .Values.config.redis.enabled) }}
+
+WARNING: Multiple replicas configured but Redis is not enabled!
+This will cause issues with distributed locking. Enable Redis with:
+  config.redis.enabled=true
+
+{{- end }}
+
+{{- if and (gt (int .Values.replicaCount) 1) (eq .Values.config.database.type "sqlite") }}
+
+WARNING: Multiple replicas with SQLite database detected!
+SQLite does not support concurrent writes. Use PostgreSQL or MySQL:
+  config.database.type=postgresql
+
+{{- end }}
+
+{{- if and (gt (int .Values.replicaCount) 1) (eq .Values.config.storage.type "local") (eq .Values.mode "deployment") }}
+
+WARNING: Multiple replicas with local storage in Deployment mode!
+Use S3 storage or switch to StatefulSet mode with shared filesystem:
+  config.storage.type=s3
+  OR
+  mode=statefulset (with NFS/GlusterFS)
+
+{{- end }}
+
+For more information, visit: https://github.com/kalbasit/ncps

--- a/charts/ncps/templates/_helpers.tpl
+++ b/charts/ncps/templates/_helpers.tpl
@@ -1,0 +1,241 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ncps.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ncps.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ncps.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ncps.labels" -}}
+helm.sh/chart: {{ include "ncps.chart" . }}
+{{ include "ncps.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ncps.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ncps.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "ncps.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ncps.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the proper ncps image name
+*/}}
+{{- define "ncps.image" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- $repositoryName := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- if .Values.global.imageRegistry }}
+  {{- $registryName = .Values.global.imageRegistry -}}
+{{- end -}}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+
+{{/*
+Return the proper init image name for directory creation
+*/}}
+{{- define "ncps.initImage" -}}
+{{- $registryName := .Values.initImage.registry -}}
+{{- $repositoryName := .Values.initImage.repository -}}
+{{- $tag := .Values.initImage.tag -}}
+{{- if .Values.global.imageRegistry }}
+  {{- $registryName = .Values.global.imageRegistry -}}
+{{- end -}}
+{{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
+{{- end -}}
+
+{{/*
+Build database URL from configuration
+*/}}
+{{- define "ncps.databaseURL" -}}
+{{- if eq .Values.config.database.type "sqlite" -}}
+sqlite:{{ .Values.config.database.sqlite.path }}
+{{- else if eq .Values.config.database.type "postgresql" -}}
+{{- $pass := .Values.config.database.postgresql.password -}}
+{{- if .Values.config.database.postgresql.existingSecret -}}
+{{- $pass = printf "${POSTGRES_PASSWORD}" -}}
+{{- end -}}
+postgresql://{{ .Values.config.database.postgresql.username | urlquery }}:{{ $pass | urlquery }}@{{ .Values.config.database.postgresql.host }}:{{ .Values.config.database.postgresql.port }}/{{ .Values.config.database.postgresql.database }}?sslmode={{ .Values.config.database.postgresql.sslMode }}{{ if .Values.config.database.postgresql.extraParams }}&{{ .Values.config.database.postgresql.extraParams }}{{ end }}
+{{- else if eq .Values.config.database.type "mysql" -}}
+{{- $pass := .Values.config.database.mysql.password -}}
+{{- if .Values.config.database.mysql.existingSecret -}}
+{{- $pass = printf "${MYSQL_PASSWORD}" -}}
+{{- end -}}
+mysql://{{ .Values.config.database.mysql.username | urlquery }}:{{ $pass | urlquery }}@{{ .Values.config.database.mysql.host }}:{{ .Values.config.database.mysql.port }}/{{ .Values.config.database.mysql.database }}{{ if .Values.config.database.mysql.extraParams }}?{{ .Values.config.database.mysql.extraParams }}{{ end }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Database environment variables for password injection
+*/}}
+{{- define "ncps.databaseEnv" -}}
+{{- if and (eq .Values.config.database.type "postgresql") .Values.config.database.postgresql.existingSecret }}
+- name: POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.config.database.postgresql.existingSecret }}
+      key: password
+{{- else if and (eq .Values.config.database.type "postgresql") .Values.config.database.postgresql.password }}
+- name: POSTGRES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ncps.fullname" . }}
+      key: postgres-password
+{{- else if and (eq .Values.config.database.type "mysql") .Values.config.database.mysql.existingSecret }}
+- name: MYSQL_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.config.database.mysql.existingSecret }}
+      key: password
+{{- else if and (eq .Values.config.database.type "mysql") .Values.config.database.mysql.password }}
+- name: MYSQL_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ncps.fullname" . }}
+      key: mysql-password
+{{- end }}
+{{- end -}}
+
+{{/*
+Database URL environment variable for migration
+Returns the DATABASE_URL env var config - either from value or secretKeyRef
+*/}}
+{{- define "ncps.migrationDatabaseURLEnv" -}}
+{{- if eq .Values.config.database.type "sqlite" }}
+- name: DATABASE_URL
+  value: {{ include "ncps.databaseURL" . | quote }}
+{{- else if or (and (eq .Values.config.database.type "postgresql") .Values.config.database.postgresql.password) (and (eq .Values.config.database.type "mysql") .Values.config.database.mysql.password) }}
+- name: DATABASE_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "ncps.fullname" . }}
+      key: database-url
+{{- else if and (eq .Values.config.database.type "postgresql") .Values.config.database.postgresql.existingSecret }}
+- name: DATABASE_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.config.database.postgresql.existingSecret }}
+      key: database-url
+{{- else if and (eq .Values.config.database.type "mysql") .Values.config.database.mysql.existingSecret }}
+- name: DATABASE_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.config.database.mysql.existingSecret }}
+      key: database-url
+{{- end }}
+{{- end -}}
+
+{{/*
+Validate configuration for incompatible settings
+This function will fail the template rendering if invalid configurations are detected
+*/}}
+{{- define "ncps.validate" -}}
+
+{{- /* HA mode validation */ -}}
+{{- if gt (int .Values.replicaCount) 1 -}}
+  {{- /* HA requires Redis */ -}}
+  {{- if not .Values.config.redis.enabled -}}
+    {{- fail "High availability mode (replicaCount > 1) requires Redis to be enabled (config.redis.enabled=true)" -}}
+  {{- end -}}
+
+  {{- /* HA cannot use SQLite */ -}}
+  {{- if eq .Values.config.database.type "sqlite" -}}
+    {{- fail "High availability mode (replicaCount > 1) is not compatible with SQLite. Use PostgreSQL or MySQL instead (config.database.type)" -}}
+  {{- end -}}
+
+  {{- /* HA with Deployment should use S3 */ -}}
+  {{- if and (eq .Values.config.storage.type "local") (eq .Values.mode "deployment") -}}
+    {{- fail "High availability mode with Deployment requires S3 storage (config.storage.type='s3') or use StatefulSet with shared filesystem" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Storage validation */ -}}
+{{- if eq .Values.config.storage.type "s3" -}}
+  {{- if not .Values.config.storage.s3.bucket -}}
+    {{- fail "S3 storage requires bucket name (config.storage.s3.bucket)" -}}
+  {{- end -}}
+  {{- if not .Values.config.storage.s3.endpoint -}}
+    {{- fail "S3 storage requires endpoint (config.storage.s3.endpoint)" -}}
+  {{- end -}}
+  {{- if and (not .Values.config.storage.s3.existingSecret) (or (not .Values.config.storage.s3.accessKeyId) (not .Values.config.storage.s3.secretAccessKey)) -}}
+    {{- fail "S3 storage requires credentials (config.storage.s3.accessKeyId/secretAccessKey or config.storage.s3.existingSecret)" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Database validation */ -}}
+{{- if eq .Values.config.database.type "postgresql" -}}
+  {{- if not .Values.config.database.postgresql.host -}}
+    {{- fail "PostgreSQL requires host (config.database.postgresql.host)" -}}
+  {{- end -}}
+{{- else if eq .Values.config.database.type "mysql" -}}
+  {{- if not .Values.config.database.mysql.host -}}
+    {{- fail "MySQL requires host (config.database.mysql.host)" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* LRU schedule requires max size */ -}}
+{{- if and .Values.config.cache.lruSchedule (not .Values.config.cache.maxSize) -}}
+  {{- fail "LRU schedule (config.cache.lruSchedule) requires max cache size (config.cache.maxSize)" -}}
+{{- end -}}
+
+{{- /* Redis validation */ -}}
+{{- if .Values.config.redis.enabled -}}
+  {{- if not .Values.config.redis.addresses -}}
+    {{- fail "Redis enabled but no addresses provided (config.redis.addresses)" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Upstream validation */ -}}
+{{- if not .Values.config.upstream.caches -}}
+  {{- fail "At least one upstream cache is required (config.upstream.caches)" -}}
+{{- end -}}
+
+{{- /* Mode validation */ -}}
+{{- if and (ne .Values.mode "deployment") (ne .Values.mode "statefulset") -}}
+  {{- fail "mode must be either 'deployment' or 'statefulset'" -}}
+{{- end -}}
+
+{{- end -}}

--- a/charts/ncps/templates/configmap.yaml
+++ b/charts/ncps/templates/configmap.yaml
@@ -1,0 +1,114 @@
+{{- include "ncps.validate" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ncps.fullname" . }}
+  labels:
+    {{- include "ncps.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    # ncps configuration
+    cache:
+      hostname: {{ .Values.config.hostname | quote }}
+      {{- if .Values.config.cache.maxSize }}
+      max-size: {{ .Values.config.cache.maxSize | quote }}
+      {{- end }}
+      {{- if .Values.config.cache.lruSchedule }}
+      lru:
+        schedule: {{ .Values.config.cache.lruSchedule | quote }}
+        timezone: {{ .Values.config.cache.lruTimezone | quote }}
+      {{- end }}
+      temp-path: {{ .Values.config.cache.tempPath | quote }}
+
+      {{- if and (or (eq .Values.config.database.type "postgresql") (eq .Values.config.database.type "mysql")) (or .Values.config.database.pool.maxOpenConns .Values.config.database.pool.maxIdleConns) }}
+      database:
+        pool:
+          {{- if .Values.config.database.pool.maxOpenConns }}
+          max-open-conns: {{ .Values.config.database.pool.maxOpenConns }}
+          {{- end }}
+          {{- if .Values.config.database.pool.maxIdleConns }}
+          max-idle-conns: {{ .Values.config.database.pool.maxIdleConns }}
+          {{- end }}
+      {{- end }}
+
+      {{- if .Values.config.permissions.allowPut }}
+      allow-put-verb: true
+      {{- end }}
+      {{- if .Values.config.permissions.allowDelete }}
+      allow-delete-verb: true
+      {{- end }}
+
+      upstream:
+        urls:
+        {{- range .Values.config.upstream.caches }}
+          - {{ .url | quote }}
+        {{- end }}
+        public-keys:
+        {{- range .Values.config.upstream.caches }}
+          - {{ .publicKey | quote }}
+        {{- end }}
+        {{- if .Values.config.upstream.dialerTimeout }}
+        dialer-timeout: {{ .Values.config.upstream.dialerTimeout | quote }}
+        {{- end }}
+        {{- if .Values.config.upstream.responseHeaderTimeout }}
+        response-header-timeout: {{ .Values.config.upstream.responseHeaderTimeout | quote }}
+        {{- end }}
+
+      {{- if .Values.config.upstream.netrcFile }}
+      netrc-file: {{ .Values.config.upstream.netrcFile | quote }}
+      {{- else if .Values.config.upstream.existingNetrcSecret }}
+      netrc-file: "/etc/ncps/netrc"
+      {{- end }}
+
+      storage:
+        {{- if eq .Values.config.storage.type "local" }}
+        local: {{ .Values.config.storage.local.path | quote }}
+        {{- else if eq .Values.config.storage.type "s3" }}
+        s3:
+          bucket: {{ .Values.config.storage.s3.bucket | quote }}
+          endpoint: {{ .Values.config.storage.s3.endpoint | quote }}
+          region: {{ .Values.config.storage.s3.region | quote }}
+          use-ssl: {{ .Values.config.storage.s3.useSSL }}
+        {{- end }}
+
+      {{- if .Values.config.redis.enabled }}
+      redis:
+        addrs:
+        {{- range .Values.config.redis.addresses }}
+          - {{ . | quote }}
+        {{- end }}
+        {{- if .Values.config.redis.username }}
+        username: {{ .Values.config.redis.username | quote }}
+        {{- end }}
+        db: {{ .Values.config.redis.db }}
+        use-tls: {{ .Values.config.redis.useTLS }}
+        pool-size: {{ .Values.config.redis.poolSize }}
+        key-prefix: {{ .Values.config.redis.keyPrefix | quote }}
+      lock:
+        download-lock-ttl: {{ .Values.config.redis.lock.downloadTTL | quote }}
+        lru-lock-ttl: {{ .Values.config.redis.lock.lruTTL | quote }}
+        retry:
+          max-attempts: {{ .Values.config.redis.lock.retry.maxAttempts }}
+          initial-delay: {{ .Values.config.redis.lock.retry.initialDelay | quote }}
+          max-delay: {{ .Values.config.redis.lock.retry.maxDelay | quote }}
+          jitter: {{ .Values.config.redis.lock.retry.jitter }}
+        {{- if .Values.config.redis.lock.allowDegradedMode }}
+        allow-degraded-mode: true
+        {{- end }}
+      {{- end }}
+
+    server:
+      addr: {{ .Values.config.server.addr | quote }}
+
+    log:
+      level: {{ .Values.config.logLevel | quote }}
+
+    {{- if .Values.config.observability.opentelemetry.enabled }}
+    opentelemetry:
+      grpc-url: {{ .Values.config.observability.opentelemetry.grpcURL | quote }}
+    {{- end }}
+
+    {{- if .Values.config.observability.prometheus.enabled }}
+    prometheus:
+      enabled: true
+    {{- end }}

--- a/charts/ncps/templates/deployment.yaml
+++ b/charts/ncps/templates/deployment.yaml
@@ -1,0 +1,234 @@
+{{- if eq .Values.mode "deployment" -}}
+{{- include "ncps.validate" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ncps.fullname" . }}
+  labels:
+    {{- include "ncps.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ncps.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "ncps.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ncps.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if or (eq .Values.config.database.type "sqlite") (and .Values.migration.enabled (eq .Values.migration.mode "initContainer")) .Values.initContainers }}
+      initContainers:
+        {{- if eq .Values.config.database.type "sqlite" }}
+        - name: create-db-dir
+          image: {{ include "ncps.initImage" . }}
+          imagePullPolicy: {{ .Values.initImage.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p $(dirname {{ .Values.config.database.sqlite.path }})
+          volumeMounts:
+            {{- if or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite") }}
+            - name: storage
+              mountPath: /storage
+            {{- end }}
+            - name: tmp
+              mountPath: {{ .Values.config.cache.tempPath }}
+          resources:
+            {{- toYaml .Values.initImage.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+        {{- end }}
+        {{- if and .Values.migration.enabled (eq .Values.migration.mode "initContainer") }}
+        - name: migration
+          securityContext:
+            {{- toYaml .Values.migration.securityContext | nindent 12 }}
+          image: {{ include "ncps.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/dbmate
+          args:
+            - up
+          env:
+            {{- include "ncps.migrationDatabaseURLEnv" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.migration.resources | nindent 12 }}
+          volumeMounts:
+            {{- if or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite") }}
+            - name: storage
+              mountPath: /storage
+            {{- end }}
+            - name: tmp
+              mountPath: {{ .Values.config.cache.tempPath }}
+        {{- end }}
+        {{- with .Values.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: ncps
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "ncps.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/ncps
+          args:
+            - serve
+            - --config
+            - /etc/ncps/config.yaml
+            {{- if or .Values.config.signing.secretKey .Values.config.signing.existingSecret }}
+            - --cache-secret-key-file
+            - /etc/ncps/secrets/signing-key
+            {{- end }}
+          env:
+            {{- if eq .Values.config.database.type "sqlite" }}
+            - name: CACHE_DATABASE_URL
+              value: {{ include "ncps.databaseURL" . | quote }}
+            {{- else if or (and (eq .Values.config.database.type "postgresql") .Values.config.database.postgresql.password) (and (eq .Values.config.database.type "mysql") .Values.config.database.mysql.password) }}
+            - name: CACHE_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ncps.fullname" . }}
+                  key: database-url
+            {{- else if and (eq .Values.config.database.type "postgresql") .Values.config.database.postgresql.existingSecret }}
+            - name: CACHE_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.database.postgresql.existingSecret }}
+                  key: database-url
+            {{- else if and (eq .Values.config.database.type "mysql") .Values.config.database.mysql.existingSecret }}
+            - name: CACHE_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.database.mysql.existingSecret }}
+                  key: database-url
+            {{- end }}
+            {{- include "ncps.databaseEnv" . | nindent 12 }}
+            {{- if and (eq .Values.config.storage.type "s3") (or .Values.config.storage.s3.existingSecret (and .Values.config.storage.s3.accessKeyId .Values.config.storage.s3.secretAccessKey)) }}
+            - name: CACHE_STORAGE_S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.storage.s3.existingSecret | default (include "ncps.fullname" .) }}
+                  key: {{ if .Values.config.storage.s3.existingSecret }}"access-key-id"{{ else }}"s3-access-key-id"{{ end }}
+            - name: CACHE_STORAGE_S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.storage.s3.existingSecret | default (include "ncps.fullname" .) }}
+                  key: {{ if .Values.config.storage.s3.existingSecret }}"secret-access-key"{{ else }}"s3-secret-access-key"{{ end }}
+            {{- end }}
+            {{- if .Values.config.redis.enabled }}
+            {{- if and .Values.config.redis.existingSecret (not .Values.config.redis.username) }}
+            - name: NCPS_CACHE_REDIS_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.redis.existingSecret }}
+                  key: username
+                  optional: true
+            {{- end }}
+            {{- if or .Values.config.redis.existingSecret .Values.config.redis.password }}
+            - name: NCPS_CACHE_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.redis.existingSecret | default (include "ncps.fullname" .) }}
+                  key: {{ if .Values.config.redis.existingSecret }}"password"{{ else }}"redis-password"{{ end }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.extraEnvVars }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.server.addr | trimPrefix ":" | regexFind "[0-9]+$" | atoi }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/ncps
+              readOnly: true
+            - name: tmp
+              mountPath: {{ .Values.config.cache.tempPath }}
+            {{- if or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite") }}
+            - name: storage
+              mountPath: /storage
+            {{- end }}
+            {{- if or .Values.config.signing.secretKey .Values.config.signing.existingSecret }}
+            - name: signing-key
+              mountPath: /etc/ncps/secrets
+              readOnly: true
+            {{- end }}
+            {{- if or .Values.config.upstream.netrcFile .Values.config.upstream.existingNetrcSecret }}
+            - name: netrc
+              mountPath: /etc/ncps/netrc
+              subPath: netrc
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- with .Values.sidecars }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "ncps.fullname" . }}
+        - name: tmp
+          emptyDir: {}
+        {{- if or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite") }}
+        - name: storage
+          {{- if or .Values.config.storage.local.persistence.enabled (eq .Values.config.database.type "sqlite") }}
+          persistentVolumeClaim:
+            claimName: {{ include "ncps.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
+        {{- if or .Values.config.signing.secretKey .Values.config.signing.existingSecret }}
+        - name: signing-key
+          secret:
+            secretName: {{ .Values.config.signing.existingSecret | default (printf "%s-signing-key" (include "ncps.fullname" .)) }}
+        {{- end }}
+        {{- if or .Values.config.upstream.netrcFile .Values.config.upstream.existingNetrcSecret }}
+        - name: netrc
+          secret:
+            secretName: {{ .Values.config.upstream.existingNetrcSecret | default (include "ncps.fullname" .) }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/ncps/templates/ingress.yaml
+++ b/charts/ncps/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ncps.fullname" . }}
+  labels:
+    {{- include "ncps.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "ncps.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/ncps/templates/migration-job.yaml
+++ b/charts/ncps/templates/migration-job.yaml
@@ -1,0 +1,114 @@
+{{- if and .Values.migration.enabled (or (eq .Values.migration.mode "job") (eq .Values.migration.mode "argocd")) }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "ncps.fullname" . }}-migration
+  labels:
+    {{- include "ncps.labels" . | nindent 4 }}
+    app.kubernetes.io/component: migration
+  annotations:
+    {{- if eq .Values.migration.mode "job" }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- else if eq .Values.migration.mode "argocd" }}
+    "argocd.argoproj.io/hook": PreSync
+    "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation
+    {{- end }}
+    {{- with .Values.migration.job.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.migration.job.backoffLimit }}
+  {{- if .Values.migration.job.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.migration.job.ttlSecondsAfterFinished }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "ncps.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migration
+    spec:
+      restartPolicy: OnFailure
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ncps.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.migration.job.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.migration.job.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.migration.job.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if eq .Values.config.database.type "sqlite" }}
+      initContainers:
+        - name: create-db-dir
+          image: {{ include "ncps.initImage" . }}
+          imagePullPolicy: {{ .Values.initImage.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p $(dirname {{ .Values.config.database.sqlite.path }})
+          volumeMounts:
+            {{- if or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite") }}
+            - name: storage
+              mountPath: /storage
+            {{- end }}
+            - name: tmp
+              mountPath: {{ .Values.config.cache.tempPath }}
+          resources:
+            {{- toYaml .Values.initImage.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+      {{- end }}
+      containers:
+        - name: migration
+          securityContext:
+            {{- toYaml .Values.migration.securityContext | nindent 12 }}
+          image: {{ include "ncps.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/dbmate
+          args:
+            - up
+          env:
+            {{- include "ncps.migrationDatabaseURLEnv" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.migration.resources | nindent 12 }}
+          volumeMounts:
+            {{- if or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite") }}
+            - name: storage
+              mountPath: /storage
+            {{- end }}
+            - name: tmp
+              mountPath: {{ .Values.config.cache.tempPath }}
+      volumes:
+        {{- if or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite") }}
+        - name: storage
+          {{- if or .Values.config.storage.local.persistence.enabled (eq .Values.config.database.type "sqlite") }}
+          persistentVolumeClaim:
+            claimName: {{ include "ncps.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/charts/ncps/templates/poddisruptionbudget.yaml
+++ b/charts/ncps/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "ncps.fullname" . }}
+  labels:
+    {{- include "ncps.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "ncps.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/ncps/templates/pvc.yaml
+++ b/charts/ncps/templates/pvc.yaml
@@ -1,0 +1,27 @@
+{{- if and (eq .Values.mode "deployment") (or (and (eq .Values.config.storage.type "local") .Values.config.storage.local.persistence.enabled) (eq .Values.config.database.type "sqlite")) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ncps.fullname" . }}
+  labels:
+    {{- include "ncps.labels" . | nindent 4 }}
+  {{- with .Values.config.storage.local.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- range .Values.config.storage.local.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.config.storage.local.persistence.size | quote }}
+  {{- if .Values.config.storage.local.persistence.storageClassName }}
+  storageClassName: {{ .Values.config.storage.local.persistence.storageClassName | quote }}
+  {{- end }}
+  {{- with .Values.config.storage.local.persistence.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/ncps/templates/secret-signing-key.yaml
+++ b/charts/ncps/templates/secret-signing-key.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.config.signing.secretKey (not .Values.config.signing.existingSecret) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ncps.fullname" . }}-signing-key
+  labels:
+    {{- include "ncps.labels" . | nindent 4 }}
+type: Opaque
+data:
+  signing-key: {{ .Values.config.signing.secretKey | b64enc | quote }}
+{{- end }}

--- a/charts/ncps/templates/secret.yaml
+++ b/charts/ncps/templates/secret.yaml
@@ -1,0 +1,45 @@
+{{- if or
+  (and (eq .Values.config.storage.type "s3") (not .Values.config.storage.s3.existingSecret) .Values.config.storage.s3.accessKeyId .Values.config.storage.s3.secretAccessKey)
+  (and (eq .Values.config.database.type "postgresql") (not .Values.config.database.postgresql.existingSecret) .Values.config.database.postgresql.password)
+  (and (eq .Values.config.database.type "mysql") (not .Values.config.database.mysql.existingSecret) .Values.config.database.mysql.password)
+  (and .Values.config.redis.enabled (not .Values.config.redis.existingSecret) (or .Values.config.redis.password .Values.config.redis.username))
+  (and .Values.config.upstream.netrcFile (not .Values.config.upstream.existingNetrcSecret))
+-}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ncps.fullname" . }}
+  labels:
+    {{- include "ncps.labels" . | nindent 4 }}
+  {{- if and .Values.migration.enabled (eq .Values.migration.mode "job") }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
+type: Opaque
+data:
+  {{- if and (eq .Values.config.storage.type "s3") (not .Values.config.storage.s3.existingSecret) .Values.config.storage.s3.accessKeyId .Values.config.storage.s3.secretAccessKey }}
+  s3-access-key-id: {{ .Values.config.storage.s3.accessKeyId | b64enc | quote }}
+  s3-secret-access-key: {{ .Values.config.storage.s3.secretAccessKey | b64enc | quote }}
+  {{- end }}
+  {{- if and (eq .Values.config.database.type "postgresql") (not .Values.config.database.postgresql.existingSecret) .Values.config.database.postgresql.password }}
+  postgres-password: {{ .Values.config.database.postgresql.password | b64enc | quote }}
+  database-url: {{ printf "postgresql://%s:%s@%s:%d/%s?sslmode=%s%s" (.Values.config.database.postgresql.username | urlquery) (.Values.config.database.postgresql.password | urlquery) .Values.config.database.postgresql.host (.Values.config.database.postgresql.port | int) .Values.config.database.postgresql.database .Values.config.database.postgresql.sslMode (ternary (printf "&%s" .Values.config.database.postgresql.extraParams) "" (ne .Values.config.database.postgresql.extraParams "")) | b64enc | quote }}
+  {{- end }}
+  {{- if and (eq .Values.config.database.type "mysql") (not .Values.config.database.mysql.existingSecret) .Values.config.database.mysql.password }}
+  mysql-password: {{ .Values.config.database.mysql.password | b64enc | quote }}
+  database-url: {{ printf "mysql://%s:%s@%s:%d/%s%s" (.Values.config.database.mysql.username | urlquery) (.Values.config.database.mysql.password | urlquery) .Values.config.database.mysql.host (.Values.config.database.mysql.port | int) .Values.config.database.mysql.database (ternary (printf "?%s" .Values.config.database.mysql.extraParams) "" (ne .Values.config.database.mysql.extraParams "")) | b64enc | quote }}
+  {{- end }}
+  {{- if and .Values.config.redis.enabled (not .Values.config.redis.existingSecret) }}
+  {{- if .Values.config.redis.password }}
+  redis-password: {{ .Values.config.redis.password | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.config.redis.username }}
+  redis-username: {{ .Values.config.redis.username | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if and .Values.config.upstream.netrcFile (not .Values.config.upstream.existingNetrcSecret) }}
+  netrc: {{ .Values.config.upstream.netrcFile | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/ncps/templates/service.yaml
+++ b/charts/ncps/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ncps.fullname" . }}
+  labels:
+    {{- include "ncps.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: {{ .Values.service.portName }}
+  selector:
+    {{- include "ncps.selectorLabels" . | nindent 4 }}

--- a/charts/ncps/templates/serviceaccount.yaml
+++ b/charts/ncps/templates/serviceaccount.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ncps.serviceAccountName" . }}
+  labels:
+    {{- include "ncps.labels" . | nindent 4 }}
+  {{- if or .Values.serviceAccount.annotations (and .Values.migration.enabled (eq .Values.migration.mode "job")) }}
+  annotations:
+    {{- if and .Values.migration.enabled (eq .Values.migration.mode "job") }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- if .Values.serviceAccount.automountServiceAccountToken }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}
+{{- end }}

--- a/charts/ncps/templates/servicemonitor.yaml
+++ b/charts/ncps/templates/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "ncps.fullname" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    {{- include "ncps.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "ncps.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: {{ .Values.service.portName }}
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      path: /metrics
+{{- end }}

--- a/charts/ncps/templates/statefulset.yaml
+++ b/charts/ncps/templates/statefulset.yaml
@@ -1,0 +1,254 @@
+{{- if eq .Values.mode "statefulset" -}}
+{{- include "ncps.validate" . -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "ncps.fullname" . }}
+  labels:
+    {{- include "ncps.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "ncps.fullname" . }}
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ncps.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "ncps.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ncps.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if or (eq .Values.config.database.type "sqlite") (and .Values.migration.enabled (eq .Values.migration.mode "initContainer")) .Values.initContainers }}
+      initContainers:
+        {{- if eq .Values.config.database.type "sqlite" }}
+        - name: create-db-dir
+          image: {{ include "ncps.initImage" . }}
+          imagePullPolicy: {{ .Values.initImage.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p $(dirname {{ .Values.config.database.sqlite.path }})
+          volumeMounts:
+            {{- if eq .Values.config.storage.type "local" }}
+            - name: storage
+              mountPath: /storage
+            {{- end }}
+            - name: tmp
+              mountPath: {{ .Values.config.cache.tempPath }}
+          resources:
+            {{- toYaml .Values.initImage.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+        {{- end }}
+        {{- if and .Values.migration.enabled (eq .Values.migration.mode "initContainer") }}
+        - name: migration
+          securityContext:
+            {{- toYaml .Values.migration.securityContext | nindent 12 }}
+          image: {{ include "ncps.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/dbmate
+          args:
+            - up
+          env:
+            {{- include "ncps.migrationDatabaseURLEnv" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.migration.resources | nindent 12 }}
+          volumeMounts:
+            {{- if eq .Values.config.storage.type "local" }}
+            - name: storage
+              mountPath: /storage
+            {{- end }}
+            - name: tmp
+              mountPath: {{ .Values.config.cache.tempPath }}
+        {{- end }}
+        {{- with .Values.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: ncps
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "ncps.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/ncps
+          args:
+            - serve
+            - --config
+            - /etc/ncps/config.yaml
+            {{- if or .Values.config.signing.secretKey .Values.config.signing.existingSecret }}
+            - --cache-secret-key-file
+            - /etc/ncps/secrets/signing-key
+            {{- end }}
+          env:
+            {{- if eq .Values.config.database.type "sqlite" }}
+            - name: CACHE_DATABASE_URL
+              value: {{ include "ncps.databaseURL" . | quote }}
+            {{- else if or (and (eq .Values.config.database.type "postgresql") .Values.config.database.postgresql.password) (and (eq .Values.config.database.type "mysql") .Values.config.database.mysql.password) }}
+            - name: CACHE_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ncps.fullname" . }}
+                  key: database-url
+            {{- else if and (eq .Values.config.database.type "postgresql") .Values.config.database.postgresql.existingSecret }}
+            - name: CACHE_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.database.postgresql.existingSecret }}
+                  key: database-url
+            {{- else if and (eq .Values.config.database.type "mysql") .Values.config.database.mysql.existingSecret }}
+            - name: CACHE_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.database.mysql.existingSecret }}
+                  key: database-url
+            {{- end }}
+            {{- include "ncps.databaseEnv" . | nindent 12 }}
+            {{- if and (eq .Values.config.storage.type "s3") (or .Values.config.storage.s3.existingSecret (and .Values.config.storage.s3.accessKeyId .Values.config.storage.s3.secretAccessKey)) }}
+            - name: CACHE_STORAGE_S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.storage.s3.existingSecret | default (include "ncps.fullname" .) }}
+                  key: {{ if .Values.config.storage.s3.existingSecret }}"access-key-id"{{ else }}"s3-access-key-id"{{ end }}
+            - name: CACHE_STORAGE_S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.storage.s3.existingSecret | default (include "ncps.fullname" .) }}
+                  key: {{ if .Values.config.storage.s3.existingSecret }}"secret-access-key"{{ else }}"s3-secret-access-key"{{ end }}
+            {{- end }}
+            {{- if .Values.config.redis.enabled }}
+            {{- if and .Values.config.redis.existingSecret (not .Values.config.redis.username) }}
+            - name: NCPS_CACHE_REDIS_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.redis.existingSecret }}
+                  key: username
+                  optional: true
+            {{- end }}
+            {{- if or .Values.config.redis.existingSecret .Values.config.redis.password }}
+            - name: NCPS_CACHE_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.redis.existingSecret | default (include "ncps.fullname" .) }}
+                  key: {{ if .Values.config.redis.existingSecret }}"password"{{ else }}"redis-password"{{ end }}
+            {{- end }}
+            {{- end }}
+            {{- with .Values.extraEnvVars }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.server.addr | trimPrefix ":" | regexFind "[0-9]+$" | atoi }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/ncps
+              readOnly: true
+            - name: tmp
+              mountPath: {{ .Values.config.cache.tempPath }}
+            {{- if or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite") }}
+            - name: storage
+              mountPath: /storage
+            {{- end }}
+            {{- if or .Values.config.signing.secretKey .Values.config.signing.existingSecret }}
+            - name: signing-key
+              mountPath: /etc/ncps/secrets
+              readOnly: true
+            {{- end }}
+            {{- if or .Values.config.upstream.netrcFile .Values.config.upstream.existingNetrcSecret }}
+            - name: netrc
+              mountPath: /etc/ncps/netrc
+              subPath: netrc
+              readOnly: true
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        {{- with .Values.sidecars }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "ncps.fullname" . }}
+        - name: tmp
+          emptyDir: {}
+        {{- if and (eq .Values.config.storage.type "local") (not .Values.config.storage.local.persistence.enabled) }}
+        - name: storage
+          emptyDir: {}
+        {{- end }}
+        {{- if or .Values.config.signing.secretKey .Values.config.signing.existingSecret }}
+        - name: signing-key
+          secret:
+            secretName: {{ .Values.config.signing.existingSecret | default (printf "%s-signing-key" (include "ncps.fullname" .)) }}
+        {{- end }}
+        {{- if or .Values.config.upstream.netrcFile .Values.config.upstream.existingNetrcSecret }}
+        - name: netrc
+          secret:
+            secretName: {{ .Values.config.upstream.existingNetrcSecret | default (include "ncps.fullname" .) }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if and (eq .Values.config.storage.type "local") .Values.config.storage.local.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+        {{- with .Values.config.storage.local.persistence.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- range .Values.config.storage.local.persistence.accessModes }}
+          - {{ . | quote }}
+          {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.config.storage.local.persistence.size | quote }}
+        {{- if .Values.config.storage.local.persistence.storageClassName }}
+        storageClassName: {{ .Values.config.storage.local.persistence.storageClassName | quote }}
+        {{- end }}
+        {{- with .Values.config.storage.local.persistence.selector }}
+        selector:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/ncps/templates/tests/test-connection.yaml
+++ b/charts/ncps/templates/tests/test-connection.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.tests.enabled -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "ncps.fullname" . }}-test-connection"
+  labels:
+    {{- include "ncps.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "ncps.fullname" . }}:{{ .Values.service.port }}/healthz']
+  restartPolicy: Never
+{{- end }}

--- a/charts/ncps/values.schema.json
+++ b/charts/ncps/values.schema.json
@@ -1,0 +1,599 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "global": {
+      "type": "object",
+      "properties": {
+        "imageRegistry": {
+          "type": "string",
+          "description": "Global image registry override"
+        }
+      }
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Number of replicas"
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["deployment", "statefulset"],
+      "description": "Deployment mode"
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "registry": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        },
+        "tag": {
+          "type": "string"
+        }
+      }
+    },
+    "config": {
+      "type": "object",
+      "required": ["hostname"],
+      "properties": {
+        "hostname": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Cache hostname (REQUIRED)"
+        },
+        "logLevel": {
+          "type": "string",
+          "enum": ["trace", "debug", "info", "warn", "error", "fatal", "panic"],
+          "description": "Logging level"
+        },
+        "server": {
+          "type": "object",
+          "properties": {
+            "addr": {
+              "type": "string",
+              "description": "Server listen address"
+            }
+          }
+        },
+        "permissions": {
+          "type": "object",
+          "properties": {
+            "allowPut": {
+              "type": "boolean"
+            },
+            "allowDelete": {
+              "type": "boolean"
+            }
+          }
+        },
+        "signing": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "secretKey": {
+              "type": "string"
+            },
+            "existingSecret": {
+              "type": "string"
+            }
+          }
+        },
+        "cache": {
+          "type": "object",
+          "properties": {
+            "maxSize": {
+              "type": "string",
+              "pattern": "^([0-9]+[BKMGT])?$",
+              "description": "Maximum cache size (e.g., 100G)"
+            },
+            "lruSchedule": {
+              "type": "string",
+              "description": "LRU cleanup cron schedule"
+            },
+            "lruTimezone": {
+              "type": "string"
+            },
+            "tempPath": {
+              "type": "string"
+            }
+          }
+        },
+        "storage": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["local", "s3"]
+            },
+            "local": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "persistence": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "storageClassName": {
+                      "type": "string"
+                    },
+                    "accessModes": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "size": {
+                      "type": "string"
+                    },
+                    "annotations": {
+                      "type": "object"
+                    },
+                    "selector": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            },
+            "s3": {
+              "type": "object",
+              "properties": {
+                "bucket": {
+                  "type": "string"
+                },
+                "endpoint": {
+                  "type": "string"
+                },
+                "region": {
+                  "type": "string"
+                },
+                "useSSL": {
+                  "type": "boolean"
+                },
+                "accessKeyId": {
+                  "type": "string"
+                },
+                "secretAccessKey": {
+                  "type": "string"
+                },
+                "existingSecret": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "database": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["sqlite", "postgresql", "mysql"]
+            },
+            "sqlite": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string"
+                }
+              }
+            },
+            "postgresql": {
+              "type": "object",
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "port": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                },
+                "database": {
+                  "type": "string"
+                },
+                "username": {
+                  "type": "string"
+                },
+                "password": {
+                  "type": "string"
+                },
+                "sslMode": {
+                  "type": "string",
+                  "enum": ["disable", "require", "verify-ca", "verify-full"]
+                },
+                "existingSecret": {
+                  "type": "string"
+                },
+                "extraParams": {
+                  "type": "string"
+                }
+              }
+            },
+            "mysql": {
+              "type": "object",
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "port": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535
+                },
+                "database": {
+                  "type": "string"
+                },
+                "username": {
+                  "type": "string"
+                },
+                "password": {
+                  "type": "string"
+                },
+                "existingSecret": {
+                  "type": "string"
+                },
+                "extraParams": {
+                  "type": "string"
+                }
+              }
+            },
+            "pool": {
+              "type": "object",
+              "properties": {
+                "maxOpenConns": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "maxIdleConns": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              }
+            }
+          }
+        },
+        "upstream": {
+          "type": "object",
+          "properties": {
+            "caches": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": ["url", "publicKey"],
+                "properties": {
+                  "url": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "publicKey": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "dialerTimeout": {
+              "type": "string"
+            },
+            "responseHeaderTimeout": {
+              "type": "string"
+            },
+            "netrcFile": {
+              "type": "string"
+            },
+            "existingNetrcSecret": {
+              "type": "string"
+            }
+          }
+        },
+        "redis": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "addresses": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "username": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "existingSecret": {
+              "type": "string"
+            },
+            "db": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 15
+            },
+            "useTLS": {
+              "type": "boolean"
+            },
+            "poolSize": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "keyPrefix": {
+              "type": "string"
+            },
+            "lock": {
+              "type": "object",
+              "properties": {
+                "downloadTTL": {
+                  "type": "string"
+                },
+                "lruTTL": {
+                  "type": "string"
+                },
+                "retry": {
+                  "type": "object",
+                  "properties": {
+                    "maxAttempts": {
+                      "type": "integer",
+                      "minimum": 1
+                    },
+                    "initialDelay": {
+                      "type": "string"
+                    },
+                    "maxDelay": {
+                      "type": "string"
+                    },
+                    "jitter": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "allowDegradedMode": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "observability": {
+          "type": "object",
+          "properties": {
+            "opentelemetry": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "grpcURL": {
+                  "type": "string"
+                }
+              }
+            },
+            "prometheus": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "portName": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "sessionAffinity": {
+          "type": "string",
+          "enum": ["None", "ClientIP"]
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "className": {
+          "type": "string"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "pathType": {
+                      "type": "string",
+                      "enum": ["Prefix", "Exact", "ImplementationSpecific"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array"
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "limits": {
+          "type": "object"
+        },
+        "requests": {
+          "type": "object"
+        }
+      }
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "labels": {
+          "type": "object"
+        },
+        "interval": {
+          "type": "string"
+        },
+        "scrapeTimeout": {
+          "type": "string"
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        }
+      }
+    },
+    "podSecurityContext": {
+      "type": "object"
+    },
+    "securityContext": {
+      "type": "object"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minAvailable": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "maxUnavailable": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "migration": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable database migration"
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["initContainer", "job", "argocd"],
+          "description": "Migration mode: initContainer, job (Helm hook), or argocd (ArgoCD hook)"
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resources for migration container/job"
+        },
+        "securityContext": {
+          "type": "object",
+          "description": "Security context for migration container/job"
+        },
+        "job": {
+          "type": "object",
+          "properties": {
+            "backoffLimit": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Backoff limit for job retries"
+            },
+            "ttlSecondsAfterFinished": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "TTL after job finishes (in seconds)"
+            },
+            "annotations": {
+              "type": "object",
+              "description": "Annotations for the job"
+            },
+            "nodeSelector": {
+              "type": "object",
+              "description": "Node selector for migration job"
+            },
+            "tolerations": {
+              "type": "array",
+              "description": "Tolerations for migration job"
+            },
+            "affinity": {
+              "type": "object",
+              "description": "Affinity for migration job"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/ncps/values.yaml
+++ b/charts/ncps/values.yaml
@@ -1,0 +1,452 @@
+# Default values for ncps.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Global configuration
+global:
+  # Image registry override (if needed)
+  imageRegistry: ""
+
+# Number of replicas
+# For HA mode, set to 2 or more
+# For single instance, set to 1
+replicaCount: 1
+
+# Deployment mode: "deployment" or "statefulset"
+# - deployment: For HA mode with S3 storage
+# - statefulset: For single instance with local storage or HA with persistent state
+mode: statefulset
+
+image:
+  registry: docker.io
+  repository: kalbasit/ncps
+  pullPolicy: IfNotPresent
+  # Overrides the image tag (default is chart appVersion)
+  tag: ""
+
+# Init image for directory creation (used for SQLite)
+initImage:
+  registry: docker.io
+  repository: busybox
+  tag: "1.37.0"
+  pullPolicy: IfNotPresent
+  # Resources for directory creation init container
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 32Mi
+    # requests:
+    #   cpu: 10m
+    #   memory: 16Mi
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # Automatically mount service account token
+  automountServiceAccountToken: false
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  fsGroupChangePolicy: "OnRootMismatch"
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+
+config:
+  # Cache hostname (REQUIRED)
+  # Used for key generation and signing
+  hostname: "ncps.example.com"
+
+  # Logging level
+  logLevel: "info"  # trace, debug, info, warn, error, fatal, panic
+
+  # Server configuration
+  server:
+    # Listen address (format: :port or ip:port)
+    addr: ":8501"
+
+  # Cache permissions
+  permissions:
+    # Allow PUT verb to push narInfo and nar files directly
+    allowPut: false
+    # Allow DELETE verb to delete narInfo and nar files
+    allowDelete: false
+
+  # NAR info signing
+  signing:
+    # Whether to sign narInfo files
+    enabled: true
+    # Signing key (provided via secret if not auto-generated)
+    # Leave empty to auto-generate
+    secretKey: ""
+    # Existing secret containing signing key
+    # Key name must be "signing-key"
+    existingSecret: ""
+
+  # Cache size management
+  cache:
+    # Maximum cache size (with units: B, K, M, G, T)
+    # Example: "100G", "5T"
+    # Leave empty for unlimited
+    maxSize: ""
+
+    # LRU cleanup schedule (cron expression)
+    # Example: "0 0 * * *" (daily at midnight)
+    # Leave empty to disable
+    lruSchedule: ""
+
+    # Timezone for cron schedule
+    # Example: "America/Los_Angeles", "UTC"
+    lruTimezone: "Local"
+
+    # Temporary directory for downloads
+    # Mounted as emptyDir volume
+    tempPath: "/tmp/ncps"
+
+  # Storage backend (choose ONE)
+  storage:
+    # Storage type: "local" or "s3"
+    type: "local"
+
+    # Local filesystem storage
+    local:
+      # Path for local storage
+      path: "/storage"
+      # Persistent volume configuration (only for local storage)
+      persistence:
+        enabled: true
+        # Storage class (leave empty for default)
+        storageClassName: ""
+        accessModes:
+          - ReadWriteOnce
+        size: 20Gi
+        # Annotations for PVC
+        annotations: {}
+        # Selector for specific PV
+        selector: {}
+
+    # S3-compatible storage
+    s3:
+      # S3 bucket name
+      bucket: ""
+      # S3 endpoint (e.g., s3.amazonaws.com or http://minio:9000)
+      endpoint: ""
+      # S3 region
+      region: "us-east-1"
+      # Use SSL/TLS
+      useSSL: true
+      # S3 credentials (provided via secret)
+      accessKeyId: ""
+      secretAccessKey: ""
+      # Existing secret containing S3 credentials
+      # Keys: "access-key-id" and "secret-access-key"
+      existingSecret: ""
+
+  # Database configuration
+  database:
+    # Database type: "sqlite", "postgresql", or "mysql"
+    type: "sqlite"
+
+    # SQLite configuration
+    sqlite:
+      # Path for SQLite database file
+      path: "/storage/db/ncps.db"
+
+    # PostgreSQL configuration
+    postgresql:
+      # PostgreSQL connection details
+      host: ""
+      port: 5432
+      database: "ncps"
+      username: "ncps"
+      password: ""
+      # SSL mode: disable, require, verify-ca, verify-full
+      sslMode: "disable"
+      # Existing secret containing PostgreSQL password
+      # Key name must be "password"
+      existingSecret: ""
+      # Additional connection parameters (e.g., "connect_timeout=10")
+      extraParams: ""
+
+    # MySQL configuration
+    mysql:
+      # MySQL connection details
+      host: ""
+      port: 3306
+      database: "ncps"
+      username: "ncps"
+      password: ""
+      # Existing secret containing MySQL password
+      # Key name must be "password"
+      existingSecret: ""
+      # Additional connection parameters (e.g., "timeout=10s")
+      extraParams: ""
+
+    # Connection pool settings
+    pool:
+      # Maximum open connections (0 = unlimited)
+      # SQLite: always 1 (cannot be changed)
+      # PostgreSQL/MySQL: default 25
+      maxOpenConns: 0
+      # Maximum idle connections
+      # Default: 5 for PostgreSQL/MySQL
+      maxIdleConns: 0
+
+  # Upstream cache configuration
+  upstream:
+    # List of upstream caches
+    caches:
+      - url: "https://cache.nixos.org"
+        publicKey: "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+
+    # Connection timeouts
+    dialerTimeout: "3s"
+    responseHeaderTimeout: "3s"
+
+    # Netrc file for authentication (optional)
+    # Provided via secret if needed
+    netrcFile: ""
+    # Existing secret containing netrc file
+    # Key name must be "netrc"
+    existingNetrcSecret: ""
+
+  # Redis configuration (for HA mode)
+  redis:
+    # Enable Redis distributed locking
+    # Required for HA deployments with multiple replicas
+    enabled: false
+
+    # Redis connection
+    addresses:
+      - "redis:6379"
+
+    # Authentication
+    username: ""
+    password: ""
+    # Existing secret containing Redis credentials
+    # Keys: "username" (optional) and "password"
+    existingSecret: ""
+
+    # Database number (0-15)
+    db: 0
+
+    # Use TLS
+    useTLS: false
+
+    # Connection pool size
+    poolSize: 10
+
+    # Key prefix for locks
+    keyPrefix: "ncps:lock:"
+
+    # Lock configuration
+    lock:
+      # Download lock TTL
+      downloadTTL: "5m"
+      # LRU lock TTL
+      lruTTL: "30m"
+
+      # Retry configuration
+      retry:
+        maxAttempts: 3
+        initialDelay: "100ms"
+        maxDelay: "2s"
+        jitter: true
+
+      # Degraded mode (emergency fallback)
+      # WARNING: Breaks HA guarantees
+      allowDegradedMode: false
+
+  # Observability
+  observability:
+    # OpenTelemetry
+    opentelemetry:
+      enabled: false
+      # gRPC collector URL
+      # Examples:
+      #   - http://otel-collector:4317 (insecure)
+      #   - https://otel-collector:4317 (secure)
+      #   - "" (stdout)
+      grpcURL: ""
+
+    # Prometheus metrics
+    prometheus:
+      enabled: false
+
+service:
+  type: ClusterIP
+  port: 8501
+  # Port name for service discovery
+  portName: http
+  annotations: {}
+  # Session affinity for HA deployments
+  # Options: None, ClientIP
+  sessionAffinity: None
+
+ingress:
+  enabled: false
+  className: "nginx"
+  annotations: {}
+    # cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    # nginx.ingress.kubernetes.io/proxy-body-size: "0"
+  hosts:
+    - host: ncps.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+    # - secretName: ncps-tls
+    #   hosts:
+    #     - ncps.example.com
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 3
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
+# Prometheus ServiceMonitor
+serviceMonitor:
+  enabled: false
+  # Namespace for ServiceMonitor (defaults to release namespace)
+  namespace: ""
+  # Additional labels for ServiceMonitor
+  labels: {}
+  # Scrape interval
+  interval: 30s
+  # Scrape timeout
+  scrapeTimeout: 10s
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+  # Example for HA anti-affinity:
+  # podAntiAffinity:
+  #   preferredDuringSchedulingIgnoredDuringExecution:
+  #     - weight: 100
+  #       podAffinityTerm:
+  #         labelSelector:
+  #           matchExpressions:
+  #             - key: app.kubernetes.io/name
+  #               operator: In
+  #               values:
+  #                 - ncps
+  #         topologyKey: kubernetes.io/hostname
+
+# Extra environment variables
+extraEnvVars: []
+  # - name: CUSTOM_VAR
+  #   value: "custom-value"
+
+# Extra volumes
+extraVolumes: []
+
+# Extra volume mounts
+extraVolumeMounts: []
+
+# Init containers
+initContainers: []
+
+# Sidecar containers
+sidecars: []
+
+# Database migration
+migration:
+  # Enable database migration
+  enabled: false
+
+  # Migration mode:
+  # - "initContainer": Run as init container in each pod (default, safest)
+  # - "job": Run as a Job with Helm hook (pre-install, pre-upgrade)
+  # - "argocd": Run as a Job with ArgoCD pre-sync hook
+  mode: "initContainer"
+
+  # Resources for migration container/job
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
+  # Security context for migration container/job
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+
+  # Job configuration (only applies when mode is "job" or "argocd")
+  job:
+    # Backoff limit for job retries
+    backoffLimit: 3
+
+    # TTL after job finishes (in seconds)
+    # Set to 0 to keep jobs indefinitely
+    ttlSecondsAfterFinished: 300
+
+    # Annotations for the job
+    annotations: {}
+
+    # Node selector for migration job
+    nodeSelector: {}
+
+    # Tolerations for migration job
+    tolerations: []
+
+    # Affinity for migration job
+    affinity: {}
+
+# Helm tests
+# NOTE: Only enable when using `helm install`/`helm upgrade` with `helm test`
+# When using `helm template` (manually or via tools like nixidy), keep disabled
+# to prevent the test pod from being rendered as a regular resource
+tests:
+  enabled: false


### PR DESCRIPTION
# Add Helm Chart for ncps (Nix Cache Proxy Server)

This PR adds a comprehensive Helm chart for deploying ncps (Nix Cache Proxy Server) on Kubernetes. The chart supports both single-instance and high-availability deployments with various configuration options.

Key features:
- Flexible deployment options (Deployment or StatefulSet)
- Multiple storage backends (local filesystem or S3)
- Database options (SQLite, PostgreSQL, MySQL)
- High-availability mode with Redis-based distributed locking
- Prometheus metrics and ServiceMonitor integration
- Ingress configuration with TLS support
- Comprehensive documentation and examples

The PR also adds a GitHub workflow for automated Helm chart releases, which:
- Triggers on `helm-v*` tags
- Updates chart version based on tag
- Packages and publishes the chart to GitHub Container Registry
- Creates a GitHub release with installation instructions

Additionally, the PR updates the Claude settings to allow Helm-related commands and updates the YAML formatting configuration to reference the new chart directory.