### PR TITLE
feat: add narinfo count and nar file count metrics

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -126,6 +126,14 @@ WHERE id NOT IN (
 SELECT CAST(COALESCE(SUM(file_size), 0) AS SIGNED) AS total_size
 FROM nar_files;
 
+-- name: GetNarInfoCount :one
+SELECT CAST(COUNT(*) AS SIGNED) AS count
+FROM narinfos;
+
+-- name: GetNarFileCount :one
+SELECT CAST(COUNT(*) AS SIGNED) AS count
+FROM nar_files;
+
 -- name: GetLeastUsedNarInfos :many
 -- NOTE: This query uses a correlated subquery which is not optimal for performance.
 -- The ideal implementation would use a window function (SUM OVER), but sqlc v1.30.0

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -130,6 +130,14 @@ WHERE id NOT IN (
 SELECT CAST(COALESCE(SUM(file_size), 0) AS BIGINT) AS total_size
 FROM nar_files;
 
+-- name: GetNarInfoCount :one
+SELECT CAST(COUNT(*) AS BIGINT) AS count
+FROM narinfos;
+
+-- name: GetNarFileCount :one
+SELECT CAST(COUNT(*) AS BIGINT) AS count
+FROM nar_files;
+
 -- name: GetLeastUsedNarInfos :many
 -- NOTE: This query uses a correlated subquery which is not optimal for performance.
 -- The ideal implementation would use a window function (SUM OVER), but sqlc v1.30.0

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -130,6 +130,14 @@ WHERE id NOT IN (
 SELECT CAST(COALESCE(SUM(file_size), 0) AS INTEGER) AS total_size
 FROM nar_files;
 
+-- name: GetNarInfoCount :one
+SELECT CAST(COUNT(*) AS INTEGER) AS count
+FROM narinfos;
+
+-- name: GetNarFileCount :one
+SELECT CAST(COUNT(*) AS INTEGER) AS count
+FROM nar_files;
+
 -- name: GetLeastUsedNarInfos :many
 -- NOTE: This query uses a correlated subquery which is not optimal for performance.
 -- The ideal implementation would use a window function (SUM OVER), but sqlc v1.30.0

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -133,6 +133,11 @@ type Querier interface {
 	//  INNER JOIN narinfo_nar_files nnf ON nf.id = nnf.nar_file_id
 	//  WHERE nnf.narinfo_id = $1
 	GetNarFileByNarInfoID(ctx context.Context, narinfoID int64) (NarFile, error)
+	//GetNarFileCount
+	//
+	//  SELECT CAST(COUNT(*) AS BIGINT) AS count
+	//  FROM nar_files
+	GetNarFileCount(ctx context.Context) (int64, error)
 	//GetNarInfoByHash
 	//
 	//  SELECT id, hash, created_at, updated_at, last_accessed_at
@@ -145,6 +150,11 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE id = $1
 	GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
+	//GetNarInfoCount
+	//
+	//  SELECT CAST(COUNT(*) AS BIGINT) AS count
+	//  FROM narinfos
+	GetNarInfoCount(ctx context.Context) (int64, error)
 	//GetNarInfoHashesByNarFileID
 	//
 	//  SELECT ni.hash

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -218,6 +218,18 @@ func (w *mysqlWrapper) GetNarFileByNarInfoID(ctx context.Context, narinfoID int6
 	return NarFile(res), nil
 }
 
+func (w *mysqlWrapper) GetNarFileCount(ctx context.Context) (int64, error) {
+	res, err := w.adapter.GetNarFileCount(ctx)
+	if err != nil {
+		// Primitive return (int64, string, etc)
+		return 0, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *mysqlWrapper) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error) {
 	res, err := w.adapter.GetNarInfoByHash(ctx, hash)
 	if err != nil {
@@ -238,6 +250,18 @@ func (w *mysqlWrapper) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, e
 	// Convert Single Domain Struct
 
 	return NarInfo(res), nil
+}
+
+func (w *mysqlWrapper) GetNarInfoCount(ctx context.Context) (int64, error) {
+	res, err := w.adapter.GetNarInfoCount(ctx)
+	if err != nil {
+		// Primitive return (int64, string, etc)
+		return 0, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
 }
 
 func (w *mysqlWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -203,6 +203,18 @@ func (w *postgresWrapper) GetNarFileByNarInfoID(ctx context.Context, narinfoID i
 	return NarFile(res), nil
 }
 
+func (w *postgresWrapper) GetNarFileCount(ctx context.Context) (int64, error) {
+	res, err := w.adapter.GetNarFileCount(ctx)
+	if err != nil {
+		// Primitive return (int64, string, etc)
+		return 0, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *postgresWrapper) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error) {
 	res, err := w.adapter.GetNarInfoByHash(ctx, hash)
 	if err != nil {
@@ -223,6 +235,18 @@ func (w *postgresWrapper) GetNarInfoByID(ctx context.Context, id int64) (NarInfo
 	// Convert Single Domain Struct
 
 	return NarInfo(res), nil
+}
+
+func (w *postgresWrapper) GetNarInfoCount(ctx context.Context) (int64, error) {
+	res, err := w.adapter.GetNarInfoCount(ctx)
+	if err != nil {
+		// Primitive return (int64, string, etc)
+		return 0, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
 }
 
 func (w *postgresWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -203,6 +203,18 @@ func (w *sqliteWrapper) GetNarFileByNarInfoID(ctx context.Context, narinfoID int
 	return NarFile(res), nil
 }
 
+func (w *sqliteWrapper) GetNarFileCount(ctx context.Context) (int64, error) {
+	res, err := w.adapter.GetNarFileCount(ctx)
+	if err != nil {
+		// Primitive return (int64, string, etc)
+		return 0, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *sqliteWrapper) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error) {
 	res, err := w.adapter.GetNarInfoByHash(ctx, hash)
 	if err != nil {
@@ -223,6 +235,18 @@ func (w *sqliteWrapper) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, 
 	// Convert Single Domain Struct
 
 	return NarInfo(res), nil
+}
+
+func (w *sqliteWrapper) GetNarInfoCount(ctx context.Context) (int64, error) {
+	res, err := w.adapter.GetNarInfoCount(ctx)
+	if err != nil {
+		// Primitive return (int64, string, etc)
+		return 0, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
 }
 
 func (w *sqliteWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -133,6 +133,11 @@ type Querier interface {
 	//  INNER JOIN narinfo_nar_files nnf ON nf.id = nnf.nar_file_id
 	//  WHERE nnf.narinfo_id = ?
 	GetNarFileByNarInfoID(ctx context.Context, narinfoID int64) (NarFile, error)
+	//GetNarFileCount
+	//
+	//  SELECT CAST(COUNT(*) AS SIGNED) AS count
+	//  FROM nar_files
+	GetNarFileCount(ctx context.Context) (int64, error)
 	//GetNarInfoByHash
 	//
 	//  SELECT id, hash, created_at, updated_at, last_accessed_at
@@ -145,6 +150,11 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE id = ?
 	GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
+	//GetNarInfoCount
+	//
+	//  SELECT CAST(COUNT(*) AS SIGNED) AS count
+	//  FROM narinfos
+	GetNarInfoCount(ctx context.Context) (int64, error)
 	//GetNarInfoHashesByNarFileID
 	//
 	//  SELECT ni.hash

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -447,6 +447,22 @@ func (q *Queries) GetNarFileByNarInfoID(ctx context.Context, narinfoID int64) (N
 	return i, err
 }
 
+const getNarFileCount = `-- name: GetNarFileCount :one
+SELECT CAST(COUNT(*) AS SIGNED) AS count
+FROM nar_files
+`
+
+// GetNarFileCount
+//
+//	SELECT CAST(COUNT(*) AS SIGNED) AS count
+//	FROM nar_files
+func (q *Queries) GetNarFileCount(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, getNarFileCount)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const getNarInfoByHash = `-- name: GetNarInfoByHash :one
 SELECT id, hash, created_at, updated_at, last_accessed_at
 FROM narinfos
@@ -493,6 +509,22 @@ func (q *Queries) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
 		&i.LastAccessedAt,
 	)
 	return i, err
+}
+
+const getNarInfoCount = `-- name: GetNarInfoCount :one
+SELECT CAST(COUNT(*) AS SIGNED) AS count
+FROM narinfos
+`
+
+// GetNarInfoCount
+//
+//	SELECT CAST(COUNT(*) AS SIGNED) AS count
+//	FROM narinfos
+func (q *Queries) GetNarInfoCount(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, getNarInfoCount)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
 }
 
 const getNarInfoHashesByNarFileID = `-- name: GetNarInfoHashesByNarFileID :many

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -135,6 +135,11 @@ type Querier interface {
 	//  INNER JOIN narinfo_nar_files nnf ON nf.id = nnf.nar_file_id
 	//  WHERE nnf.narinfo_id = $1
 	GetNarFileByNarInfoID(ctx context.Context, narinfoID int64) (NarFile, error)
+	//GetNarFileCount
+	//
+	//  SELECT CAST(COUNT(*) AS BIGINT) AS count
+	//  FROM nar_files
+	GetNarFileCount(ctx context.Context) (int64, error)
 	//GetNarInfoByHash
 	//
 	//  SELECT id, hash, created_at, updated_at, last_accessed_at
@@ -147,6 +152,11 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE id = $1
 	GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
+	//GetNarInfoCount
+	//
+	//  SELECT CAST(COUNT(*) AS BIGINT) AS count
+	//  FROM narinfos
+	GetNarInfoCount(ctx context.Context) (int64, error)
 	//GetNarInfoHashesByNarFileID
 	//
 	//  SELECT ni.hash

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -482,6 +482,22 @@ func (q *Queries) GetNarFileByNarInfoID(ctx context.Context, narinfoID int64) (N
 	return i, err
 }
 
+const getNarFileCount = `-- name: GetNarFileCount :one
+SELECT CAST(COUNT(*) AS BIGINT) AS count
+FROM nar_files
+`
+
+// GetNarFileCount
+//
+//	SELECT CAST(COUNT(*) AS BIGINT) AS count
+//	FROM nar_files
+func (q *Queries) GetNarFileCount(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, getNarFileCount)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const getNarInfoByHash = `-- name: GetNarInfoByHash :one
 SELECT id, hash, created_at, updated_at, last_accessed_at
 FROM narinfos
@@ -528,6 +544,22 @@ func (q *Queries) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
 		&i.LastAccessedAt,
 	)
 	return i, err
+}
+
+const getNarInfoCount = `-- name: GetNarInfoCount :one
+SELECT CAST(COUNT(*) AS BIGINT) AS count
+FROM narinfos
+`
+
+// GetNarInfoCount
+//
+//	SELECT CAST(COUNT(*) AS BIGINT) AS count
+//	FROM narinfos
+func (q *Queries) GetNarInfoCount(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, getNarInfoCount)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
 }
 
 const getNarInfoHashesByNarFileID = `-- name: GetNarInfoHashesByNarFileID :many

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -135,6 +135,11 @@ type Querier interface {
 	//  INNER JOIN narinfo_nar_files nnf ON nf.id = nnf.nar_file_id
 	//  WHERE nnf.narinfo_id = ?
 	GetNarFileByNarInfoID(ctx context.Context, narinfoID int64) (NarFile, error)
+	//GetNarFileCount
+	//
+	//  SELECT CAST(COUNT(*) AS INTEGER) AS count
+	//  FROM nar_files
+	GetNarFileCount(ctx context.Context) (int64, error)
 	//GetNarInfoByHash
 	//
 	//  SELECT id, hash, created_at, updated_at, last_accessed_at
@@ -147,6 +152,11 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE id = ?
 	GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
+	//GetNarInfoCount
+	//
+	//  SELECT CAST(COUNT(*) AS INTEGER) AS count
+	//  FROM narinfos
+	GetNarInfoCount(ctx context.Context) (int64, error)
 	//GetNarInfoHashesByNarFileID
 	//
 	//  SELECT ni.hash

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -482,6 +482,22 @@ func (q *Queries) GetNarFileByNarInfoID(ctx context.Context, narinfoID int64) (N
 	return i, err
 }
 
+const getNarFileCount = `-- name: GetNarFileCount :one
+SELECT CAST(COUNT(*) AS INTEGER) AS count
+FROM nar_files
+`
+
+// GetNarFileCount
+//
+//	SELECT CAST(COUNT(*) AS INTEGER) AS count
+//	FROM nar_files
+func (q *Queries) GetNarFileCount(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, getNarFileCount)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const getNarInfoByHash = `-- name: GetNarInfoByHash :one
 SELECT id, hash, created_at, updated_at, last_accessed_at
 FROM narinfos
@@ -528,6 +544,22 @@ func (q *Queries) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
 		&i.LastAccessedAt,
 	)
 	return i, err
+}
+
+const getNarInfoCount = `-- name: GetNarInfoCount :one
+SELECT CAST(COUNT(*) AS INTEGER) AS count
+FROM narinfos
+`
+
+// GetNarInfoCount
+//
+//	SELECT CAST(COUNT(*) AS INTEGER) AS count
+//	FROM narinfos
+func (q *Queries) GetNarInfoCount(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, getNarInfoCount)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
 }
 
 const getNarInfoHashesByNarFileID = `-- name: GetNarInfoHashesByNarFileID :many


### PR DESCRIPTION
This adds `ncps_narinfo_count` and `ncps_nar_file_count` metrics to the cache.
It includes:
- Adding `GetNarInfoCount` and `GetNarFileCount` queries to all supported databases.
- Initializing the new metrics in `pkg/cache/cache.go`.
- Registering a callback to update these metrics periodically from the database.
- Updating generated database code.

closes #309