### PR TITLE
feat: Add project logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://github.com/kalbasit/ncps/raw/main/docs/images/logo.svg" alt="ncps logo" width="200"/>
+</p>
+
 # ncps: Nix Cache Proxy Server
 
 > A high-performance proxy server that accelerates Nix dependency retrieval across your local network

--- a/docs/images/logo.svg
+++ b/docs/images/logo.svg
@@ -1,0 +1,17 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <title>NCPS Logo</title>
+  <desc>Logo for the Nix Cache Proxy Server (NCPS) project. It features a hexagonal design with a download arrow and the letters NCPS.</desc>
+  <rect width="512" height="512" rx="100" fill="#24292e"/>
+
+  <g transform="translate(0, -40)">
+    <path d="M256 60L425.7 158V354L256 452L86.3 354V158L256 60Z" stroke="#7ebae4" stroke-width="20" fill="none"/>
+
+    <path d="M176 300L336 300" stroke="#ffffff" stroke-width="24" stroke-linecap="round"/>
+    <path d="M176 360L336 360" stroke="#ffffff" stroke-width="24" stroke-linecap="round"/>
+
+    <path d="M190 220L256 150L322 220" stroke="#5277c3" stroke-width="30" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <path d="M256 260V150" stroke="#5277c3" stroke-width="30" stroke-linecap="round"/>
+  </g>
+
+  <text x="50%" y="480" text-anchor="middle" font-family="monospace" font-weight="bold" font-size="60" fill="#7ebae4" letter-spacing="4">NCPS</text>
+</svg>


### PR DESCRIPTION
Added logo to the README

This PR adds a new logo for the ncps project. The logo features a hexagonal design with download arrows and horizontal lines, rendered in Nix blue and white colors on a dark background. The logo is placed at the top of the README file for better project branding.