### PR TITLE
feat(chart): switch default image registry to GHCR

### DIFF
--- a/charts/ncps/values.yaml
+++ b/charts/ncps/values.yaml
@@ -18,7 +18,7 @@ replicaCount: 1
 mode: statefulset
 
 image:
-  registry: docker.io
+  registry: ghcr.io
   repository: kalbasit/ncps
   pullPolicy: IfNotPresent
   # Overrides the image tag (default is chart appVersion)


### PR DESCRIPTION
This commit updates the default image registry in the ncps Helm chart from docker.io to ghcr.io to align with the move to GitHub Container Registry.

part of #532 