### PR TITLE
feat: implement PutNarInfo database write logic

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -59,10 +59,34 @@ ON DUPLICATE KEY UPDATE
 
 -- name: CreateNarInfo :execresult
 INSERT INTO narinfos (
-    hash
+    hash, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 ) VALUES (
-    ?
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 );
+
+-- name: AddNarInfoReference :exec
+INSERT INTO narinfo_references (
+    narinfo_id, reference
+) VALUES (
+    ?, ?
+);
+
+-- name: AddNarInfoSignature :exec
+INSERT INTO narinfo_signatures (
+    narinfo_id, signature
+) VALUES (
+    ?, ?
+);
+
+-- name: GetNarInfoReferences :many
+SELECT reference
+FROM narinfo_references
+WHERE narinfo_id = ?;
+
+-- name: GetNarInfoSignatures :many
+SELECT signature
+FROM narinfo_signatures
+WHERE narinfo_id = ?;
 
 -- name: CreateNarFile :execresult
 INSERT INTO nar_files (

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -61,11 +61,35 @@ DO UPDATE SET
 
 -- name: CreateNarInfo :one
 INSERT INTO narinfos (
-    hash
+    hash, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 ) VALUES (
-    $1
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
 RETURNING *;
+
+-- name: AddNarInfoReference :exec
+INSERT INTO narinfo_references (
+    narinfo_id, reference
+) VALUES (
+    $1, $2
+);
+
+-- name: AddNarInfoSignature :exec
+INSERT INTO narinfo_signatures (
+    narinfo_id, signature
+) VALUES (
+    $1, $2
+);
+
+-- name: GetNarInfoReferences :many
+SELECT reference
+FROM narinfo_references
+WHERE narinfo_id = $1;
+
+-- name: GetNarInfoSignatures :many
+SELECT signature
+FROM narinfo_signatures
+WHERE narinfo_id = $1;
 
 -- name: CreateNarFile :one
 INSERT INTO nar_files (

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -61,11 +61,35 @@ DO UPDATE SET
 
 -- name: CreateNarInfo :one
 INSERT INTO narinfos (
-    hash
+    hash, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 ) VALUES (
-    ?
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 )
 RETURNING *;
+
+-- name: AddNarInfoReference :exec
+INSERT INTO narinfo_references (
+    narinfo_id, reference
+) VALUES (
+    ?, ?
+);
+
+-- name: AddNarInfoSignature :exec
+INSERT INTO narinfo_signatures (
+    narinfo_id, signature
+) VALUES (
+    ?, ?
+);
+
+-- name: GetNarInfoReferences :many
+SELECT reference
+FROM narinfo_references
+WHERE narinfo_id = ?;
+
+-- name: GetNarInfoSignatures :many
+SELECT signature
+FROM narinfo_signatures
+WHERE narinfo_id = ?;
 
 -- name: CreateNarFile :one
 INSERT INTO nar_files (

--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -532,7 +532,7 @@ func TestRunLRUWithSharedNar(t *testing.T) {
 		FileSize:    50,
 	})
 	require.NoError(t, err)
-	ni4, err := c.db.CreateNarInfo(ctx, "nar-info-4")
+	ni4, err := c.db.CreateNarInfo(ctx, database.CreateNarInfoParams{Hash: "nar-info-4"})
 	require.NoError(t, err)
 	require.NoError(t, c.db.LinkNarInfoToNarFile(ctx, database.LinkNarInfoToNarFileParams{
 		NarInfoID: ni4.ID,
@@ -546,7 +546,7 @@ func TestRunLRUWithSharedNar(t *testing.T) {
 		FileSize:    100,
 	})
 	require.NoError(t, err)
-	ni1, err := c.db.CreateNarInfo(ctx, "nar-info-1")
+	ni1, err := c.db.CreateNarInfo(ctx, database.CreateNarInfoParams{Hash: "nar-info-1"})
 	require.NoError(t, err)
 	require.NoError(t, c.db.LinkNarInfoToNarFile(ctx, database.LinkNarInfoToNarFileParams{
 		NarInfoID: ni1.ID,
@@ -554,7 +554,7 @@ func TestRunLRUWithSharedNar(t *testing.T) {
 	}))
 
 	// NarFile A (100 bytes), NarInfo 2
-	ni2, err := c.db.CreateNarInfo(ctx, "nar-info-2")
+	ni2, err := c.db.CreateNarInfo(ctx, database.CreateNarInfoParams{Hash: "nar-info-2"})
 	require.NoError(t, err)
 	require.NoError(t, c.db.LinkNarInfoToNarFile(ctx, database.LinkNarInfoToNarFileParams{
 		NarInfoID: ni2.ID,

--- a/pkg/database/contract_test.go
+++ b/pkg/database/contract_test.go
@@ -87,7 +87,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			hash, err := helper.RandString(32, nil)
 			require.NoError(t, err)
 
-			ni1, err := db.CreateNarInfo(context.Background(), hash)
+			ni1, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
 			require.NoError(t, err)
 
 			ni2, err := db.GetNarInfoByHash(context.Background(), hash)
@@ -104,7 +104,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			hash, err := helper.RandString(32, nil)
 			require.NoError(t, err)
 
-			nio, err := db.CreateNarInfo(context.Background(), hash)
+			nio, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
 			require.NoError(t, err)
 
 			rows, err := db.DB().QueryContext(
@@ -143,10 +143,10 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			hash, err := helper.RandString(32, nil)
 			require.NoError(t, err)
 
-			_, err = db.CreateNarInfo(context.Background(), hash)
+			_, err = db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
 			require.NoError(t, err)
 
-			_, err = db.CreateNarInfo(context.Background(), hash)
+			_, err = db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
 			assert.True(t, database.IsDuplicateKeyError(err))
 		})
 
@@ -170,7 +170,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 						return
 					}
 
-					if _, err := db.CreateNarInfo(context.Background(), hash); err != nil {
+					if _, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash}); err != nil {
 						errC <- fmt.Errorf("error creating the narinfo record: %w", err)
 					}
 				}()
@@ -202,7 +202,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			hash, err := helper.RandString(32, nil)
 			require.NoError(t, err)
 
-			_, err = db.CreateNarInfo(context.Background(), hash)
+			_, err = db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
 			require.NoError(t, err)
 
 			t.Run("confirm created_at == last_accessed_at, and no updated_at", func(t *testing.T) {
@@ -290,7 +290,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			require.NoError(t, err)
 
 			t.Run("create the narinfo", func(t *testing.T) {
-				_, err = db.CreateNarInfo(context.Background(), hash)
+				_, err = db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
 				require.NoError(t, err)
 			})
 
@@ -392,7 +392,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			narInfoHash, err := helper.RandString(32, nil)
 			require.NoError(t, err)
 
-			_, err = db.CreateNarInfo(context.Background(), narInfoHash)
+			_, err = db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: narInfoHash})
 			require.NoError(t, err)
 
 			narHash, err := helper.RandString(32, nil)

--- a/pkg/database/generated_models.go
+++ b/pkg/database/generated_models.go
@@ -6,6 +6,16 @@ import (
 	"time"
 )
 
+type AddNarInfoReferenceParams struct {
+	NarInfoID int64
+	Reference string
+}
+
+type AddNarInfoSignatureParams struct {
+	NarInfoID int64
+	Signature string
+}
+
 type Config struct {
 	ID        int64
 	Key       string
@@ -24,6 +34,20 @@ type CreateNarFileParams struct {
 	Compression string
 	Query       string
 	FileSize    uint64
+}
+
+type CreateNarInfoParams struct {
+	Hash        string
+	StorePath   sql.NullString
+	URL         sql.NullString
+	Compression sql.NullString
+	FileHash    sql.NullString
+	FileSize    sql.NullInt64
+	NarHash     sql.NullString
+	NarSize     sql.NullInt64
+	Deriver     sql.NullString
+	System      sql.NullString
+	Ca          sql.NullString
 }
 
 type LinkNarInfoToNarFileParams struct {
@@ -49,7 +73,7 @@ type NarInfo struct {
 	UpdatedAt      sql.NullTime
 	LastAccessedAt sql.NullTime
 	StorePath      sql.NullString
-	Url            sql.NullString
+	URL            sql.NullString
 	Compression    sql.NullString
 	FileHash       sql.NullString
 	FileSize       sql.NullInt64

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -7,6 +7,22 @@ import (
 )
 
 type Querier interface {
+	//AddNarInfoReference
+	//
+	//  INSERT INTO narinfo_references (
+	//      narinfo_id, reference
+	//  ) VALUES (
+	//      $1, $2
+	//  )
+	AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error
+	//AddNarInfoSignature
+	//
+	//  INSERT INTO narinfo_signatures (
+	//      narinfo_id, signature
+	//  ) VALUES (
+	//      $1, $2
+	//  )
+	AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error
 	//CreateConfig
 	//
 	//  INSERT INTO config (
@@ -28,12 +44,12 @@ type Querier interface {
 	//CreateNarInfo
 	//
 	//  INSERT INTO narinfos (
-	//      hash
+	//      hash, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	//  ) VALUES (
-	//      $1
+	//      $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 	//  )
 	//  RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-	CreateNarInfo(ctx context.Context, hash string) (NarInfo, error)
+	CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (NarInfo, error)
 	//DeleteNarFileByHash
 	//
 	//  DELETE FROM nar_files
@@ -162,6 +178,18 @@ type Querier interface {
 	//  INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
 	//  WHERE nnf.nar_file_id = $1
 	GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error)
+	//GetNarInfoReferences
+	//
+	//  SELECT reference
+	//  FROM narinfo_references
+	//  WHERE narinfo_id = $1
+	GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error)
+	//GetNarInfoSignatures
+	//
+	//  SELECT signature
+	//  FROM narinfo_signatures
+	//  WHERE narinfo_id = $1
+	GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error)
 	//GetNarTotalSize
 	//
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS BIGINT) AS total_size

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -13,6 +13,26 @@ type mysqlWrapper struct {
 	adapter *mysqldb.Adapter
 }
 
+func (w *mysqlWrapper) AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error {
+	err := w.adapter.AddNarInfoReference(ctx, mysqldb.AddNarInfoReferenceParams(arg))
+	if err != nil {
+		return err
+	}
+
+	// No return value (void)
+	return nil
+}
+
+func (w *mysqlWrapper) AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error {
+	err := w.adapter.AddNarInfoSignature(ctx, mysqldb.AddNarInfoSignatureParams(arg))
+	if err != nil {
+		return err
+	}
+
+	// No return value (void)
+	return nil
+}
+
 func (w *mysqlWrapper) CreateConfig(ctx context.Context, arg CreateConfigParams) (Config, error) {
 	// MySQL does not support RETURNING for INSERTs.
 	// We insert, get LastInsertId, and then fetch the object.
@@ -45,10 +65,10 @@ func (w *mysqlWrapper) CreateNarFile(ctx context.Context, arg CreateNarFileParam
 	return w.GetNarFileByID(ctx, id)
 }
 
-func (w *mysqlWrapper) CreateNarInfo(ctx context.Context, hash string) (NarInfo, error) {
+func (w *mysqlWrapper) CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (NarInfo, error) {
 	// MySQL does not support RETURNING for INSERTs.
 	// We insert, get LastInsertId, and then fetch the object.
-	res, err := w.adapter.CreateNarInfo(ctx, hash)
+	res, err := w.adapter.CreateNarInfo(ctx, mysqldb.CreateNarInfoParams(arg))
 	if err != nil {
 		return NarInfo{}, err
 	}
@@ -266,6 +286,26 @@ func (w *mysqlWrapper) GetNarInfoCount(ctx context.Context) (int64, error) {
 
 func (w *mysqlWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {
 	res, err := w.adapter.GetNarInfoHashesByNarFileID(ctx, narFileID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return Slice of Primitives (direct match)
+	return res, nil
+}
+
+func (w *mysqlWrapper) GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error) {
+	res, err := w.adapter.GetNarInfoReferences(ctx, narinfoID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return Slice of Primitives (direct match)
+	return res, nil
+}
+
+func (w *mysqlWrapper) GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error) {
+	res, err := w.adapter.GetNarInfoSignatures(ctx, narinfoID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -13,6 +13,26 @@ type postgresWrapper struct {
 	adapter *postgresdb.Adapter
 }
 
+func (w *postgresWrapper) AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error {
+	err := w.adapter.AddNarInfoReference(ctx, postgresdb.AddNarInfoReferenceParams(arg))
+	if err != nil {
+		return err
+	}
+
+	// No return value (void)
+	return nil
+}
+
+func (w *postgresWrapper) AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error {
+	err := w.adapter.AddNarInfoSignature(ctx, postgresdb.AddNarInfoSignatureParams(arg))
+	if err != nil {
+		return err
+	}
+
+	// No return value (void)
+	return nil
+}
+
 func (w *postgresWrapper) CreateConfig(ctx context.Context, arg CreateConfigParams) (Config, error) {
 	res, err := w.adapter.CreateConfig(ctx, postgresdb.CreateConfigParams(arg))
 	if err != nil {
@@ -35,8 +55,8 @@ func (w *postgresWrapper) CreateNarFile(ctx context.Context, arg CreateNarFilePa
 	return NarFile(res), nil
 }
 
-func (w *postgresWrapper) CreateNarInfo(ctx context.Context, hash string) (NarInfo, error) {
-	res, err := w.adapter.CreateNarInfo(ctx, hash)
+func (w *postgresWrapper) CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (NarInfo, error) {
+	res, err := w.adapter.CreateNarInfo(ctx, postgresdb.CreateNarInfoParams(arg))
 	if err != nil {
 		return NarInfo{}, err
 	}
@@ -251,6 +271,26 @@ func (w *postgresWrapper) GetNarInfoCount(ctx context.Context) (int64, error) {
 
 func (w *postgresWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {
 	res, err := w.adapter.GetNarInfoHashesByNarFileID(ctx, narFileID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return Slice of Primitives (direct match)
+	return res, nil
+}
+
+func (w *postgresWrapper) GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error) {
+	res, err := w.adapter.GetNarInfoReferences(ctx, narinfoID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return Slice of Primitives (direct match)
+	return res, nil
+}
+
+func (w *postgresWrapper) GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error) {
+	res, err := w.adapter.GetNarInfoSignatures(ctx, narinfoID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -13,6 +13,26 @@ type sqliteWrapper struct {
 	adapter *sqlitedb.Adapter
 }
 
+func (w *sqliteWrapper) AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error {
+	err := w.adapter.AddNarInfoReference(ctx, sqlitedb.AddNarInfoReferenceParams(arg))
+	if err != nil {
+		return err
+	}
+
+	// No return value (void)
+	return nil
+}
+
+func (w *sqliteWrapper) AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error {
+	err := w.adapter.AddNarInfoSignature(ctx, sqlitedb.AddNarInfoSignatureParams(arg))
+	if err != nil {
+		return err
+	}
+
+	// No return value (void)
+	return nil
+}
+
 func (w *sqliteWrapper) CreateConfig(ctx context.Context, arg CreateConfigParams) (Config, error) {
 	res, err := w.adapter.CreateConfig(ctx, sqlitedb.CreateConfigParams(arg))
 	if err != nil {
@@ -35,8 +55,8 @@ func (w *sqliteWrapper) CreateNarFile(ctx context.Context, arg CreateNarFilePara
 	return NarFile(res), nil
 }
 
-func (w *sqliteWrapper) CreateNarInfo(ctx context.Context, hash string) (NarInfo, error) {
-	res, err := w.adapter.CreateNarInfo(ctx, hash)
+func (w *sqliteWrapper) CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (NarInfo, error) {
+	res, err := w.adapter.CreateNarInfo(ctx, sqlitedb.CreateNarInfoParams(arg))
 	if err != nil {
 		return NarInfo{}, err
 	}
@@ -251,6 +271,26 @@ func (w *sqliteWrapper) GetNarInfoCount(ctx context.Context) (int64, error) {
 
 func (w *sqliteWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {
 	res, err := w.adapter.GetNarInfoHashesByNarFileID(ctx, narFileID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return Slice of Primitives (direct match)
+	return res, nil
+}
+
+func (w *sqliteWrapper) GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error) {
+	res, err := w.adapter.GetNarInfoReferences(ctx, narinfoID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return Slice of Primitives (direct match)
+	return res, nil
+}
+
+func (w *sqliteWrapper) GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error) {
+	res, err := w.adapter.GetNarInfoSignatures(ctx, narinfoID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/database/mysqldb/models.go
+++ b/pkg/database/mysqldb/models.go
@@ -35,7 +35,7 @@ type NarInfo struct {
 	UpdatedAt      sql.NullTime
 	LastAccessedAt sql.NullTime
 	StorePath      sql.NullString
-	Url            sql.NullString
+	URL            sql.NullString
 	Compression    sql.NullString
 	FileHash       sql.NullString
 	FileSize       sql.NullInt64

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -10,6 +10,22 @@ import (
 )
 
 type Querier interface {
+	//AddNarInfoReference
+	//
+	//  INSERT INTO narinfo_references (
+	//      narinfo_id, reference
+	//  ) VALUES (
+	//      ?, ?
+	//  )
+	AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error
+	//AddNarInfoSignature
+	//
+	//  INSERT INTO narinfo_signatures (
+	//      narinfo_id, signature
+	//  ) VALUES (
+	//      ?, ?
+	//  )
+	AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error
 	//CreateConfig
 	//
 	//  INSERT INTO config (
@@ -29,11 +45,11 @@ type Querier interface {
 	//CreateNarInfo
 	//
 	//  INSERT INTO narinfos (
-	//      hash
+	//      hash, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	//  ) VALUES (
-	//      ?
+	//      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 	//  )
-	CreateNarInfo(ctx context.Context, hash string) (sql.Result, error)
+	CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (sql.Result, error)
 	//DeleteNarFileByHash
 	//
 	//  DELETE FROM nar_files
@@ -162,6 +178,18 @@ type Querier interface {
 	//  INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
 	//  WHERE nnf.nar_file_id = ?
 	GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error)
+	//GetNarInfoReferences
+	//
+	//  SELECT reference
+	//  FROM narinfo_references
+	//  WHERE narinfo_id = ?
+	GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error)
+	//GetNarInfoSignatures
+	//
+	//  SELECT signature
+	//  FROM narinfo_signatures
+	//  WHERE narinfo_id = ?
+	GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error)
 	//GetNarTotalSize
 	//
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS SIGNED) AS total_size

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -10,6 +10,56 @@ import (
 	"database/sql"
 )
 
+const addNarInfoReference = `-- name: AddNarInfoReference :exec
+INSERT INTO narinfo_references (
+    narinfo_id, reference
+) VALUES (
+    ?, ?
+)
+`
+
+type AddNarInfoReferenceParams struct {
+	NarInfoID int64
+	Reference string
+}
+
+// AddNarInfoReference
+//
+//	INSERT INTO narinfo_references (
+//	    narinfo_id, reference
+//	) VALUES (
+//	    ?, ?
+//	)
+func (q *Queries) AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error {
+	_, err := q.db.ExecContext(ctx, addNarInfoReference, arg.NarInfoID, arg.Reference)
+	return err
+}
+
+const addNarInfoSignature = `-- name: AddNarInfoSignature :exec
+INSERT INTO narinfo_signatures (
+    narinfo_id, signature
+) VALUES (
+    ?, ?
+)
+`
+
+type AddNarInfoSignatureParams struct {
+	NarInfoID int64
+	Signature string
+}
+
+// AddNarInfoSignature
+//
+//	INSERT INTO narinfo_signatures (
+//	    narinfo_id, signature
+//	) VALUES (
+//	    ?, ?
+//	)
+func (q *Queries) AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error {
+	_, err := q.db.ExecContext(ctx, addNarInfoSignature, arg.NarInfoID, arg.Signature)
+	return err
+}
+
 const createConfig = `-- name: CreateConfig :execresult
 INSERT INTO config (
     ` + "`" + `key` + "`" + `, value
@@ -67,21 +117,47 @@ func (q *Queries) CreateNarFile(ctx context.Context, arg CreateNarFileParams) (s
 
 const createNarInfo = `-- name: CreateNarInfo :execresult
 INSERT INTO narinfos (
-    hash
+    hash, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 ) VALUES (
-    ?
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 )
 `
+
+type CreateNarInfoParams struct {
+	Hash        string
+	StorePath   sql.NullString
+	URL         sql.NullString
+	Compression sql.NullString
+	FileHash    sql.NullString
+	FileSize    sql.NullInt64
+	NarHash     sql.NullString
+	NarSize     sql.NullInt64
+	Deriver     sql.NullString
+	System      sql.NullString
+	Ca          sql.NullString
+}
 
 // CreateNarInfo
 //
 //	INSERT INTO narinfos (
-//	    hash
+//	    hash, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 //	) VALUES (
-//	    ?
+//	    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 //	)
-func (q *Queries) CreateNarInfo(ctx context.Context, hash string) (sql.Result, error) {
-	return q.db.ExecContext(ctx, createNarInfo, hash)
+func (q *Queries) CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, createNarInfo,
+		arg.Hash,
+		arg.StorePath,
+		arg.URL,
+		arg.Compression,
+		arg.FileHash,
+		arg.FileSize,
+		arg.NarHash,
+		arg.NarSize,
+		arg.Deriver,
+		arg.System,
+		arg.Ca,
+	)
 }
 
 const deleteNarFileByHash = `-- name: DeleteNarFileByHash :execrows
@@ -351,7 +427,7 @@ func (q *Queries) GetLeastUsedNarInfos(ctx context.Context, fileSize uint64) ([]
 			&i.UpdatedAt,
 			&i.LastAccessedAt,
 			&i.StorePath,
-			&i.Url,
+			&i.URL,
 			&i.Compression,
 			&i.FileHash,
 			&i.FileSize,
@@ -494,7 +570,7 @@ func (q *Queries) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, e
 		&i.UpdatedAt,
 		&i.LastAccessedAt,
 		&i.StorePath,
-		&i.Url,
+		&i.URL,
 		&i.Compression,
 		&i.FileHash,
 		&i.FileSize,
@@ -528,7 +604,7 @@ func (q *Queries) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
 		&i.UpdatedAt,
 		&i.LastAccessedAt,
 		&i.StorePath,
-		&i.Url,
+		&i.URL,
 		&i.Compression,
 		&i.FileHash,
 		&i.FileSize,
@@ -583,6 +659,74 @@ func (q *Queries) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int
 			return nil, err
 		}
 		items = append(items, hash)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getNarInfoReferences = `-- name: GetNarInfoReferences :many
+SELECT reference
+FROM narinfo_references
+WHERE narinfo_id = ?
+`
+
+// GetNarInfoReferences
+//
+//	SELECT reference
+//	FROM narinfo_references
+//	WHERE narinfo_id = ?
+func (q *Queries) GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, getNarInfoReferences, narinfoID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var reference string
+		if err := rows.Scan(&reference); err != nil {
+			return nil, err
+		}
+		items = append(items, reference)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getNarInfoSignatures = `-- name: GetNarInfoSignatures :many
+SELECT signature
+FROM narinfo_signatures
+WHERE narinfo_id = ?
+`
+
+// GetNarInfoSignatures
+//
+//	SELECT signature
+//	FROM narinfo_signatures
+//	WHERE narinfo_id = ?
+func (q *Queries) GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, getNarInfoSignatures, narinfoID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var signature string
+		if err := rows.Scan(&signature); err != nil {
+			return nil, err
+		}
+		items = append(items, signature)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err

--- a/pkg/database/postgresdb/models.go
+++ b/pkg/database/postgresdb/models.go
@@ -35,7 +35,7 @@ type NarInfo struct {
 	UpdatedAt      sql.NullTime
 	LastAccessedAt sql.NullTime
 	StorePath      sql.NullString
-	Url            sql.NullString
+	URL            sql.NullString
 	Compression    sql.NullString
 	FileHash       sql.NullString
 	FileSize       sql.NullInt64

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -9,6 +9,22 @@ import (
 )
 
 type Querier interface {
+	//AddNarInfoReference
+	//
+	//  INSERT INTO narinfo_references (
+	//      narinfo_id, reference
+	//  ) VALUES (
+	//      $1, $2
+	//  )
+	AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error
+	//AddNarInfoSignature
+	//
+	//  INSERT INTO narinfo_signatures (
+	//      narinfo_id, signature
+	//  ) VALUES (
+	//      $1, $2
+	//  )
+	AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error
 	//CreateConfig
 	//
 	//  INSERT INTO config (
@@ -30,12 +46,12 @@ type Querier interface {
 	//CreateNarInfo
 	//
 	//  INSERT INTO narinfos (
-	//      hash
+	//      hash, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	//  ) VALUES (
-	//      $1
+	//      $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 	//  )
 	//  RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-	CreateNarInfo(ctx context.Context, hash string) (NarInfo, error)
+	CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (NarInfo, error)
 	//DeleteNarFileByHash
 	//
 	//  DELETE FROM nar_files
@@ -164,6 +180,18 @@ type Querier interface {
 	//  INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
 	//  WHERE nnf.nar_file_id = $1
 	GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error)
+	//GetNarInfoReferences
+	//
+	//  SELECT reference
+	//  FROM narinfo_references
+	//  WHERE narinfo_id = $1
+	GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error)
+	//GetNarInfoSignatures
+	//
+	//  SELECT signature
+	//  FROM narinfo_signatures
+	//  WHERE narinfo_id = $1
+	GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error)
 	//GetNarTotalSize
 	//
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS BIGINT) AS total_size

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -7,7 +7,58 @@ package postgresdb
 
 import (
 	"context"
+	"database/sql"
 )
+
+const addNarInfoReference = `-- name: AddNarInfoReference :exec
+INSERT INTO narinfo_references (
+    narinfo_id, reference
+) VALUES (
+    $1, $2
+)
+`
+
+type AddNarInfoReferenceParams struct {
+	NarInfoID int64
+	Reference string
+}
+
+// AddNarInfoReference
+//
+//	INSERT INTO narinfo_references (
+//	    narinfo_id, reference
+//	) VALUES (
+//	    $1, $2
+//	)
+func (q *Queries) AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error {
+	_, err := q.db.ExecContext(ctx, addNarInfoReference, arg.NarInfoID, arg.Reference)
+	return err
+}
+
+const addNarInfoSignature = `-- name: AddNarInfoSignature :exec
+INSERT INTO narinfo_signatures (
+    narinfo_id, signature
+) VALUES (
+    $1, $2
+)
+`
+
+type AddNarInfoSignatureParams struct {
+	NarInfoID int64
+	Signature string
+}
+
+// AddNarInfoSignature
+//
+//	INSERT INTO narinfo_signatures (
+//	    narinfo_id, signature
+//	) VALUES (
+//	    $1, $2
+//	)
+func (q *Queries) AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error {
+	_, err := q.db.ExecContext(ctx, addNarInfoSignature, arg.NarInfoID, arg.Signature)
+	return err
+}
 
 const createConfig = `-- name: CreateConfig :one
 INSERT INTO config (
@@ -91,23 +142,49 @@ func (q *Queries) CreateNarFile(ctx context.Context, arg CreateNarFileParams) (N
 
 const createNarInfo = `-- name: CreateNarInfo :one
 INSERT INTO narinfos (
-    hash
+    hash, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 ) VALUES (
-    $1
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
 RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 `
 
+type CreateNarInfoParams struct {
+	Hash        string
+	StorePath   sql.NullString
+	URL         sql.NullString
+	Compression sql.NullString
+	FileHash    sql.NullString
+	FileSize    sql.NullInt64
+	NarHash     sql.NullString
+	NarSize     sql.NullInt64
+	Deriver     sql.NullString
+	System      sql.NullString
+	Ca          sql.NullString
+}
+
 // CreateNarInfo
 //
 //	INSERT INTO narinfos (
-//	    hash
+//	    hash, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 //	) VALUES (
-//	    $1
+//	    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 //	)
 //	RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-func (q *Queries) CreateNarInfo(ctx context.Context, hash string) (NarInfo, error) {
-	row := q.db.QueryRowContext(ctx, createNarInfo, hash)
+func (q *Queries) CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (NarInfo, error) {
+	row := q.db.QueryRowContext(ctx, createNarInfo,
+		arg.Hash,
+		arg.StorePath,
+		arg.URL,
+		arg.Compression,
+		arg.FileHash,
+		arg.FileSize,
+		arg.NarHash,
+		arg.NarSize,
+		arg.Deriver,
+		arg.System,
+		arg.Ca,
+	)
 	var i NarInfo
 	err := row.Scan(
 		&i.ID,
@@ -116,7 +193,7 @@ func (q *Queries) CreateNarInfo(ctx context.Context, hash string) (NarInfo, erro
 		&i.UpdatedAt,
 		&i.LastAccessedAt,
 		&i.StorePath,
-		&i.Url,
+		&i.URL,
 		&i.Compression,
 		&i.FileHash,
 		&i.FileSize,
@@ -396,7 +473,7 @@ func (q *Queries) GetLeastUsedNarInfos(ctx context.Context, fileSize uint64) ([]
 			&i.UpdatedAt,
 			&i.LastAccessedAt,
 			&i.StorePath,
-			&i.Url,
+			&i.URL,
 			&i.Compression,
 			&i.FileHash,
 			&i.FileSize,
@@ -539,7 +616,7 @@ func (q *Queries) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, e
 		&i.UpdatedAt,
 		&i.LastAccessedAt,
 		&i.StorePath,
-		&i.Url,
+		&i.URL,
 		&i.Compression,
 		&i.FileHash,
 		&i.FileSize,
@@ -573,7 +650,7 @@ func (q *Queries) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
 		&i.UpdatedAt,
 		&i.LastAccessedAt,
 		&i.StorePath,
-		&i.Url,
+		&i.URL,
 		&i.Compression,
 		&i.FileHash,
 		&i.FileSize,
@@ -628,6 +705,74 @@ func (q *Queries) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int
 			return nil, err
 		}
 		items = append(items, hash)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getNarInfoReferences = `-- name: GetNarInfoReferences :many
+SELECT reference
+FROM narinfo_references
+WHERE narinfo_id = $1
+`
+
+// GetNarInfoReferences
+//
+//	SELECT reference
+//	FROM narinfo_references
+//	WHERE narinfo_id = $1
+func (q *Queries) GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, getNarInfoReferences, narinfoID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var reference string
+		if err := rows.Scan(&reference); err != nil {
+			return nil, err
+		}
+		items = append(items, reference)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getNarInfoSignatures = `-- name: GetNarInfoSignatures :many
+SELECT signature
+FROM narinfo_signatures
+WHERE narinfo_id = $1
+`
+
+// GetNarInfoSignatures
+//
+//	SELECT signature
+//	FROM narinfo_signatures
+//	WHERE narinfo_id = $1
+func (q *Queries) GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, getNarInfoSignatures, narinfoID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var signature string
+		if err := rows.Scan(&signature); err != nil {
+			return nil, err
+		}
+		items = append(items, signature)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err

--- a/pkg/database/sqlitedb/models.go
+++ b/pkg/database/sqlitedb/models.go
@@ -35,7 +35,7 @@ type NarInfo struct {
 	UpdatedAt      sql.NullTime
 	LastAccessedAt sql.NullTime
 	StorePath      sql.NullString
-	Url            sql.NullString
+	URL            sql.NullString
 	Compression    sql.NullString
 	FileHash       sql.NullString
 	FileSize       sql.NullInt64

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -9,6 +9,22 @@ import (
 )
 
 type Querier interface {
+	//AddNarInfoReference
+	//
+	//  INSERT INTO narinfo_references (
+	//      narinfo_id, reference
+	//  ) VALUES (
+	//      ?, ?
+	//  )
+	AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error
+	//AddNarInfoSignature
+	//
+	//  INSERT INTO narinfo_signatures (
+	//      narinfo_id, signature
+	//  ) VALUES (
+	//      ?, ?
+	//  )
+	AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error
 	//CreateConfig
 	//
 	//  INSERT INTO config (
@@ -30,12 +46,12 @@ type Querier interface {
 	//CreateNarInfo
 	//
 	//  INSERT INTO narinfos (
-	//      hash
+	//      hash, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	//  ) VALUES (
-	//      ?
+	//      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 	//  )
 	//  RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-	CreateNarInfo(ctx context.Context, hash string) (NarInfo, error)
+	CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (NarInfo, error)
 	//DeleteNarFileByHash
 	//
 	//  DELETE FROM nar_files
@@ -164,6 +180,18 @@ type Querier interface {
 	//  INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
 	//  WHERE nnf.nar_file_id = ?
 	GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error)
+	//GetNarInfoReferences
+	//
+	//  SELECT reference
+	//  FROM narinfo_references
+	//  WHERE narinfo_id = ?
+	GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error)
+	//GetNarInfoSignatures
+	//
+	//  SELECT signature
+	//  FROM narinfo_signatures
+	//  WHERE narinfo_id = ?
+	GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error)
 	//GetNarTotalSize
 	//
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS INTEGER) AS total_size

--- a/sqlc.yml
+++ b/sqlc.yml
@@ -15,6 +15,7 @@ sql:
             go_type: uint64
         rename:
           narinfo_id: NarInfoID
+          url: URL
   # PostgreSQL engine
   - engine: "postgresql"
     queries: "db/query.postgres.sql"
@@ -30,6 +31,7 @@ sql:
             go_type: uint64
         rename:
           narinfo_id: NarInfoID
+          url: URL
   # MySQL engine
   - engine: "mysql"
     queries: "db/query.mysql.sql"
@@ -45,6 +47,7 @@ sql:
             go_type: uint64
         rename:
           narinfo_id: NarInfoID
+          url: URL
 overrides:
   go:
     rename:


### PR DESCRIPTION
This commit implements the database write logic for NarInfo, moving from file-based storage to a de-normalized approach in the database.

Key changes:
- Updated pkg/cache/cache.go: storeInDatabase now maps all narinfo.NarInfo fields into the database and inserts references and signatures into helper tables.
- Updated pkg/database/models.go: Renamed Url to URL for consistency.
- Updated pkg/database/querier.go and generated code: Reflected schema updates and naming conventions.
- Updated tests: pkg/database/contract_test.go and pkg/cache/cache_internal_test.go now use the new CreateNarInfo signature.
- Corrected migrations: Added dbmate tags and down blocks to 20260117195000_add_narinfo_de_normalized.sql.
- Cleaned up: Removed the obsolete pkg/database/queries_narinfo.go.

Part of #581