### PR TITLE
docs: update analytics documentation and clarify HA lock backends

### DIFF
--- a/docs/docs/User Guide/Configuration/Reference.md
+++ b/docs/docs/User Guide/Configuration/Reference.md
@@ -283,7 +283,10 @@ Configure anonymous usage statistics reporting to help improve ncps.
 
 **What is collected:**
 
-- **Resource attributes**: Database type (`sqlite`/`postgres`/`mysql`), lock type (`local`/`redis`), cluster UUID
+- **Resource attributes**:
+  - Database backend type: `sqlite`, `postgres`, or `mysql`
+  - Lock mechanism type: `local`, `redis`, or `postgres`
+  - Cluster UUID (randomly generated identifier)
 - **Metrics** (hourly): Total cache size, upstream count, upstream health
 - **Logs**: Startup events, panic/crash events with stack traces
 
@@ -414,8 +417,6 @@ cache:
     redis:
       key-prefix: "ncps:lock:"
     postgres:
-      key-prefix: "ncps:lock:"
-    mysql:
       key-prefix: "ncps:lock:"
     retry:
       max-attempts: 3

--- a/docs/docs/User Guide/Deployment/Distributed Locking.md
+++ b/docs/docs/User Guide/Deployment/Distributed Locking.md
@@ -68,7 +68,7 @@ ncps supports running multiple instances in a high-availability configuration us
      │                  │                  │
      │   ┌──────────────▼──────────┐       │
      │   │                         │       │
-     ├──►│    Redis Server         │◄──────┤
+     ├──►│    Redis Server         │◄──────┘
      │   │  (Distributed Locks)    │
      │   └─────────────────────────┘
      │
@@ -302,7 +302,7 @@ Advisory locks provide a distributed locking alternative for deployments that:
 #### Advisory Lock Prerequisites
 
 > [!IMPORTANT]
-> Database advisory locks require PostgreSQL 9.1+. SQLite does not support advisory locks.
+> Database advisory locks require PostgreSQL 9.1+. SQLite and MySQL do not support advisory locks in ncps. If you use MySQL as your database, you must use Redis for distributed locking.
 
 1. **Shared Database** (PostgreSQL)
    - Version 9.1 or later (12+ recommended)

--- a/docs/docs/User Guide/Deployment/High Availability.md
+++ b/docs/docs/User Guide/Deployment/High Availability.md
@@ -56,6 +56,7 @@ Running multiple ncps instances provides:
 1. **PostgreSQL or MySQL database** (shared across all instances)
    - PostgreSQL 12+ or MySQL 8.0+
    - **SQLite is NOT supported for HA**
+   - **NOTE: MySQL is only supported for data storage, NOT for distributed locking. If using MySQL, you must use Redis for locking.**
 1. **Load balancer** to distribute requests
    - nginx, HAProxy, cloud load balancer, etc.
 
@@ -209,7 +210,7 @@ cache:
     password: ${REDIS_PASSWORD}  # If using auth
 
   lock:
-    backend: redis  # Options: local, redis, postgres, mysql
+    backend: redis  # Options: local, redis, postgres
     download-lock-ttl: 5m
     lru-lock-ttl: 30m
     retry:

--- a/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
+++ b/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
@@ -122,6 +122,12 @@ The following table lists the configurable parameters of the ncps chart and thei
 | `config.signing.secretKey` | Signing secret key | `""` |
 | `config.signing.existingSecret` | Existing secret with signing key | `""` |
 
+### Analytics
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `config.analytics.reporting.enabled` | Enable anonymous usage statistics reporting | `true` |
+
 ### Cache Management
 
 | Parameter | Description | Default |
@@ -203,6 +209,7 @@ The following table lists the configurable parameters of the ncps chart and thei
 
 | Parameter | Description | Default |
 | --- | --- | --- |
+| `config.lock.backend` | Lock backend: `local`, `redis`, or `postgres` (auto-set to `redis` if `config.redis.enabled=true`) | `local` |
 | `config.lock.redis.keyPrefix` | Redis lock key prefix | `ncps:lock:` |
 | `config.lock.postgres.keyPrefix` | PostgreSQL lock key prefix | `ncps:lock:` |
 | `config.lock.downloadTTL` | Download lock TTL | `5m` |
@@ -212,6 +219,10 @@ The following table lists the configurable parameters of the ncps chart and thei
 | `config.lock.retry.maxDelay` | Maximum retry delay | `2s` |
 | `config.lock.retry.jitter` | Enable retry jitter | `true` |
 | `config.lock.allowDegradedMode` | Allow degraded mode | `false` |
+
+**Note on Lock Backend Selection:**
+
+When `config.redis.enabled=true`, the chart automatically sets the lock backend to `redis`, regardless of the `config.lock.backend` value. This ensures proper distributed locking for HA deployments using Redis. If you want to use PostgreSQL advisory locks instead, set `config.redis.enabled=false` and `config.lock.backend=postgres`.
 
 ### Observability
 


### PR DESCRIPTION
This update expands the analytics documentation to clearly state what data is collected, including the addition of PostgreSQL as a supported lock mechanism. It also clarifies that while MySQL is supported as a database (metadata) backend, it is NOT supported as a distributed locking backend; in such cases, Redis must be used.