### PR TITLE
feat: add Graphite workflows and standardize .agent/workflows

### DIFF
--- a/.agent/workflows/build.md
+++ b/.agent/workflows/build.md
@@ -1,6 +1,6 @@
-______________________________________________________________________
-
-## description: Build the project
+---
+description: Build the project
+---
 
 1. Build with Go:
 

--- a/.agent/workflows/database-migration.md
+++ b/.agent/workflows/database-migration.md
@@ -1,6 +1,6 @@
-______________________________________________________________________
-
-## description: Create a new database migration
+---
+description: Create a new database migration
+---
 
 1. Read `CLAUDE.md` section "Creating Database Migrations" and "Transaction Handling" to understand the critical rules (NO manual transactions).
 

--- a/.agent/workflows/gt-amend.md
+++ b/.agent/workflows/gt-amend.md
@@ -1,0 +1,22 @@
+---
+description: Amend the current commit with a semantic commit message
+---
+
+1. Amend the current commit. You must provide a semantic commit message (feat, fix, docs, style, refactor, test, chore) following the format `type: title`.
+
+2. The commit message MUST include a description that explains the **why** and **how** of the change.
+
+```bash
+git commit --amend -m "<type>: <title>
+
+<detailed description of why and how>"
+```
+
+Example:
+```bash
+git commit --amend -m "feat: improve performance of storage backend
+
+By using a bunked read approach, we reduce the number of I/O operations.
+This implementation caches the most frequently accessed chunks in memory...
+"
+```

--- a/.agent/workflows/gt-create.md
+++ b/.agent/workflows/gt-create.md
@@ -1,0 +1,23 @@
+---
+description: Create a new Graphite stack (semantic commit)
+---
+
+1. Create a new stack using `gt create`. You must provide a semantic commit message (feat, fix, docs, style, refactor, test, chore) following the format `type: title`.
+
+2. The commit message MUST include a description that explains the **why** and **how** of the change.
+
+```bash
+gt create -am "<type>: <title>
+
+<detailed description of why and how>"
+```
+
+Example:
+```bash
+gt create -am "feat: add support for new storage backend
+
+This adds support for S3-compatible storage backends. It was needed to
+enable deployments in cloud environments without persistent local volumes.
+The implementation utilizes the AWS SDK for Go and supports...
+"
+```

--- a/.agent/workflows/gt-restack.md
+++ b/.agent/workflows/gt-restack.md
@@ -1,0 +1,27 @@
+---
+description: Restack the current Graphite stack and resolve conflicts
+---
+
+1. Start the restacking process:
+
+```bash
+gt restack
+```
+
+2. If conflicts are found:
+    - Review the output to identify which commit is being rebased and the files involved.
+    - Examine the conflict markers in the affected files.
+    - Resolve the conflicts by choosing the correct changes based on the context of the PR stack.
+    - Stage the resolved files:
+
+    ```bash
+    git add <resolved-files>
+    ```
+
+    - **CRITICAL**: Do NOT run `git rebase --continue`. Instead, use Graphite's continue command:
+
+    ```bash
+    gt continue
+    ```
+
+3. Repeat step 2 as necessary until the restack is complete.

--- a/.agent/workflows/gt-ss.md
+++ b/.agent/workflows/gt-ss.md
@@ -1,0 +1,9 @@
+---
+description: Submit the current Graphite stack in non-interactive mode
+---
+
+1. Submit the stack:
+
+```bash
+gt ss --no-interactive --publish
+```

--- a/.agent/workflows/lint.md
+++ b/.agent/workflows/lint.md
@@ -1,6 +1,6 @@
-______________________________________________________________________
-
-## description: Lint and format code
+---
+description: Lint and format code
+---
 
 // turbo-all
 

--- a/.agent/workflows/test.md
+++ b/.agent/workflows/test.md
@@ -1,6 +1,6 @@
-______________________________________________________________________
-
-## description: Run project tests
+---
+description: Run project tests
+---
 
 1. Run standard tests with race detection:
 


### PR DESCRIPTION
This commit introduces new workflows for Graphite: gt-create and gt-restack.
It also standardizes the existing workflow files (build, test, lint,
database-migration) to use YAML frontmatter for descriptions instead of
malformed markdown headings.

Standardizing the format ensures that the agent can correctly parse and
display the workflow descriptions. Adding Graphite-specific workflows
improves the development experience when working with stacked PRs.