### PR TITLE
fix: Reorder NCPS command line arguments to place serve after config

### DIFF
--- a/charts/ncps/templates/deployment.yaml
+++ b/charts/ncps/templates/deployment.yaml
@@ -91,9 +91,9 @@ spec:
           command:
             - /bin/ncps
           args:
-            - serve
             - --config
             - /etc/ncps/config.yaml
+            - serve
             {{- if and (ne .Values.config.signing.enabled false) (or .Values.config.signing.secretKey .Values.config.signing.existingSecret) }}
             - --cache-secret-key-file
             - /etc/ncps/secrets/signing-key

--- a/charts/ncps/templates/statefulset.yaml
+++ b/charts/ncps/templates/statefulset.yaml
@@ -92,9 +92,9 @@ spec:
           command:
             - /bin/ncps
           args:
-            - serve
             - --config
             - /etc/ncps/config.yaml
+            - serve
             {{- if and (ne .Values.config.signing.enabled false) (or .Values.config.signing.secretKey .Values.config.signing.existingSecret) }}
             - --cache-secret-key-file
             - /etc/ncps/secrets/signing-key


### PR DESCRIPTION
Fix command line argument order in NCPS Helm chart

Reordered the command line arguments in the NCPS Helm chart to place the `serve` command after the `--config` flag and its value. This change ensures the command line arguments are passed in the correct order for the NCPS binary to function properly.