### PR TITLE
fix: Update regex pattern in helm release workflow

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -29,7 +29,7 @@ jobs:
           TAG_REF=${GITHUB_REF#refs/tags/}
 
           # Regex to match helm-v{CHART}-app-v{APP}
-          REGEX="^helm-v(.*)-app-v(.*)$"
+          REGEX="^helm-(v.*)-app-(v.*)$"
 
           if [[ "$TAG_REF" =~ $REGEX ]]; then
             CHART_VERSION="${BASH_REMATCH[1]}"


### PR DESCRIPTION
Fixed regex pattern in helm-release.yaml workflow to correctly extract chart and app versions from tag references. The updated pattern now captures version strings with the 'v' prefix, ensuring proper version extraction from tags formatted as 'helm-v{CHART}-app-v{APP}'. The helm release is now version with the prefix v and more importantly it refers to the ncps package on Dockerhub with the required v prefix.