### PR TITLE
fix: Use subPath for config and signing-key volume mounts

### DIFF
--- a/charts/ncps/templates/deployment.yaml
+++ b/charts/ncps/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/signing-key-secret: {{ include (print $.Template.BasePath "/secret-signing-key.yaml") . | sha256sum }}
       labels:
         {{- include "ncps.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/ncps/templates/statefulset.yaml
+++ b/charts/ncps/templates/statefulset.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        checksum/signing-key-secret: {{ include (print $.Template.BasePath "/secret-signing-key.yaml") . | sha256sum }}
       labels:
         {{- include "ncps.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
This PR updates the volume mount configuration in both deployment and statefulset templates to use `subPath` for more precise mounting. Instead of mounting entire directories, it now mounts specific files:

1. Changed the config volume mount to target `/etc/ncps/config.yaml` with `subPath: config.yaml` instead of mounting to the entire `/etc/ncps` directory
2. Modified the signing-key volume mount to target `/etc/ncps/secrets/signing-key` with `subPath: signing-key` instead of mounting to the entire `/etc/ncps/secrets` directory

These changes provide better isolation between mounted files and prevent potential conflicts when multiple volumes are mounted to the same parent directory.