### PR TITLE
fix: rely on database upsert in ensureNarFile

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -95,6 +95,7 @@ INSERT INTO nar_files (
     ?, ?, ?, ?
 )
 ON DUPLICATE KEY UPDATE
+    id = LAST_INSERT_ID(id),
     updated_at = CURRENT_TIMESTAMP;
 
 -- name: LinkNarInfoToNarFile :exec

--- a/pkg/database/contract_test.go
+++ b/pkg/database/contract_test.go
@@ -517,7 +517,15 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 					})
 					require.NoError(t, err)
 
+					nf3, err := db.CreateNarFile(context.Background(), database.CreateNarFileParams{
+						Hash:        hash,
+						Compression: "",
+						FileSize:    123,
+					})
+					require.NoError(t, err)
+
 					assert.Equal(t, nf1.ID, nf2.ID)
+					assert.Equal(t, nf1.ID, nf3.ID)
 				})
 			})
 		}

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -42,6 +42,7 @@ type Querier interface {
 	//      ?, ?, ?, ?
 	//  )
 	//  ON DUPLICATE KEY UPDATE
+	//      id = LAST_INSERT_ID(id),
 	//      updated_at = CURRENT_TIMESTAMP
 	CreateNarFile(ctx context.Context, arg CreateNarFileParams) (sql.Result, error)
 	//CreateNarInfo

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -91,6 +91,7 @@ INSERT INTO nar_files (
     ?, ?, ?, ?
 )
 ON DUPLICATE KEY UPDATE
+    id = LAST_INSERT_ID(id),
     updated_at = CURRENT_TIMESTAMP
 `
 
@@ -109,6 +110,7 @@ type CreateNarFileParams struct {
 //	    ?, ?, ?, ?
 //	)
 //	ON DUPLICATE KEY UPDATE
+//	    id = LAST_INSERT_ID(id),
 //	    updated_at = CURRENT_TIMESTAMP
 func (q *Queries) CreateNarFile(ctx context.Context, arg CreateNarFileParams) (sql.Result, error) {
 	return q.db.ExecContext(ctx, createNarFile,


### PR DESCRIPTION
This commit simplifies ensureNarFile to rely on the database's upsert
behavior (ON CONFLICT DO UPDATE / ON DUPLICATE KEY UPDATE) instead of
manual existence checks.

To safely rely on this behavior in MySQL, the CreateNarFile query was
updated to use the LAST_INSERT_ID(id) trick, ensuring the ID of the
inserted/updated record is always returned even when no columns are
changed.

A regression test was added to pkg/database/contract_test.go to verify
this behavior across all backends.