### PR TITLE
chore: remove gt-ss workflow

### DIFF
--- a/.agent/workflows/gt-ss.md
+++ b/.agent/workflows/gt-ss.md
@@ -1,9 +1,0 @@
----
-description: Submit the current Graphite stack in non-interactive mode
----
-
-1. Submit the stack. If called with `-m` (e.g., `/gt-ss -m`), include the `--merge-when-ready` flag.
-
-```bash
-gt ss --no-interactive --publish $([[ " $* " == *" -m "* ]] && echo "--merge-when-ready")
-```


### PR DESCRIPTION
This removes the /gt-ss workflow as it is no longer needed after the
introduction of the Graphite skill, which prohibits the agent from
running gt ss/submit/squash. The agent should now rely on the skill's
guidance and avoid automated submission/squashing.