### PR TITLE
fix: Helm release workflow regex matching versions

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -25,19 +25,23 @@ jobs:
       - name: Extract version info
         id: extract_version
         run: |
+          set -euo pipefail
           TAG_REF=${GITHUB_REF#refs/tags/}
 
           # Regex to match helm-v{CHART}-app-v{APP}
-          # This captures everything between 'helm-v' and '-app-v' as group 1
-          # and everything after '-app-v' as group 2.
           REGEX="^helm-v(.*)-app-v(.*)$"
 
-          CHART_VERSION="${BASH_REMATCH[1]}"
-          APP_VERSION="${BASH_REMATCH[2]}"
+          if [[ "$TAG_REF" =~ $REGEX ]]; then
+            CHART_VERSION="${BASH_REMATCH[1]}"
+            APP_VERSION="${BASH_REMATCH[2]}"
 
-          echo "Detected Strategy: Decoupled"
-          echo "Chart Version: $CHART_VERSION"
-          echo "App Version:   $APP_VERSION"
+            echo "Detected Strategy: Decoupled"
+            echo "Chart Version: $CHART_VERSION"
+            echo "App Version:   $APP_VERSION"
+          else
+            echo "::error::Tag '$TAG_REF' does not match expected format 'helm-v*-app-v*'"
+            exit 1
+          fi
 
           echo "chart_version=$CHART_VERSION" >> $GITHUB_OUTPUT
           echo "app_version=$APP_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Improved error handling in Helm release workflow

This PR enhances the version extraction logic in the Helm release GitHub Action by:

1. Adding proper error handling when the tag format doesn't match the expected pattern
2. Adding the `set -euo pipefail` directive to ensure the script fails on errors
3. Wrapping the version extraction in a conditional to verify the regex match before using the captured groups

These changes will prevent silent failures and provide clearer error messages when tags don't follow the required `helm-v{CHART}-app-v{APP}` format.