### PR TITLE
fix: semverRegex too restrictive for pre-release in tag

### DIFF
--- a/nix/packages/ncps/default.nix
+++ b/nix/packages/ncps/default.nix
@@ -13,7 +13,7 @@
             let
               tag =
                 let
-                  semverRegex = "v[0-9]+(\\.[0-9]+){0,2}(-[a-zA-Z0-9]+)?";
+                  semverRegex = "v[0-9]+(\\.[0-9]+){0,2}(-[a-zA-Z0-9.-]+)?";
                   tag' = self.tag or "";
                 in
                 if builtins.match semverRegex tag' != null then tag' else "";


### PR DESCRIPTION
The regular expression for matching semver tags is too restrictive for
the pre-release part. According to the semver specification, pre-release
versions can contain hyphens and dots (e.g., v1.2.3-pre-release or
v1.2.3-alpha.1). The current regex (-[a-zA-Z0-9]+)? does not allow for
this, as the character class [a-zA-Z0-9] excludes hyphens and dots.