### PR TITLE
fix: Handle storage.ErrAlreadyExists gracefully in cache operations

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -667,7 +667,7 @@ func (c *Cache) storeNarFromTempFile(ctx context.Context, tempPath string, narUR
 			// Already exists is not an error - another request stored it first
 			zerolog.Ctx(ctx).Debug().Msg("nar already exists in storage, skipping")
 
-			return 0, storage.ErrAlreadyExists
+			return 0, nil
 		}
 
 		zerolog.Ctx(ctx).
@@ -795,7 +795,7 @@ func (c *Cache) pullNarIntoStore(
 	}
 
 	written, err := c.storeNarFromTempFile(ctx, ds.assetPath, narURL)
-	if err != nil && !errors.Is(err, storage.ErrAlreadyExists) {
+	if err != nil {
 		ds.setError(err)
 
 		return


### PR DESCRIPTION
# Improve error handling for already existing NAR and NarInfo files

This PR enhances error handling when storing NAR files and NarInfo metadata by properly handling the `storage.ErrAlreadyExists` error case. Instead of treating this as an error condition, the code now:

1. Treats already existing files as a success case for PUT operations
2. Logs appropriate debug messages when skipping already existing files
3. Continues processing in cases where another concurrent request may have stored the file first

This change prevents unnecessary error logs and improves behavior in concurrent scenarios where multiple requests might attempt to store the same file.