### PR TITLE
fix: rely on URL instead of StorePath

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1859,9 +1859,9 @@ func (c *Cache) populateNarInfoFromDatabase(
 		return nil, nil, fmt.Errorf("error fetching the narinfo record from database: %w", err)
 	}
 
-	// If store_path is not valid, it means this record hasn't been migrated yet
+	// If URL is not valid, it means this record hasn't been migrated yet
 	// (it might have been created by an older version of ncps as a placeholder).
-	if !nir.StorePath.Valid {
+	if !nir.URL.Valid {
 		return nil, nil, storage.ErrNotFound
 	}
 


### PR DESCRIPTION
The migrate command relies on URL and the URL is the minimum for a valid narinfo so rely on it instead of a storepath when determining if a narinfo is valid

Part of #581