### PR TITLE
fix: fix blocking postgres locking and clarify mysql limitations

### DIFF
--- a/docs/!!!meta.json
+++ b/docs/!!!meta.json
@@ -16,6 +16,20 @@
             "mime": "text/html",
             "attributes": [
                 {
+                    "type": "relation",
+                    "name": "internalLink",
+                    "value": "0RC0xXheV6Ng",
+                    "isInheritable": false,
+                    "position": 10
+                },
+                {
+                    "type": "relation",
+                    "name": "internalLink",
+                    "value": "hykHhxU5DhfF",
+                    "isInheritable": false,
+                    "position": 20
+                },
+                {
                     "type": "label",
                     "name": "shareRootLink",
                     "value": "/",
@@ -28,20 +42,6 @@
                     "value": "promoted,alias=Slug,single,text",
                     "isInheritable": true,
                     "position": 20
-                },
-                {
-                    "type": "relation",
-                    "name": "internalLink",
-                    "value": "0RC0xXheV6Ng",
-                    "isInheritable": false,
-                    "position": 30
-                },
-                {
-                    "type": "relation",
-                    "name": "internalLink",
-                    "value": "hykHhxU5DhfF",
-                    "isInheritable": false,
-                    "position": 40
                 }
             ],
             "format": "markdown",
@@ -350,18 +350,18 @@
                             "mime": "text/markdown",
                             "attributes": [
                                 {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "hykHhxU5DhfF",
+                                    "isInheritable": false,
+                                    "position": 10
+                                },
+                                {
                                     "type": "label",
                                     "name": "shareAlias",
                                     "value": "contributing",
                                     "isInheritable": false,
                                     "position": 30
-                                },
-                                {
-                                    "type": "relation",
-                                    "name": "internalLink",
-                                    "value": "hykHhxU5DhfF",
-                                    "isInheritable": false,
-                                    "position": 40
                                 }
                             ],
                             "format": "markdown",
@@ -456,65 +456,72 @@
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "Zjh0gpeFlaIp",
+                            "value": "QXVK8oy1Fxt4",
                             "isInheritable": false,
                             "position": 50
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "9QwQ6aHPcZLC",
+                            "value": "Zjh0gpeFlaIp",
                             "isInheritable": false,
                             "position": 60
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "k6reolKURi7J",
+                            "value": "9QwQ6aHPcZLC",
                             "isInheritable": false,
                             "position": 70
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "NzeU5J2tfb2t",
+                            "value": "k6reolKURi7J",
                             "isInheritable": false,
                             "position": 80
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "XGLieGaoykBR",
+                            "value": "NzeU5J2tfb2t",
                             "isInheritable": false,
                             "position": 90
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "UXDDvFoeQqNj",
+                            "value": "XGLieGaoykBR",
                             "isInheritable": false,
                             "position": 100
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "uFlRz3KNEjhF",
+                            "value": "UXDDvFoeQqNj",
                             "isInheritable": false,
                             "position": 110
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "hykHhxU5DhfF",
+                            "value": "uFlRz3KNEjhF",
                             "isInheritable": false,
                             "position": 120
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "BZHwwCSb38Lu",
+                            "value": "hykHhxU5DhfF",
                             "isInheritable": false,
                             "position": 130
+                        },
+                        {
+                            "type": "relation",
+                            "name": "internalLink",
+                            "value": "BZHwwCSb38Lu",
+                            "isInheritable": false,
+                            "position": 140
                         },
                         {
                             "type": "relation",
@@ -561,63 +568,63 @@
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "QXVK8oy1Fxt4",
+                            "value": "IjYqLhriG6Le",
                             "isInheritable": false,
                             "position": 210
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "IjYqLhriG6Le",
+                            "value": "BWy0GQ2M438N",
                             "isInheritable": false,
                             "position": 220
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "BWy0GQ2M438N",
+                            "value": "J5kUVB5QITti",
                             "isInheritable": false,
                             "position": 230
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "J5kUVB5QITti",
+                            "value": "Pk6ASn7EDz7R",
                             "isInheritable": false,
                             "position": 240
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "Pk6ASn7EDz7R",
+                            "value": "7SEbHWQ3kEs5",
                             "isInheritable": false,
                             "position": 250
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "7SEbHWQ3kEs5",
+                            "value": "3PqatYARSWot",
                             "isInheritable": false,
                             "position": 260
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "3PqatYARSWot",
+                            "value": "kvh5y1D2GXM5",
                             "isInheritable": false,
                             "position": 270
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "kvh5y1D2GXM5",
+                            "value": "96JPlIXsD5jk",
                             "isInheritable": false,
                             "position": 280
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
-                            "value": "96JPlIXsD5jk",
+                            "value": "btAHOppSLATG",
                             "isInheritable": false,
                             "position": 290
                         },
@@ -626,42 +633,35 @@
                             "name": "internalLink",
                             "value": "W6VXRIUUO0ya",
                             "isInheritable": false,
-                            "position": 310
+                            "position": 300
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "Bj05XwpRo8b0",
                             "isInheritable": false,
-                            "position": 320
+                            "position": 310
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "QqRZJ7tA6XxY",
                             "isInheritable": false,
-                            "position": 330
+                            "position": 320
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "4malwusc4F5y",
                             "isInheritable": false,
-                            "position": 340
+                            "position": 330
                         },
                         {
                             "type": "relation",
                             "name": "internalLink",
                             "value": "D5ZVhAqWDlqG",
                             "isInheritable": false,
-                            "position": 350
-                        },
-                        {
-                            "type": "relation",
-                            "name": "internalLink",
-                            "value": "btAHOppSLATG",
-                            "isInheritable": false,
-                            "position": 360
+                            "position": 340
                         },
                         {
                             "type": "label",
@@ -691,6 +691,97 @@
                             "type": "text",
                             "mime": "text/html",
                             "attributes": [
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "QXVK8oy1Fxt4",
+                                    "isInheritable": false,
+                                    "position": 10
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "IjYqLhriG6Le",
+                                    "isInheritable": false,
+                                    "position": 20
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "BWy0GQ2M438N",
+                                    "isInheritable": false,
+                                    "position": 30
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "J5kUVB5QITti",
+                                    "isInheritable": false,
+                                    "position": 40
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "Pk6ASn7EDz7R",
+                                    "isInheritable": false,
+                                    "position": 50
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "r0BrgOh6rAAe",
+                                    "isInheritable": false,
+                                    "position": 60
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "ede4f7aOfleT",
+                                    "isInheritable": false,
+                                    "position": 70
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "6GuMxxGzmbTg",
+                                    "isInheritable": false,
+                                    "position": 80
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "zgxCSCE7ahlS",
+                                    "isInheritable": false,
+                                    "position": 90
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "ml3AjuLkzrf0",
+                                    "isInheritable": false,
+                                    "position": 100
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "o8ubSQYiRlMv",
+                                    "isInheritable": false,
+                                    "position": 110
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "EeU04vVXDPum",
+                                    "isInheritable": false,
+                                    "position": 120
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "Xfu0l3KoHmVw",
+                                    "isInheritable": false,
+                                    "position": 130
+                                },
                                 {
                                     "type": "label",
                                     "name": "shareAlias",
@@ -1333,6 +1424,97 @@
                             "mime": "text/markdown",
                             "attributes": [
                                 {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "7SEbHWQ3kEs5",
+                                    "isInheritable": false,
+                                    "position": 10
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "3PqatYARSWot",
+                                    "isInheritable": false,
+                                    "position": 20
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "kvh5y1D2GXM5",
+                                    "isInheritable": false,
+                                    "position": 30
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "GX125fUuNk1Z",
+                                    "isInheritable": false,
+                                    "position": 40
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "EGVIZbhvD0GD",
+                                    "isInheritable": false,
+                                    "position": 50
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "2pEwDEMRvx8v",
+                                    "isInheritable": false,
+                                    "position": 60
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "sdejt46AiLSZ",
+                                    "isInheritable": false,
+                                    "position": 70
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "axNcpQh0e0ZB",
+                                    "isInheritable": false,
+                                    "position": 80
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "k6reolKURi7J",
+                                    "isInheritable": false,
+                                    "position": 90
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "XGLieGaoykBR",
+                                    "isInheritable": false,
+                                    "position": 100
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "NzeU5J2tfb2t",
+                                    "isInheritable": false,
+                                    "position": 110
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "Xfu0l3KoHmVw",
+                                    "isInheritable": false,
+                                    "position": 120
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "QXVK8oy1Fxt4",
+                                    "isInheritable": false,
+                                    "position": 130
+                                },
+                                {
                                     "type": "label",
                                     "name": "shareAlias",
                                     "value": "deployment",
@@ -1716,9 +1898,16 @@
                                         {
                                             "type": "relation",
                                             "name": "internalLink",
-                                            "value": "QXVK8oy1Fxt4",
+                                            "value": "UXDDvFoeQqNj",
                                             "isInheritable": false,
                                             "position": 80
+                                        },
+                                        {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "QXVK8oy1Fxt4",
+                                            "isInheritable": false,
+                                            "position": 90
                                         },
                                         {
                                             "type": "label",
@@ -1933,32 +2122,39 @@
                                     "mime": "text/markdown",
                                     "attributes": [
                                         {
-                                            "type": "label",
-                                            "name": "shareAlias",
-                                            "value": "helm-chart",
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "4malwusc4F5y",
                                             "isInheritable": false,
                                             "position": 10
                                         },
                                         {
                                             "type": "relation",
                                             "name": "internalLink",
-                                            "value": "0RC0xXheV6Ng",
+                                            "value": "k6reolKURi7J",
                                             "isInheritable": false,
-                                            "position": 50
+                                            "position": 20
                                         },
                                         {
                                             "type": "relation",
                                             "name": "internalLink",
-                                            "value": "Xfu0l3KoHmVw",
+                                            "value": "XGLieGaoykBR",
                                             "isInheritable": false,
-                                            "position": 60
+                                            "position": 30
                                         },
                                         {
                                             "type": "relation",
                                             "name": "internalLink",
-                                            "value": "sdejt46AiLSZ",
+                                            "value": "3PqatYARSWot",
                                             "isInheritable": false,
-                                            "position": 70
+                                            "position": 40
+                                        },
+                                        {
+                                            "type": "label",
+                                            "name": "shareAlias",
+                                            "value": "helm-chart",
+                                            "isInheritable": false,
+                                            "position": 10
                                         }
                                     ],
                                     "format": "markdown",
@@ -1996,6 +2192,13 @@
                                                     "value": "Xfu0l3KoHmVw",
                                                     "isInheritable": false,
                                                     "position": 20
+                                                },
+                                                {
+                                                    "type": "relation",
+                                                    "name": "internalLink",
+                                                    "value": "sdejt46AiLSZ",
+                                                    "isInheritable": false,
+                                                    "position": 30
                                                 },
                                                 {
                                                     "type": "label",
@@ -2341,49 +2544,49 @@
                                     "name": "internalLink",
                                     "value": "XGLieGaoykBR",
                                     "isInheritable": false,
-                                    "position": 30
+                                    "position": 10
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
                                     "value": "btAHOppSLATG",
                                     "isInheritable": false,
-                                    "position": 40
+                                    "position": 20
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
                                     "value": "W6VXRIUUO0ya",
                                     "isInheritable": false,
-                                    "position": 50
+                                    "position": 30
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
                                     "value": "Bj05XwpRo8b0",
                                     "isInheritable": false,
-                                    "position": 60
+                                    "position": 40
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
                                     "value": "QXVK8oy1Fxt4",
                                     "isInheritable": false,
-                                    "position": 70
+                                    "position": 50
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
                                     "value": "Zjh0gpeFlaIp",
                                     "isInheritable": false,
-                                    "position": 80
+                                    "position": 60
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
                                     "value": "9QwQ6aHPcZLC",
                                     "isInheritable": false,
-                                    "position": 90
+                                    "position": 70
                                 },
                                 {
                                     "type": "label",
@@ -2501,16 +2704,23 @@
                                         {
                                             "type": "relation",
                                             "name": "internalLink",
-                                            "value": "XGLieGaoykBR",
+                                            "value": "kvh5y1D2GXM5",
                                             "isInheritable": false,
                                             "position": 10
                                         },
                                         {
                                             "type": "relation",
                                             "name": "internalLink",
-                                            "value": "NzeU5J2tfb2t",
+                                            "value": "XGLieGaoykBR",
                                             "isInheritable": false,
                                             "position": 20
+                                        },
+                                        {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "NzeU5J2tfb2t",
+                                            "isInheritable": false,
+                                            "position": 30
                                         },
                                         {
                                             "type": "label",
@@ -2586,16 +2796,37 @@
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
-                                    "value": "96JPlIXsD5jk",
+                                    "value": "k6reolKURi7J",
                                     "isInheritable": false,
                                     "position": 10
                                 },
                                 {
                                     "type": "relation",
                                     "name": "internalLink",
-                                    "value": "k6reolKURi7J",
+                                    "value": "96JPlIXsD5jk",
+                                    "isInheritable": false,
+                                    "position": 20
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "QXVK8oy1Fxt4",
                                     "isInheritable": false,
                                     "position": 30
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "XGLieGaoykBR",
+                                    "isInheritable": false,
+                                    "position": 40
+                                },
+                                {
+                                    "type": "relation",
+                                    "name": "internalLink",
+                                    "value": "btAHOppSLATG",
+                                    "isInheritable": false,
+                                    "position": 50
                                 },
                                 {
                                     "type": "label",

--- a/docs/docs/Developer Guide/Architecture/Components.md
+++ b/docs/docs/Developer Guide/Architecture/Components.md
@@ -73,14 +73,25 @@ Detailed breakdown of ncps system components.
 
 **Implementations:**
 
-- **Local** (`lock/local/`) - In-process locks (sync.Mutex)
-- **Redis** (`lock/redis/`) - Distributed locks (Redlock)
+- **Local** (`lock/local/`) - In-process locks (sync.Mutex, sync.RWMutex)
+- **Redis** (`lock/redis/`) - Distributed locks (Redlock algorithm)
+- **PostgreSQL** (`lock/postgres/`) - Distributed locks (PostgreSQL advisory locks)
+- **MySQL** (`lock/mysql/`) - Distributed locks (MySQL/MariaDB GET_LOCK)
 
 **Responsibilities:**
 
 - Coordinate downloads (prevent duplicates)
 - Coordinate LRU cleanup
 - Handle lock retries
+- Provide both exclusive and shared (read-write) locking
+
+**Lock Types:**
+
+- `Locker` - Exclusive locks only (Lock/Unlock/TryLock)
+- `RWLocker` - Read-write locks (Lock/Unlock/RLock/RUnlock)
+  - PostgreSQL: True shared read locks via `pg_advisory_lock_shared()`
+  - MySQL: **Exclusive only** (RLock behaves like Lock - no read concurrency)
+  - Redis: True shared read locks via Redis hash sets
 
 ## NAR Handler (pkg/nar/)
 

--- a/pkg/lock/mysql/rwlocker.go
+++ b/pkg/lock/mysql/rwlocker.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/rs/zerolog"
+
 	"github.com/kalbasit/ncps/pkg/database"
 	"github.com/kalbasit/ncps/pkg/lock"
 )
@@ -31,6 +33,11 @@ func NewRWLocker(
 	if err != nil {
 		return nil, err
 	}
+
+	// Log a warning about MySQL's exclusive-only locking limitation
+	zerolog.Ctx(ctx).Warn().
+		Msg("MySQL RWLocker uses exclusive locks for both RLock and Lock - no read concurrency is provided. " +
+			"Consider using PostgreSQL or Redis for true shared read locks.")
 
 	return &RWLocker{
 		Locker: locker,


### PR DESCRIPTION
This change addresses a bug where PostgreSQL read-write locking was
unintentionally blocking. It now uses pg_try_advisory_lock_shared with
retries for non-blocking behavior.

Additionally:
- Clarifies MySQL's exclusive-only locking limitation in code and docs
- Adds warnings when using MySQL RWLocker
- Updates documentation with deployment recommendations for high-traffic caches
- Refactors MySQL metrics recording to use a consistent mode constant