### PR TITLE
docs: add Graphite over Git lesson to skill documentation

### DIFF
--- a/.agent/skills/graphite/SKILL.md
+++ b/.agent/skills/graphite/SKILL.md
@@ -72,6 +72,7 @@ Many Graphite commands (`gt modify`, `gt move`, `gt split`, `gt restack`) are in
 
 **The Solution**: Always prefer `gt` commands over their standard `git` counterparts for commit and branch management.
 
+- **Creating a new branch**: Use `gt create <branch-name>` instead of `git checkout -b <branch-name>`.
 - **Creating a new commit**: Use `gt modify -c -m "message"` instead of `git commit -m "message"`.
 - **Amending a commit**: Use `gt modify --amend` instead of `git commit --amend`.
 - **Staging and committing everything**: Use `gt modify -cam "message"` instead of `git commit -am "message"`.


### PR DESCRIPTION
This lesson explains why agents should prefer 'gt' commands over standard 'git'
commands for commit and branch management. Using 'git commit' directly can
lead to stack desynchronization and requires manual restacking, whereas
'gt modify' and 'gt create' handle metadata integrity and automatic
restacking of descendants.

The lesson was added to the 'Common Fixes & Lessons' section of the
Graphite skill documentation.