### PR TITLE
fix: Use writeShellScriptBin for push-docker-image script

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,7 +92,7 @@ jobs:
           DOCKER_IMAGE_TAGS: ${{ needs.docker-meta.outputs.tags }}
         shell: bash
         run: |
-          ./result
+          ./result/bin/push-docker-image
   docker-manifest:
     if: inputs.push_images
     runs-on: ubuntu-24.04

--- a/nix/packages/docker.nix
+++ b/nix/packages/docker.nix
@@ -105,7 +105,7 @@
         '';
       };
 
-      packages.push-docker-image = pkgs.writeShellScript "push-docker-image" ''
+      packages.push-docker-image = pkgs.writeShellScriptBin "push-docker-image" ''
         set -euo pipefail
 
         if [[ ! -v DOCKER_IMAGE_TAGS ]]; then


### PR DESCRIPTION
# Fix Docker image push script packaging

This PR fixes the Docker image push script by changing it from a shell script to a binary executable. The script is now properly packaged using `writeShellScriptBin` instead of `writeShellScript` in the Nix configuration, and the workflow has been updated to call the script from its new location at `./result/bin/push-docker-image` instead of directly executing `./result`. This PR makes it possible to run the command `nix run .#push-docker-image` which was not working before.

fixes #409