### PR TITLE
fix: Use HEAD instead of GET method in HasNar function

### DIFF
--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -458,7 +458,7 @@ func (c *Cache) HasNar(ctx context.Context, narURL nar.URL, mutators ...func(*ht
 		Info().
 		Msg("heading the nar from upstream")
 
-	resp, err := c.doRequest(ctx, http.MethodGet, u, mutators...)
+	resp, err := c.doRequest(ctx, http.MethodHead, u, mutators...)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Fixed `HasNar` method to use HTTP HEAD instead of GET

This PR fixes a bug in the `HasNar` method where it was incorrectly using an HTTP GET request instead of HEAD when checking for the existence of a NAR file from upstream. Using HEAD is more efficient as it only retrieves the headers without downloading the entire file content.

closes #427

