### PR TITLE
fix: rely on database upsert in ensureNarFile [backport 627]

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -71,6 +71,7 @@ INSERT INTO nar_files (
     ?, ?, ?, ?
 )
 ON DUPLICATE KEY UPDATE
+    id = LAST_INSERT_ID(id),
     updated_at = CURRENT_TIMESTAMP;
 
 -- name: LinkNarInfoToNarFile :exec

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1961,26 +1961,9 @@ func (c *Cache) ensureNarFile(
 	narURL nar.URL,
 	fileSize uint64,
 ) (int64, error) {
-	// Check if nar_file already exists (multiple narinfos can share the same nar_file)
-	existingNarFile, err := qtx.GetNarFileByHash(ctx, narURL.Hash)
-	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return 0, fmt.Errorf("error checking for existing nar_file: %w", err)
-	}
-
-	if err == nil {
-		if err := c.validateNarFile(ctx, existingNarFile, narURL, fileSize); err != nil {
-			return 0, err
-		}
-
-		zerolog.Ctx(ctx).
-			Debug().
-			Str("nar_hash", narURL.Hash).
-			Msg("reusing existing nar_file")
-
-		return existingNarFile.ID, nil
-	}
-
-	// Create new nar_file
+	// Create (or update existing) nar_file record.
+	// The query uses ON CONFLICT DO UPDATE (or ON DUPLICATE KEY UPDATE), so duplicates are handled
+	// by updating the timestamp and returning the record.
 	newNarFile, err := qtx.CreateNarFile(ctx, database.CreateNarFileParams{
 		Hash:        narURL.Hash,
 		Compression: narURL.Compression.String(),
@@ -1988,26 +1971,12 @@ func (c *Cache) ensureNarFile(
 		FileSize:    fileSize,
 	})
 	if err != nil {
-		if !database.IsDuplicateKeyError(err) {
-			return 0, fmt.Errorf("error inserting the nar_file record in the database: %w", err)
-		}
+		return 0, fmt.Errorf("error creating or updating nar_file record in the database: %w", err)
+	}
 
-		// Handle race condition: record was inserted by another transaction
-		zerolog.Ctx(ctx).
-			Debug().
-			Str("nar_hash", narURL.Hash).
-			Msg("nar_file already exists (race condition handled), fetching existing record")
-
-		existingNarFile, err := qtx.GetNarFileByHash(ctx, narURL.Hash)
-		if err != nil {
-			return 0, fmt.Errorf("error fetching existing nar_file after duplicate key error: %w", err)
-		}
-
-		if err := c.validateNarFile(ctx, existingNarFile, narURL, fileSize); err != nil {
-			return 0, err
-		}
-
-		return existingNarFile.ID, nil
+	// Validate that the returned record (new or existing) matches our expectations.
+	if err := c.validateNarFile(ctx, newNarFile, narURL, fileSize); err != nil {
+		return 0, err
 	}
 
 	return newNarFile.ID, nil

--- a/pkg/database/contract_test.go
+++ b/pkg/database/contract_test.go
@@ -517,7 +517,15 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 					})
 					require.NoError(t, err)
 
+					nf3, err := db.CreateNarFile(context.Background(), database.CreateNarFileParams{
+						Hash:        hash,
+						Compression: "",
+						FileSize:    123,
+					})
+					require.NoError(t, err)
+
 					assert.Equal(t, nf1.ID, nf2.ID)
+					assert.Equal(t, nf1.ID, nf3.ID)
 				})
 			})
 		}

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -26,6 +26,7 @@ type Querier interface {
 	//      ?, ?, ?, ?
 	//  )
 	//  ON DUPLICATE KEY UPDATE
+	//      id = LAST_INSERT_ID(id),
 	//      updated_at = CURRENT_TIMESTAMP
 	CreateNarFile(ctx context.Context, arg CreateNarFileParams) (sql.Result, error)
 	//CreateNarInfo

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -41,6 +41,7 @@ INSERT INTO nar_files (
     ?, ?, ?, ?
 )
 ON DUPLICATE KEY UPDATE
+    id = LAST_INSERT_ID(id),
     updated_at = CURRENT_TIMESTAMP
 `
 
@@ -59,6 +60,7 @@ type CreateNarFileParams struct {
 //	    ?, ?, ?, ?
 //	)
 //	ON DUPLICATE KEY UPDATE
+//	    id = LAST_INSERT_ID(id),
 //	    updated_at = CURRENT_TIMESTAMP
 func (q *Queries) CreateNarFile(ctx context.Context, arg CreateNarFileParams) (sql.Result, error) {
 	return q.db.ExecContext(ctx, createNarFile,


### PR DESCRIPTION
Bot-based backport to `release-0.7`, triggered by a label in #627.

This commit simplifies ensureNarFile to rely on the database's upsert
behavior (ON CONFLICT DO UPDATE / ON DUPLICATE KEY UPDATE) instead of
manual existence checks.

To safely rely on this behavior in MySQL, the CreateNarFile query was
updated to use the LAST_INSERT_ID(id) trick, ensuring the ID of the
inserted/updated record is always returned even when no columns are
changed.

A regression test was added to pkg/database/contract_test.go to verify
this behavior across all backends.