### PR TITLE
fix: Improve dbmate wrapper setup in Docker container

### DIFF
--- a/nix/packages/docker.nix
+++ b/nix/packages/docker.nix
@@ -60,8 +60,14 @@
             pkgs.tzdata
 
             # required for migrating the database
-            pkgs.dbmate
-            config.packages.dbmate-wrapper
+            # Use real dbmate for the wrapper to call
+            (pkgs.writeShellScriptBin "dbmate.real" ''
+              exec ${pkgs.dbmate}/bin/dbmate "$@"
+            '')
+            # dbmate-wrapper provides the dbmate command
+            (pkgs.writeShellScriptBin "dbmate" ''
+              exec ${config.packages.dbmate-wrapper}/bin/dbmate-wrapper "$@"
+            '')
 
             # the ncps package
             package-ncps
@@ -96,11 +102,6 @@
           #!${pkgs.runtimeShell}
           mkdir -p tmp
           chmod -R 1777 tmp
-
-          # Rename real dbmate binary and create symlink to dbmate-wrapper
-          # The wrapper auto-detects the migrations directory based on the database URL
-          mv bin/dbmate bin/dbmate.real
-          ln -s dbmate-wrapper bin/dbmate
         '';
       };
 


### PR DESCRIPTION
Refactored dbmate setup in Docker image to use shell script wrappers instead of symlinks. This approach creates dedicated shell scripts for both `dbmate` and `dbmate.real`, eliminating the need for post-installation file renaming and symlinking. The functionality remains the same, with the wrapper auto-detecting the migrations directory based on the database URL, but the implementation is now cleaner and more explicit.