### PR TITLE
feat: add OpenTelemetry metrics and improve narinfo migration

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -208,3 +208,19 @@ WHERE url IS NULL;
 SELECT hash
 FROM narinfos
 WHERE url IS NOT NULL;
+
+-- name: IsNarInfoMigrated :one
+-- Check if a narinfo hash has been migrated (has a URL).
+SELECT EXISTS(
+    SELECT 1
+    FROM narinfos
+    WHERE hash = ? AND url IS NOT NULL
+) AS is_migrated;
+
+-- name: GetMigratedNarInfoHashesPaginated :many
+-- Get migrated narinfo hashes with pagination support.
+SELECT hash
+FROM narinfos
+WHERE url IS NOT NULL
+ORDER BY hash
+LIMIT ? OFFSET ?;

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -226,3 +226,19 @@ WHERE url IS NULL;
 SELECT hash
 FROM narinfos
 WHERE url IS NOT NULL;
+
+-- name: IsNarInfoMigrated :one
+-- Check if a narinfo hash has been migrated (has a URL).
+SELECT EXISTS(
+    SELECT 1
+    FROM narinfos
+    WHERE hash = $1 AND url IS NOT NULL
+) AS is_migrated;
+
+-- name: GetMigratedNarInfoHashesPaginated :many
+-- Get migrated narinfo hashes with pagination support.
+SELECT hash
+FROM narinfos
+WHERE url IS NOT NULL
+ORDER BY hash
+LIMIT $1 OFFSET $2;

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -212,3 +212,19 @@ WHERE url IS NULL;
 SELECT hash
 FROM narinfos
 WHERE url IS NOT NULL;
+
+-- name: IsNarInfoMigrated :one
+-- Check if a narinfo hash has been migrated (has a URL).
+SELECT EXISTS(
+    SELECT 1
+    FROM narinfos
+    WHERE hash = ? AND url IS NOT NULL
+) AS is_migrated;
+
+-- name: GetMigratedNarInfoHashesPaginated :many
+-- Get migrated narinfo hashes with pagination support.
+SELECT hash
+FROM narinfos
+WHERE url IS NOT NULL
+ORDER BY hash
+LIMIT ? OFFSET ?;

--- a/pkg/database/generated_models.go
+++ b/pkg/database/generated_models.go
@@ -60,6 +60,11 @@ type CreateNarInfoParams struct {
 	Ca          sql.NullString
 }
 
+type GetMigratedNarInfoHashesPaginatedParams struct {
+	Limit  int32
+	Offset int32
+}
+
 type LinkNarInfoToNarFileParams struct {
 	NarInfoID int64
 	NarFileID int64

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -150,6 +150,14 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url IS NOT NULL
 	GetMigratedNarInfoHashes(ctx context.Context) ([]string, error)
+	// Get migrated narinfo hashes with pagination support.
+	//
+	//  SELECT hash
+	//  FROM narinfos
+	//  WHERE url IS NOT NULL
+	//  ORDER BY hash
+	//  LIMIT $1 OFFSET $2
+	GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error)
 	//GetNarFileByHash
 	//
 	//  SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at
@@ -228,6 +236,14 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url IS NULL
 	GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error)
+	// Check if a narinfo hash has been migrated (has a URL).
+	//
+	//  SELECT EXISTS(
+	//      SELECT 1
+	//      FROM narinfos
+	//      WHERE hash = $1 AND url IS NOT NULL
+	//  ) AS is_migrated
+	IsNarInfoMigrated(ctx context.Context, hash string) (bool, error)
 	//LinkNarInfoToNarFile
 	//
 	//  INSERT INTO narinfo_nar_files (

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -269,6 +269,19 @@ func (w *mysqlWrapper) GetMigratedNarInfoHashes(ctx context.Context) ([]string, 
 	return res, nil
 }
 
+func (w *mysqlWrapper) GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error) {
+	res, err := w.adapter.GetMigratedNarInfoHashesPaginated(ctx, mysqldb.GetMigratedNarInfoHashesPaginatedParams{
+		Limit:  arg.Limit,
+		Offset: arg.Offset,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Return Slice of Primitives (direct match)
+	return res, nil
+}
+
 func (w *mysqlWrapper) GetNarFileByHash(ctx context.Context, hash string) (NarFile, error) {
 	res, err := w.adapter.GetNarFileByHash(ctx, hash)
 	if err != nil {
@@ -409,6 +422,17 @@ func (w *mysqlWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string
 	}
 
 	// Return Slice of Primitives (direct match)
+	return res, nil
+}
+
+func (w *mysqlWrapper) IsNarInfoMigrated(ctx context.Context, hash string) (bool, error) {
+	res, err := w.adapter.IsNarInfoMigrated(ctx, hash)
+	if err != nil {
+		// Primitive return (int64, string, etc)
+		return false, err
+	}
+
+	// Return Primitive / *sql.DB / etc
 	return res, nil
 }
 

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -246,6 +246,19 @@ func (w *postgresWrapper) GetMigratedNarInfoHashes(ctx context.Context) ([]strin
 	return res, nil
 }
 
+func (w *postgresWrapper) GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error) {
+	res, err := w.adapter.GetMigratedNarInfoHashesPaginated(ctx, postgresdb.GetMigratedNarInfoHashesPaginatedParams{
+		Limit:  arg.Limit,
+		Offset: arg.Offset,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Return Slice of Primitives (direct match)
+	return res, nil
+}
+
 func (w *postgresWrapper) GetNarFileByHash(ctx context.Context, hash string) (NarFile, error) {
 	res, err := w.adapter.GetNarFileByHash(ctx, hash)
 	if err != nil {
@@ -386,6 +399,17 @@ func (w *postgresWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]str
 	}
 
 	// Return Slice of Primitives (direct match)
+	return res, nil
+}
+
+func (w *postgresWrapper) IsNarInfoMigrated(ctx context.Context, hash string) (bool, error) {
+	res, err := w.adapter.IsNarInfoMigrated(ctx, hash)
+	if err != nil {
+		// Primitive return (int64, string, etc)
+		return false, err
+	}
+
+	// Return Primitive / *sql.DB / etc
 	return res, nil
 }
 

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -254,6 +254,19 @@ func (w *sqliteWrapper) GetMigratedNarInfoHashes(ctx context.Context) ([]string,
 	return res, nil
 }
 
+func (w *sqliteWrapper) GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error) {
+	res, err := w.adapter.GetMigratedNarInfoHashesPaginated(ctx, sqlitedb.GetMigratedNarInfoHashesPaginatedParams{
+		Limit:  int64(arg.Limit),
+		Offset: int64(arg.Offset),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Return Slice of Primitives (direct match)
+	return res, nil
+}
+
 func (w *sqliteWrapper) GetNarFileByHash(ctx context.Context, hash string) (NarFile, error) {
 	res, err := w.adapter.GetNarFileByHash(ctx, hash)
 	if err != nil {
@@ -395,6 +408,17 @@ func (w *sqliteWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]strin
 
 	// Return Slice of Primitives (direct match)
 	return res, nil
+}
+
+func (w *sqliteWrapper) IsNarInfoMigrated(ctx context.Context, hash string) (bool, error) {
+	res, err := w.adapter.IsNarInfoMigrated(ctx, hash)
+	if err != nil {
+		// Primitive return (int64, string, etc)
+		return false, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+	return res != 0, nil
 }
 
 func (w *sqliteWrapper) LinkNarInfoToNarFile(ctx context.Context, arg LinkNarInfoToNarFileParams) error {

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -136,6 +136,14 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url IS NOT NULL
 	GetMigratedNarInfoHashes(ctx context.Context) ([]string, error)
+	// Get migrated narinfo hashes with pagination support.
+	//
+	//  SELECT hash
+	//  FROM narinfos
+	//  WHERE url IS NOT NULL
+	//  ORDER BY hash
+	//  LIMIT ? OFFSET ?
+	GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error)
 	//GetNarFileByHash
 	//
 	//  SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at
@@ -214,6 +222,14 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url IS NULL
 	GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error)
+	// Check if a narinfo hash has been migrated (has a URL).
+	//
+	//  SELECT EXISTS(
+	//      SELECT 1
+	//      FROM narinfos
+	//      WHERE hash = ? AND url IS NOT NULL
+	//  ) AS is_migrated
+	IsNarInfoMigrated(ctx context.Context, hash string) (bool, error)
 	//LinkNarInfoToNarFile
 	//
 	//  INSERT INTO narinfo_nar_files (

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -484,6 +484,49 @@ func (q *Queries) GetMigratedNarInfoHashes(ctx context.Context) ([]string, error
 	return items, nil
 }
 
+const getMigratedNarInfoHashesPaginated = `-- name: GetMigratedNarInfoHashesPaginated :many
+SELECT hash
+FROM narinfos
+WHERE url IS NOT NULL
+ORDER BY hash
+LIMIT ? OFFSET ?
+`
+
+type GetMigratedNarInfoHashesPaginatedParams struct {
+	Limit  int32
+	Offset int32
+}
+
+// Get migrated narinfo hashes with pagination support.
+//
+//	SELECT hash
+//	FROM narinfos
+//	WHERE url IS NOT NULL
+//	ORDER BY hash
+//	LIMIT ? OFFSET ?
+func (q *Queries) GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, getMigratedNarInfoHashesPaginated, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var hash string
+		if err := rows.Scan(&hash); err != nil {
+			return nil, err
+		}
+		items = append(items, hash)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getNarFileByHash = `-- name: GetNarFileByHash :one
 SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at
 FROM nar_files
@@ -864,6 +907,28 @@ func (q *Queries) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, err
 		return nil, err
 	}
 	return items, nil
+}
+
+const isNarInfoMigrated = `-- name: IsNarInfoMigrated :one
+SELECT EXISTS(
+    SELECT 1
+    FROM narinfos
+    WHERE hash = ? AND url IS NOT NULL
+) AS is_migrated
+`
+
+// Check if a narinfo hash has been migrated (has a URL).
+//
+//	SELECT EXISTS(
+//	    SELECT 1
+//	    FROM narinfos
+//	    WHERE hash = ? AND url IS NOT NULL
+//	) AS is_migrated
+func (q *Queries) IsNarInfoMigrated(ctx context.Context, hash string) (bool, error) {
+	row := q.db.QueryRowContext(ctx, isNarInfoMigrated, hash)
+	var is_migrated bool
+	err := row.Scan(&is_migrated)
+	return is_migrated, err
 }
 
 const linkNarInfoToNarFile = `-- name: LinkNarInfoToNarFile :exec

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -152,6 +152,14 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url IS NOT NULL
 	GetMigratedNarInfoHashes(ctx context.Context) ([]string, error)
+	// Get migrated narinfo hashes with pagination support.
+	//
+	//  SELECT hash
+	//  FROM narinfos
+	//  WHERE url IS NOT NULL
+	//  ORDER BY hash
+	//  LIMIT $1 OFFSET $2
+	GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error)
 	//GetNarFileByHash
 	//
 	//  SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at
@@ -230,6 +238,14 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url IS NULL
 	GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error)
+	// Check if a narinfo hash has been migrated (has a URL).
+	//
+	//  SELECT EXISTS(
+	//      SELECT 1
+	//      FROM narinfos
+	//      WHERE hash = $1 AND url IS NOT NULL
+	//  ) AS is_migrated
+	IsNarInfoMigrated(ctx context.Context, hash string) (bool, error)
 	//LinkNarInfoToNarFile
 	//
 	//  INSERT INTO narinfo_nar_files (

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -138,6 +138,14 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url IS NOT NULL
 	GetMigratedNarInfoHashes(ctx context.Context) ([]string, error)
+	// Get migrated narinfo hashes with pagination support.
+	//
+	//  SELECT hash
+	//  FROM narinfos
+	//  WHERE url IS NOT NULL
+	//  ORDER BY hash
+	//  LIMIT ? OFFSET ?
+	GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error)
 	//GetNarFileByHash
 	//
 	//  SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at
@@ -216,6 +224,14 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url IS NULL
 	GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error)
+	// Check if a narinfo hash has been migrated (has a URL).
+	//
+	//  SELECT EXISTS(
+	//      SELECT 1
+	//      FROM narinfos
+	//      WHERE hash = ? AND url IS NOT NULL
+	//  ) AS is_migrated
+	IsNarInfoMigrated(ctx context.Context, hash string) (int64, error)
 	//LinkNarInfoToNarFile
 	//
 	//  INSERT INTO narinfo_nar_files (

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -530,6 +530,49 @@ func (q *Queries) GetMigratedNarInfoHashes(ctx context.Context) ([]string, error
 	return items, nil
 }
 
+const getMigratedNarInfoHashesPaginated = `-- name: GetMigratedNarInfoHashesPaginated :many
+SELECT hash
+FROM narinfos
+WHERE url IS NOT NULL
+ORDER BY hash
+LIMIT ? OFFSET ?
+`
+
+type GetMigratedNarInfoHashesPaginatedParams struct {
+	Limit  int64
+	Offset int64
+}
+
+// Get migrated narinfo hashes with pagination support.
+//
+//	SELECT hash
+//	FROM narinfos
+//	WHERE url IS NOT NULL
+//	ORDER BY hash
+//	LIMIT ? OFFSET ?
+func (q *Queries) GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, getMigratedNarInfoHashesPaginated, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var hash string
+		if err := rows.Scan(&hash); err != nil {
+			return nil, err
+		}
+		items = append(items, hash)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getNarFileByHash = `-- name: GetNarFileByHash :one
 SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at
 FROM nar_files
@@ -910,6 +953,28 @@ func (q *Queries) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, err
 		return nil, err
 	}
 	return items, nil
+}
+
+const isNarInfoMigrated = `-- name: IsNarInfoMigrated :one
+SELECT EXISTS(
+    SELECT 1
+    FROM narinfos
+    WHERE hash = ? AND url IS NOT NULL
+) AS is_migrated
+`
+
+// Check if a narinfo hash has been migrated (has a URL).
+//
+//	SELECT EXISTS(
+//	    SELECT 1
+//	    FROM narinfos
+//	    WHERE hash = ? AND url IS NOT NULL
+//	) AS is_migrated
+func (q *Queries) IsNarInfoMigrated(ctx context.Context, hash string) (int64, error) {
+	row := q.db.QueryRowContext(ctx, isNarInfoMigrated, hash)
+	var is_migrated int64
+	err := row.Scan(&is_migrated)
+	return is_migrated, err
 }
 
 const linkNarInfoToNarFile = `-- name: LinkNarInfoToNarFile :exec

--- a/pkg/ncps/metrics.go
+++ b/pkg/ncps/metrics.go
@@ -1,0 +1,113 @@
+package ncps
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const (
+	otelPackageNameMetrics = "github.com/kalbasit/ncps/pkg/ncps"
+
+	// Migration result constants for metrics.
+	MigrationResultSuccess = "success"
+	MigrationResultFailure = "failure"
+	MigrationResultSkipped = "skipped"
+
+	// Migration operation constants for metrics.
+	MigrationOperationMigrate = "migrate"
+	MigrationOperationDelete  = "delete"
+)
+
+var (
+	//nolint:gochecknoglobals
+	meterMigration metric.Meter
+
+	// migrationNarInfosTotal tracks total narinfos processed during migration.
+	//nolint:gochecknoglobals
+	migrationNarInfosTotal metric.Int64Counter
+
+	// migrationDuration tracks the duration of migration operations.
+	//nolint:gochecknoglobals
+	migrationDuration metric.Float64Histogram
+
+	// migrationBatchSize tracks the number of narinfos in each migration batch.
+	//nolint:gochecknoglobals
+	migrationBatchSize metric.Int64Histogram
+)
+
+//nolint:gochecknoinits
+func init() {
+	meterMigration = otel.Meter(otelPackageNameMetrics)
+
+	var err error
+
+	migrationNarInfosTotal, err = meterMigration.Int64Counter(
+		"ncps_migration_narinfos_total",
+		metric.WithDescription("Total number of narinfos processed during migration"),
+		metric.WithUnit("{narinfo}"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	migrationDuration, err = meterMigration.Float64Histogram(
+		"ncps_migration_duration_seconds",
+		metric.WithDescription("Duration of narinfo migration operations"),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	migrationBatchSize, err = meterMigration.Int64Histogram(
+		"ncps_migration_batch_size",
+		metric.WithDescription("Number of narinfos in each migration batch"),
+		metric.WithUnit("{narinfo}"),
+	)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// RecordMigrationNarInfo records a narinfo migration operation.
+// operation should be one of MigrationOperation* constants.
+// result should be one of MigrationResult* constants.
+func RecordMigrationNarInfo(ctx context.Context, operation, result string) {
+	if migrationNarInfosTotal == nil {
+		return
+	}
+
+	migrationNarInfosTotal.Add(ctx, 1,
+		metric.WithAttributes(
+			attribute.String("operation", operation),
+			attribute.String("result", result),
+		),
+	)
+}
+
+// RecordMigrationDuration records the duration of a migration operation.
+// operation should be one of MigrationOperation* constants.
+// duration should be in seconds.
+func RecordMigrationDuration(ctx context.Context, operation string, duration float64) {
+	if migrationDuration == nil {
+		return
+	}
+
+	migrationDuration.Record(ctx, duration,
+		metric.WithAttributes(
+			attribute.String("operation", operation),
+		),
+	)
+}
+
+// RecordMigrationBatchSize records the size of a migration batch.
+func RecordMigrationBatchSize(ctx context.Context, size int64) {
+	if migrationBatchSize == nil {
+		return
+	}
+
+	migrationBatchSize.Record(ctx, size)
+}


### PR DESCRIPTION
This change introduces OpenTelemetry metrics to track narinfo migration
progress and results, providing better observability into the migration
process.

Key changes:
- Added `pkg/ncps/metrics.go` to define and record migration metrics.
- Introduced `IsNarInfoMigrated` and `GetMigratedNarInfoHashesPaginated`
  SQL queries across all supported databases (SQLite, MySQL, PostgreSQL).
- Updated `migrateNarInfoCommand` in `pkg/ncps/migrate_narinfo.go` to
  utilize the new metrics and improved state tracking.
- Refined logging and context handling during narinfo deletion and
  migration steps.

Part of #581