### PR TITLE
feat: Add ncps user to Docker container

### DIFF
--- a/nix/packages/docker.nix
+++ b/nix/packages/docker.nix
@@ -34,6 +34,7 @@
               name = "passwd";
               text = ''
                 root:x:0:0:Super User:/homeless-shelter:/dev/null
+                ncps:x:1000:1000:NCPS:/homeless-shelter:/dev/null
               '';
               destination = "/etc/passwd";
             };
@@ -42,6 +43,7 @@
               name = "group";
               text = ''
                 root:x:0:
+                ncps:x:1000:
               '';
               destination = "/etc/group";
             };


### PR DESCRIPTION
### TL;DR

Added an `ncps` user and group to the Docker container configuration.

### What changed?

- Added a new user `ncps` with UID/GID 1000 to the `/etc/passwd` file in the Docker container
- Added a new group `ncps` with GID 1000 to the `/etc/group` file in the Docker container

### Why make this change?

Adding a dedicated non-root user improves container security by allowing processes to run with fewer privileges. The `ncps` user with UID 1000 follows the convention for the first non-root user in Linux systems and provides a specific identity for NCPS-related processes.