### PR TITLE
refactor: Extract common locking and transaction patterns into helper methods

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -324,18 +324,18 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadClose
 			WithContext(ctx)
 
 		if c.narStore.HasNar(ctx, narURL) {
-            metricAttrs = append(metricAttrs,
-                attribute.String("result", "hit"),
-            )
+			metricAttrs = append(metricAttrs,
+				attribute.String("result", "hit"),
+			)
 
-            var err error
+			var err error
 
-            size, reader, err = c.getNarFromStore(ctx, &narURL)
-            if err != nil {
-                metricAttrs = append(metricAttrs, attribute.String("status", "error"))
-            } else {
-                metricAttrs = append(metricAttrs, attribute.String("status", "success"))
-            }
+			size, reader, err = c.getNarFromStore(ctx, &narURL)
+			if err != nil {
+				metricAttrs = append(metricAttrs, attribute.String("status", "error"))
+			} else {
+				metricAttrs = append(metricAttrs, attribute.String("status", "success"))
+			}
 
 			return err
 		}


### PR DESCRIPTION
# Refactor Cache Operations with Helper Functions

This PR refactors the cache operations by introducing two helper functions to reduce code duplication and improve maintainability:

1. `withReadLock` - Encapsulates the pattern of acquiring and releasing read locks for cache operations
2. `withTransaction` - Handles database transaction lifecycle (begin, commit, rollback)

The changes apply these helper functions across multiple cache operations:
- GetNar
- PutNar
- DeleteNar
- GetNarInfo
- PutNarInfo
- DeleteNarInfo

Additionally, the PR improves the structure of the `GetNar` function by using variable declarations at the beginning and returning values only at the end of the function, making the control flow more consistent.

These changes make the code more maintainable by eliminating repeated lock handling and transaction management patterns while preserving the same functionality.