### PR TITLE
refactor: Extract NAR download logic into separate helper functions

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -730,6 +730,8 @@ func (c *Cache) pullNarIntoStore(
 		return
 	}
 
+	defer f.Close()
+
 	ds.assetPath = f.Name()
 
 	// Track download completion for cleanup synchronization
@@ -759,8 +761,6 @@ func (c *Cache) pullNarIntoStore(
 
 		return
 	}
-
-	f.Close()
 
 	written, err := c.storeNarFromTempFile(ctx, ds.assetPath, narURL)
 	if err != nil {


### PR DESCRIPTION
# Refactor NAR download process into modular functions

This PR refactors the NAR download process in the cache package by extracting functionality into three clear helper methods:

1. `createTempNarFile` - Creates a temporary file for storing the NAR during download and sets up cleanup
2. `streamResponseToFile` - Handles streaming HTTP response data to the file in chunks while updating download state
3. `storeNarFromTempFile` - Reopens the temporary file and stores it in the NAR store

The refactoring improves code organization and readability by breaking down the monolithic `pullNarIntoStore` function into smaller, focused components with clear responsibilities. Error handling remains consistent with the original implementation.