### PR TITLE
fix: handle NarFile race condition in database

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -93,7 +93,9 @@ INSERT INTO nar_files (
     hash, compression, `query`, file_size
 ) VALUES (
     ?, ?, ?, ?
-);
+)
+ON DUPLICATE KEY UPDATE
+    updated_at = CURRENT_TIMESTAMP;
 
 -- name: LinkNarInfoToNarFile :exec
 INSERT INTO narinfo_nar_files (

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -111,6 +111,8 @@ INSERT INTO nar_files (
 ) VALUES (
     $1, $2, $3, $4
 )
+ON CONFLICT (hash) DO UPDATE SET
+    updated_at = EXCLUDED.updated_at
 RETURNING *;
 
 -- name: LinkNarInfoToNarFile :exec

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -97,6 +97,8 @@ INSERT INTO nar_files (
 ) VALUES (
     ?, ?, ?, ?
 )
+ON CONFLICT (hash) DO UPDATE SET
+    updated_at = excluded.updated_at
 RETURNING *;
 
 -- name: LinkNarInfoToNarFile :exec

--- a/pkg/database/contract_test.go
+++ b/pkg/database/contract_test.go
@@ -499,24 +499,25 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 					}
 				})
 
-				t.Run("hash is unique", func(t *testing.T) {
+				t.Run("upsert on duplicate hash", func(t *testing.T) {
 					hash, err := helper.RandString(32, nil)
 					require.NoError(t, err)
 
-					_, err = db.CreateNarFile(context.Background(), database.CreateNarFileParams{
+					nf1, err := db.CreateNarFile(context.Background(), database.CreateNarFileParams{
 						Hash:        hash,
 						Compression: "",
 						FileSize:    123,
 					})
 					require.NoError(t, err)
 
-					_, err = db.CreateNarFile(context.Background(), database.CreateNarFileParams{
+					nf2, err := db.CreateNarFile(context.Background(), database.CreateNarFileParams{
 						Hash:        hash,
 						Compression: "",
 						FileSize:    123,
 					})
+					require.NoError(t, err)
 
-					assert.True(t, database.IsDuplicateKeyError(err))
+					assert.Equal(t, nf1.ID, nf2.ID)
 				})
 			})
 		}

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -53,6 +53,8 @@ type Querier interface {
 	//  ) VALUES (
 	//      $1, $2, $3, $4
 	//  )
+	//  ON CONFLICT (hash) DO UPDATE SET
+	//      updated_at = EXCLUDED.updated_at
 	//  RETURNING id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at
 	CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error)
 	//CreateNarInfo

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -41,6 +41,8 @@ type Querier interface {
 	//  ) VALUES (
 	//      ?, ?, ?, ?
 	//  )
+	//  ON DUPLICATE KEY UPDATE
+	//      updated_at = CURRENT_TIMESTAMP
 	CreateNarFile(ctx context.Context, arg CreateNarFileParams) (sql.Result, error)
 	//CreateNarInfo
 	//

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -90,6 +90,8 @@ INSERT INTO nar_files (
 ) VALUES (
     ?, ?, ?, ?
 )
+ON DUPLICATE KEY UPDATE
+    updated_at = CURRENT_TIMESTAMP
 `
 
 type CreateNarFileParams struct {
@@ -106,6 +108,8 @@ type CreateNarFileParams struct {
 //	) VALUES (
 //	    ?, ?, ?, ?
 //	)
+//	ON DUPLICATE KEY UPDATE
+//	    updated_at = CURRENT_TIMESTAMP
 func (q *Queries) CreateNarFile(ctx context.Context, arg CreateNarFileParams) (sql.Result, error) {
 	return q.db.ExecContext(ctx, createNarFile,
 		arg.Hash,

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -55,6 +55,8 @@ type Querier interface {
 	//  ) VALUES (
 	//      $1, $2, $3, $4
 	//  )
+	//  ON CONFLICT (hash) DO UPDATE SET
+	//      updated_at = EXCLUDED.updated_at
 	//  RETURNING id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at
 	CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error)
 	//CreateNarInfo

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -149,6 +149,8 @@ INSERT INTO nar_files (
 ) VALUES (
     $1, $2, $3, $4
 )
+ON CONFLICT (hash) DO UPDATE SET
+    updated_at = EXCLUDED.updated_at
 RETURNING id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at
 `
 
@@ -166,6 +168,8 @@ type CreateNarFileParams struct {
 //	) VALUES (
 //	    $1, $2, $3, $4
 //	)
+//	ON CONFLICT (hash) DO UPDATE SET
+//	    updated_at = EXCLUDED.updated_at
 //	RETURNING id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at
 func (q *Queries) CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error) {
 	row := q.db.QueryRowContext(ctx, createNarFile,

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -41,6 +41,8 @@ type Querier interface {
 	//  ) VALUES (
 	//      ?, ?, ?, ?
 	//  )
+	//  ON CONFLICT (hash) DO UPDATE SET
+	//      updated_at = excluded.updated_at
 	//  RETURNING id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at
 	CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error)
 	//CreateNarInfo

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -101,6 +101,8 @@ INSERT INTO nar_files (
 ) VALUES (
     ?, ?, ?, ?
 )
+ON CONFLICT (hash) DO UPDATE SET
+    updated_at = excluded.updated_at
 RETURNING id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at
 `
 
@@ -118,6 +120,8 @@ type CreateNarFileParams struct {
 //	) VALUES (
 //	    ?, ?, ?, ?
 //	)
+//	ON CONFLICT (hash) DO UPDATE SET
+//	    updated_at = excluded.updated_at
 //	RETURNING id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at
 func (q *Queries) CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error) {
 	row := q.db.QueryRowContext(ctx, createNarFile,

--- a/testhelper/mysql.go
+++ b/testhelper/mysql.go
@@ -2,12 +2,18 @@ package testhelper
 
 import (
 	"context"
+	"fmt"
+	"net/url"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/helper"
 )
 
 // MigrateMySQLDatabase will migrate the MySQL database using dbmate.
@@ -46,4 +52,63 @@ func MigrateMySQLDatabase(t *testing.T, dbURL string) {
 	require.NoErrorf(t, err, "Running %q has failed", cmd.String())
 
 	t.Logf("%s: %s", cmd.String(), output)
+}
+
+// SetupMySQL sets up a new temporary MySQL database for testing.
+// It requires the NCPS_TEST_ADMIN_MYSQL_URL environment variable to be set.
+// It returns a database connection and a cleanup function.
+func SetupMySQL(t *testing.T) (database.Querier, func()) {
+	t.Helper()
+
+	adminDbURL := os.Getenv("NCPS_TEST_ADMIN_MYSQL_URL")
+	if adminDbURL == "" {
+		t.Skip("Skipping MySQL test: NCPS_TEST_ADMIN_MYSQL_URL not set")
+	}
+
+	adminDb, err := database.Open(adminDbURL, nil)
+	require.NoError(t, err, "failed to connect to the mysql database")
+
+	dbName := "test-" + helper.MustRandString(58, nil)
+
+	// MySQL CREATE DATABASE
+	_, err = adminDb.DB().ExecContext(context.Background(), fmt.Sprintf("CREATE DATABASE `%s`", dbName))
+	require.NoError(t, err, "failed to create database %s", dbName)
+
+	// Replace the database name in the URL
+	u, err := url.Parse(adminDbURL)
+	require.NoError(t, err)
+
+	u.Path = "/" + dbName
+	dbURL := u.String()
+
+	// Helper to recover from migration panic
+	var errMigration error
+
+	// We can't defer the check here easily because t.Fatalf stops the test.
+	// But MigrateMySQLDatabase might panic? The original code had a defer recover block.
+	// Let's keep it safe.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				errMigration = fmt.Errorf("database migration panicked: %v", r) //nolint:err113
+			}
+		}()
+
+		MigrateMySQLDatabase(t, dbURL)
+	}()
+
+	if errMigration != nil {
+		t.Fatalf("Failed to migrate MySQL database: %v", errMigration)
+	}
+
+	db, err := database.Open(dbURL, nil)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		_ = db.DB().Close()
+		_, _ = adminDb.DB().ExecContext(context.Background(), fmt.Sprintf("DROP DATABASE `%s`", dbName))
+		_ = adminDb.DB().Close()
+	}
+
+	return db, cleanup
 }

--- a/testhelper/postgres.go
+++ b/testhelper/postgres.go
@@ -2,12 +2,18 @@ package testhelper
 
 import (
 	"context"
+	"fmt"
+	"net/url"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/helper"
 )
 
 // MigratePostgresDatabase will migrate the PostgreSQL database using dbmate.
@@ -43,7 +49,61 @@ func MigratePostgresDatabase(t *testing.T, dbURL string) {
 	)
 
 	output, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "Running %q has failed", cmd.String())
+	require.NoErrorf(t, err, "Running %q has failed. Output:\n%s", cmd.String(), string(output))
 
 	t.Logf("%s: %s", cmd.String(), output)
+}
+
+// SetupPostgres sets up a new temporary PostgreSQL database for testing.
+// It requires the NCPS_TEST_ADMIN_POSTGRES_URL environment variable to be set.
+// It returns a database connection and a cleanup function.
+func SetupPostgres(t *testing.T) (database.Querier, func()) {
+	t.Helper()
+
+	adminDbURL := os.Getenv("NCPS_TEST_ADMIN_POSTGRES_URL")
+	if adminDbURL == "" {
+		t.Skip("Skipping Postgres test: NCPS_TEST_ADMIN_POSTGRES_URL not set")
+	}
+
+	adminDb, err := database.Open(adminDbURL, nil)
+	require.NoError(t, err, "failed to connect to the postgres database")
+
+	dbName := "test-" + helper.MustRandString(58, nil)
+	_, err = adminDb.DB().ExecContext(context.Background(), "SELECT create_test_db($1);", dbName)
+	require.NoError(t, err, "failed to create database %s", dbName)
+
+	// Replace the test-db with the ephemeral database in the dbURL
+	u, err := url.Parse(adminDbURL)
+	require.NoError(t, err)
+
+	u.Path = "/" + dbName
+	dbURL := u.String()
+
+	// Helper to recover from migration panic
+	var errMigration error
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				errMigration = fmt.Errorf("database migration panicked: %v", r) //nolint:err113
+			}
+		}()
+
+		MigratePostgresDatabase(t, dbURL)
+	}()
+
+	if errMigration != nil {
+		t.Fatalf("Failed to migrate PostgreSQL database: %v", errMigration)
+	}
+
+	db, err := database.Open(dbURL, nil)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		_ = db.DB().Close()
+		_, _ = adminDb.DB().ExecContext(context.Background(), "SELECT drop_test_db($1);", dbName)
+		_ = adminDb.DB().Close()
+	}
+
+	return db, cleanup
 }


### PR DESCRIPTION
This change fixes a race condition where multiple concurrent requests
for different NarInfos sharing the same NarFile could cause unique
constraint violations in the database. It updates PostgreSQL and
SQLite queries to use `ON CONFLICT DO UPDATE` for `CreateNarFile`,
gracefully handling duplicates and returning the existing record to
avoid transaction aborts.

Additionally, it adds application-level handling for `DuplicateKeyError`
in `storeInDatabase` to retry fetching the existing record if insertion
fails, providing robustness across all database backends.

A resource leak in the reproduction test `TestPutNarInfoConcurrentSharedNar`
was also fixed to prevent connection exhaustion.

This change also refactors the database test helpers by extracting
MySQL and PostgreSQL setup logic into `testhelper/mysql.go` and
`testhelper/postgres.go`, making them reusable across different tests.

fixes #623