### PR TITLE
fix: build the docker with the correct version [backport #635]

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,18 +66,14 @@ jobs:
       - uses: actions/checkout@v6
       - name: Build the docker image
         shell: bash
-        env:
-          RELEASE_VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          nix build -L --impure .#packages.${{ matrix.system }}.docker
+          nix build -L .#packages.${{ matrix.system }}.docker
       - name: Build the docker image pusher
         shell: bash
-        env:
-          RELEASE_VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          nix build -L --impure .#packages.${{ matrix.system }}.push-docker-image
+          nix build -L .#packages.${{ matrix.system }}.push-docker-image
       - name: Login to Docker Hub
         if: inputs.push_images
         uses: docker/login-action@v3

--- a/nix/packages/ncps/default.nix
+++ b/nix/packages/ncps/default.nix
@@ -9,16 +9,24 @@
     {
       packages.ncps =
         let
-          shortRev = self.shortRev or self.dirtyShortRev;
-          rev = self.rev or self.dirtyRev;
-          tag = builtins.getEnv "RELEASE_VERSION";
+          version =
+            let
+              tag =
+                let
+                  semverRegex = "v[0-9]+(\\.[0-9]+){0,2}(-[a-zA-Z0-9]+)?";
+                  tag' = self.tag or "";
+                in
+                if builtins.match semverRegex tag' != null then tag' else "";
 
-          version = if tag != "" then tag else rev;
+              rev = self.rev or self.dirtyRev;
+            in
+            if tag != "" then tag else rev;
 
           vendorHash = "sha256-nnt4HIG4Fs7RhHjVb7mYJ39UgvFKc46Cu42cURMmr1s=";
         in
         pkgs.buildGoModule {
-          name = "ncps-${shortRev}";
+          pname = "ncps";
+          inherit version;
 
           src = lib.fileset.toSource {
             fileset = lib.fileset.unions [


### PR DESCRIPTION
Bot-based backport to `release-0.7`, triggered by a label in #635.

The version was being given with an environment variable, and it broke for some reason. Either way, using self.tag is a better option, and the build can be done without resorting to invoking impure.