### PR TITLE
test: Add PostgreSQL lock behavior and failure tests

### DIFF
--- a/pkg/lock/postgres/behavior_test.go
+++ b/pkg/lock/postgres/behavior_test.go
@@ -1,0 +1,71 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/lock"
+	"github.com/kalbasit/ncps/pkg/lock/postgres"
+)
+
+func TestLocker_LockContentionTimeout(t *testing.T) {
+	t.Parallel()
+
+	skipIfPostgresNotAvailable(t)
+
+	ctx := context.Background()
+
+	querier, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	// Config with low retry count and small delays for fast test
+	cfg := getTestConfig()
+	retryCfg := lock.RetryConfig{
+		MaxAttempts:  3,
+		InitialDelay: 50 * time.Millisecond,
+		MaxDelay:     100 * time.Millisecond,
+		Jitter:       false,
+	}
+
+	locker1, err := postgres.NewLocker(ctx, querier, cfg, retryCfg, false)
+	require.NoError(t, err)
+
+	locker2, err := postgres.NewLocker(ctx, querier, cfg, retryCfg, false)
+	require.NoError(t, err)
+
+	key := getUniqueKey(t, "contention-timeout")
+
+	// 1. Locker1 acquires the lock
+	err = locker1.Lock(ctx, key, 5*time.Second)
+	require.NoError(t, err)
+
+	// 2. Locker2 tries to acquire the same lock
+	// Should attempt 3 times with backoff, then fail with "lock acquisition failed"
+	startTime := time.Now()
+	err = locker2.Lock(ctx, key, 5*time.Second)
+	duration := time.Since(startTime)
+
+	// Verify error
+	require.Error(t, err)
+	require.ErrorIs(t, err, postgres.ErrLockAcquisitionFailed)
+	require.Contains(t, err.Error(), "after 3 attempts")
+
+	// Verify it actually waited (approx 50ms + 100ms = 150ms minimum)
+	// We allow some slop, but it should definitely be > 140ms
+	require.Greater(t, duration, 140*time.Millisecond,
+		"Lock should have waited for ~150ms before failing, took %v", duration)
+
+	// 3. Locker1 unlocks
+	err = locker1.Unlock(ctx, key)
+	require.NoError(t, err)
+
+	// 4. Locker2 can now acquire the lock
+	err = locker2.Lock(ctx, key, 5*time.Second)
+	require.NoError(t, err)
+
+	assert.NoError(t, locker2.Unlock(ctx, key))
+}

--- a/pkg/lock/postgres/export_test.go
+++ b/pkg/lock/postgres/export_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"database/sql"
 	"time"
 
 	"github.com/kalbasit/ncps/pkg/lock"
@@ -35,4 +36,21 @@ func CalculateBackoff(cfg lock.RetryConfig, attempt int) time.Duration {
 // GetCircuitBreaker returns the circuit breaker from a Locker for testing.
 func (l *Locker) GetCircuitBreaker() *circuitBreaker {
 	return l.circuitBreaker
+}
+
+// GetDB returns the underlying sql.DB for testing.
+func (l *Locker) GetDB() *sql.DB {
+	return l.db
+}
+
+// GetAcquisitionTime returns the stored acquisition time for a key, for testing.
+func (l *Locker) GetAcquisitionTime(key string) (time.Time, bool) {
+	val, ok := l.acquisitionTimes.Load(key)
+	if !ok {
+		return time.Time{}, false
+	}
+
+	t, ok := val.(time.Time)
+
+	return t, ok
 }

--- a/pkg/lock/postgres/failure_test.go
+++ b/pkg/lock/postgres/failure_test.go
@@ -1,0 +1,85 @@
+package postgres_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/lock"
+	"github.com/kalbasit/ncps/pkg/lock/postgres"
+)
+
+func TestLocker_CircuitBreaker_DBFailure(t *testing.T) {
+	t.Parallel()
+
+	skipIfPostgresNotAvailable(t)
+
+	ctx := context.Background()
+
+	querier, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	cfg := getTestConfig()
+	retryCfg := lock.RetryConfig{
+		MaxAttempts:  2,
+		InitialDelay: 10 * time.Millisecond,
+		MaxDelay:     50 * time.Millisecond,
+		Jitter:       false,
+	}
+
+	// Disable degraded mode to test circuit breaker error
+	locker, err := postgres.NewLocker(ctx, querier, cfg, retryCfg, false)
+	require.NoError(t, err)
+
+	pgLocker, ok := locker.(*postgres.Locker)
+	require.True(t, ok, "Expected postgres.Locker")
+
+	cb := pgLocker.GetCircuitBreaker()
+	assert.False(t, cb.IsOpen(), "Circuit breaker should be closed initially")
+
+	// Verify lock works initially
+	key := getUniqueKey(t, "cb-failure-test")
+	err = locker.Lock(ctx, key, 1*time.Second)
+	require.NoError(t, err)
+	err = locker.Unlock(ctx, key)
+	require.NoError(t, err)
+
+	// Close the underlying database connection to simulate failure
+	db := pgLocker.GetDB()
+	require.NoError(t, db.Close())
+
+	// Try to acquire a lock - should fail and record failure in circuit breaker
+	// We might need multiple attempts to trip the breaker depending on threshold
+	// The default threshold is 5 (from NewLocker call in locker.go which uses newCircuitBreaker(5, ...))
+	// So we need to fail 5 times.
+	threshold := 5
+
+	// Try to acquire a lock multiple times until circuit breaker opens
+	// Since MaxAttempts > 1, each Lock call records multiple failures
+	circuitOpened := false
+
+	for i := 0; i < threshold*2; i++ {
+		testKey := getUniqueKey(t, "cb-failure-attempt")
+		err := locker.Lock(ctx, testKey, 1*time.Second)
+		require.Error(t, err)
+
+		if errors.Is(err, postgres.ErrCircuitBreakerOpen) {
+			circuitOpened = true
+
+			break
+		}
+
+		require.Contains(t, err.Error(), "database is closed")
+	}
+
+	assert.True(t, circuitOpened, "Circuit breaker should have opened")
+
+	// Next attempt should return ErrCircuitBreakerOpen immediately
+	err = locker.Lock(ctx, getUniqueKey(t, "cb-failure-final"), 1*time.Second)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, postgres.ErrCircuitBreakerOpen)
+}

--- a/pkg/lock/postgres/metrics_test.go
+++ b/pkg/lock/postgres/metrics_test.go
@@ -1,0 +1,93 @@
+package postgres_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/lock"
+	"github.com/kalbasit/ncps/pkg/lock/postgres"
+)
+
+// MockMetricRecorder is a mock for recording metrics
+// We can't easily mock the global lock.RecordLockDuration package function effectively
+// without changing the package structure, but we can verify side effects or
+// ensure that the code path that calls it is executed.
+//
+// However, since we can't mock the package-level functions in `pkg/lock`,
+// we will instead verify that the `acquisitionTimes` map in Locker is populated/cleared correctly,
+// which is the prerequisite for recording duration.
+
+func TestRWLocker_WriteMetrics(t *testing.T) {
+	t.Parallel()
+
+	skipIfPostgresNotAvailable(t)
+
+	ctx := context.Background()
+
+	querier, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	cfg := getTestConfig()
+	retryCfg := lock.RetryConfig{MaxAttempts: 1, InitialDelay: 10 * time.Millisecond, MaxDelay: 50 * time.Millisecond}
+
+	rwLockerInterface, err := postgres.NewRWLocker(ctx, querier, cfg, retryCfg, false)
+	require.NoError(t, err)
+
+	rwLocker := rwLockerInterface.(*postgres.RWLocker)
+
+	key := getUniqueKey(t, "metrics-write")
+
+	// Acquire Write Lock
+	err = rwLocker.Lock(ctx, key, 1*time.Second)
+	require.NoError(t, err)
+
+	// Verify that the acquisition time is stored
+	acqTime, ok := rwLocker.GetAcquisitionTime(key)
+	assert.True(t, ok, "Acquisition time should be stored for write lock")
+	assert.WithinDuration(t, time.Now(), acqTime, 1*time.Second)
+
+	// Release Write Lock
+	err = rwLocker.Unlock(ctx, key)
+	require.NoError(t, err)
+
+	// Verify that the acquisition time is cleared
+	_, ok = rwLocker.GetAcquisitionTime(key)
+	assert.False(t, ok, "Acquisition time should be cleared after unlock")
+}
+
+func TestRWLocker_ReadMetrics_NotRecorded(t *testing.T) {
+	t.Parallel()
+
+	skipIfPostgresNotAvailable(t)
+
+	ctx := context.Background()
+
+	querier, cleanup := getTestDatabase(t)
+	defer cleanup()
+
+	cfg := getTestConfig()
+	retryCfg := lock.RetryConfig{MaxAttempts: 1}
+
+	rwLockerInterface, err := postgres.NewRWLocker(ctx, querier, cfg, retryCfg, false)
+	require.NoError(t, err)
+
+	rwLocker := rwLockerInterface.(*postgres.RWLocker)
+
+	key := getUniqueKey(t, "metrics-read")
+
+	// Acquire Read Lock
+	err = rwLocker.RLock(ctx, key, 1*time.Second)
+	require.NoError(t, err)
+
+	// Verify that the acquisition time is NOT stored for read locks
+	_, ok := rwLocker.GetAcquisitionTime(key)
+	assert.False(t, ok, "Acquisition time should NOT be stored for read lock")
+
+	// Release Read Lock
+	err = rwLocker.RUnlock(ctx, key)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
# Add comprehensive test coverage for PostgreSQL lock implementation

This PR adds three new test files to improve test coverage for the PostgreSQL lock implementation:

1. `behavior_test.go`: Tests lock contention timeout behavior with multiple lockers competing for the same lock, verifying proper retry behavior and error handling.

2. `failure_test.go`: Tests circuit breaker functionality when database connections fail, ensuring the system properly detects failures and prevents cascading issues.

3. `metrics_test.go`: Verifies that lock acquisition metrics are properly tracked for both read and write locks.

Additionally, the PR adds a `GetDB()` helper method to the test exports to facilitate testing database connection failures.

These tests ensure the lock implementation behaves correctly under various edge cases including contention, database failures, and proper metrics recording.