### PR TITLE
feat: add bulk insert support for all database engines in gen-db-wrappers

### DIFF
--- a/nix/gen-db-wrappers/flake-module.nix
+++ b/nix/gen-db-wrappers/flake-module.nix
@@ -6,7 +6,7 @@
         name = "gen-db-wrappers";
         src = ./src;
 
-        vendorHash = null;
+        vendorHash = "sha256-EsZuN5MPT1bTImjkcyNd5sxy7srSS0JlDJiGGfpEhtM=";
 
         meta = {
           description = "Generate database wrappers based on the Querier interface";

--- a/nix/gen-db-wrappers/src/go.mod
+++ b/nix/gen-db-wrappers/src/go.mod
@@ -1,3 +1,5 @@
 module gen-db-wrappers
 
 go 1.25.5
+
+require github.com/jinzhu/inflection v1.0.0

--- a/nix/gen-db-wrappers/src/go.sum
+++ b/nix/gen-db-wrappers/src/go.sum
@@ -1,0 +1,2 @@
+github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
+github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=

--- a/nix/gen-db-wrappers/src/main.go
+++ b/nix/gen-db-wrappers/src/main.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+
+	"github.com/jinzhu/inflection"
 )
 
 const generatedFilePrefix = "generated_"
@@ -41,6 +43,7 @@ type MethodInfo struct {
 	ReturnsSelf  bool   // Does it return the wrapper type (like WithTx)?
 	HasValue     bool   // Does it return a value (non-error)?
 	Docs         []string
+	BulkFor      string // Extracted from @bulk-for annotation
 }
 
 type Param struct {
@@ -115,6 +118,11 @@ func main() {
 						if field.Doc != nil {
 							for _, comment := range field.Doc.List {
 								m.Docs = append(m.Docs, comment.Text)
+								if strings.Contains(comment.Text, "@bulk-for") {
+									if bulkFor := extractBulkFor(comment.Text); bulkFor != "" {
+										m.BulkFor = bulkFor
+									}
+								}
 							}
 						}
 
@@ -230,7 +238,7 @@ func main() {
 	// We need to re-evaluate IsCreate now that we have full struct knowledge, or just rely on naming convention
 	// The previous isDomainStruct check relied on string pattern, which is still valid.
 	for _, engine := range engines {
-		generateWrapper(targetDir, engine, methods)
+		generateWrapper(targetDir, engine, methods, structs)
 	}
 }
 
@@ -256,21 +264,44 @@ func generateQuerier(dir string, methods []MethodInfo) {
 	writeFile(dir, generatedFilePrefix+"querier.go", buf.Bytes())
 }
 
-func generateWrapper(dir string, engine Engine, methods []MethodInfo) {
+func generateWrapper(dir string, engine Engine, methods []MethodInfo, structs map[string]StructInfo) {
 	t := template.Must(template.New("wrapper").Funcs(template.FuncMap{
 		"joinParamsSignature": joinParamsSignature,
-		"joinParamsCall":      joinParamsCall,
 		"joinReturns":         joinReturns,
 		"isSlice":             isSlice,
 		"firstReturnType":     firstReturnType,
 		"isDomainStruct":      isDomainStructFunc,
 		"zeroValue":           zeroValue,
+		"getStruct":           func(name string) StructInfo { return structs[name] },
+		"hasSliceField":       hasSliceField,
+		"getSliceField":       getSliceField,
+		"toSingular":          toSingular,
+		"trimPrefix":          strings.TrimPrefix,
+		"joinParamsCall": func(params []Param, engPkg string) (string, error) {
+			return joinParamsCall(params, engPkg)
+		},
+		"dict": func(values ...interface{}) (map[string]interface{}, error) {
+			if len(values)%2 != 0 {
+				return nil, fmt.Errorf("invalid dict call")
+			}
+			dict := make(map[string]interface{}, len(values)/2)
+			for i := 0; i < len(values); i += 2 {
+				key, ok := values[i].(string)
+				if !ok {
+					return nil, fmt.Errorf("dict keys must be strings")
+				}
+				dict[key] = values[i+1]
+			}
+			return dict, nil
+		},
+		"hasSuffix": strings.HasSuffix,
 	}).Parse(wrapperTemplate))
 
 	var buf bytes.Buffer
 	data := map[string]interface{}{
 		"Engine":  engine,
 		"Methods": methods,
+		"Structs": structs,
 	}
 
 	if err := t.Execute(&buf, data); err != nil {
@@ -278,6 +309,18 @@ func generateWrapper(dir string, engine Engine, methods []MethodInfo) {
 	}
 	writeFile(dir, fmt.Sprintf("%swrapper_%s.go", generatedFilePrefix, engine.Name), buf.Bytes())
 }
+
+func extractBulkFor(comment string) string {
+	parts := strings.Fields(comment)
+	for i, p := range parts {
+		if p == "@bulk-for" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return ""
+}
+
+func toSingular(s string) string { return inflection.Singular(s) }
 
 func writeFile(dir, filename string, content []byte) {
 	formatted, err := format.Source(content)
@@ -301,16 +344,20 @@ func joinParamsSignature(params []Param) string {
 	return strings.Join(p, ", ")
 }
 
-func joinParamsCall(params []Param, engPkg string) string {
+func joinParamsCall(params []Param, engPkg string) (string, error) {
 	var p []string
 	for _, param := range params {
 		if isDomainStructFunc(param.Type) {
-			p = append(p, fmt.Sprintf("%s.%s(%s)", engPkg, param.Type, param.Name))
+			if strings.HasPrefix(param.Type, "[]") {
+				return "", fmt.Errorf("unsupported parameter type: slice of domain struct %s. Slices of domain structs are not supported as direct parameters, as they require a conversion loop to be generated. The auto-looping for bulk inserts handles this by operating on a struct parameter containing a slice.", param.Type)
+			} else {
+				p = append(p, fmt.Sprintf("%s.%s(%s)", engPkg, param.Type, param.Name))
+			}
 		} else {
 			p = append(p, param.Name)
 		}
 	}
-	return strings.Join(p, ", ")
+	return strings.Join(p, ", "), nil
 }
 
 func joinReturns(returns []Return) string {
@@ -455,47 +502,105 @@ type {{.Engine.Name}}Wrapper struct {
 }
 
 {{range .Methods}}
+{{- $methodParams := .Params }}
 func (w *{{$.Engine.Name}}Wrapper) {{.Name}}({{joinParamsSignature .Params}}) ({{joinReturns .Returns}}) {
+	{{- /* --- Auto-Loop for Bulk Insert on Non-Postgres --- */ -}}
+	{{- $isAutoLoop := false -}}
+	{{- $singularMethodName := "" -}}
+	{{- $paramType := "" -}}
+	{{- $sliceField := dict "Name" "" -}}
+	{{- if and (not $.Engine.IsPostgres) (gt (len .Params) 1) -}}
+		{{- $pType := (index .Params 1).Type -}}
+		{{- $sInfo := getStruct $pType -}}
+		{{- if hasSliceField $sInfo -}}
+			{{- if .BulkFor -}}
+				{{- $isAutoLoop = true -}}
+				{{- $singularMethodName = .BulkFor -}}
+				{{- $paramType = $pType -}}
+				{{- $sliceField = getSliceField $sInfo -}}
+			{{- else if hasSuffix .Name "s" -}}
+				{{- $singularMethodName = toSingular .Name -}}
+				{{- if ne $singularMethodName .Name -}}
+					{{- $singularParamType := printf "%sParams" $singularMethodName -}}
+					{{- $sInfoSingular := getStruct $singularParamType -}}
+					{{- if ne $sInfoSingular.Name "" -}}
+						{{- $isAutoLoop = true -}}
+						{{- $paramType = $pType -}}
+						{{- $sliceField = getSliceField $sInfo -}}
+					{{- end -}}
+				{{- end -}}
+			{{- end -}}
+		{{- end -}}
+	{{- end -}}
+
+	{{- if $isAutoLoop -}}
+		{{- $singularParamType := printf "%sParams" $singularMethodName -}}
+		{{- $structInfo := getStruct $singularParamType -}}
+		for _, v := range {{(index $methodParams 1).Name}}.{{$sliceField.Name}} {
+			err := w.adapter.{{$singularMethodName}}({{(index $methodParams 0).Name}}, {{$.Engine.Package}}.{{$singularParamType}}{
+				{{- $sliceElemType := trimPrefix $sliceField.Type "[]" -}}
+				{{- range $structInfo.Fields -}}
+				{{- if eq .Type $sliceElemType }}
+					{{.Name}}: v,
+				{{- else }}
+					{{.Name}}: {{(index $methodParams 1).Name}}.{{.Name}},
+				{{- end -}}
+				{{- end -}}
+			})
+			if err != nil {
+				if IsDuplicateKeyError(err) {
+					continue
+				}
+				return err
+			}
+		}
+		return nil
+	{{- else -}}
+		{{- template "standardBody" (dict "Method" . "Engine" $.Engine) -}}
+	{{- end -}}
+}
+{{end}}
+
+{{define "standardBody"}}
 	{{- /* --- MySQL CREATE Special Handling --- */ -}}
-	{{if and $.Engine.IsMySQL .IsCreate}}
+	{{if and .Engine.IsMySQL .Method.IsCreate}}
 		// MySQL does not support RETURNING for INSERTs.
 		// We insert, get LastInsertId, and then fetch the object.
-		res, err := w.adapter.{{.Name}}({{joinParamsCall .Params $.Engine.Package}})
+		res, err := w.adapter.{{.Method.Name}}({{joinParamsCall .Method.Params .Engine.Package}})
 		if err != nil {
-			return {{.ReturnElem}}{}, err
+			return {{.Method.ReturnElem}}{}, err
 		}
 
 		id, err := res.LastInsertId()
 		if err != nil {
-			return {{.ReturnElem}}{}, err
+			return {{.Method.ReturnElem}}{}, err
 		}
 
-
-		return w.Get{{.ReturnElem}}ByID(ctx, id)
+		return w.Get{{.Method.ReturnElem}}ByID(ctx, id)
 
 	{{- else -}}
 
 	{{- /* --- Standard Handling --- */ -}}
-		{{- $retType := firstReturnType .Returns -}}
+		{{- $retType := firstReturnType .Method.Returns -}}
 
 		{{/* 1. CALL ADAPTER */}}
-		{{- if .HasValue -}}
-			res{{if .ReturnsError}}, err{{end}} := w.adapter.{{.Name}}({{joinParamsCall .Params $.Engine.Package}})
+		{{- if .Method.HasValue -}}
+			res{{if .Method.ReturnsError}}, err{{end}} := w.adapter.{{.Method.Name}}({{joinParamsCall .Method.Params .Engine.Package}})
 		{{- else -}}
-			err := w.adapter.{{.Name}}({{joinParamsCall .Params $.Engine.Package}})
+			err := w.adapter.{{.Method.Name}}({{joinParamsCall .Method.Params .Engine.Package}})
 		{{- end -}}
 
 		{{/* 2. HANDLE ERROR */}}
-		{{- if .ReturnsError}}
+		{{- if .Method.ReturnsError}}
 		if err != nil {
-			{{- if .ReturnsSelf}}
+			{{- if .Method.ReturnsSelf}}
 				return nil // returns Querier
-			{{- else if not .HasValue}}
+			{{- else if not .Method.HasValue}}
 				return err
 			{{- else if isSlice $retType}}
 				return nil, err
-			{{- else if isDomainStruct .ReturnElem}}
-				return {{.ReturnElem}}{}, err
+			{{- else if isDomainStruct .Method.ReturnElem}}
+				return {{.Method.ReturnElem}}{}, err
 			{{- else}}
 				// Primitive return (int64, string, etc)
 				return {{zeroValue $retType}}, err
@@ -504,42 +609,41 @@ func (w *{{$.Engine.Name}}Wrapper) {{.Name}}({{joinParamsSignature .Params}}) ({
 		{{- end}}
 
 		{{/* 3. RETURN RESULTS */}}
-		{{- if .ReturnsSelf}}
+		{{- if .Method.ReturnsSelf}}
 			// Wrap the returned adapter (for WithTx)
 
-			return &{{$.Engine.Name}}Wrapper{adapter: res}
+			return &{{.Engine.Name}}Wrapper{adapter: res}
 
 		{{- else if isSlice $retType }}
-			{{- if isDomainStruct .ReturnElem}}
+			{{- if isDomainStruct .Method.ReturnElem}}
 				// Convert Slice of Domain Structs
-				items := make([]{{.ReturnElem}}, len(res))
+				items := make([]{{.Method.ReturnElem}}, len(res))
 				for i, v := range res {
-					items[i] = {{.ReturnElem}}(v)
+					items[i] = {{.Method.ReturnElem}}(v)
 				}
 
-				return items{{if .ReturnsError}}, nil{{end}}
+				return items{{if .Method.ReturnsError}}, nil{{end}}
 			{{- else}}
 				// Return Slice of Primitives (direct match)
-				return res{{if .ReturnsError}}, nil{{end}}
+				return res{{if .Method.ReturnsError}}, nil{{end}}
 			{{- end}}
 
-		{{- else if isDomainStruct .ReturnElem}}
+		{{- else if isDomainStruct .Method.ReturnElem}}
 			// Convert Single Domain Struct
 
-			return {{.ReturnElem}}(res){{if .ReturnsError}}, nil{{end}}
+			return {{.Method.ReturnElem}}(res){{if .Method.ReturnsError}}, nil{{end}}
 
-		{{- else if .HasValue}}
+		{{- else if .Method.HasValue}}
 			// Return Primitive / *sql.DB / etc
 
-			return res{{if .ReturnsError}}, nil{{end}}
+			return res{{if .Method.ReturnsError}}, nil{{end}}
 
 		{{- else}}
 			// No return value (void)
-			{{if .ReturnsError}}return nil{{end}}
+			{{if .Method.ReturnsError}}return nil{{end}}
 		{{- end}}
 
 	{{- end}}
-}
 {{end}}
 
 func (w *{{.Engine.Name}}Wrapper) WithTx(tx *sql.Tx) Querier {
@@ -552,4 +656,23 @@ func (w *{{.Engine.Name}}Wrapper) DB() *sql.DB {
 }
 `
 
-func (e Engine) IsMySQL() bool { return e.Name == "mysql" }
+func (e Engine) IsMySQL() bool    { return e.Name == "mysql" }
+func (e Engine) IsPostgres() bool { return e.Name == "postgres" }
+
+func hasSliceField(s StructInfo) bool {
+	for _, f := range s.Fields {
+		if strings.HasPrefix(f.Type, "[]") && f.Type != "[]byte" {
+			return true
+		}
+	}
+	return false
+}
+
+func getSliceField(s StructInfo) FieldInfo {
+	for _, f := range s.Fields {
+		if strings.HasPrefix(f.Type, "[]") && f.Type != "[]byte" {
+			return f
+		}
+	}
+	return FieldInfo{}
+}

--- a/nix/gen-db-wrappers/src/main_test.go
+++ b/nix/gen-db-wrappers/src/main_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"go/ast"
+	"strings"
 	"testing"
+	"text/template"
 )
 
 func TestExprToString(t *testing.T) {
@@ -99,5 +103,214 @@ func TestZeroValue(t *testing.T) {
 		if got := zeroValue(tt.typeName); got != tt.want {
 			t.Errorf("zeroValue(%q) = %q, want %q", tt.typeName, got, tt.want)
 		}
+	}
+}
+
+func TestExtractBulkFor(t *testing.T) {
+	tests := []struct {
+		comment string
+		want    string
+	}{
+		{"// CreateUsers creates users @bulk-for CreateUser", "CreateUser"},
+		{"// @bulk-for CreateUser", "CreateUser"},
+		{"// No annotation here", ""},
+		{"// Multiple @bulk-for First @bulk-for Second", "First"},
+		{"// @bulk-for", ""},
+	}
+
+	for _, tt := range tests {
+		if got := extractBulkFor(tt.comment); got != tt.want {
+			t.Errorf("extractBulkFor(%q) = %q, want %q", tt.comment, got, tt.want)
+		}
+	}
+}
+
+func TestToSingular(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Users", "User"},
+		{"Process", "Process"},
+		{"GetStatus", "GetStatus"},
+		{"Status", "Status"},
+		{"Addresses", "Address"},
+	}
+
+	for _, tt := range tests {
+		if got := toSingular(tt.input); got != tt.want {
+			t.Errorf("toSingular(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestJoinParamsCall(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  []Param
+		engPkg  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Simple Params",
+			params: []Param{
+				{Name: "ctx", Type: "context.Context"},
+				{Name: "id", Type: "int64"},
+			},
+			engPkg: "sqlitedb",
+			want:   "ctx, id",
+		},
+		{
+			name: "Domain Struct Param",
+			params: []Param{
+				{Name: "user", Type: "User"},
+			},
+			engPkg: "postgresdb",
+			want:   "postgresdb.User(user)",
+		},
+		{
+			name: "Unsupported Slice of Domain Struct",
+			params: []Param{
+				{Name: "users", Type: "[]User"},
+			},
+			engPkg:  "postgresdb",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := joinParamsCall(tt.params, tt.engPkg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("joinParamsCall() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("joinParamsCall() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWrapperTemplate(t *testing.T) {
+	// Mock engines
+	sqlite := Engine{Name: "sqlite", Package: "sqlitedb"}
+
+	// Mock structs
+	structs := map[string]StructInfo{
+		"CreateUserParams": {
+			Name: "CreateUserParams",
+			Fields: []FieldInfo{
+				{Name: "Username", Type: "string"},
+			},
+		},
+		"CreateUsersParams": {
+			Name: "CreateUsersParams",
+			Fields: []FieldInfo{
+				{Name: "Usernames", Type: "[]string"},
+			},
+		},
+	}
+
+	// Mock methods
+	methods := []MethodInfo{
+		{
+			Name: "CreateUsers",
+			Params: []Param{
+				{Name: "ctx", Type: "context.Context"},
+				{Name: "arg", Type: "CreateUsersParams"},
+			},
+			Returns: []Return{{Type: "error"}},
+			Docs:    []string{"// CreateUsers creates users"},
+		},
+	}
+
+	// Helper functions as defined in main.go
+	funcMap := template.FuncMap{
+		"joinParamsSignature": joinParamsSignature,
+		"joinReturns":         joinReturns,
+		"isSlice":             isSlice,
+		"firstReturnType":     firstReturnType,
+		"isDomainStruct":      isDomainStructFunc,
+		"zeroValue":           zeroValue,
+		"getStruct":           func(name string) StructInfo { return structs[name] },
+		"hasSliceField":       hasSliceField,
+		"getSliceField":       getSliceField,
+		"toSingular":          toSingular,
+		"trimPrefix":          strings.TrimPrefix,
+		"dict": func(values ...interface{}) (map[string]interface{}, error) {
+			if len(values)%2 != 0 {
+				return nil, fmt.Errorf("invalid dict call")
+			}
+			dict := make(map[string]interface{}, len(values)/2)
+			for i := 0; i < len(values); i += 2 {
+				key, ok := values[i].(string)
+				if !ok {
+					return nil, fmt.Errorf("dict keys must be strings")
+				}
+				dict[key] = values[i+1]
+			}
+			return dict, nil
+		},
+		"joinParamsCall": func(params []Param, engPkg string) (string, error) {
+			return joinParamsCall(params, engPkg)
+		},
+		"hasSuffix": strings.HasSuffix,
+	}
+
+	tmpl, err := template.New("wrapper").Funcs(funcMap).Parse(wrapperTemplate)
+	if err != nil {
+		t.Fatalf("failed to parse template: %v", err)
+	}
+
+	data := map[string]interface{}{
+		"Engine":  sqlite,
+		"Methods": methods,
+		"Structs": structs,
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+
+	output := buf.String()
+
+	// Verify auto-looping was triggered
+	if !strings.Contains(output, "for _, v := range arg.Usernames") {
+		t.Errorf("expected output to contain loop over arg.Usernames, but it didn't\n%s", output)
+	}
+
+	// Verify field mapping by type
+	// CreateUsers -> singular is CreateUser. CreateUserParams has Username (string).
+	// arg.Usernames is []string. So v is string.
+	// We expect Username: v
+	if !strings.Contains(output, "Username: v,") {
+		t.Errorf("expected output to contain 'Username: v,', but it didn't\n%s", output)
+	}
+
+	// 2. Test GetStatus (should NOT loop because GetStatuParams does not exist)
+	methods = []MethodInfo{
+		{
+			Name: "GetStatus",
+			Params: []Param{
+				{Name: "ctx", Type: "context.Context"},
+				{Name: "hash", Type: "string"},
+			},
+			Returns: []Return{{Type: "Status"}, {Type: "error"}},
+			Docs:    []string{"// GetStatus gets status"},
+		},
+	}
+
+	data["Methods"] = methods
+	buf.Reset()
+	if err := tmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("failed to execute template: %v", err)
+	}
+
+	output = buf.String()
+	if strings.Contains(output, "for _, v := range") {
+		t.Errorf("expected output NOT to contain loop for GetStatus, but it did\n%s", output)
 	}
 }


### PR DESCRIPTION
Bot-based backport to `release-0.7`, triggered by a label in #597.