### PR TITLE
fix: Add missing enabled flag to OpenTelemetry configuration

### DIFF
--- a/charts/ncps/templates/configmap.yaml
+++ b/charts/ncps/templates/configmap.yaml
@@ -105,6 +105,7 @@ data:
 
     {{- if .Values.config.observability.opentelemetry.enabled }}
     opentelemetry:
+      enabled: true
       grpc-url: {{ .Values.config.observability.opentelemetry.grpcURL | quote }}
     {{- end }}
 


### PR DESCRIPTION
Added `enabled: true` flag to the OpenTelemetry configuration in the NCPS Helm chart. This ensures that when OpenTelemetry is enabled via the values file, the generated configuration explicitly includes the enabled flag, making the configuration more consistent and explicit.