### PR TITLE
ci: add support for pushing Docker images to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,7 @@
 name: Docker images
+permissions:
+  contents: read
+  packages: write
 on:
   push:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
 name: CI
+permissions:
+  contents: read
+  packages: write
 on:
   pull_request:
     branches:
@@ -18,7 +21,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v4
         with:
-          version: 'v3.16.3'
+          version: "v3.16.3"
       - name: Run Helm validation tests
         run: ./charts/ncps/tests/run-tests.sh
   docker:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,7 @@
 name: Build and push Docker images with mult-arch support
+permissions:
+  contents: read
+  packages: write
 on:
   workflow_call:
     inputs:
@@ -37,7 +40,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ inputs.images }}
+          images: |
+            ${{ inputs.images }}
+            ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -79,6 +84,13 @@ jobs:
         with:
           username: ${{ inputs.username }}
           password: ${{ secrets.password }}
+      - name: Login to GitHub Container Registry
+        if: inputs.push_images
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push the docker image
         if: inputs.push_images
         env:
@@ -97,6 +109,12 @@ jobs:
         with:
           username: ${{ inputs.username }}
           password: ${{ secrets.password }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create a multi-architecture manifest
         env:
           DOCKER_IMAGE_TAGS: ${{ needs.docker-meta.outputs.tags }}

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,4 +1,7 @@
 name: Releases
+permissions:
+  contents: read
+  packages: write
 on:
   push:
     tags:


### PR DESCRIPTION
This commit updates the GitHub Actions workflows to support pushing Docker images to the GitHub Container Registry (GHCR).

Changes:
- Added necessary permissions (packages: write) to workflows.
- Configured docker/metadata-action to include ghcr.io as a destination.
- Added login steps for ghcr.io in the Docker build workflow.

part of #532 