### PR TITLE
fix: Return ErrAlreadyExists instead of nil when narinfo/nar already exist

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -53,6 +53,9 @@ var (
 	// errNarInfoPurged is returned if the narinfo was purged.
 	errNarInfoPurged = errors.New("the narinfo was purged")
 
+	// ErrAlreadyExists is returned when attempting to store a narinfo/nar that already exists in the database.
+	ErrAlreadyExists = errors.New("narinfo or nar already exists")
+
 	//nolint:gochecknoglobals
 	meter metric.Meter
 
@@ -1520,7 +1523,7 @@ func (c *Cache) storeInDatabase(
 					Warn().
 					Msg("narinfo record was not added to database because it already exists")
 
-				return nil
+				return ErrAlreadyExists
 			}
 
 			return fmt.Errorf("error inserting the narinfo record for hash %q in the database: %w", hash, err)
@@ -1544,7 +1547,7 @@ func (c *Cache) storeInDatabase(
 					Warn().
 					Msg("nar record was not added to database because it already exists")
 
-				return nil
+				return ErrAlreadyExists
 			}
 
 			return fmt.Errorf("error inserting the nar record in the database: %w", err)


### PR DESCRIPTION
Introduce `ErrAlreadyExists` error for duplicate narinfo/nar entries

This PR adds a new exported error `ErrAlreadyExists` that is returned when attempting to store a narinfo or nar that already exists in the database. Previously, these cases would return `nil`, making it impossible for callers to distinguish between successful storage and skipping due to existing entries.

The change modifies the `storeInDatabase` method to return this new error instead of `nil` when it encounters duplicate entries, allowing consumers to handle this specific case appropriately.

part of #454