### PR TITLE
docs: document PostgreSQL advisory lock connection pool implications

### DIFF
--- a/docs/docs/User Guide/Configuration/Database/PostgreSQL Configuration.md
+++ b/docs/docs/User Guide/Configuration/Database/PostgreSQL Configuration.md
@@ -101,6 +101,11 @@ cache:
       max-idle-conns: 10
 ```
 
+> [!WARNING]
+> **Advisory Locks and Connection Pools:** If you use PostgreSQL as your distributed lock backend (`--cache-lock-backend=postgres`), each active lock consumes a dedicated connection from the pool. A single request can consume up to 3 connections simultaneously.
+>
+> To avoid deadlocks under concurrent load, ensure `--cache-database-pool-max-open-conns` is significantly higher than your expected concurrency (at least 50-100 is recommended).
+
 ### Initialization
 
 ```

--- a/docs/docs/User Guide/Configuration/Reference.md
+++ b/docs/docs/User Guide/Configuration/Reference.md
@@ -131,6 +131,9 @@ See <a class="reference-link" href="Storage.md">Storage</a> for details.
 | `--cache-lru-schedule` | LRU cleanup cron schedule | `CACHE_LRU_SCHEDULE` | - |
 | `--cache-temp-path` | Temporary download directory | `CACHE_TEMP_PATH` | system temp |
 
+> [!IMPORTANT]
+> When using PostgreSQL advisory locks (`--cache-lock-backend=postgres`), each active lock consumes one connection from this pool. A single request can use up to 3 connections. Set this value high (e.g., 50-100) to avoid deadlocks.
+
 **Database URL Formats:**
 
 - SQLite: `sqlite:/var/lib/ncps/db/db.sqlite`

--- a/docs/docs/User Guide/Operations/Troubleshooting.md
+++ b/docs/docs/User Guide/Operations/Troubleshooting.md
@@ -97,6 +97,14 @@ sudo chown -R ncps:ncps /var/lib/ncps
 
 See <a class="reference-link" href="../Deployment/Distributed%20Locking.md">Distributed Locking</a>.
 
+### Database Connection Exhaustion (HA)
+
+**Symptom:** Requests hang for 5 minutes and then fail with "context canceled" or "bad connection".
+
+**Common Cause:** Using PostgreSQL advisory locks with a small connection pool. Each request can consume up to 3 connections, leading to deadlocks if the pool is exhausted.
+
+**Solution:** Increase `--cache-database-pool-max-open-conns` to at least 50-100 or switch to Redis for locking.
+
 ## Debug Logging
 
 Enable debug mode:


### PR DESCRIPTION
This update adds essential guidance on managing database connection pools when using PostgreSQL advisory locks for distributed locking.

Investigation into performance issues revealed that each advisory lock requires a dedicated database connection. Under concurrent load, requests can consume up to 3 connections (shared cache lock, exclusive download lock, and metadata transaction), which can lead to deadlocks if the connection pool is not adequately sized.

Changes:
- Added warnings about connection pool exhaustion to PostgreSQL configuration, Distributed Locking, and Reference docs.
- Added a new troubleshooting section for identifying and resolving these deadlocks.
- Recommended increasing connection pool limits to 50-100 for HA deployments.