### PR TITLE
refactor: Downgrade log levels for upstream cache errors and duplicate narinfo records

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -739,7 +739,7 @@ func (c *Cache) pullNarIntoStore(
 				Msg("error getting the nar from upstream caches")
 		} else {
 			zerolog.Ctx(ctx).
-				Info().
+				Debug().
 				Err(err).
 				Msg("error getting the nar from upstream caches")
 		}
@@ -1608,7 +1608,7 @@ func (c *Cache) storeInDatabase(
 		if err != nil {
 			if database.IsDuplicateKeyError(err) {
 				zerolog.Ctx(ctx).
-					Warn().
+					Debug().
 					Msg("nar record was not added to database because it already exists")
 
 				return ErrAlreadyExists


### PR DESCRIPTION
Changed log levels for two error messages in the cache package. The first change reduces the log level from "Info" to "Debug" for errors when retrieving narInfo from upstream caches. The second change reduces the log level from "Warn" to "Debug" for the message about narinfo records already existing in the database. These changes help reduce log verbosity for common, non-critical events.