### PR TITLE
fix: handle NarFile race condition in database [backport #624]

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -69,7 +69,9 @@ INSERT INTO nar_files (
     hash, compression, `query`, file_size
 ) VALUES (
     ?, ?, ?, ?
-);
+)
+ON DUPLICATE KEY UPDATE
+    updated_at = CURRENT_TIMESTAMP;
 
 -- name: LinkNarInfoToNarFile :exec
 INSERT INTO narinfo_nar_files (

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -73,6 +73,8 @@ INSERT INTO nar_files (
 ) VALUES (
     $1, $2, $3, $4
 )
+ON CONFLICT (hash) DO UPDATE SET
+    updated_at = EXCLUDED.updated_at
 RETURNING *;
 
 -- name: LinkNarInfoToNarFile :exec

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -73,6 +73,8 @@ INSERT INTO nar_files (
 ) VALUES (
     ?, ?, ?, ?
 )
+ON CONFLICT (hash) DO UPDATE SET
+    updated_at = excluded.updated_at
 RETURNING *;
 
 -- name: LinkNarInfoToNarFile :exec

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1937,55 +1937,10 @@ func (c *Cache) storeInDatabase(
 		}
 
 		// Check if nar_file already exists (multiple narinfos can share the same nar_file)
-		existingNarFile, err := qtx.GetNarFileByHash(ctx, narURL.Hash)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("error checking for existing nar_file: %w", err)
-		}
 
-		var narFileID int64
-
-		if err == nil {
-			// Nar file already exists - verify properties match
-			if existingNarFile.Compression != narURL.Compression.String() ||
-				existingNarFile.Query != narURL.Query.Encode() ||
-				existingNarFile.FileSize != narInfo.FileSize {
-				zerolog.Ctx(ctx).
-					Warn().
-					Str("nar_hash", narURL.Hash).
-					Str("existing_compression", existingNarFile.Compression).
-					Str("new_compression", narURL.Compression.String()).
-					Str("existing_query", existingNarFile.Query).
-					Str("new_query", narURL.Query.Encode()).
-					Uint64("existing_file_size", existingNarFile.FileSize).
-					Uint64("new_file_size", narInfo.FileSize).
-					Msg("nar_file already exists but properties don't match")
-
-				return fmt.Errorf(
-					"%w: nar_file for hash %s already exists with different properties",
-					ErrInconsistentState,
-					narURL.Hash,
-				)
-			}
-
-			zerolog.Ctx(ctx).
-				Debug().
-				Str("nar_hash", narURL.Hash).
-				Msg("reusing existing nar_file")
-
-			narFileID = existingNarFile.ID
-		} else {
-			// Create new nar_file
-			newNarFile, err := qtx.CreateNarFile(ctx, database.CreateNarFileParams{
-				Hash:        narURL.Hash,
-				Compression: narURL.Compression.String(),
-				Query:       narURL.Query.Encode(),
-				FileSize:    narInfo.FileSize,
-			})
-			if err != nil {
-				return fmt.Errorf("error inserting the nar_file record in the database: %w", err)
-			}
-
-			narFileID = newNarFile.ID
+		narFileID, err := c.ensureNarFile(ctx, qtx, narURL, narInfo.FileSize)
+		if err != nil {
+			return err
 		}
 
 		// Link narinfo to nar_file
@@ -1998,6 +1953,94 @@ func (c *Cache) storeInDatabase(
 
 		return nil
 	})
+}
+
+func (c *Cache) ensureNarFile(
+	ctx context.Context,
+	qtx database.Querier,
+	narURL nar.URL,
+	fileSize uint64,
+) (int64, error) {
+	// Check if nar_file already exists (multiple narinfos can share the same nar_file)
+	existingNarFile, err := qtx.GetNarFileByHash(ctx, narURL.Hash)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return 0, fmt.Errorf("error checking for existing nar_file: %w", err)
+	}
+
+	if err == nil {
+		if err := c.validateNarFile(ctx, existingNarFile, narURL, fileSize); err != nil {
+			return 0, err
+		}
+
+		zerolog.Ctx(ctx).
+			Debug().
+			Str("nar_hash", narURL.Hash).
+			Msg("reusing existing nar_file")
+
+		return existingNarFile.ID, nil
+	}
+
+	// Create new nar_file
+	newNarFile, err := qtx.CreateNarFile(ctx, database.CreateNarFileParams{
+		Hash:        narURL.Hash,
+		Compression: narURL.Compression.String(),
+		Query:       narURL.Query.Encode(),
+		FileSize:    fileSize,
+	})
+	if err != nil {
+		if !database.IsDuplicateKeyError(err) {
+			return 0, fmt.Errorf("error inserting the nar_file record in the database: %w", err)
+		}
+
+		// Handle race condition: record was inserted by another transaction
+		zerolog.Ctx(ctx).
+			Debug().
+			Str("nar_hash", narURL.Hash).
+			Msg("nar_file already exists (race condition handled), fetching existing record")
+
+		existingNarFile, err := qtx.GetNarFileByHash(ctx, narURL.Hash)
+		if err != nil {
+			return 0, fmt.Errorf("error fetching existing nar_file after duplicate key error: %w", err)
+		}
+
+		if err := c.validateNarFile(ctx, existingNarFile, narURL, fileSize); err != nil {
+			return 0, err
+		}
+
+		return existingNarFile.ID, nil
+	}
+
+	return newNarFile.ID, nil
+}
+
+func (c *Cache) validateNarFile(
+	ctx context.Context,
+	existingNarFile database.NarFile,
+	narURL nar.URL,
+	fileSize uint64,
+) error {
+	if existingNarFile.Compression != narURL.Compression.String() ||
+		existingNarFile.Query != narURL.Query.Encode() ||
+		existingNarFile.FileSize != fileSize {
+		zerolog.Ctx(ctx).
+			Warn().
+			Str("nar_hash", narURL.Hash).
+			Str("existing_compression", existingNarFile.Compression).
+			Str("new_compression", narURL.Compression.String()).
+			Str("existing_query", existingNarFile.Query).
+			Str("new_query", narURL.Query.Encode()).
+			Uint64("existing_file_size", existingNarFile.FileSize).
+			Uint64("new_file_size", fileSize).
+			Msg("nar_file already exists but properties don't match")
+
+		return fmt.Errorf(
+			"%w: nar_file for hash %s already exists with different properties",
+			ErrInconsistentState,
+			narURL.Hash,
+		)
+	}
+
+	return nil
 }
 
 func (c *Cache) deleteNarInfoFromStore(ctx context.Context, hash string) error {

--- a/pkg/database/contract_test.go
+++ b/pkg/database/contract_test.go
@@ -499,24 +499,25 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 					}
 				})
 
-				t.Run("hash is unique", func(t *testing.T) {
+				t.Run("upsert on duplicate hash", func(t *testing.T) {
 					hash, err := helper.RandString(32, nil)
 					require.NoError(t, err)
 
-					_, err = db.CreateNarFile(context.Background(), database.CreateNarFileParams{
+					nf1, err := db.CreateNarFile(context.Background(), database.CreateNarFileParams{
 						Hash:        hash,
 						Compression: "",
 						FileSize:    123,
 					})
 					require.NoError(t, err)
 
-					_, err = db.CreateNarFile(context.Background(), database.CreateNarFileParams{
+					nf2, err := db.CreateNarFile(context.Background(), database.CreateNarFileParams{
 						Hash:        hash,
 						Compression: "",
 						FileSize:    123,
 					})
+					require.NoError(t, err)
 
-					assert.True(t, database.IsDuplicateKeyError(err))
+					assert.Equal(t, nf1.ID, nf2.ID)
 				})
 			})
 		}

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -23,6 +23,8 @@ type Querier interface {
 	//  ) VALUES (
 	//      $1, $2, $3, $4
 	//  )
+	//  ON CONFLICT (hash) DO UPDATE SET
+	//      updated_at = EXCLUDED.updated_at
 	//  RETURNING id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at
 	CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error)
 	//CreateNarInfo

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -25,6 +25,8 @@ type Querier interface {
 	//  ) VALUES (
 	//      ?, ?, ?, ?
 	//  )
+	//  ON DUPLICATE KEY UPDATE
+	//      updated_at = CURRENT_TIMESTAMP
 	CreateNarFile(ctx context.Context, arg CreateNarFileParams) (sql.Result, error)
 	//CreateNarInfo
 	//

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -40,6 +40,8 @@ INSERT INTO nar_files (
 ) VALUES (
     ?, ?, ?, ?
 )
+ON DUPLICATE KEY UPDATE
+    updated_at = CURRENT_TIMESTAMP
 `
 
 type CreateNarFileParams struct {
@@ -56,6 +58,8 @@ type CreateNarFileParams struct {
 //	) VALUES (
 //	    ?, ?, ?, ?
 //	)
+//	ON DUPLICATE KEY UPDATE
+//	    updated_at = CURRENT_TIMESTAMP
 func (q *Queries) CreateNarFile(ctx context.Context, arg CreateNarFileParams) (sql.Result, error) {
 	return q.db.ExecContext(ctx, createNarFile,
 		arg.Hash,

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -25,6 +25,8 @@ type Querier interface {
 	//  ) VALUES (
 	//      $1, $2, $3, $4
 	//  )
+	//  ON CONFLICT (hash) DO UPDATE SET
+	//      updated_at = EXCLUDED.updated_at
 	//  RETURNING id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at
 	CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error)
 	//CreateNarInfo

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -50,6 +50,8 @@ INSERT INTO nar_files (
 ) VALUES (
     $1, $2, $3, $4
 )
+ON CONFLICT (hash) DO UPDATE SET
+    updated_at = EXCLUDED.updated_at
 RETURNING id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at
 `
 
@@ -67,6 +69,8 @@ type CreateNarFileParams struct {
 //	) VALUES (
 //	    $1, $2, $3, $4
 //	)
+//	ON CONFLICT (hash) DO UPDATE SET
+//	    updated_at = EXCLUDED.updated_at
 //	RETURNING id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at
 func (q *Queries) CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error) {
 	row := q.db.QueryRowContext(ctx, createNarFile,

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -25,6 +25,8 @@ type Querier interface {
 	//  ) VALUES (
 	//      ?, ?, ?, ?
 	//  )
+	//  ON CONFLICT (hash) DO UPDATE SET
+	//      updated_at = excluded.updated_at
 	//  RETURNING id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at
 	CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error)
 	//CreateNarInfo

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -50,6 +50,8 @@ INSERT INTO nar_files (
 ) VALUES (
     ?, ?, ?, ?
 )
+ON CONFLICT (hash) DO UPDATE SET
+    updated_at = excluded.updated_at
 RETURNING id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at
 `
 
@@ -67,6 +69,8 @@ type CreateNarFileParams struct {
 //	) VALUES (
 //	    ?, ?, ?, ?
 //	)
+//	ON CONFLICT (hash) DO UPDATE SET
+//	    updated_at = excluded.updated_at
 //	RETURNING id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at
 func (q *Queries) CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error) {
 	row := q.db.QueryRowContext(ctx, createNarFile,

--- a/testhelper/mysql.go
+++ b/testhelper/mysql.go
@@ -2,12 +2,18 @@ package testhelper
 
 import (
 	"context"
+	"fmt"
+	"net/url"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/helper"
 )
 
 // MigrateMySQLDatabase will migrate the MySQL database using dbmate.
@@ -46,4 +52,63 @@ func MigrateMySQLDatabase(t *testing.T, dbURL string) {
 	require.NoErrorf(t, err, "Running %q has failed", cmd.String())
 
 	t.Logf("%s: %s", cmd.String(), output)
+}
+
+// SetupMySQL sets up a new temporary MySQL database for testing.
+// It requires the NCPS_TEST_ADMIN_MYSQL_URL environment variable to be set.
+// It returns a database connection and a cleanup function.
+func SetupMySQL(t *testing.T) (database.Querier, func()) {
+	t.Helper()
+
+	adminDbURL := os.Getenv("NCPS_TEST_ADMIN_MYSQL_URL")
+	if adminDbURL == "" {
+		t.Skip("Skipping MySQL test: NCPS_TEST_ADMIN_MYSQL_URL not set")
+	}
+
+	adminDb, err := database.Open(adminDbURL, nil)
+	require.NoError(t, err, "failed to connect to the mysql database")
+
+	dbName := "test-" + helper.MustRandString(58, nil)
+
+	// MySQL CREATE DATABASE
+	_, err = adminDb.DB().ExecContext(context.Background(), fmt.Sprintf("CREATE DATABASE `%s`", dbName))
+	require.NoError(t, err, "failed to create database %s", dbName)
+
+	// Replace the database name in the URL
+	u, err := url.Parse(adminDbURL)
+	require.NoError(t, err)
+
+	u.Path = "/" + dbName
+	dbURL := u.String()
+
+	// Helper to recover from migration panic
+	var errMigration error
+
+	// We can't defer the check here easily because t.Fatalf stops the test.
+	// But MigrateMySQLDatabase might panic? The original code had a defer recover block.
+	// Let's keep it safe.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				errMigration = fmt.Errorf("database migration panicked: %v", r) //nolint:err113
+			}
+		}()
+
+		MigrateMySQLDatabase(t, dbURL)
+	}()
+
+	if errMigration != nil {
+		t.Fatalf("Failed to migrate MySQL database: %v", errMigration)
+	}
+
+	db, err := database.Open(dbURL, nil)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		_ = db.DB().Close()
+		_, _ = adminDb.DB().ExecContext(context.Background(), fmt.Sprintf("DROP DATABASE `%s`", dbName))
+		_ = adminDb.DB().Close()
+	}
+
+	return db, cleanup
 }

--- a/testhelper/postgres.go
+++ b/testhelper/postgres.go
@@ -2,12 +2,18 @@ package testhelper
 
 import (
 	"context"
+	"fmt"
+	"net/url"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/helper"
 )
 
 // MigratePostgresDatabase will migrate the PostgreSQL database using dbmate.
@@ -43,7 +49,61 @@ func MigratePostgresDatabase(t *testing.T, dbURL string) {
 	)
 
 	output, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "Running %q has failed", cmd.String())
+	require.NoErrorf(t, err, "Running %q has failed. Output:\n%s", cmd.String(), string(output))
 
 	t.Logf("%s: %s", cmd.String(), output)
+}
+
+// SetupPostgres sets up a new temporary PostgreSQL database for testing.
+// It requires the NCPS_TEST_ADMIN_POSTGRES_URL environment variable to be set.
+// It returns a database connection and a cleanup function.
+func SetupPostgres(t *testing.T) (database.Querier, func()) {
+	t.Helper()
+
+	adminDbURL := os.Getenv("NCPS_TEST_ADMIN_POSTGRES_URL")
+	if adminDbURL == "" {
+		t.Skip("Skipping Postgres test: NCPS_TEST_ADMIN_POSTGRES_URL not set")
+	}
+
+	adminDb, err := database.Open(adminDbURL, nil)
+	require.NoError(t, err, "failed to connect to the postgres database")
+
+	dbName := "test-" + helper.MustRandString(58, nil)
+	_, err = adminDb.DB().ExecContext(context.Background(), "SELECT create_test_db($1);", dbName)
+	require.NoError(t, err, "failed to create database %s", dbName)
+
+	// Replace the test-db with the ephemeral database in the dbURL
+	u, err := url.Parse(adminDbURL)
+	require.NoError(t, err)
+
+	u.Path = "/" + dbName
+	dbURL := u.String()
+
+	// Helper to recover from migration panic
+	var errMigration error
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				errMigration = fmt.Errorf("database migration panicked: %v", r) //nolint:err113
+			}
+		}()
+
+		MigratePostgresDatabase(t, dbURL)
+	}()
+
+	if errMigration != nil {
+		t.Fatalf("Failed to migrate PostgreSQL database: %v", errMigration)
+	}
+
+	db, err := database.Open(dbURL, nil)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		_ = db.DB().Close()
+		_, _ = adminDb.DB().ExecContext(context.Background(), "SELECT drop_test_db($1);", dbName)
+		_ = adminDb.DB().Close()
+	}
+
+	return db, cleanup
 }


### PR DESCRIPTION
This change fixes a race condition where multiple concurrent requests
for different NarInfos sharing the same NarFile could cause unique
constraint violations in the database. It updates PostgreSQL and
SQLite queries to use `ON CONFLICT DO UPDATE` for `CreateNarFile`,
gracefully handling duplicates and returning the existing record to
avoid transaction aborts.

Additionally, it adds application-level handling for `DuplicateKeyError`
in `storeInDatabase` to retry fetching the existing record if insertion
fails, providing robustness across all database backends.

A resource leak in the reproduction test
`TestPutNarInfoConcurrentSharedNar`
was also fixed to prevent connection exhaustion.

This change also refactors the database test helpers by extracting
MySQL and PostgreSQL setup logic into `testhelper/mysql.go` and
`testhelper/postgres.go`, making them reusable across different tests.

fixes #623

(cherry picked from commit a2370250ca12a84e723853b16378c6d1c6dfb755)