### PR TITLE
fix: Clear DNS search paths in kind cluster configuration

### DIFF
--- a/dev-scripts/k8s-cluster.sh
+++ b/dev-scripts/k8s-cluster.sh
@@ -189,6 +189,8 @@ create_cluster() {
         cat <<EOF | kind create cluster --name "$CLUSTER_NAME" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+# Disable DNS search path inheritance from the host to prevent resolution
+# issues, particularly on systems like NixOS.
 networking:
   dnsSearch: []
 nodes:


### PR DESCRIPTION
Disable DNS search in Kind cluster to prevent DNS resolution issues

This PR disables DNS search in the Kind cluster configuration by adding `networking.dnsSearch: []` to the cluster spec. This prevents potential DNS resolution issues that can occur when the host's search domains are inherited by containers in the cluster.

This fixes the cluster on NixOS.

