### PR TITLE
feat: add database socket support to --database-url

### DIFF
--- a/docs/docs/User Guide/Configuration/Database/MySQLMariaDB Configuration.md
+++ b/docs/docs/User Guide/Configuration/Database/MySQLMariaDB Configuration.md
@@ -49,14 +49,21 @@ mysql://[username]:[password]@[host]:[port]/[database]?[options]
 
 **Common options:**
 
-- `tls=true` - Enable TLS
-- `charset=utf8mb4` - Set character encoding
+- `socket` - Path to the Unix domain socket.
+- `tls=true` - Enable TLS.
+- `charset=utf8mb4` - Set character encoding.
 
 **Examples:**
 
-```
-# Local connection
+```sh
+# Local connection (TCP)
 mysql://ncps:password@localhost:3306/ncps
+
+# Unix Domain Socket (Standard)
+mysql://ncps:password@/ncps?socket=/var/run/mysqld/mysqld.sock
+
+# Unix Domain Socket (Specialized scheme)
+mysql+unix:///var/run/mysqld/mysqld.sock/ncps
 
 # With TLS
 mysql://ncps:password@db.example.com:3306/ncps?tls=true

--- a/docs/docs/User Guide/Configuration/Database/PostgreSQL Configuration.md
+++ b/docs/docs/User Guide/Configuration/Database/PostgreSQL Configuration.md
@@ -57,15 +57,22 @@ postgresql://[username]:[password]@[host]:[port]/[database]?[options]
 
 **Common options:**
 
-- `sslmode=require` - Require TLS encryption
-- `sslmode=disable` - Disable TLS (not recommended for production)
-- `connect_timeout=10` - Connection timeout in seconds
+- `host` - Hostname or path to the directory containing the Unix domain socket.
+- `sslmode=require` - Require TLS encryption.
+- `sslmode=disable` - Disable TLS (not recommended for production).
+- `connect_timeout=10` - Connection timeout in seconds.
 
 **Examples:**
 
-```
-# Local without TLS
+```sh
+# Local via TCP without TLS
 postgresql://ncps:password@localhost:5432/ncps?sslmode=disable
+
+# Local via Unix Domain Socket
+postgresql:///ncps?host=/var/run/postgresql
+
+# Local via Unix Domain Socket (Specialized scheme)
+postgres+unix:///var/run/postgresql/ncps
 
 # Remote with TLS
 postgresql://ncps:password@db.example.com:5432/ncps?sslmode=require

--- a/docs/docs/User Guide/Configuration/Reference.md
+++ b/docs/docs/User Guide/Configuration/Reference.md
@@ -138,11 +138,20 @@ See <a class="reference-link" href="Storage.md">Storage</a> for details.
 
 - SQLite: `sqlite:/var/lib/ncps/db/db.sqlite`
 - PostgreSQL: `postgresql://user:pass@host:5432/database?sslmode=require`
+- PostgreSQL (Socket): `postgresql:///database?host=/var/run/postgresql`
 - MySQL: `mysql://user:pass@host:3306/database`
+- MySQL (Socket): `mysql://user:pass@/database?socket=/var/run/mysqld/mysqld.sock`
+
+**Notes on Sockets:**
+
+For MySQL and PostgreSQL, you can use specialized schemes for Unix domain sockets:
+
+- `mysql+unix:///path/to/socket.sock/database`
+- `postgres+unix:///path/to/socket_dir/database`
 
 **Example:**
 
-```
+```sh
 ncps serve \
   --cache-database-url=postgresql://ncps:password@localhost:5432/ncps?sslmode=require \
   --cache-max-size=100G \

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/XSAM/otelsql"
@@ -19,6 +20,12 @@ import (
 
 	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver
 	_ "github.com/mattn/go-sqlite3"    // SQLite driver
+)
+
+const (
+	netTypeUnix      = "unix"
+	schemePostgres   = "postgres"
+	schemePostgresql = "postgresql"
 )
 
 // PoolConfig holds database connection pool settings.
@@ -141,7 +148,12 @@ func openSQLite(dbURL string, poolCfg *PoolConfig) (*sql.DB, error) {
 }
 
 func openPostgreSQL(dbURL string, poolCfg *PoolConfig) (*sql.DB, error) {
-	sdb, err := otelsql.Open("pgx", dbURL, otelsql.WithAttributes(
+	processedURL, err := parsePostgreSQLURL(dbURL)
+	if err != nil {
+		return nil, err
+	}
+
+	sdb, err := otelsql.Open("pgx", processedURL, otelsql.WithAttributes(
 		semconv.DBSystemPostgreSQL,
 	))
 	if err != nil {
@@ -155,52 +167,50 @@ func openPostgreSQL(dbURL string, poolCfg *PoolConfig) (*sql.DB, error) {
 	return sdb, nil
 }
 
-func openMySQL(dbURL string, poolCfg *PoolConfig) (*sql.DB, error) {
-	// Convert mysql://user:pass@host:port/database to the format expected by go-sql-driver/mysql
+func parsePostgreSQLURL(dbURL string) (string, error) {
 	u, err := url.Parse(dbURL)
 	if err != nil {
+		return "", err
+	}
+
+	// pgx only supports postgres:// and postgresql:// schemes.
+	// If the user provided postgres+unix:// or similar, we normalize it
+	// and restructure the URL for pgx.
+	scheme := strings.ToLower(u.Scheme)
+	if strings.Contains(scheme, "+unix") {
+		socketDir, dbName := path.Split(u.Path)
+		if dbName == "" {
+			return "", fmt.Errorf("%w: missing database name in path: %s", ErrInvalidPostgresUnixURL, dbURL)
+		}
+		// After split, socketDir will have a trailing slash. If path is just "/dbname", it will be "/".
+		if socketDir == "" {
+			return "", fmt.Errorf("%w: missing socket directory in path: %s", ErrInvalidPostgresUnixURL, dbURL)
+		}
+
+		socketDir = path.Clean(socketDir) // Clean up extra slashes and trailing slash.
+
+		// Rebuild URL for pgx: postgresql:///dbname?host=/path/to/socket
+		u.Path = "/" + dbName
+		q := u.Query()
+		q.Set("host", socketDir)
+		u.RawQuery = q.Encode()
+	}
+
+	if strings.Contains(scheme, "+") {
+		if strings.HasPrefix(scheme, schemePostgresql) {
+			u.Scheme = schemePostgresql
+		} else if strings.HasPrefix(scheme, schemePostgres) {
+			u.Scheme = schemePostgres
+		}
+	}
+
+	return u.String(), nil
+}
+
+func openMySQL(dbURL string, poolCfg *PoolConfig) (*sql.DB, error) {
+	cfg, err := parseMySQLConfig(dbURL)
+	if err != nil {
 		return nil, err
-	}
-
-	cfg := mysql.NewConfig()
-
-	// 1. Set credentials and address
-	if u.User != nil {
-		cfg.User = u.User.Username()
-		if password, ok := u.User.Password(); ok {
-			cfg.Passwd = password
-		}
-	}
-
-	if u.Host != "" {
-		cfg.Net = "tcp"
-		cfg.Addr = u.Host
-	}
-
-	if u.Path != "" {
-		cfg.DBName = strings.TrimPrefix(u.Path, "/")
-	}
-
-	// 2. Initialize params with your SAFE defaults
-	// These run regardless of whether the user provided other params.
-	cfg.Params = map[string]string{
-		"parseTime": "true",     // Required for scanning into time.Time
-		"loc":       "UTC",      // logical timezone for the driver
-		"time_zone": "'+00:00'", // Server-side session timezone (Critical for your test fix)
-	}
-
-	// 3. Overwrite defaults if the user explicitly specified them in the URL
-	if u.RawQuery != "" {
-		query, err := url.ParseQuery(u.RawQuery)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing MySQL query parameters: %w", err)
-		}
-
-		for k, v := range query {
-			if len(v) > 0 {
-				cfg.Params[k] = v[0]
-			}
-		}
 	}
 
 	dsn := cfg.FormatDSN()
@@ -215,4 +225,86 @@ func openMySQL(dbURL string, poolCfg *PoolConfig) (*sql.DB, error) {
 	applyPoolSettings(sdb, poolCfg, 25, 5)
 
 	return sdb, nil
+}
+
+func parseMySQLConfig(dbURL string) (*mysql.Config, error) {
+	// Convert mysql://user:pass@host:port/database to the format expected by go-sql-driver/mysql
+	u, err := url.Parse(dbURL)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := mysql.NewConfig()
+
+	// 1. Set credentials
+	if u.User != nil {
+		cfg.User = u.User.Username()
+		if password, ok := u.User.Password(); ok {
+			cfg.Passwd = password
+		}
+	}
+
+	// 2. Set address (TCP or Unix)
+	query := u.Query()
+
+	scheme := strings.ToLower(u.Scheme)
+	switch {
+	case strings.Contains(scheme, "+unix"):
+		if err := parseMySQLUnixPath(cfg, u, dbURL); err != nil {
+			return nil, err
+		}
+	case query.Get("socket") != "":
+		cfg.Net = netTypeUnix
+		cfg.Addr = query.Get("socket")
+	case query.Get("unix_socket") != "":
+		cfg.Net = netTypeUnix
+		cfg.Addr = query.Get("unix_socket")
+	case query.Get("host") != "" && strings.HasPrefix(query.Get("host"), "/"):
+		cfg.Net = netTypeUnix
+		cfg.Addr = query.Get("host")
+	case u.Host != "":
+		cfg.Net = "tcp"
+		cfg.Addr = u.Host
+	}
+
+	if cfg.DBName == "" && u.Path != "" {
+		cfg.DBName = strings.TrimPrefix(u.Path, "/")
+	}
+
+	// 3. Initialize params with your SAFE defaults
+	// These run regardless of whether the user provided other params.
+	cfg.Params = map[string]string{
+		"parseTime": "true",     // Required for scanning into time.Time
+		"loc":       "UTC",      // logical timezone for the driver
+		"time_zone": "'+00:00'", // Server-side session timezone (Critical for your test fix)
+	}
+
+	// 4. Overwrite defaults if the user explicitly specified them in the URL
+	for k, v := range query {
+		if len(v) > 0 {
+			cfg.Params[k] = v[0]
+		}
+	}
+
+	return cfg, nil
+}
+
+func parseMySQLUnixPath(cfg *mysql.Config, u *url.URL, dbURL string) error {
+	// Handle mysql+unix://<socket_path>/<db_name>
+	socketPath, dbName := path.Split(u.Path)
+	if dbName == "" {
+		return fmt.Errorf("%w: missing database name in path: %s", ErrInvalidMySQLUnixURL, dbURL)
+	}
+
+	if socketPath == "" {
+		return fmt.Errorf("%w: missing socket path in path: %s", ErrInvalidMySQLUnixURL, dbURL)
+	}
+
+	socketPath = path.Clean(socketPath)
+
+	cfg.Net = netTypeUnix
+	cfg.Addr = socketPath
+	cfg.DBName = dbName
+
+	return nil
 }

--- a/pkg/database/errors.go
+++ b/pkg/database/errors.go
@@ -55,4 +55,10 @@ var (
 
 	// ErrUnsupportedDriver is returned when the database driver is not recognized.
 	ErrUnsupportedDriver = errors.New("unsupported database driver")
+
+	// ErrInvalidPostgresUnixURL is returned when a postgres+unix URL is invalid.
+	ErrInvalidPostgresUnixURL = errors.New("invalid postgres+unix URL")
+
+	// ErrInvalidMySQLUnixURL is returned when a mysql+unix URL is invalid.
+	ErrInvalidMySQLUnixURL = errors.New("invalid mysql+unix URL")
 )

--- a/pkg/database/type.go
+++ b/pkg/database/type.go
@@ -24,6 +24,11 @@ func DetectFromDatabaseURL(dbURL string) (Type, error) {
 
 	scheme := strings.ToLower(u.Scheme)
 
+	// Normalize scheme by removing everything after + if it exists (e.g., mysql+unix -> mysql)
+	if idx := strings.Index(scheme, "+"); idx != -1 {
+		scheme = scheme[:idx]
+	}
+
 	switch scheme {
 	case "mysql":
 		return TypeMySQL, nil

--- a/pkg/database/url_internal_test.go
+++ b/pkg/database/url_internal_test.go
@@ -1,0 +1,138 @@
+package database
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePostgreSQLURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		dbURL    string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "Standard TCP URL",
+			dbURL:    "postgres://user:pass@localhost:5432/dbname?sslmode=disable",
+			expected: "postgres://user:pass@localhost:5432/dbname?sslmode=disable",
+			wantErr:  false,
+		},
+		{
+			name:     "Postgres+unix specialized scheme",
+			dbURL:    "postgres+unix:///var/run/postgresql/dbname",
+			expected: "postgres:///dbname?host=%2Fvar%2Frun%2Fpostgresql",
+			wantErr:  false,
+		},
+		{
+			name:     "Postgresql+unix specialized scheme",
+			dbURL:    "postgresql+unix:///var/run/postgresql/dbname",
+			expected: "postgresql:///dbname?host=%2Fvar%2Frun%2Fpostgresql",
+			wantErr:  false,
+		},
+		{
+			name:     "Postgres+unix with root socket directory",
+			dbURL:    "postgres+unix:///dbname",
+			expected: "postgres:///dbname?host=%2F",
+			wantErr:  false,
+		},
+		{
+			name:     "Postgres+unix with redundant slashes",
+			dbURL:    "postgres+unix:////var/run/postgresql//dbname",
+			expected: "postgres:///dbname?host=%2Fvar%2Frun%2Fpostgresql",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parsePostgreSQLURL(tt.dbURL)
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestParseMySQLConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		dbURL          string
+		expectedNet    string
+		expectedAddr   string
+		expectedDBName string
+		wantErr        bool
+	}{
+		{
+			name:           "Standard TCP URL",
+			dbURL:          "mysql://user:pass@localhost:3306/dbname",
+			expectedNet:    "tcp",
+			expectedAddr:   "localhost:3306",
+			expectedDBName: "dbname",
+			wantErr:        false,
+		},
+		{
+			name:           "MySQL+unix specialized scheme",
+			dbURL:          "mysql+unix:///var/run/mysqld/mysqld.sock/dbname",
+			expectedNet:    "unix",
+			expectedAddr:   "/var/run/mysqld/mysqld.sock",
+			expectedDBName: "dbname",
+			wantErr:        false,
+		},
+		{
+			name:           "MySQL with socket parameter",
+			dbURL:          "mysql://user:pass@/dbname?socket=/var/run/mysqld/mysqld.sock",
+			expectedNet:    "unix",
+			expectedAddr:   "/var/run/mysqld/mysqld.sock",
+			expectedDBName: "dbname",
+			wantErr:        false,
+		},
+		{
+			name:           "MySQL+unix with root socket path",
+			dbURL:          "mysql+unix:///dbname",
+			expectedNet:    "unix",
+			expectedAddr:   "/",
+			expectedDBName: "dbname",
+			wantErr:        false,
+		},
+		{
+			name:           "MySQL+unix with redundant slashes",
+			dbURL:          "mysql+unix:////var/run/mysqld/mysqld.sock//dbname",
+			expectedNet:    "unix",
+			expectedAddr:   "/var/run/mysqld/mysqld.sock",
+			expectedDBName: "dbname",
+			wantErr:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg, err := parseMySQLConfig(tt.dbURL)
+			if tt.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedNet, cfg.Net)
+			assert.Equal(t, tt.expectedAddr, cfg.Addr)
+			assert.Equal(t, tt.expectedDBName, cfg.DBName)
+		})
+	}
+}

--- a/pkg/database/url_test.go
+++ b/pkg/database/url_test.go
@@ -1,0 +1,49 @@
+package database_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/database"
+)
+
+func TestDetectFromDatabaseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		url      string
+		expected database.Type
+		wantErr  bool
+	}{
+		{"mysql://user:pass@localhost/db", database.TypeMySQL, false},
+		{"mysql+unix:///tmp/mysql.sock/db", database.TypeMySQL, false},
+		{"postgres://user:pass@localhost/db", database.TypePostgreSQL, false},
+		{"postgresql://user:pass@localhost/db", database.TypePostgreSQL, false},
+		{"postgres+unix:///tmp/pg.sock/db", database.TypePostgreSQL, false},
+		{"postgresql+unix:///tmp/pg.sock/db", database.TypePostgreSQL, false},
+		{"sqlite:///tmp/db.sqlite", database.TypeSQLite, false},
+		{"sqlite3:///tmp/db.sqlite", database.TypeSQLite, false},
+		// Invalid URLs
+		{"invalid-url", database.TypeUnknown, true},
+		{"unknown://localhost/db", database.TypeUnknown, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := database.DetectFromDatabaseURL(tt.url)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, tt.expected, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
Bot-based backport to `release-0.7`, triggered by a label in #617.