### PR TITLE
fix: proper argument in Helm chart

### DIFF
--- a/charts/ncps/templates/deployment.yaml
+++ b/charts/ncps/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
             - /etc/ncps/config.yaml
             - serve
             {{- if and (ne .Values.config.signing.enabled false) (or .Values.config.signing.secretKey .Values.config.signing.existingSecret) }}
-            - --cache-secret-key-file
+            - --cache-secret-key-path
             - /etc/ncps/secrets/signing-key
             {{- end }}
           env:

--- a/charts/ncps/templates/statefulset.yaml
+++ b/charts/ncps/templates/statefulset.yaml
@@ -97,7 +97,7 @@ spec:
             - /etc/ncps/config.yaml
             - serve
             {{- if and (ne .Values.config.signing.enabled false) (or .Values.config.signing.secretKey .Values.config.signing.existingSecret) }}
-            - --cache-secret-key-file
+            - --cache-secret-key-path
             - /etc/ncps/secrets/signing-key
             {{- end }}
           env:


### PR DESCRIPTION
(Note: I haven't been able to test this yet)

It looks like the deployment and statefulset in the Helm chart are using the wrong argument name for the secret key. This should fix that.