### PR TITLE
feat: Add init container, database migration, and security context enhancements

### DIFF
--- a/charts/ncps/README.md
+++ b/charts/ncps/README.md
@@ -144,9 +144,9 @@ The following table lists the configurable parameters of the ncps chart and thei
 | `config.storage.local.persistence.annotations` | PVC annotations | `{}` |
 | `config.storage.local.persistence.selector` | PV selector | `{}` |
 | `config.storage.s3.bucket` | S3 bucket name | `""` |
-| `config.storage.s3.endpoint` | S3 endpoint | `""` |
+| `config.storage.s3.endpoint` | S3 endpoint with scheme (https:// or http://) | `""` |
 | `config.storage.s3.region` | S3 region | `us-east-1` |
-| `config.storage.s3.useSSL` | Use SSL/TLS | `true` |
+| `config.storage.s3.forcePathStyle` | Force path-style addressing (required for MinIO) | `false` |
 | `config.storage.s3.accessKeyId` | S3 access key ID | `""` |
 | `config.storage.s3.secretAccessKey` | S3 secret access key | `""` |
 | `config.storage.s3.existingSecret` | Existing secret with S3 credentials | `""` |
@@ -325,9 +325,8 @@ config:
     type: s3
     s3:
       bucket: my-nix-cache
-      endpoint: s3.amazonaws.com
+      endpoint: https://s3.amazonaws.com
       region: us-west-2
-      useSSL: true
       accessKeyId: AKIA...
       secretAccessKey: secret...
   database:
@@ -353,9 +352,8 @@ config:
     type: s3
     s3:
       bucket: my-nix-cache-ha
-      endpoint: s3.amazonaws.com
+      endpoint: https://s3.amazonaws.com
       region: us-west-2
-      useSSL: true
       accessKeyId: AKIA...
       secretAccessKey: secret...
   database:

--- a/charts/ncps/templates/configmap.yaml
+++ b/charts/ncps/templates/configmap.yaml
@@ -70,7 +70,9 @@ data:
           bucket: {{ .Values.config.storage.s3.bucket | quote }}
           endpoint: {{ .Values.config.storage.s3.endpoint | quote }}
           region: {{ .Values.config.storage.s3.region | quote }}
-          use-ssl: {{ .Values.config.storage.s3.useSSL }}
+          {{- if .Values.config.storage.s3.forcePathStyle }}
+          force-path-style: true
+          {{- end }}
         {{- end }}
 
       {{- if .Values.config.redis.enabled }}

--- a/charts/ncps/values.schema.json
+++ b/charts/ncps/values.schema.json
@@ -160,7 +160,7 @@
                 "region": {
                   "type": "string"
                 },
-                "useSSL": {
+                "forcePathStyle": {
                   "type": "boolean"
                 },
                 "accessKeyId": {

--- a/charts/ncps/values.yaml
+++ b/charts/ncps/values.yaml
@@ -150,12 +150,14 @@ config:
     s3:
       # S3 bucket name
       bucket: ""
-      # S3 endpoint (e.g., s3.amazonaws.com or http://minio:9000)
+      # S3 endpoint with scheme (e.g., https://s3.amazonaws.com or http://minio:9000)
+      # The scheme (https:// or http://) determines SSL usage
       endpoint: ""
       # S3 region
       region: "us-east-1"
-      # Use SSL/TLS
-      useSSL: true
+      # Force path-style S3 addressing (bucket/key vs key.bucket)
+      # Required for MinIO, optional for AWS S3
+      forcePathStyle: false
       # S3 credentials (provided via secret)
       accessKeyId: ""
       secretAccessKey: ""

--- a/docs/installation/helm.md
+++ b/docs/installation/helm.md
@@ -146,7 +146,6 @@ config:
       bucket: my-ncps-cache
       endpoint: https://s3.amazonaws.com
       region: us-east-1
-      useSSL: true
       accessKeyId: YOUR_ACCESS_KEY
       secretAccessKey: YOUR_SECRET_KEY
 
@@ -175,7 +174,6 @@ config:
       bucket: my-ncps-cache
       endpoint: https://s3.amazonaws.com
       region: us-east-1
-      useSSL: true
       accessKeyId: YOUR_ACCESS_KEY
       secretAccessKey: YOUR_SECRET_KEY
 
@@ -388,7 +386,6 @@ config:
       bucket: my-ncps-cache
       endpoint: https://s3.amazonaws.com
       region: us-east-1
-      useSSL: true
       accessKeyId: YOUR_ACCESS_KEY
       secretAccessKey: YOUR_SECRET_KEY
 ```
@@ -403,7 +400,7 @@ config:
       bucket: ncps
       endpoint: http://minio.minio.svc.cluster.local:9000
       region: us-east-1
-      useSSL: false
+      forcePathStyle: true  # Required for MinIO
       accessKeyId: minioadmin
       secretAccessKey: minioadmin
 ```
@@ -535,7 +532,6 @@ config:
       bucket: ncps-production
       endpoint: https://s3.amazonaws.com
       region: us-east-1
-      useSSL: true
 
   database:
     type: postgresql
@@ -667,7 +663,7 @@ kubectl -n ncps logs job/ncps-migration
 **S3 connection errors:**
 
 - Verify S3 credentials and endpoint
-- For MinIO, ensure `forcePathStyle: true` is set
+- For MinIO, ensure `config.storage.s3.forcePathStyle: true` is set
 - Check endpoint includes proper scheme (http:// or https://)
 
 ## Complete Values Reference


### PR DESCRIPTION
# Enhanced Helm Chart Configuration Options

This PR adds several new configuration options to the NCPS Helm chart:

- Added init image configuration parameters for customizing the init container
- Added database migration support with three modes: initContainer, job, and argocd
- Enhanced security context settings with seccomp profile, capabilities, and fsGroup change policy
- Expanded PostgreSQL and MySQL database configuration with support for:
    - Full connection strings via existing secrets
    - Additional connection parameters
    - Better documentation of connection string building
- Added support for existing PVC claims for local storage
- Added PVC annotations and selector options for persistent storage
- Improved documentation with clearer examples for database configuration
- Remove old useSSL flag that was removed in a previous version
- Expose the flag forcePathStyle that was recently added to the package but not to the chart.

These changes provide more flexibility for production deployments while maintaining backward compatibility.