### PR TITLE
feat: add narinfo schema tables

### DIFF
--- a/db/migrations/mysql/20260117195000_add_narinfo_de_normalized.sql
+++ b/db/migrations/mysql/20260117195000_add_narinfo_de_normalized.sql
@@ -1,0 +1,46 @@
+-- migrate:up
+-- Migration to add de-normalized NarInfo fields and helper tables
+
+-- Add columns to narinfos table
+ALTER TABLE narinfos ADD COLUMN store_path TEXT;
+ALTER TABLE narinfos ADD COLUMN url TEXT;
+ALTER TABLE narinfos ADD COLUMN compression VARCHAR(255);
+ALTER TABLE narinfos ADD COLUMN file_hash VARCHAR(255);
+ALTER TABLE narinfos ADD COLUMN file_size BIGINT UNSIGNED;
+ALTER TABLE narinfos ADD COLUMN nar_hash VARCHAR(255);
+ALTER TABLE narinfos ADD COLUMN nar_size BIGINT UNSIGNED;
+ALTER TABLE narinfos ADD COLUMN deriver TEXT;
+ALTER TABLE narinfos ADD COLUMN system VARCHAR(255);
+ALTER TABLE narinfos ADD COLUMN ca TEXT;
+
+-- Create references table
+CREATE TABLE narinfo_references (
+    narinfo_id BIGINT NOT NULL,
+    reference VARCHAR(255) NOT NULL,
+    PRIMARY KEY (narinfo_id, reference),
+    CONSTRAINT fk_narinfo_references_narinfo_id FOREIGN KEY (narinfo_id) REFERENCES narinfos (id) ON DELETE CASCADE
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
+CREATE INDEX idx_narinfo_references_reference ON narinfo_references (reference);
+
+-- Create signatures table
+CREATE TABLE narinfo_signatures (
+    narinfo_id BIGINT NOT NULL,
+    signature VARCHAR(255) NOT NULL,
+    PRIMARY KEY (narinfo_id, signature),
+    CONSTRAINT fk_narinfo_signatures_narinfo_id FOREIGN KEY (narinfo_id) REFERENCES narinfos (id) ON DELETE CASCADE
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
+CREATE INDEX idx_narinfo_signatures_signature ON narinfo_signatures (signature);
+
+-- migrate:down
+DROP TABLE narinfo_signatures;
+DROP TABLE narinfo_references;
+ALTER TABLE narinfos DROP COLUMN ca;
+ALTER TABLE narinfos DROP COLUMN system;
+ALTER TABLE narinfos DROP COLUMN deriver;
+ALTER TABLE narinfos DROP COLUMN nar_size;
+ALTER TABLE narinfos DROP COLUMN nar_hash;
+ALTER TABLE narinfos DROP COLUMN file_size;
+ALTER TABLE narinfos DROP COLUMN file_hash;
+ALTER TABLE narinfos DROP COLUMN compression;
+ALTER TABLE narinfos DROP COLUMN url;
+ALTER TABLE narinfos DROP COLUMN store_path;

--- a/db/migrations/postgres/20260117195000_add_narinfo_de_normalized.sql
+++ b/db/migrations/postgres/20260117195000_add_narinfo_de_normalized.sql
@@ -1,0 +1,46 @@
+-- migrate:up
+-- Migration to add de-normalized NarInfo fields and helper tables
+
+-- Add columns to narinfos table
+ALTER TABLE narinfos ADD COLUMN store_path TEXT;
+ALTER TABLE narinfos ADD COLUMN url TEXT;
+ALTER TABLE narinfos ADD COLUMN compression TEXT;
+ALTER TABLE narinfos ADD COLUMN file_hash TEXT;
+ALTER TABLE narinfos ADD COLUMN file_size BIGINT CHECK (file_size >= 0);
+ALTER TABLE narinfos ADD COLUMN nar_hash TEXT;
+ALTER TABLE narinfos ADD COLUMN nar_size BIGINT CHECK (nar_size >= 0);
+ALTER TABLE narinfos ADD COLUMN deriver TEXT;
+ALTER TABLE narinfos ADD COLUMN system TEXT;
+ALTER TABLE narinfos ADD COLUMN ca TEXT;
+
+-- Create references table
+CREATE TABLE narinfo_references (
+    narinfo_id BIGINT NOT NULL,
+    reference TEXT NOT NULL,
+    PRIMARY KEY (narinfo_id, reference),
+    FOREIGN KEY (narinfo_id) REFERENCES narinfos (id) ON DELETE CASCADE
+);
+CREATE INDEX idx_narinfo_references_reference ON narinfo_references (reference);
+
+-- Create signatures table
+CREATE TABLE narinfo_signatures (
+    narinfo_id BIGINT NOT NULL,
+    signature TEXT NOT NULL,
+    PRIMARY KEY (narinfo_id, signature),
+    FOREIGN KEY (narinfo_id) REFERENCES narinfos (id) ON DELETE CASCADE
+);
+CREATE INDEX idx_narinfo_signatures_signature ON narinfo_signatures (signature);
+
+-- migrate:down
+DROP TABLE narinfo_signatures;
+DROP TABLE narinfo_references;
+ALTER TABLE narinfos DROP COLUMN ca;
+ALTER TABLE narinfos DROP COLUMN system;
+ALTER TABLE narinfos DROP COLUMN deriver;
+ALTER TABLE narinfos DROP COLUMN nar_size;
+ALTER TABLE narinfos DROP COLUMN nar_hash;
+ALTER TABLE narinfos DROP COLUMN file_size;
+ALTER TABLE narinfos DROP COLUMN file_hash;
+ALTER TABLE narinfos DROP COLUMN compression;
+ALTER TABLE narinfos DROP COLUMN url;
+ALTER TABLE narinfos DROP COLUMN store_path;

--- a/db/migrations/sqlite/20260117195000_add_narinfo_de_normalized.sql
+++ b/db/migrations/sqlite/20260117195000_add_narinfo_de_normalized.sql
@@ -1,0 +1,46 @@
+-- migrate:up
+-- Migration to add de-normalized NarInfo fields and helper tables
+
+-- Add columns to narinfos table
+ALTER TABLE narinfos ADD COLUMN store_path TEXT;
+ALTER TABLE narinfos ADD COLUMN url TEXT;
+ALTER TABLE narinfos ADD COLUMN compression TEXT;
+ALTER TABLE narinfos ADD COLUMN file_hash TEXT;
+ALTER TABLE narinfos ADD COLUMN file_size BIGINT CHECK (file_size >= 0);
+ALTER TABLE narinfos ADD COLUMN nar_hash TEXT;
+ALTER TABLE narinfos ADD COLUMN nar_size BIGINT CHECK (nar_size >= 0);
+ALTER TABLE narinfos ADD COLUMN deriver TEXT;
+ALTER TABLE narinfos ADD COLUMN system TEXT;
+ALTER TABLE narinfos ADD COLUMN ca TEXT;
+
+-- Create references table
+CREATE TABLE narinfo_references (
+    narinfo_id BIGINT NOT NULL,
+    reference TEXT NOT NULL,
+    PRIMARY KEY (narinfo_id, reference),
+    FOREIGN KEY (narinfo_id) REFERENCES narinfos (id) ON DELETE CASCADE
+);
+CREATE INDEX idx_narinfo_references_reference ON narinfo_references (reference);
+
+-- Create signatures table
+CREATE TABLE narinfo_signatures (
+    narinfo_id BIGINT NOT NULL,
+    signature TEXT NOT NULL,
+    PRIMARY KEY (narinfo_id, signature),
+    FOREIGN KEY (narinfo_id) REFERENCES narinfos (id) ON DELETE CASCADE
+);
+CREATE INDEX idx_narinfo_signatures_signature ON narinfo_signatures (signature);
+
+-- migrate:down
+DROP TABLE narinfo_signatures;
+DROP TABLE narinfo_references;
+ALTER TABLE narinfos DROP COLUMN ca;
+ALTER TABLE narinfos DROP COLUMN system;
+ALTER TABLE narinfos DROP COLUMN deriver;
+ALTER TABLE narinfos DROP COLUMN nar_size;
+ALTER TABLE narinfos DROP COLUMN nar_hash;
+ALTER TABLE narinfos DROP COLUMN file_size;
+ALTER TABLE narinfos DROP COLUMN file_hash;
+ALTER TABLE narinfos DROP COLUMN compression;
+ALTER TABLE narinfos DROP COLUMN url;
+ALTER TABLE narinfos DROP COLUMN store_path;

--- a/db/schema/mysql.sql
+++ b/db/schema/mysql.sql
@@ -71,6 +71,36 @@ CREATE TABLE `narinfo_nar_files` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `narinfo_references`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `narinfo_references` (
+  `narinfo_id` bigint(20) NOT NULL,
+  `reference` varchar(255) NOT NULL,
+  PRIMARY KEY (`narinfo_id`,`reference`),
+  KEY `idx_narinfo_references_reference` (`reference`),
+  CONSTRAINT `fk_narinfo_references_narinfo_id` FOREIGN KEY (`narinfo_id`) REFERENCES `narinfos` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `narinfo_signatures`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `narinfo_signatures` (
+  `narinfo_id` bigint(20) NOT NULL,
+  `signature` varchar(255) NOT NULL,
+  PRIMARY KEY (`narinfo_id`,`signature`),
+  KEY `idx_narinfo_signatures_signature` (`signature`),
+  CONSTRAINT `fk_narinfo_signatures_narinfo_id` FOREIGN KEY (`narinfo_id`) REFERENCES `narinfos` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `narinfos`
 --
 
@@ -82,6 +112,16 @@ CREATE TABLE `narinfos` (
   `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
   `updated_at` timestamp NULL DEFAULT NULL,
   `last_accessed_at` timestamp NULL DEFAULT current_timestamp(),
+  `store_path` text DEFAULT NULL,
+  `url` text DEFAULT NULL,
+  `compression` varchar(255) DEFAULT NULL,
+  `file_hash` varchar(255) DEFAULT NULL,
+  `file_size` bigint(20) unsigned DEFAULT NULL,
+  `nar_hash` varchar(255) DEFAULT NULL,
+  `nar_size` bigint(20) unsigned DEFAULT NULL,
+  `deriver` text DEFAULT NULL,
+  `system` varchar(255) DEFAULT NULL,
+  `ca` text DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_narinfos_hash` (`hash`),
   KEY `idx_narinfos_last_accessed_at` (`last_accessed_at`)
@@ -121,5 +161,6 @@ CREATE TABLE `schema_migrations` (
 
 LOCK TABLES `schema_migrations` WRITE;
 INSERT INTO `schema_migrations` (version) VALUES
-  ('20260101000000');
+  ('20260101000000'),
+  ('20260117195000');
 UNLOCK TABLES;

--- a/db/schema/postgres.sql
+++ b/db/schema/postgres.sql
@@ -93,6 +93,26 @@ CREATE TABLE public.narinfo_nar_files (
 
 
 --
+-- Name: narinfo_references; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.narinfo_references (
+    narinfo_id bigint NOT NULL,
+    reference text NOT NULL
+);
+
+
+--
+-- Name: narinfo_signatures; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.narinfo_signatures (
+    narinfo_id bigint NOT NULL,
+    signature text NOT NULL
+);
+
+
+--
 -- Name: narinfos; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -101,7 +121,19 @@ CREATE TABLE public.narinfos (
     hash text NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at timestamp with time zone,
-    last_accessed_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+    last_accessed_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    store_path text,
+    url text,
+    compression text,
+    file_hash text,
+    file_size bigint,
+    nar_hash text,
+    nar_size bigint,
+    deriver text,
+    system text,
+    ca text,
+    CONSTRAINT narinfos_file_size_check CHECK ((file_size >= 0)),
+    CONSTRAINT narinfos_nar_size_check CHECK ((nar_size >= 0))
 );
 
 
@@ -195,6 +227,22 @@ ALTER TABLE ONLY public.narinfo_nar_files
 
 
 --
+-- Name: narinfo_references narinfo_references_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.narinfo_references
+    ADD CONSTRAINT narinfo_references_pkey PRIMARY KEY (narinfo_id, reference);
+
+
+--
+-- Name: narinfo_signatures narinfo_signatures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.narinfo_signatures
+    ADD CONSTRAINT narinfo_signatures_pkey PRIMARY KEY (narinfo_id, signature);
+
+
+--
 -- Name: narinfos narinfos_hash_key; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -233,6 +281,20 @@ CREATE INDEX idx_narinfo_nar_files_nar_file_id ON public.narinfo_nar_files USING
 
 
 --
+-- Name: idx_narinfo_references_reference; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_narinfo_references_reference ON public.narinfo_references USING btree (reference);
+
+
+--
+-- Name: idx_narinfo_signatures_signature; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_narinfo_signatures_signature ON public.narinfo_signatures USING btree (signature);
+
+
+--
 -- Name: idx_narinfos_last_accessed_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -256,6 +318,22 @@ ALTER TABLE ONLY public.narinfo_nar_files
 
 
 --
+-- Name: narinfo_references narinfo_references_narinfo_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.narinfo_references
+    ADD CONSTRAINT narinfo_references_narinfo_id_fkey FOREIGN KEY (narinfo_id) REFERENCES public.narinfos(id) ON DELETE CASCADE;
+
+
+--
+-- Name: narinfo_signatures narinfo_signatures_narinfo_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.narinfo_signatures
+    ADD CONSTRAINT narinfo_signatures_narinfo_id_fkey FOREIGN KEY (narinfo_id) REFERENCES public.narinfos(id) ON DELETE CASCADE;
+
+
+--
 -- PostgreSQL database dump complete
 --
 
@@ -266,4 +344,5 @@ ALTER TABLE ONLY public.narinfo_nar_files
 --
 
 INSERT INTO public.schema_migrations (version) VALUES
-    ('20260101000000');
+    ('20260101000000'),
+    ('20260117195000');

--- a/db/schema/sqlite.sql
+++ b/db/schema/sqlite.sql
@@ -5,7 +5,7 @@ CREATE TABLE narinfos (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at TIMESTAMP,
     last_accessed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
+, store_path TEXT, url TEXT, compression TEXT, file_hash TEXT, file_size BIGINT CHECK (file_size >= 0), nar_hash TEXT, nar_size BIGINT CHECK (nar_size >= 0), deriver TEXT, system TEXT, ca TEXT);
 CREATE INDEX idx_narinfos_last_accessed_at ON narinfos (last_accessed_at);
 CREATE TABLE IF NOT EXISTS "config" (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -32,6 +32,20 @@ CREATE TABLE narinfo_nar_files (
 );
 CREATE INDEX idx_narinfo_nar_files_narinfo_id ON narinfo_nar_files (narinfo_id);
 CREATE INDEX idx_narinfo_nar_files_nar_file_id ON narinfo_nar_files (nar_file_id);
+CREATE TABLE narinfo_references (
+    narinfo_id BIGINT NOT NULL,
+    reference TEXT NOT NULL,
+    PRIMARY KEY (narinfo_id, reference),
+    FOREIGN KEY (narinfo_id) REFERENCES narinfos (id) ON DELETE CASCADE
+);
+CREATE INDEX idx_narinfo_references_reference ON narinfo_references (reference);
+CREATE TABLE narinfo_signatures (
+    narinfo_id BIGINT NOT NULL,
+    signature TEXT NOT NULL,
+    PRIMARY KEY (narinfo_id, signature),
+    FOREIGN KEY (narinfo_id) REFERENCES narinfos (id) ON DELETE CASCADE
+);
+CREATE INDEX idx_narinfo_signatures_signature ON narinfo_signatures (signature);
 -- Dbmate schema migrations
 INSERT INTO "schema_migrations" (version) VALUES
   ('20241210054814'),
@@ -40,4 +54,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20251230224159'),
   ('20260101000000'),
   ('20260105025735'),
-  ('20260105030513');
+  ('20260105030513'),
+  ('20260117195000');

--- a/pkg/database/generated_models.go
+++ b/pkg/database/generated_models.go
@@ -48,6 +48,16 @@ type NarInfo struct {
 	CreatedAt      time.Time
 	UpdatedAt      sql.NullTime
 	LastAccessedAt sql.NullTime
+	StorePath      sql.NullString
+	Url            sql.NullString
+	Compression    sql.NullString
+	FileHash       sql.NullString
+	FileSize       sql.NullInt64
+	NarHash        sql.NullString
+	NarSize        sql.NullInt64
+	Deriver        sql.NullString
+	System         sql.NullString
+	Ca             sql.NullString
 }
 
 type SetConfigParams struct {

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -32,7 +32,7 @@ type Querier interface {
 	//  ) VALUES (
 	//      $1
 	//  )
-	//  RETURNING id, hash, created_at, updated_at, last_accessed_at
+	//  RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	CreateNarInfo(ctx context.Context, hash string) (NarInfo, error)
 	//DeleteNarFileByHash
 	//
@@ -100,7 +100,7 @@ type Querier interface {
 	// does not properly support filtering on window function results in subqueries.
 	// Gets the least-used narinfos up to a certain total file size (accounting for their nar_files).
 	//
-	//  SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at
+	//  SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at, ni1.store_path, ni1.url, ni1.compression, ni1.file_hash, ni1.file_size, ni1.nar_hash, ni1.nar_size, ni1.deriver, ni1.system, ni1.ca
 	//  FROM narinfos ni1
 	//  WHERE (
 	//      SELECT COALESCE(SUM(nf.file_size), 0)
@@ -140,13 +140,13 @@ type Querier interface {
 	GetNarFileCount(ctx context.Context) (int64, error)
 	//GetNarInfoByHash
 	//
-	//  SELECT id, hash, created_at, updated_at, last_accessed_at
+	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	//  FROM narinfos
 	//  WHERE hash = $1
 	GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error)
 	//GetNarInfoByID
 	//
-	//  SELECT id, hash, created_at, updated_at, last_accessed_at
+	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	//  FROM narinfos
 	//  WHERE id = $1
 	GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)

--- a/pkg/database/mysqldb/models.go
+++ b/pkg/database/mysqldb/models.go
@@ -34,9 +34,29 @@ type NarInfo struct {
 	CreatedAt      time.Time
 	UpdatedAt      sql.NullTime
 	LastAccessedAt sql.NullTime
+	StorePath      sql.NullString
+	Url            sql.NullString
+	Compression    sql.NullString
+	FileHash       sql.NullString
+	FileSize       sql.NullInt64
+	NarHash        sql.NullString
+	NarSize        sql.NullInt64
+	Deriver        sql.NullString
+	System         sql.NullString
+	Ca             sql.NullString
 }
 
 type NarinfoNarFile struct {
 	NarInfoID int64
 	NarFileID int64
+}
+
+type NarinfoReference struct {
+	NarInfoID int64
+	Reference string
+}
+
+type NarinfoSignature struct {
+	NarInfoID int64
+	Signature string
 }

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -100,7 +100,7 @@ type Querier interface {
 	// does not properly support filtering on window function results in subqueries.
 	// Gets the least-used narinfos up to a certain total file size (accounting for their nar_files).
 	//
-	//  SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at
+	//  SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at, ni1.store_path, ni1.url, ni1.compression, ni1.file_hash, ni1.file_size, ni1.nar_hash, ni1.nar_size, ni1.deriver, ni1.`system`, ni1.ca
 	//  FROM narinfos ni1
 	//  WHERE (
 	//      SELECT COALESCE(SUM(nf.file_size), 0)
@@ -140,13 +140,13 @@ type Querier interface {
 	GetNarFileCount(ctx context.Context) (int64, error)
 	//GetNarInfoByHash
 	//
-	//  SELECT id, hash, created_at, updated_at, last_accessed_at
+	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, `system`, ca
 	//  FROM narinfos
 	//  WHERE hash = ?
 	GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error)
 	//GetNarInfoByID
 	//
-	//  SELECT id, hash, created_at, updated_at, last_accessed_at
+	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, `system`, ca
 	//  FROM narinfos
 	//  WHERE id = ?
 	GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -302,7 +302,7 @@ func (q *Queries) GetLeastUsedNarFiles(ctx context.Context, fileSize uint64) ([]
 }
 
 const getLeastUsedNarInfos = `-- name: GetLeastUsedNarInfos :many
-SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at
+SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at, ni1.store_path, ni1.url, ni1.compression, ni1.file_hash, ni1.file_size, ni1.nar_hash, ni1.nar_size, ni1.deriver, ni1.` + "`" + `system` + "`" + `, ni1.ca
 FROM narinfos ni1
 WHERE (
     SELECT COALESCE(SUM(nf.file_size), 0)
@@ -322,7 +322,7 @@ WHERE (
 // does not properly support filtering on window function results in subqueries.
 // Gets the least-used narinfos up to a certain total file size (accounting for their nar_files).
 //
-//	SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at
+//	SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at, ni1.store_path, ni1.url, ni1.compression, ni1.file_hash, ni1.file_size, ni1.nar_hash, ni1.nar_size, ni1.deriver, ni1.`system`, ni1.ca
 //	FROM narinfos ni1
 //	WHERE (
 //	    SELECT COALESCE(SUM(nf.file_size), 0)
@@ -350,6 +350,16 @@ func (q *Queries) GetLeastUsedNarInfos(ctx context.Context, fileSize uint64) ([]
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.LastAccessedAt,
+			&i.StorePath,
+			&i.Url,
+			&i.Compression,
+			&i.FileHash,
+			&i.FileSize,
+			&i.NarHash,
+			&i.NarSize,
+			&i.Deriver,
+			&i.System,
+			&i.Ca,
 		); err != nil {
 			return nil, err
 		}
@@ -464,14 +474,14 @@ func (q *Queries) GetNarFileCount(ctx context.Context) (int64, error) {
 }
 
 const getNarInfoByHash = `-- name: GetNarInfoByHash :one
-SELECT id, hash, created_at, updated_at, last_accessed_at
+SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, ` + "`" + `system` + "`" + `, ca
 FROM narinfos
 WHERE hash = ?
 `
 
 // GetNarInfoByHash
 //
-//	SELECT id, hash, created_at, updated_at, last_accessed_at
+//	SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, `system`, ca
 //	FROM narinfos
 //	WHERE hash = ?
 func (q *Queries) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error) {
@@ -483,19 +493,29 @@ func (q *Queries) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, e
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.LastAccessedAt,
+		&i.StorePath,
+		&i.Url,
+		&i.Compression,
+		&i.FileHash,
+		&i.FileSize,
+		&i.NarHash,
+		&i.NarSize,
+		&i.Deriver,
+		&i.System,
+		&i.Ca,
 	)
 	return i, err
 }
 
 const getNarInfoByID = `-- name: GetNarInfoByID :one
-SELECT id, hash, created_at, updated_at, last_accessed_at
+SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, ` + "`" + `system` + "`" + `, ca
 FROM narinfos
 WHERE id = ?
 `
 
 // GetNarInfoByID
 //
-//	SELECT id, hash, created_at, updated_at, last_accessed_at
+//	SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, `system`, ca
 //	FROM narinfos
 //	WHERE id = ?
 func (q *Queries) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error) {
@@ -507,6 +527,16 @@ func (q *Queries) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.LastAccessedAt,
+		&i.StorePath,
+		&i.Url,
+		&i.Compression,
+		&i.FileHash,
+		&i.FileSize,
+		&i.NarHash,
+		&i.NarSize,
+		&i.Deriver,
+		&i.System,
+		&i.Ca,
 	)
 	return i, err
 }

--- a/pkg/database/postgresdb/models.go
+++ b/pkg/database/postgresdb/models.go
@@ -34,9 +34,29 @@ type NarInfo struct {
 	CreatedAt      time.Time
 	UpdatedAt      sql.NullTime
 	LastAccessedAt sql.NullTime
+	StorePath      sql.NullString
+	Url            sql.NullString
+	Compression    sql.NullString
+	FileHash       sql.NullString
+	FileSize       sql.NullInt64
+	NarHash        sql.NullString
+	NarSize        sql.NullInt64
+	Deriver        sql.NullString
+	System         sql.NullString
+	Ca             sql.NullString
 }
 
 type NarinfoNarFile struct {
 	NarInfoID int64
 	NarFileID int64
+}
+
+type NarinfoReference struct {
+	NarInfoID int64
+	Reference string
+}
+
+type NarinfoSignature struct {
+	NarInfoID int64
+	Signature string
 }

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -34,7 +34,7 @@ type Querier interface {
 	//  ) VALUES (
 	//      $1
 	//  )
-	//  RETURNING id, hash, created_at, updated_at, last_accessed_at
+	//  RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	CreateNarInfo(ctx context.Context, hash string) (NarInfo, error)
 	//DeleteNarFileByHash
 	//
@@ -102,7 +102,7 @@ type Querier interface {
 	// does not properly support filtering on window function results in subqueries.
 	// Gets the least-used narinfos up to a certain total file size (accounting for their nar_files).
 	//
-	//  SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at
+	//  SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at, ni1.store_path, ni1.url, ni1.compression, ni1.file_hash, ni1.file_size, ni1.nar_hash, ni1.nar_size, ni1.deriver, ni1.system, ni1.ca
 	//  FROM narinfos ni1
 	//  WHERE (
 	//      SELECT COALESCE(SUM(nf.file_size), 0)
@@ -142,13 +142,13 @@ type Querier interface {
 	GetNarFileCount(ctx context.Context) (int64, error)
 	//GetNarInfoByHash
 	//
-	//  SELECT id, hash, created_at, updated_at, last_accessed_at
+	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	//  FROM narinfos
 	//  WHERE hash = $1
 	GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error)
 	//GetNarInfoByID
 	//
-	//  SELECT id, hash, created_at, updated_at, last_accessed_at
+	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	//  FROM narinfos
 	//  WHERE id = $1
 	GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -95,7 +95,7 @@ INSERT INTO narinfos (
 ) VALUES (
     $1
 )
-RETURNING id, hash, created_at, updated_at, last_accessed_at
+RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 `
 
 // CreateNarInfo
@@ -105,7 +105,7 @@ RETURNING id, hash, created_at, updated_at, last_accessed_at
 //	) VALUES (
 //	    $1
 //	)
-//	RETURNING id, hash, created_at, updated_at, last_accessed_at
+//	RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 func (q *Queries) CreateNarInfo(ctx context.Context, hash string) (NarInfo, error) {
 	row := q.db.QueryRowContext(ctx, createNarInfo, hash)
 	var i NarInfo
@@ -115,6 +115,16 @@ func (q *Queries) CreateNarInfo(ctx context.Context, hash string) (NarInfo, erro
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.LastAccessedAt,
+		&i.StorePath,
+		&i.Url,
+		&i.Compression,
+		&i.FileHash,
+		&i.FileSize,
+		&i.NarHash,
+		&i.NarSize,
+		&i.Deriver,
+		&i.System,
+		&i.Ca,
 	)
 	return i, err
 }
@@ -337,7 +347,7 @@ func (q *Queries) GetLeastUsedNarFiles(ctx context.Context, fileSize uint64) ([]
 }
 
 const getLeastUsedNarInfos = `-- name: GetLeastUsedNarInfos :many
-SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at
+SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at, ni1.store_path, ni1.url, ni1.compression, ni1.file_hash, ni1.file_size, ni1.nar_hash, ni1.nar_size, ni1.deriver, ni1.system, ni1.ca
 FROM narinfos ni1
 WHERE (
     SELECT COALESCE(SUM(nf.file_size), 0)
@@ -357,7 +367,7 @@ WHERE (
 // does not properly support filtering on window function results in subqueries.
 // Gets the least-used narinfos up to a certain total file size (accounting for their nar_files).
 //
-//	SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at
+//	SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at, ni1.store_path, ni1.url, ni1.compression, ni1.file_hash, ni1.file_size, ni1.nar_hash, ni1.nar_size, ni1.deriver, ni1.system, ni1.ca
 //	FROM narinfos ni1
 //	WHERE (
 //	    SELECT COALESCE(SUM(nf.file_size), 0)
@@ -385,6 +395,16 @@ func (q *Queries) GetLeastUsedNarInfos(ctx context.Context, fileSize uint64) ([]
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.LastAccessedAt,
+			&i.StorePath,
+			&i.Url,
+			&i.Compression,
+			&i.FileHash,
+			&i.FileSize,
+			&i.NarHash,
+			&i.NarSize,
+			&i.Deriver,
+			&i.System,
+			&i.Ca,
 		); err != nil {
 			return nil, err
 		}
@@ -499,14 +519,14 @@ func (q *Queries) GetNarFileCount(ctx context.Context) (int64, error) {
 }
 
 const getNarInfoByHash = `-- name: GetNarInfoByHash :one
-SELECT id, hash, created_at, updated_at, last_accessed_at
+SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 FROM narinfos
 WHERE hash = $1
 `
 
 // GetNarInfoByHash
 //
-//	SELECT id, hash, created_at, updated_at, last_accessed_at
+//	SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 //	FROM narinfos
 //	WHERE hash = $1
 func (q *Queries) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error) {
@@ -518,19 +538,29 @@ func (q *Queries) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, e
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.LastAccessedAt,
+		&i.StorePath,
+		&i.Url,
+		&i.Compression,
+		&i.FileHash,
+		&i.FileSize,
+		&i.NarHash,
+		&i.NarSize,
+		&i.Deriver,
+		&i.System,
+		&i.Ca,
 	)
 	return i, err
 }
 
 const getNarInfoByID = `-- name: GetNarInfoByID :one
-SELECT id, hash, created_at, updated_at, last_accessed_at
+SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 FROM narinfos
 WHERE id = $1
 `
 
 // GetNarInfoByID
 //
-//	SELECT id, hash, created_at, updated_at, last_accessed_at
+//	SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 //	FROM narinfos
 //	WHERE id = $1
 func (q *Queries) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error) {
@@ -542,6 +572,16 @@ func (q *Queries) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.LastAccessedAt,
+		&i.StorePath,
+		&i.Url,
+		&i.Compression,
+		&i.FileHash,
+		&i.FileSize,
+		&i.NarHash,
+		&i.NarSize,
+		&i.Deriver,
+		&i.System,
+		&i.Ca,
 	)
 	return i, err
 }

--- a/pkg/database/sqlitedb/models.go
+++ b/pkg/database/sqlitedb/models.go
@@ -34,9 +34,29 @@ type NarInfo struct {
 	CreatedAt      time.Time
 	UpdatedAt      sql.NullTime
 	LastAccessedAt sql.NullTime
+	StorePath      sql.NullString
+	Url            sql.NullString
+	Compression    sql.NullString
+	FileHash       sql.NullString
+	FileSize       sql.NullInt64
+	NarHash        sql.NullString
+	NarSize        sql.NullInt64
+	Deriver        sql.NullString
+	System         sql.NullString
+	Ca             sql.NullString
 }
 
 type NarinfoNarFile struct {
 	NarInfoID int64
 	NarFileID int64
+}
+
+type NarinfoReference struct {
+	NarInfoID int64
+	Reference string
+}
+
+type NarinfoSignature struct {
+	NarInfoID int64
+	Signature string
 }

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -34,7 +34,7 @@ type Querier interface {
 	//  ) VALUES (
 	//      ?
 	//  )
-	//  RETURNING id, hash, created_at, updated_at, last_accessed_at
+	//  RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	CreateNarInfo(ctx context.Context, hash string) (NarInfo, error)
 	//DeleteNarFileByHash
 	//
@@ -102,7 +102,7 @@ type Querier interface {
 	// does not properly support filtering on window function results in subqueries.
 	// Gets the least-used narinfos up to a certain total file size (accounting for their nar_files).
 	//
-	//  SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at
+	//  SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at, ni1.store_path, ni1.url, ni1.compression, ni1.file_hash, ni1.file_size, ni1.nar_hash, ni1.nar_size, ni1.deriver, ni1.system, ni1.ca
 	//  FROM narinfos ni1
 	//  WHERE (
 	//      SELECT COALESCE(SUM(nf.file_size), 0)
@@ -142,13 +142,13 @@ type Querier interface {
 	GetNarFileCount(ctx context.Context) (int64, error)
 	//GetNarInfoByHash
 	//
-	//  SELECT id, hash, created_at, updated_at, last_accessed_at
+	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	//  FROM narinfos
 	//  WHERE hash = ?
 	GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error)
 	//GetNarInfoByID
 	//
-	//  SELECT id, hash, created_at, updated_at, last_accessed_at
+	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	//  FROM narinfos
 	//  WHERE id = ?
 	GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -95,7 +95,7 @@ INSERT INTO narinfos (
 ) VALUES (
     ?
 )
-RETURNING id, hash, created_at, updated_at, last_accessed_at
+RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 `
 
 // CreateNarInfo
@@ -105,7 +105,7 @@ RETURNING id, hash, created_at, updated_at, last_accessed_at
 //	) VALUES (
 //	    ?
 //	)
-//	RETURNING id, hash, created_at, updated_at, last_accessed_at
+//	RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 func (q *Queries) CreateNarInfo(ctx context.Context, hash string) (NarInfo, error) {
 	row := q.db.QueryRowContext(ctx, createNarInfo, hash)
 	var i NarInfo
@@ -115,6 +115,16 @@ func (q *Queries) CreateNarInfo(ctx context.Context, hash string) (NarInfo, erro
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.LastAccessedAt,
+		&i.StorePath,
+		&i.Url,
+		&i.Compression,
+		&i.FileHash,
+		&i.FileSize,
+		&i.NarHash,
+		&i.NarSize,
+		&i.Deriver,
+		&i.System,
+		&i.Ca,
 	)
 	return i, err
 }
@@ -337,7 +347,7 @@ func (q *Queries) GetLeastUsedNarFiles(ctx context.Context, fileSize uint64) ([]
 }
 
 const getLeastUsedNarInfos = `-- name: GetLeastUsedNarInfos :many
-SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at
+SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at, ni1.store_path, ni1.url, ni1.compression, ni1.file_hash, ni1.file_size, ni1.nar_hash, ni1.nar_size, ni1.deriver, ni1.system, ni1.ca
 FROM narinfos ni1
 WHERE (
     SELECT COALESCE(SUM(nf.file_size), 0)
@@ -357,7 +367,7 @@ WHERE (
 // does not properly support filtering on window function results in subqueries.
 // Gets the least-used narinfos up to a certain total file size (accounting for their nar_files).
 //
-//	SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at
+//	SELECT ni1.id, ni1.hash, ni1.created_at, ni1.updated_at, ni1.last_accessed_at, ni1.store_path, ni1.url, ni1.compression, ni1.file_hash, ni1.file_size, ni1.nar_hash, ni1.nar_size, ni1.deriver, ni1.system, ni1.ca
 //	FROM narinfos ni1
 //	WHERE (
 //	    SELECT COALESCE(SUM(nf.file_size), 0)
@@ -385,6 +395,16 @@ func (q *Queries) GetLeastUsedNarInfos(ctx context.Context, fileSize uint64) ([]
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.LastAccessedAt,
+			&i.StorePath,
+			&i.Url,
+			&i.Compression,
+			&i.FileHash,
+			&i.FileSize,
+			&i.NarHash,
+			&i.NarSize,
+			&i.Deriver,
+			&i.System,
+			&i.Ca,
 		); err != nil {
 			return nil, err
 		}
@@ -499,14 +519,14 @@ func (q *Queries) GetNarFileCount(ctx context.Context) (int64, error) {
 }
 
 const getNarInfoByHash = `-- name: GetNarInfoByHash :one
-SELECT id, hash, created_at, updated_at, last_accessed_at
+SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 FROM narinfos
 WHERE hash = ?
 `
 
 // GetNarInfoByHash
 //
-//	SELECT id, hash, created_at, updated_at, last_accessed_at
+//	SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 //	FROM narinfos
 //	WHERE hash = ?
 func (q *Queries) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error) {
@@ -518,19 +538,29 @@ func (q *Queries) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, e
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.LastAccessedAt,
+		&i.StorePath,
+		&i.Url,
+		&i.Compression,
+		&i.FileHash,
+		&i.FileSize,
+		&i.NarHash,
+		&i.NarSize,
+		&i.Deriver,
+		&i.System,
+		&i.Ca,
 	)
 	return i, err
 }
 
 const getNarInfoByID = `-- name: GetNarInfoByID :one
-SELECT id, hash, created_at, updated_at, last_accessed_at
+SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 FROM narinfos
 WHERE id = ?
 `
 
 // GetNarInfoByID
 //
-//	SELECT id, hash, created_at, updated_at, last_accessed_at
+//	SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 //	FROM narinfos
 //	WHERE id = ?
 func (q *Queries) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error) {
@@ -542,6 +572,16 @@ func (q *Queries) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.LastAccessedAt,
+		&i.StorePath,
+		&i.Url,
+		&i.Compression,
+		&i.FileHash,
+		&i.FileSize,
+		&i.NarHash,
+		&i.NarSize,
+		&i.Deriver,
+		&i.System,
+		&i.Ca,
 	)
 	return i, err
 }


### PR DESCRIPTION
Add de-normalized narinfo tables and helper tables for references and signatures. This migration prepares the DB for storing narinfo metadata directly.

Part of #581