### PR TITLE
ci: configure concurrency.group to auto-cancel workflows

### DIFF
--- a/.github/workflows/auto-generate-code.yaml
+++ b/.github/workflows/auto-generate-code.yaml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
       - "release-*"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   filter:
     if: github.event.pull_request.head.repo.fork == false

--- a/.github/workflows/auto-update-vendorhash.yaml
+++ b/.github/workflows/auto-update-vendorhash.yaml
@@ -7,6 +7,9 @@ on:
     paths:
       - "go.mod"
       - "go.sum"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   update-vendor-hash:
     if: github.event.pull_request.head.repo.fork == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
       - "release-*"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   flake:
     uses: ./.github/workflows/flake.yml


### PR DESCRIPTION
Auto-cancel workflows on commits if a new commit was pushed to the same
pull request.