### PR TITLE
feat: Add script and workflow for fetching unresolved PR comments

### DIFF
--- a/.agent/workflows/get-unresolved-comments.md
+++ b/.agent/workflows/get-unresolved-comments.md
@@ -1,0 +1,44 @@
+---
+description: Get unresolved comments in a PR
+---
+
+# Fetch Unresolved PR Comments
+
+This workflow provides a way to fetch only the unresolved comments from a GitHub Pull Request using the `gh` CLI and a helper script.
+
+## Pre-requisites
+
+- `gh` CLI installed and authenticated.
+- `jq` installed for JSON processing.
+
+## Running the script
+
+Use the helper script `dev-scripts/get-unresolved-comments.sh` to fetch unresolved comments:
+
+```bash
+# Example: Fetch unresolved comments for PR 517
+./dev-scripts/get-unresolved-comments.sh 517
+```
+
+The script will output a JSON array of unresolved comments.
+
+## Internal details
+
+The script uses `gh api graphql` to fetch `reviewThreads` where `isResolved` is false. It uses `mktemp -d` and `trap` internally to handle temporary files securely outside the project directory.
+
+## Example: Processing the output
+
+If you need to save the output to a temporary file for further processing while following security best practices:
+
+```bash
+# Create a secure temporary directory
+TMP_DIR=$(mktemp -d)
+# Ensure it is removed on exit
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Fetch comments to a temporary file
+./dev-scripts/get-unresolved-comments.sh 517 > "$TMP_DIR/unresolved.json"
+
+# Process the file
+jq '.' "$TMP_DIR/unresolved.json"
+```

--- a/dev-scripts/get-unresolved-comments.sh
+++ b/dev-scripts/get-unresolved-comments.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -eo pipefail
+
+# get-unresolved-comments.sh: Fetches unresolved PR comments using GitHub GraphQL API.
+# Usage: ./get-unresolved-comments.sh <pr-number>
+
+PR_NUMBER=$1
+if [ -z "$PR_NUMBER" ]; then
+  echo "Usage: $0 <pr-number>" >&2
+  exit 1
+fi
+
+# Infer repo owner and name
+REPO_INFO=$(gh repo view --json owner,name)
+OWNER=$(echo "$REPO_INFO" | jq -r .owner.login)
+NAME=$(echo "$REPO_INFO" | jq -r .name)
+
+# Create a secure temporary directory
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# GraphQL query to fetch unresolved threads
+QUERY='
+query($owner: String!, $name: String!, $pr: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          comments(first: 100) {
+            nodes {
+              body
+              path
+              line
+              author {
+                login
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+
+# Save result to a temp file in the secure location
+RESULT_FILE="$TMP_DIR/result.json"
+
+gh api graphql -F owner="$OWNER" -F name="$NAME" -F pr="$PR_NUMBER" -f query="$QUERY" > "$RESULT_FILE"
+
+# Filter and output only unresolved comments
+jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .comments.nodes[]' "$RESULT_FILE"

--- a/nix/formatter/flake-module.nix
+++ b/nix/formatter/flake-module.nix
@@ -5,6 +5,7 @@
   perSystem = {
     treefmt = {
       settings.global.excludes = [
+        ".agent/workflows/*.md"
         ".env"
         ".envrc"
         "LICENSE"


### PR DESCRIPTION
# Add Script to Fetch Unresolved PR Comments

This PR adds a new utility script `dev-scripts/get-unresolved-comments.sh` that allows developers to fetch unresolved comments from GitHub Pull Requests using the GitHub GraphQL API. The script:

- Takes a PR number as input and returns unresolved comments as JSON
- Uses secure temporary file handling with `mktemp -d` and `trap`
- Automatically infers repository owner and name using `gh repo view`
- Filters for only unresolved review threads

Additionally, this PR:

- Adds documentation in `.agent/workflows/get-unresolved-comments.md` explaining how to use the script
- Updates the Nix formatter configuration to exclude the new workflow documentation

This tool will help developers more easily track and address outstanding review comments in PRs.

Reapply #524

