### PR TITLE
feat: add trilium-edit-docs to the development environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,6 +36,42 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "git-hooks-nix": {
       "inputs": {
         "flake-compat": "flake-compat",
@@ -95,6 +131,28 @@
         "type": "github"
       }
     },
+    "pnpm2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "trilium",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749022118,
+        "narHash": "sha256-7Qzmy1snKbxFBKoqUrfyxxmEB8rPxDdV7PQwRiAR01o=",
+        "owner": "FliegendeWurst",
+        "repo": "pnpm2nix-nzbr",
+        "rev": "35f88a41d29839b3989f31871263451c8e092cb1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "FliegendeWurst",
+        "repo": "pnpm2nix-nzbr",
+        "type": "github"
+      }
+    },
     "process-compose-flake": {
       "locked": {
         "lastModified": 1764915241,
@@ -116,7 +174,38 @@
         "git-hooks-nix": "git-hooks-nix",
         "nixpkgs": "nixpkgs",
         "process-compose-flake": "process-compose-flake",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix",
+        "trilium": "trilium"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     },
     "treefmt-nix": {
@@ -136,6 +225,28 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "trilium": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pnpm2nix": "pnpm2nix"
+      },
+      "locked": {
+        "lastModified": 1768369687,
+        "narHash": "sha256-OSuL9wtFKWg3ksXjKOTDeZTd97WooWx9LEeslGfaDH0=",
+        "owner": "TriliumNext",
+        "repo": "Trilium",
+        "rev": "f466367c4da1a58805a56e618829f527ece8a98e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "TriliumNext",
+        "repo": "Trilium",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
       url = "github:numtide/treefmt-nix";
     };
+
+    trilium = {
+      inputs.nixpkgs.follows = "nixpkgs";
+      url = "github:TriliumNext/Trilium";
+    };
   };
 
   outputs =

--- a/nix/devshells/flake-module.nix
+++ b/nix/devshells/flake-module.nix
@@ -1,6 +1,11 @@
+{ inputs, ... }:
 {
   perSystem =
-    { config, pkgs, ... }:
+    {
+      config,
+      pkgs,
+      ...
+    }:
     {
       devShells.default = pkgs.mkShell {
         buildInputs = [
@@ -123,6 +128,20 @@
           pkgs.sqlc
           pkgs.sqlfluff
           pkgs.watchexec
+
+          # Provide trilium-edit-docs in the environment so the user can easily edit the docs using Trilium.
+          (pkgs.writeShellScriptBin "trilium-edit-docs" (
+            let
+              # Construct the URI for the trilium-edit-docs package lazily.
+              # We use inputs.trilium.rev to pin it to the same version as the flake.lock.
+              # If rev is not available (e.g. local input), we fall back to the URL.
+              rev = inputs.trilium.rev or null;
+              uri = if rev != null then "github:TriliumNext/Trilium/${rev}" else "github:TriliumNext/Trilium";
+            in
+            ''
+              exec nix run "${uri}#edit-docs" -- "$@"
+            ''
+          ))
         ];
 
         _GO_VERSION = "${pkgs.go.version}";


### PR DESCRIPTION
Integrating TriliumNext/Trilium into the development environment allows developers to easily edit project documentation using Trilium.

How:
- Add `github:TriliumNext/Trilium` as a flake input in `flake.nix`.
- Create a wrapper script `trilium-edit-docs` in `nix/devshells/flake-module.nix`.
- The script uses `nix run` to execute the `edit-docs` package from the trilium flake, pinned to the version in `flake.lock`.
- Export the wrapper script into the default devShell.