### PR TITLE
refactor: Improve LRU cache cleanup with modular functions

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1808,6 +1808,41 @@ func (c *Cache) withReadLock(ctx context.Context, operation string, fn func() er
 }
 
 // calculateCleanupSize validates the total NAR size and calculates how much needs to be cleaned up.
+// Returns 0 if no cleanup is needed.
+func (c *Cache) calculateCleanupSize(ctx context.Context, qtx database.Querier, log zerolog.Logger) (uint64, error) {
+	narTotalSize, err := qtx.GetNarTotalSize(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("error fetching the total nar size")
+
+		return 0, err
+	}
+
+	if narTotalSize == 0 {
+		log.Info().Msg("SUM(file_size) is zero, nothing to clean up")
+
+		return 0, nil
+	}
+
+	log = log.With().Int64("nar_total_size", narTotalSize).Logger()
+
+	//nolint:gosec
+	if uint64(narTotalSize) <= c.maxSize {
+		log.Info().Msg("store size is less than max-size, not removing any nars")
+
+		return 0, nil
+	}
+
+	//nolint:gosec
+	cleanupSize := uint64(narTotalSize) - c.maxSize
+
+	log = log.With().Uint64("cleanup_size", cleanupSize).Logger()
+	log.Info().Msg("going to remove nars")
+
+	return cleanupSize, nil
+}
+
+// deleteLRURecordsFromDB gets the least used NARs and deletes them from the database.
+// Returns the narinfo hashes and NAR URLs that need to be deleted from stores.
 func (c *Cache) deleteLRURecordsFromDB(
 	ctx context.Context,
 	qtx database.Querier,
@@ -1843,8 +1878,10 @@ func (c *Cache) deleteLRURecordsFromDB(
 					Err(err).
 					Int64("ID", narRecord.NarInfoID).
 					Msg("error fetching narinfo from the database")
+
 				return nil, nil, err
 			}
+
 			log.Warn().
 				Err(err).
 				Int64("ID", narRecord.NarInfoID).
@@ -1857,6 +1894,7 @@ func (c *Cache) deleteLRURecordsFromDB(
 					Err(err).
 					Str("narinfo_hash", narInfo.Hash).
 					Msg("error removing narinfo from database")
+
 				return nil, nil, err
 			}
 
@@ -1870,42 +1908,8 @@ func (c *Cache) deleteLRURecordsFromDB(
 				Err(err).
 				Str("nar_hash", narRecord.Hash).
 				Msg("error removing nar from database")
+
 			return nil, nil, err
-		}
-
-		// NOTE: we don't need the query when working with store so it's
-		// explicitly omitted.
-		narURLsToRemove = append(narURLsToRemove, nar.URL{
-			Hash:        narRecord.Hash,
-			Compression: nar.CompressionTypeFromString(narRecord.Compression),
-		})
-	}
-
-	return narInfoHashesToRemove, narURLsToRemove, nil
-}
-
-			if _, err := qtx.DeleteNarInfoByHash(ctx, narInfo.Hash); err != nil {
-				log.Error().
-					Err(err).
-					Str("narinfo_hash", narInfo.Hash).
-					Msg("error removing narinfo from database")
-			}
-
-			narInfoHashesToRemove = append(narInfoHashesToRemove, narInfo.Hash)
-		} else {
-			log.Error().
-				Err(err).
-				Int64("ID", narRecord.NarInfoID).
-				Msg("error fetching narinfo from the database")
-		}
-
-		log.Info().Str("nar_hash", narRecord.Hash).Msg("deleting nar record")
-
-		if _, err := qtx.DeleteNarByHash(ctx, narRecord.Hash); err != nil {
-			log.Error().
-				Err(err).
-				Str("nar_hash", narRecord.Hash).
-				Msg("error removing nar from database")
 		}
 
 		// NOTE: we don't need the query when working with store so it's


### PR DESCRIPTION
# Refactor LRU Cleanup Logic for Better Maintainability

This PR refactors the LRU (Least Recently Used) cleanup logic in the cache package by extracting functionality into separate methods:

1. Added `calculateCleanupSize` to validate total NAR size and determine how much needs to be cleaned up
2. Added `deleteLRURecordsFromDB` to handle database operations for removing least used NARs
3. Added `parallelDeleteFromStores` to manage parallel deletion of narinfos and nars from stores

The main improvement is that the transaction is now committed before deleting from stores, which ensures database consistency even if store deletions fail. The code is also more modular and easier to test.