### PR TITLE
feat: add comprehensive progress reporting to narinfo migration

### DIFF
--- a/pkg/ncps/migrate_narinfo.go
+++ b/pkg/ncps/migrate_narinfo.go
@@ -184,7 +184,10 @@ func migrateNarInfoCommand(
 						skipped := atomic.LoadInt32(&totalSkipped)
 						failed := atomic.LoadInt32(&totalFailed)
 
-						rate := float64(processed) / elapsed.Seconds()
+						var rate float64
+						if durationInSeconds := elapsed.Seconds(); durationInSeconds > 0 {
+							rate = float64(processed) / durationInSeconds
+						}
 
 						logger.Info().
 							Int32("found", found).
@@ -276,7 +279,10 @@ func migrateNarInfoCommand(
 			skipped := atomic.LoadInt32(&totalSkipped)
 			failed := atomic.LoadInt32(&totalFailed)
 
-			rate := float64(processed) / duration.Seconds()
+			var rate float64
+			if durationInSeconds := duration.Seconds(); durationInSeconds > 0 {
+				rate = float64(processed) / durationInSeconds
+			}
 
 			logger.Info().
 				Int32("found", found).


### PR DESCRIPTION
To provide better visibility into the narinfo migration process, this change implements
a ticker-based progress reporting mechanism.

- Added a progress reporter that logs metrics every 5 seconds.
- Metrics include found, processed, succeeded, skipped, and failed counts, as well as elapsed time and processing rate.
- Implemented a final summary report showing total duration and final counts.
- Used atomic counters to ensure thread-safety across concurrent workers.
- Improved the migration CLI to accurately track skipped items and handle deletions correctly in the reporting.

Part of #581