### PR TITLE
fix: optimize golomb encoding/decoding and improve error handling

### DIFF
--- a/pkg/golomb/golomb_test.go
+++ b/pkg/golomb/golomb_test.go
@@ -92,7 +92,7 @@ func TestGolombExample(t *testing.T) {
 	err = enc.Encode(1000)
 	require.NoError(t, err)
 
-	_ = enc.Flush()
+	require.NoError(t, enc.Flush())
 
 	// 1110 1110 1000 0000 (padded) -> EE 80
 	decodedBytes := buf.Bytes()


### PR DESCRIPTION
This commit addresses performance concerns raised in PR 564.

Changes:
- Optimizes `EncodeBig` and `DecodeBig` in `pkg/golomb` to use `uint64` arithmetic for quotient operations when possible, avoiding expensive `big.Int` allocations and operations for common cases.
- Updates `pkg/golomb/golomb_test.go` to properly handle errors from `Flush()`.

This significantly reduces the overhead of Golomb coding for standard integer sizes while maintaining correctness for arbitrarily large numbers.

Follow-up on #564 that I merged prematurely by accident.