### PR TITLE
fix: Update ncps vendorHash path in auto-update workflow

### DIFF
--- a/.github/workflows/auto-update-vendorhash.yaml
+++ b/.github/workflows/auto-update-vendorhash.yaml
@@ -31,7 +31,7 @@ jobs:
             exit 1
           fi
 
-          sed -e "s#vendorHash =.*\$#vendorHash = \"$hash\";#g" -i nix/packages/ncps.nix
+          sed -e "s#vendorHash =.*\$#vendorHash = \"$hash\";#g" -i nix/packages/ncps/default.nix
 
           git diff
       - uses: stefanzweifel/git-auto-commit-action@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,7 +372,7 @@ nix flake check
 nix build
 ```
 
-The Nix build (`nix/packages/ncps.nix`) automatically:
+The Nix build (`nix/packages/ncps/default.nix`) automatically:
 
 1. Starts MinIO, PostgreSQL, MariaDB, and Redis servers in the `preCheck` phase
 1. Creates test databases, buckets, and credentials


### PR DESCRIPTION
Updated path to ncps package in auto-update workflow and documentation

This PR updates references to the ncps Nix package file, changing the path from `nix/packages/ncps.nix` to `nix/packages/ncps/default.nix`. The changes affect:

1. The GitHub workflow for auto-updating vendor hash
2. The documentation in CLAUDE.md that describes the Nix build process