### PR TITLE
feat: Add PostgreSQL advisory lock backend option

### DIFF
--- a/pkg/cache/cache_distributed_test.go
+++ b/pkg/cache/cache_distributed_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kalbasit/ncps/pkg/cache"
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
 	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/lock"
 	"github.com/kalbasit/ncps/pkg/lock/redis"
 	"github.com/kalbasit/ncps/pkg/nar"
 	"github.com/kalbasit/ncps/pkg/storage/local"
@@ -99,7 +100,7 @@ func TestDistributedDownloadDeduplication(t *testing.T) {
 		KeyPrefix: "ncps:test:dedup:",
 	}
 
-	retryCfg := redis.RetryConfig{
+	retryCfg := lock.RetryConfig{
 		MaxAttempts:  3,
 		InitialDelay: 100 * time.Millisecond,
 		MaxDelay:     2 * time.Second,
@@ -353,7 +354,7 @@ func TestDistributedLockFailover(t *testing.T) {
 		KeyPrefix: "ncps:test:failover:",
 	}
 
-	retryCfg := redis.RetryConfig{
+	retryCfg := lock.RetryConfig{
 		MaxAttempts:  5,
 		InitialDelay: 100 * time.Millisecond,
 		MaxDelay:     1 * time.Second,

--- a/pkg/lock/config.go
+++ b/pkg/lock/config.go
@@ -1,0 +1,30 @@
+package lock
+
+import "time"
+
+// RetryConfig holds retry configuration for lock acquisition.
+// This is used by both Redis and PostgreSQL distributed lock implementations.
+type RetryConfig struct {
+	// MaxAttempts is the maximum number of attempts to acquire a lock.
+	MaxAttempts int
+
+	// InitialDelay is the initial delay between retry attempts.
+	InitialDelay time.Duration
+
+	// MaxDelay is the maximum delay between retry attempts.
+	// Exponential backoff will be capped at this value.
+	MaxDelay time.Duration
+
+	// Jitter enables random jitter in retry delays to prevent thundering herd.
+	Jitter bool
+}
+
+// DefaultRetryConfig returns sensible default retry configuration.
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxAttempts:  3,
+		InitialDelay: 100 * time.Millisecond,
+		MaxDelay:     2 * time.Second,
+		Jitter:       true,
+	}
+}

--- a/pkg/lock/postgres/circuit_breaker_integration_test.go
+++ b/pkg/lock/postgres/circuit_breaker_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kalbasit/ncps/pkg/lock"
 	"github.com/kalbasit/ncps/pkg/lock/postgres"
 )
 
@@ -26,7 +27,7 @@ func TestLocker_CircuitBreakerOpensAfterFailures(t *testing.T) {
 
 	// Create a locker with a low circuit breaker threshold for testing
 	cfg := getTestConfig()
-	retryCfg := postgres.RetryConfig{
+	retryCfg := lock.RetryConfig{
 		MaxAttempts:  2, // Low retry count for faster test
 		InitialDelay: 10 * time.Millisecond,
 		MaxDelay:     50 * time.Millisecond,
@@ -72,7 +73,7 @@ func TestLocker_DegradedModeFallback(t *testing.T) {
 	defer cleanup()
 
 	cfg := getTestConfig()
-	retryCfg := postgres.RetryConfig{
+	retryCfg := lock.RetryConfig{
 		MaxAttempts:  2,
 		InitialDelay: 10 * time.Millisecond,
 		MaxDelay:     50 * time.Millisecond,
@@ -156,7 +157,7 @@ func TestRWLocker_DegradedMode(t *testing.T) {
 	defer cleanup()
 
 	cfg := getTestConfig()
-	retryCfg := postgres.RetryConfig{
+	retryCfg := lock.RetryConfig{
 		MaxAttempts:  2,
 		InitialDelay: 10 * time.Millisecond,
 		MaxDelay:     50 * time.Millisecond,

--- a/pkg/lock/postgres/config.go
+++ b/pkg/lock/postgres/config.go
@@ -1,36 +1,8 @@
 package postgres
 
-import "time"
-
 // Config holds the configuration for PostgreSQL advisory locks.
 type Config struct {
 	// KeyPrefix is prepended to all lock keys for namespacing.
 	// Defaults to "ncps:lock:" if empty.
 	KeyPrefix string
-}
-
-// RetryConfig holds retry configuration for lock acquisition.
-type RetryConfig struct {
-	// MaxAttempts is the maximum number of attempts to acquire a lock.
-	MaxAttempts int
-
-	// InitialDelay is the initial delay between retry attempts.
-	InitialDelay time.Duration
-
-	// MaxDelay is the maximum delay between retry attempts.
-	// Exponential backoff will be capped at this value.
-	MaxDelay time.Duration
-
-	// Jitter enables random jitter in retry delays to prevent thundering herd.
-	Jitter bool
-}
-
-// DefaultRetryConfig returns sensible default retry configuration.
-func DefaultRetryConfig() RetryConfig {
-	return RetryConfig{
-		MaxAttempts:  3,
-		InitialDelay: 100 * time.Millisecond,
-		MaxDelay:     2 * time.Second,
-		Jitter:       true,
-	}
 }

--- a/pkg/lock/postgres/export_test.go
+++ b/pkg/lock/postgres/export_test.go
@@ -1,6 +1,10 @@
 package postgres
 
-import "time"
+import (
+	"time"
+
+	"github.com/kalbasit/ncps/pkg/lock"
+)
 
 // Export internal identifiers for testing.
 func NewCircuitBreaker(threshold int, timeout time.Duration) *circuitBreaker {
@@ -24,7 +28,7 @@ func MockTimeNow(t time.Time) func() {
 	return func() { timeNow = original }
 }
 
-func CalculateBackoff(cfg RetryConfig, attempt int) time.Duration {
+func CalculateBackoff(cfg lock.RetryConfig, attempt int) time.Duration {
 	return calculateBackoff(cfg, attempt)
 }
 

--- a/pkg/lock/postgres/lock_unit_test.go
+++ b/pkg/lock/postgres/lock_unit_test.go
@@ -13,7 +13,7 @@ import (
 func TestCalculateBackoff(t *testing.T) {
 	t.Parallel()
 
-	cfg := postgres.RetryConfig{
+	cfg := lock.RetryConfig{
 		InitialDelay: 100 * time.Millisecond,
 		MaxDelay:     1 * time.Second,
 		Jitter:       false,

--- a/pkg/lock/postgres/locker.go
+++ b/pkg/lock/postgres/locker.go
@@ -30,7 +30,7 @@ const (
 type Locker struct {
 	db                *sql.DB
 	keyPrefix         string
-	retryConfig       RetryConfig
+	retryConfig       lock.RetryConfig
 	allowDegradedMode bool
 
 	// connections tracks dedicated connections for each active lock
@@ -52,7 +52,7 @@ func NewLocker(
 	ctx context.Context,
 	querier database.Querier,
 	cfg Config,
-	retryCfg RetryConfig,
+	retryCfg lock.RetryConfig,
 	allowDegradedMode bool,
 ) (lock.Locker, error) {
 	if querier == nil {
@@ -404,7 +404,7 @@ func (l *Locker) calculateBackoff(attempt int) time.Duration {
 }
 
 // calculateBackoff calculates the backoff duration based on retry config and attempt number.
-func calculateBackoff(cfg RetryConfig, attempt int) time.Duration {
+func calculateBackoff(cfg lock.RetryConfig, attempt int) time.Duration {
 	// Formula: InitialDelay * 2^(attempt-1)
 	delay := cfg.InitialDelay * time.Duration(math.Pow(2, float64(attempt-1)))
 

--- a/pkg/lock/postgres/postgres_test.go
+++ b/pkg/lock/postgres/postgres_test.go
@@ -89,8 +89,8 @@ func getTestConfig() postgres.Config {
 }
 
 // getTestRetryConfig returns a retry configuration for testing.
-func getTestRetryConfig() postgres.RetryConfig {
-	return postgres.RetryConfig{
+func getTestRetryConfig() lock.RetryConfig {
+	return lock.RetryConfig{
 		MaxAttempts:  3,
 		InitialDelay: 50 * time.Millisecond,
 		MaxDelay:     500 * time.Millisecond,
@@ -229,7 +229,7 @@ func TestLocker_RetryWithBackoff(t *testing.T) {
 	defer cleanup()
 
 	cfg := getTestConfig()
-	retryCfg := postgres.RetryConfig{
+	retryCfg := lock.RetryConfig{
 		MaxAttempts:  5,
 		InitialDelay: 100 * time.Millisecond,
 		MaxDelay:     1 * time.Second,

--- a/pkg/lock/postgres/rwlocker.go
+++ b/pkg/lock/postgres/rwlocker.go
@@ -29,7 +29,7 @@ func NewRWLocker(
 	ctx context.Context,
 	querier database.Querier,
 	cfg Config,
-	retryCfg RetryConfig,
+	retryCfg lock.RetryConfig,
 	allowDegradedMode bool,
 ) (lock.RWLocker, error) {
 	locker, err := NewLocker(ctx, querier, cfg, retryCfg, allowDegradedMode)

--- a/pkg/lock/redis/locker.go
+++ b/pkg/lock/redis/locker.go
@@ -25,7 +25,7 @@ type Locker struct {
 	clients           []*redis.Client // All connected Redis clients for HA
 	redsync           *redsync.Redsync
 	keyPrefix         string
-	retryConfig       RetryConfig
+	retryConfig       lock.RetryConfig
 	allowDegradedMode bool
 
 	// mutexes tracks acquired locks for cleanup
@@ -43,7 +43,12 @@ type Locker struct {
 }
 
 // NewLocker creates a new Redis-based locker.
-func NewLocker(ctx context.Context, cfg Config, retryCfg RetryConfig, allowDegradedMode bool) (lock.Locker, error) {
+func NewLocker(
+	ctx context.Context,
+	cfg Config,
+	retryCfg lock.RetryConfig,
+	allowDegradedMode bool,
+) (lock.Locker, error) {
 	if len(cfg.Addrs) == 0 {
 		return nil, ErrNoRedisAddrs
 	}

--- a/pkg/lock/redis/redis.go
+++ b/pkg/lock/redis/redis.go
@@ -14,7 +14,6 @@ package redis
 
 import (
 	"errors"
-	"time"
 )
 
 // Errors returned by Redis lock operations.
@@ -59,19 +58,4 @@ type Config struct {
 
 	// KeyPrefix for all distributed lock keys.
 	KeyPrefix string
-}
-
-// RetryConfig configures retry behavior for lock acquisition.
-type RetryConfig struct {
-	// MaxAttempts is the maximum number of retry attempts.
-	MaxAttempts int
-
-	// InitialDelay is the initial retry delay.
-	InitialDelay time.Duration
-
-	// MaxDelay is the maximum retry delay (exponential backoff caps at this).
-	MaxDelay time.Duration
-
-	// Jitter enables adding random jitter to prevent thundering herd.
-	Jitter bool
 }

--- a/pkg/lock/redis/redis_test.go
+++ b/pkg/lock/redis/redis_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kalbasit/ncps/pkg/lock"
 	"github.com/kalbasit/ncps/pkg/lock/redis"
 )
 
@@ -45,8 +46,8 @@ func getTestConfig() redis.Config {
 }
 
 // getTestRetryConfig returns a retry configuration for testing.
-func getTestRetryConfig() redis.RetryConfig {
-	return redis.RetryConfig{
+func getTestRetryConfig() lock.RetryConfig {
+	return lock.RetryConfig{
 		MaxAttempts:  3,
 		InitialDelay: 50 * time.Millisecond,
 		MaxDelay:     500 * time.Millisecond,
@@ -200,7 +201,7 @@ func TestLocker_RetryWithBackoff(t *testing.T) {
 
 	ctx := context.Background()
 	cfg := getTestConfig()
-	retryCfg := redis.RetryConfig{
+	retryCfg := lock.RetryConfig{
 		MaxAttempts:  5,
 		InitialDelay: 100 * time.Millisecond,
 		MaxDelay:     1 * time.Second,

--- a/pkg/lock/redis/rwlocker.go
+++ b/pkg/lock/redis/rwlocker.go
@@ -23,7 +23,7 @@ import (
 type RWLocker struct {
 	client            redis.UniversalClient // Supports both single-node and cluster
 	keyPrefix         string
-	retryConfig       RetryConfig
+	retryConfig       lock.RetryConfig
 	allowDegradedMode bool
 
 	// readerID stores the unique reader ID for this locker instance
@@ -42,7 +42,12 @@ type RWLocker struct {
 }
 
 // NewRWLocker creates a new Redis-based read-write locker.
-func NewRWLocker(ctx context.Context, cfg Config, retryCfg RetryConfig, allowDegradedMode bool) (lock.RWLocker, error) {
+func NewRWLocker(
+	ctx context.Context,
+	cfg Config,
+	retryCfg lock.RetryConfig,
+	allowDegradedMode bool,
+) (lock.RWLocker, error) {
 	if len(cfg.Addrs) == 0 {
 		return nil, ErrNoRedisAddrs
 	}


### PR DESCRIPTION
# Add PostgreSQL Advisory Lock Support for Distributed Locking

This PR adds PostgreSQL advisory locks as a new distributed locking backend option alongside the existing Redis and local backends. The implementation:

- Introduces a new `--cache-lock-backend` flag with three options:
  - `local` (single instance, default)
  - `redis` (distributed)
  - `postgres` (distributed, requires PostgreSQL)

- Maintains backward compatibility by automatically using Redis if Redis addresses are provided but no explicit backend is specified (with a deprecation warning)

- Refactors the locking system to support multiple backends with consistent configuration

- Adds proper error handling for invalid configurations:
  - `ErrRedisAddrsRequired` when Redis backend is selected without addresses
  - `ErrUnknownLockBackend` when an invalid backend is specified

- Reuses the existing retry configuration across all distributed backends

This change allows users to leverage PostgreSQL advisory locks for distributed locking when they already have a PostgreSQL database configured, potentially simplifying their infrastructure requirements.