### PR TITLE
docs: Add GitHub sponsor badge and support section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,7 @@ See the [Deployment Guide](docs/deployment/) for detailed setup instructions.
 
 If you find `ncps` useful, please consider supporting its development! Sponsoring helps maintain the project, fund new features, and ensure long-term sustainability.
 
-<a href="https://github.com/sponsors/kalbasit">
-  <img src="https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86" alt="Sponsor this project" />
-</a>
+[![Sponsor this project](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/kalbasit)
 
 ## Contributing
 


### PR DESCRIPTION
### TL;DR

Added GitHub sponsorship information to the README.

### What changed?

- Added a GitHub sponsor badge to the top of the README
- Added a new "Support the Project" section with information about sponsorship
- Improved table formatting in the Installation Methods section
- Added a "Sponsor" link to the footer navigation

### How to test?

- Verify the sponsor badge appears correctly at the top of the README
- Check that the new "Support the Project" section is properly formatted
- Confirm the sponsor link in the footer works correctly
- Ensure the installation methods table displays properly with the updated formatting

### Why make this change?

This change adds sponsorship options to help sustain the project's development. By providing clear pathways for users to financially support the project, we can ensure continued maintenance, feature development, and long-term sustainability.