### PR TITLE
feat: Read DATABASE_URL from environment in dbmate wrapper

### DIFF
--- a/nix/dbmate-wrapper/src/main.go
+++ b/nix/dbmate-wrapper/src/main.go
@@ -13,10 +13,11 @@ func main() {
 }
 
 func run() int {
-	// Parse args to find --url value and check if --migrations-dir is provided
-	var dbURL string
+	// Parse the database URL from the environment.
+	dbURL := os.Getenv("DATABASE_URL")
 
-	hasMigrationsDir := false
+	// Parse args to find --url value and check if --migrations-dir is provided
+	var hasMigrationsDir bool
 
 	for i, arg := range os.Args[1:] {
 		if arg == "--url" && i+1 < len(os.Args)-1 {


### PR DESCRIPTION
This PR modifies the `dbmate-wrapper` to prioritize the `DATABASE_URL` environment variable when determining the database connection URL. Previously, the wrapper only looked for the URL in command-line arguments, but now it first checks the environment variable and uses that as the default value. The PR also improves variable initialization by directly declaring `hasMigrationsDir` as a boolean with a default value of `false`.

This makes it work in the same way dbmate itself works by honoring --url and DATABASE_URL.

