### PR TITLE
feat: Disable analytics reporting in dev script

### DIFF
--- a/dev-scripts/run.py
+++ b/dev-scripts/run.py
@@ -259,6 +259,7 @@ def main():
             "go",
             "run",
             ".",
+            "--analytics-reporting-enabled=false",
             "serve",
             "--cache-allow-put-verb",
             f"--cache-hostname=cache-{i}.example.com",


### PR DESCRIPTION
Disable analytics reporting in the development environment by adding the `--analytics-reporting-enabled=false` flag to the `go run` command in the run script.