### PR TITLE
feat(lock/redis): Return concrete Locker type in degraded mode

### DIFF
--- a/pkg/lock/redis/return_type_test.go
+++ b/pkg/lock/redis/return_type_test.go
@@ -1,0 +1,33 @@
+package redis_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/lock"
+	"github.com/kalbasit/ncps/pkg/lock/redis"
+)
+
+func TestNewLocker_ReturnType(t *testing.T) {
+	t.Parallel()
+
+	// Connect to non-existent Redis addresses to trigger degraded mode
+	cfg := redis.Config{
+		Addrs: []string{"localhost:9999", "localhost:9998"},
+	}
+	retryCfg := lock.RetryConfig{}
+
+	ctx := context.Background()
+
+	// When allowDegradedMode is true, it should return *redis.Locker even if Redis is down
+	l, err := redis.NewLocker(ctx, cfg, retryCfg, true)
+	require.NoError(t, err)
+	assert.IsType(t, (*redis.Locker)(nil), l, "NewLocker should return *redis.Locker in degraded mode")
+
+	// When allowDegradedMode is false, it should return an error
+	_, err = redis.NewLocker(ctx, cfg, retryCfg, false)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
# Fix Redis Locker Degraded Mode Implementation

This PR improves the Redis locking implementation when operating in degraded mode:

1. Changed the return type of `NewLocker()` from `lock.Locker` interface to concrete `*Locker` type to ensure consistent behavior
2. Added proper circuit breaker initialization in degraded mode for both `Locker` and `RWLocker`
3. Moved the key prefix initialization earlier in the code to ensure it's set before any potential early returns
4. Added a test to verify the return type consistency in degraded mode

The changes ensure that when Redis is unavailable and degraded mode is enabled, we return the same concrete type with proper circuit breaker initialization rather than a different implementation.