### PR TITLE
docs: update image references to use GHCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,17 @@ Get ncps running in minutes with Docker:
 
 ```bash
 # Pull images and create storage
-docker pull alpine && docker pull kalbasit/ncps
+docker pull alpine && docker pull ghcr.io/kalbasit/ncps
 docker volume create ncps-storage
 docker run --rm -v ncps-storage:/storage alpine /bin/sh -c \
   "mkdir -m 0755 -p /storage/var && mkdir -m 0700 -p /storage/var/ncps && mkdir -m 0700 -p /storage/var/ncps/db"
 
 # Initialize database
-docker run --rm -v ncps-storage:/storage kalbasit/ncps \
+docker run --rm -v ncps-storage:/storage ghcr.io/kalbasit/ncps \
   /bin/dbmate --url=sqlite:/storage/var/ncps/db/db.sqlite up
 
 # Start the server
-docker run -d --name ncps -p 8501:8501 -v ncps-storage:/storage kalbasit/ncps \
+docker run -d --name ncps -p 8501:8501 -v ncps-storage:/storage ghcr.io/kalbasit/ncps \
   /bin/ncps serve \
   --cache-hostname=your-ncps-hostname \
   --cache-storage-local=/storage \

--- a/docs/docs/User Guide/Deployment/High Availability.md
+++ b/docs/docs/User Guide/Deployment/High Availability.md
@@ -237,17 +237,17 @@ prometheus:
 # Start instance 1
 docker run -d --name ncps-1 -p 8501:8501 \
   -v $(pwd)/config.yaml:/config.yaml \
-  kalbasit/ncps /bin/ncps serve --config=/config.yaml
+  ghcr.io/kalbasit/ncps /bin/ncps serve --config=/config.yaml
 
 # Start instance 2
 docker run -d --name ncps-2 -p 8502:8501 \
   -v $(pwd)/config.yaml:/config.yaml \
-  kalbasit/ncps /bin/ncps serve --config=/config.yaml
+  ghcr.io/kalbasit/ncps /bin/ncps serve --config=/config.yaml
 
 # Start instance 3
 docker run -d --name ncps-3 -p 8503:8501 \
   -v $(pwd)/config.yaml:/config.yaml \
-  kalbasit/ncps /bin/ncps serve --config=/config.yaml
+  ghcr.io/kalbasit/ncps /bin/ncps serve --config=/config.yaml
 ```
 
 **Kubernetes:**
@@ -269,7 +269,7 @@ spec:
     spec:
       containers:
         - name: ncps
-          image: kalbasit/ncps:latest
+          image: ghcr.io/kalbasit/ncps:latest
           # ... configuration ...
 ```
 
@@ -387,7 +387,7 @@ Update instances one at a time for zero downtime:
 # Update instance 1
 docker stop ncps-1
 docker rm ncps-1
-docker pull kalbasit/ncps:latest
+docker pull ghcr.io/kalbasit/ncps:latest
 docker run -d --name ncps-1 ... # Same command
 
 # Wait and verify instance 1 is healthy

--- a/docs/docs/User Guide/Getting Started/Quick Start.md
+++ b/docs/docs/User Guide/Getting Started/Quick Start.md
@@ -18,7 +18,7 @@ This is the simplest setup perfect for testing and single-machine deployments.
 
 ```
 docker pull alpine
-docker pull kalbasit/ncps
+docker pull ghcr.io/kalbasit/ncps
 ```
 
 ### Step 2: Create and Initialize Storage
@@ -35,7 +35,7 @@ docker run --rm -v ncps-storage:/storage alpine /bin/sh -c \
 ### Step 3: Initialize Database
 
 ```
-docker run --rm -v ncps-storage:/storage kalbasit/ncps \
+docker run --rm -v ncps-storage:/storage ghcr.io/kalbasit/ncps \
   /bin/dbmate --url=sqlite:/storage/var/ncps/db/db.sqlite up
 ```
 
@@ -46,7 +46,7 @@ docker run -d \
   --name ncps \
   -p 8501:8501 \
   -v ncps-storage:/storage \
-  kalbasit/ncps \
+  ghcr.io/kalbasit/ncps \
   /bin/ncps serve \
   --cache-hostname=your-ncps-hostname \
   --cache-storage-local=/storage \
@@ -79,7 +79,7 @@ This setup uses S3-compatible storage, which is required for high-availability d
 ### Step 1: Pull Image
 
 ```
-docker pull kalbasit/ncps
+docker pull ghcr.io/kalbasit/ncps
 ```
 
 ### Step 2: Create Database Volume
@@ -93,7 +93,7 @@ docker run --rm -v ncps-db:/db alpine mkdir -m 0700 -p /db
 ### Step 3: Initialize Database
 
 ```
-docker run --rm -v ncps-db:/db kalbasit/ncps \
+docker run --rm -v ncps-db:/db ghcr.io/kalbasit/ncps \
   /bin/dbmate --url=sqlite:/db/db.sqlite up
 ```
 
@@ -104,7 +104,7 @@ docker run -d \
   --name ncps \
   -p 8501:8501 \
   -v ncps-db:/db \
-  kalbasit/ncps \
+  ghcr.io/kalbasit/ncps \
   /bin/ncps serve \
   --cache-hostname=your-ncps-hostname \
   --cache-storage-s3-bucket=my-ncps-cache \

--- a/docs/docs/User Guide/Installation/Docker Compose.md
+++ b/docs/docs/User Guide/Installation/Docker Compose.md
@@ -31,7 +31,7 @@ services:
     restart: "no"
 
   migrate-database:
-    image: kalbasit/ncps:latest
+    image: ghcr.io/kalbasit/ncps:latest
     depends_on:
       create-directories:
         condition: service_completed_successfully
@@ -42,7 +42,7 @@ services:
     restart: "no"
 
   ncps:
-    image: kalbasit/ncps:latest
+    image: ghcr.io/kalbasit/ncps:latest
     depends_on:
       migrate-database:
         condition: service_completed_successfully
@@ -160,7 +160,7 @@ services:
 
   # Migrate database
   migrate-database:
-    image: kalbasit/ncps:latest
+    image: ghcr.io/kalbasit/ncps:latest
     depends_on:
       postgres:
         condition: service_healthy
@@ -170,7 +170,7 @@ services:
 
   # ncps instance 1
   ncps-1:
-    image: kalbasit/ncps:latest
+    image: ghcr.io/kalbasit/ncps:latest
     depends_on:
       migrate-database:
         condition: service_completed_successfully
@@ -196,7 +196,7 @@ services:
 
   # ncps instance 2 (for HA)
   ncps-2:
-    image: kalbasit/ncps:latest
+    image: ghcr.io/kalbasit/ncps:latest
     depends_on:
       migrate-database:
         condition: service_completed_successfully

--- a/docs/docs/User Guide/Installation/Docker.md
+++ b/docs/docs/User Guide/Installation/Docker.md
@@ -16,7 +16,7 @@ Install and run ncps using Docker. This is the simplest installation method, per
 ### Step 1: Pull the Image
 
 ```sh
-docker pull kalbasit/ncps
+docker pull ghcr.io/kalbasit/ncps
 ```
 
 **Available tags:**
@@ -40,7 +40,7 @@ docker run --rm -v ncps-storage:/storage alpine /bin/sh -c \
    chown -R 1000:1000 /storage"
 
 # Initialize the database
-docker run --rm -v ncps-storage:/storage kalbasit/ncps \
+docker run --rm -v ncps-storage:/storage ghcr.io/kalbasit/ncps \
   /bin/dbmate --url=sqlite:/storage/var/ncps/db/db.sqlite migrate up
 ```
 
@@ -61,7 +61,7 @@ docker run -d \
   -p 8501:8501 \
   -v ncps-storage:/storage \
   --restart unless-stopped \
-  kalbasit/ncps \
+  ghcr.io/kalbasit/ncps \
   /bin/ncps serve \
   --cache-hostname=your-ncps-hostname \
   --cache-storage-local=/storage \
@@ -114,7 +114,7 @@ docker volume create ncps-db
 docker run --rm -v ncps-db:/db alpine mkdir -m 0700 -p /db
 
 # Initialize database
-docker run --rm -v ncps-db:/db kalbasit/ncps \
+docker run --rm -v ncps-db:/db ghcr.io/kalbasit/ncps \
   /bin/dbmate --url=sqlite:/db/db.sqlite migrate up
 
 # Start server with S3 storage
@@ -123,7 +123,7 @@ docker run -d \
   -p 8501:8501 \
   -v ncps-db:/db \
   --restart unless-stopped \
-  kalbasit/ncps \
+  ghcr.io/kalbasit/ncps \
   /bin/ncps serve \
   --cache-hostname=your-ncps-hostname \
   --cache-storage-s3-bucket=my-ncps-cache \
@@ -159,7 +159,7 @@ docker run -d \
   -e CACHE_DATABASE_URL=sqlite:/storage/var/ncps/db/db.sqlite \
   -e CACHE_UPSTREAM_URLS=https://cache.nixos.org \
   -e CACHE_UPSTREAM_PUBLIC_KEYS=cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= \
-  kalbasit/ncps /bin/ncps serve
+  ghcr.io/kalbasit/ncps /bin/ncps serve
 ```
 
 See <a class="reference-link" href="../Configuration/Reference.md">Reference</a> for all environment variables.
@@ -189,7 +189,7 @@ docker run -d \
   -p 8501:8501 \
   -v ncps-storage:/storage \
   -v $(pwd)/config.yaml:/config.yaml:ro \
-  kalbasit/ncps \
+  ghcr.io/kalbasit/ncps \
   /bin/ncps serve --config=/config.yaml
 ```
 
@@ -214,7 +214,7 @@ docker restart ncps
 ### Update to Latest Version
 
 ```
-docker pull kalbasit/ncps:latest
+docker pull ghcr.io/kalbasit/ncps:latest
 docker stop ncps
 docker rm ncps
 # Then re-run the docker run command from Step 3
@@ -271,7 +271,7 @@ docker port ncps
 **Solution:** Run the database migration step:
 
 ```
-docker run --rm -v ncps-storage:/storage kalbasit/ncps \
+docker run --rm -v ncps-storage:/storage ghcr.io/kalbasit/ncps \
   /bin/dbmate --url=sqlite:/storage/var/ncps/db/db.sqlite migrate up
 ```
 

--- a/docs/docs/User Guide/Installation/Kubernetes.md
+++ b/docs/docs/User Guide/Installation/Kubernetes.md
@@ -90,7 +90,7 @@ spec:
 
         # Run database migrations
         - name: migrate-database
-          image: kalbasit/ncps:latest
+          image: ghcr.io/kalbasit/ncps:latest
           command:
             - /bin/dbmate
             - --url=sqlite:/storage/var/ncps/db/db.sqlite
@@ -102,7 +102,7 @@ spec:
 
       containers:
         - name: ncps
-          image: kalbasit/ncps:latest
+          image: ghcr.io/kalbasit/ncps:latest
           args:
             - /bin/ncps
             - serve
@@ -291,7 +291,7 @@ spec:
     spec:
       initContainers:
         - name: migrate-database
-          image: kalbasit/ncps:latest
+          image: ghcr.io/kalbasit/ncps:latest
           command:
             - /bin/dbmate
             - migrate
@@ -309,7 +309,7 @@ spec:
 
       containers:
         - name: ncps
-          image: kalbasit/ncps:latest
+          image: ghcr.io/kalbasit/ncps:latest
           args:
             - /bin/ncps
             - serve

--- a/docs/docs/User Guide/Operations/Upgrading.md
+++ b/docs/docs/User Guide/Operations/Upgrading.md
@@ -13,7 +13,7 @@ Upgrade ncps to newer versions.
 docker stop ncps
 
 # Pull new version
-docker pull kalbasit/ncps:latest
+docker pull ghcr.io/kalbasit/ncps:latest
 
 # Remove old container
 docker rm ncps
@@ -47,7 +47,7 @@ Perform rolling updates:
 # Update instance 1
 docker stop ncps-1
 docker rm ncps-1
-docker pull kalbasit/ncps:latest
+docker pull ghcr.io/kalbasit/ncps:latest
 docker run -d --name ncps-1 ...
 
 # Wait and verify instance 1 is healthy
@@ -90,7 +90,7 @@ If upgrade fails:
 ```
 docker stop ncps
 docker rm ncps
-docker run -d --name ncps kalbasit/ncps:v0.4.0 ...  # Previous version
+docker run -d --name ncps ghcr.io/kalbasit/ncps:v0.4.0 ...  # Previous version
 ```
 
 **Helm:**


### PR DESCRIPTION
This commit updates all Docker image references in the documentation and README to point to the new GitHub Container Registry (ghcr.io/kalbasit/ncps) instead of Docker Hub.

closes #532 