### PR TITLE
feat: wire up new index feature into pkg/cache/upstream

### DIFF
--- a/pkg/cache/upstream/cache_index_test.go
+++ b/pkg/cache/upstream/cache_index_test.go
@@ -1,0 +1,92 @@
+package upstream_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/cache/upstream"
+	"github.com/kalbasit/ncps/pkg/nixcacheindex"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+func TestExperimentalCacheIndex(t *testing.T) {
+	t.Parallel()
+
+	// 1. Setup Mock Server
+	var requestedNarInfo bool
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/nix-cache-info":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("StoreDir: /nix/store\nWantMassQuery: 1\nPriority: 40\n"))
+
+		case r.URL.Path == "/nix-cache-index/manifest.json":
+			w.WriteHeader(http.StatusOK)
+
+			m := nixcacheindex.NewManifest()
+			// Update URLs to point to this mock server
+			scheme := "http"
+			if r.TLS != nil {
+				scheme = "https"
+			}
+
+			baseURL := fmt.Sprintf("%s://%s/nix-cache-index/", scheme, r.Host)
+			m.Urls.JournalBase = baseURL + "journal/"
+			m.Urls.ShardsBase = baseURL + "shards/"
+			m.Urls.DeltasBase = baseURL + "deltas/"
+
+			_ = json.NewEncoder(w).Encode(m)
+
+		case strings.HasPrefix(r.URL.Path, "/nix-cache-index/journal/"):
+			// Simulate missing/empty journal segments
+			w.WriteHeader(http.StatusNotFound)
+
+		case strings.HasPrefix(r.URL.Path, "/nix-cache-index/shards/"):
+			// Simulate missing shards -> implies DefiniteMiss
+			w.WriteHeader(http.StatusNotFound)
+
+		case strings.HasSuffix(r.URL.Path, ".narinfo"):
+			requestedNarInfo = true
+
+			w.WriteHeader(http.StatusOK)
+			// Should not be reached in Hit case if we were testing Hits,
+			// but for Miss check we want to ensure it's NOT reached
+			_, _ = w.Write([]byte("StorePath: /nix/store/abc-example"))
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	// 2. Setup Upstream Cache with Index Enabled
+	opts := &upstream.Options{
+		ExperimentalCacheIndex: true,
+	}
+
+	c, err := upstream.New(
+		newContext(),
+		testhelper.MustParseURL(t, ts.URL),
+		opts,
+	)
+	require.NoError(t, err)
+
+	// 3. Perform Request
+	// The mock setup ensures that checking shards returns 404, which the client interprets as DefiniteMiss.
+	// Therefore, GetNarInfo should return ErrNotFound WITHOUT requesting the .narinfo file.
+
+	_, err = c.GetNarInfo(context.Background(), "00000000000000000000000000000000") // 32 chars
+
+	// 4. Verification
+	require.ErrorIs(t, err, upstream.ErrNotFound)
+	assert.False(t, requestedNarInfo, "Should not have requested the narinfo file from upstream")
+}

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -250,6 +250,11 @@ func serveCommand(
 				Sources: flagSources("server.addr", "SERVER_ADDR"),
 				Value:   ":8501",
 			},
+			&cli.BoolFlag{
+				Name:    "experimental-cache-index",
+				Usage:   "Enable the use of the experimental binary cache index",
+				Sources: flagSources("experimental.cache-index", "EXPERIMENTAL_CACHE_INDEX"),
+			},
 
 			// Redis Configuration (optional - for distributed locking in HA deployments)
 			&cli.StringSliceFlag{
@@ -583,6 +588,7 @@ func getUpstreamCaches(ctx context.Context, cmd *cli.Command, netrcData *netrc.N
 	dialerTimeout := cmd.Duration("cache-upstream-dialer-timeout")
 	deprecatedResponseHeaderTimeout := cmd.Duration("upstream-response-header-timeout")
 	responseHeaderTimeout := cmd.Duration("cache-upstream-response-header-timeout")
+	experimentalCacheIndex := cmd.Bool("experimental-cache-index")
 
 	// Show deprecation warning for upstream-cache
 	if len(deprecatedUpstreamCache) > 0 {
@@ -679,8 +685,9 @@ func getUpstreamCaches(ctx context.Context, cmd *cli.Command, netrcData *netrc.N
 
 		// Build options for this upstream cache
 		opts := &upstream.Options{
-			DialerTimeout:         dialerTimeout,
-			ResponseHeaderTimeout: responseHeaderTimeout,
+			DialerTimeout:          dialerTimeout,
+			ResponseHeaderTimeout:  responseHeaderTimeout,
+			ExperimentalCacheIndex: experimentalCacheIndex,
 		}
 
 		// Find public keys for this upstream

--- a/pkg/nixcacheindex/client_test.go
+++ b/pkg/nixcacheindex/client_test.go
@@ -23,7 +23,7 @@ type MockFetcher struct {
 	fetchCalls int
 }
 
-func (m *MockFetcher) Fetch(path string) (io.ReadCloser, error) {
+func (m *MockFetcher) Fetch(_ context.Context, path string) (io.ReadCloser, error) {
 	m.fetchCalls++
 	if data, ok := m.files[path]; ok {
 		return io.NopCloser(bytes.NewReader(data)), nil
@@ -96,7 +96,7 @@ func TestClientQuery_EndToEnd(t *testing.T) {
 	}
 
 	fetcher := &MockFetcher{files: mockFiles}
-	client := nixcacheindex.NewClient(fetcher)
+	client := nixcacheindex.NewClient(context.Background(), fetcher)
 
 	// Test Cases
 
@@ -164,7 +164,7 @@ func TestClientQuery_Caching(t *testing.T) {
 	mockFiles["https://mock/shards/1/root.idx.zst"] = compressedShardBuf.Bytes()
 
 	fetcher := &MockFetcher{files: mockFiles}
-	client := nixcacheindex.NewClient(fetcher)
+	client := nixcacheindex.NewClient(context.Background(), fetcher)
 
 	// First query: should fetch shard
 	res, err := client.Query(context.Background(), hashA)


### PR DESCRIPTION
This change integrates the Nix binary cache index protocol into the upstream cache.
It is gated behind an experimental flag --experimental-cache-index.

When enabled, the upstream cache will query the index (manifest, journal, shards)
before making requests for .narinfo files. If the index indicates a definite
miss, the cache returns a NOT FOUND error immediately, avoiding unnecessary
network calls to the upstream binary cache.

Changes:
- Implement nixcacheindex.Fetcher on upstream.Cache.
- Integrate nixcacheindex.Client into upstream.Cache.
- Add --experimental-cache-index flag to serve command.
- Add verification tests in pkg/cache/upstream/cache_index_test.go.