### PR TITLE
refactor: Remove redundant detectors from telemetry resource

### DIFF
--- a/pkg/telemetry/resource.go
+++ b/pkg/telemetry/resource.go
@@ -36,12 +36,6 @@ func NewResource(
 		// Add Custom attributes.
 		resource.WithAttributes(attrs...),
 
-		// Discover and provide command-line information.
-		resource.WithProcessCommandArgs(),
-
-		// Discover and provide runtime information.
-		resource.WithProcessRuntimeVersion(),
-
 		// Discover and provide attributes from OTEL_RESOURCE_ATTRIBUTES and
 		// OTEL_SERVICE_NAME environment variables.
 		resource.WithFromEnv(),


### PR DESCRIPTION
### TL;DR

Remove process command-line arguments and runtime version detectors, they are already called from within `WithProcess()`.

### What changed?

Removed two resource providers from the `NewResource` function in `pkg/telemetry/resource.go`:

- Removed `resource.WithProcessCommandArgs()` which was adding command-line information
- Removed `resource.WithProcessRuntimeVersion()` which was adding runtime information

The function still includes custom attributes and environment variable-based configuration.