### PR TITLE
ci: treat release-* branches the same as the main branch

### DIFF
--- a/.github/workflows/auto-update-vendorhash.yaml
+++ b/.github/workflows/auto-update-vendorhash.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+      - "release-*"
     paths:
       - "go.mod"
       - "go.sum"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - "main"
+      - "release-*"
 jobs:
   flake:
     uses: ./.github/workflows/flake.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+      - "release-*"
 jobs:
   flake:
     uses: ./.github/workflows/flake.yml

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -8,6 +8,7 @@ on:
       - reopened
     branches:
       - main
+      - "release-*"
 permissions:
   pull-requests: read
 jobs:


### PR DESCRIPTION
Pull requests targeting the release-* branches should run CI jobs as if it's the main branch.