### PR TITLE
feat: add --cache-lock-backend flag

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -900,6 +900,11 @@ func serveDetectExtraResourceAttrs(
 	if backend := cmd.String("cache-lock-backend"); backend != "" {
 		lockType = backend
 	} else if hasRedis {
+		zerolog.Ctx(ctx).Warn().
+			Msg("--cache-redis-addrs is set but --cache-lock-backend is 'local'. " +
+				"Please explicitly set --cache-lock-backend=redis. " +
+				"Defaulting to Redis for backward compatibility.")
+
 		lockType = lockBackendRedis
 	}
 

--- a/dev-scripts/run.py
+++ b/dev-scripts/run.py
@@ -285,9 +285,12 @@ def main():
             )
 
         # Locker Args
+        if args.locker == "local":
+            cmd.extend(["--cache-lock-backend=local"])
         if args.locker == "redis":
             cmd.extend(
                 [
+                    "--cache-lock-backend=redis",
                     f"--cache-redis-addrs={REDIS_ADDR}",
                     "--cache-lock-download-ttl=5m",
                     "--cache-lock-lru-ttl=30m",


### PR DESCRIPTION
This backports the --cache-lock-backend flag to the v0.6 branch. It allows
users to explicitly choose between local and Redis locking backends.

The implementation:
- Defaults to Redis if configured, otherwise falls back to local locking.
- Warns if Redis is configured but the backend is set to 'local'.
- Errors if the backend is set to 'redis' but no addresses are provided.
- Updates telemetry to include the lock type as a resource attribute.