### PR TITLE
refactor: Remove projectRootFile from treefmt configuration

### DIFF
--- a/nix/formatter/flake-module.nix
+++ b/nix/formatter/flake-module.nix
@@ -4,9 +4,6 @@
 
   perSystem = {
     treefmt = {
-      # Used to find the project root
-      projectRootFile = ".git/config";
-
       settings.global.excludes = [
         ".env"
         ".envrc"


### PR DESCRIPTION
Removed `projectRootFile` configuration from treefmt settings as it's no longer needed to find the project root.