### PR TITLE
fix: prevent pager interference in dev-scripts

### DIFF
--- a/dev-scripts/get-unresolved-comments.sh
+++ b/dev-scripts/get-unresolved-comments.sh
@@ -4,6 +4,9 @@ set -eo pipefail
 # get-unresolved-comments.sh: Fetches unresolved PR comments using GitHub GraphQL API.
 # Usage: ./get-unresolved-comments.sh <pr-number>
 
+# Ensure no pager interfers with any of the commands
+export PAGER=""
+
 PR_NUMBER=$1
 if [ -z "$PR_NUMBER" ]; then
   PR_NUMBER=$(PAGER= gh pr view --json number --jq '.number' || true)

--- a/dev-scripts/resolve-pr-comment.sh
+++ b/dev-scripts/resolve-pr-comment.sh
@@ -4,6 +4,9 @@ set -eo pipefail
 # resolve-pr-comment.sh: Resolves a GitHub PR review thread.
 # Usage: ./resolve-pr-comment.sh <thread-id>
 
+# Ensure no pager interfers with any of the commands
+export PAGER=""
+
 THREAD_ID=$1
 if [ -z "$THREAD_ID" ]; then
   echo "Usage: $0 <thread-id>" >&2


### PR DESCRIPTION
This adds 'export PAGER=""' to 'get-unresolved-comments.sh' and
'resolve-pr-comment.sh'. This is necessary to prevent terminal pagers
from pausing execution during automated script runs, especially when
invoked by persistent agentic processes.