### PR TITLE
fix: Hide the noisy logs of the dependencies when building ncps [backport #636]

### DIFF
--- a/nix/packages/ncps/pre-check-minio.sh
+++ b/nix/packages/ncps/pre-check-minio.sh
@@ -21,7 +21,7 @@ export MINIO_TEST_S3_BUCKET="test-bucket";
 export MINIO_TEST_S3_SECRET_ACCESS_KEY="test-secret-key";
 
 # Start MinIO server in background
-bash $src/nix/process-compose/start-minio.sh &
+bash $src/nix/process-compose/start-minio.sh >"$NIX_BUILD_TOP/minio.log" 2>&1 &
 export MINIO_PID=$!
 
 # Wait for MinIO to be ready

--- a/nix/packages/ncps/pre-check-mysql.sh
+++ b/nix/packages/ncps/pre-check-mysql.sh
@@ -21,7 +21,7 @@ export MYSQL_MIGRATION_PASSWORD="migration-password"
 export MYSQL_MIGRATION_DB="migration-db"
 
 # Start MariaDB server in background
-bash $src/nix/process-compose/start-mysql.sh &
+bash $src/nix/process-compose/start-mysql.sh >"$NIX_BUILD_TOP/mariadb.log" 2>&1 &
 export MYSQL_PID=$!
 
 # Wait for MariaDB to be ready

--- a/nix/packages/ncps/pre-check-postgres.sh
+++ b/nix/packages/ncps/pre-check-postgres.sh
@@ -22,7 +22,7 @@ export PG_MIGRATION_PASSWORD="migration-password"
 export PG_MIGRATION_DB="migration-db"
 
 # Start PostgreSQL server in background
-bash $src/nix/process-compose/start-postgres.sh &
+bash $src/nix/process-compose/start-postgres.sh >"$NIX_BUILD_TOP/postgres.log" 2>&1 &
 export POSTGRES_PID=$!
 
 # Wait for PostgreSQL to be ready

--- a/nix/packages/ncps/pre-check-redis.sh
+++ b/nix/packages/ncps/pre-check-redis.sh
@@ -9,7 +9,7 @@ export REDIS_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)
 export REDIS_HOST="127.0.0.1"
 
 # Start Redis server in background
-bash $src/nix/process-compose/start-redis.sh &
+bash $src/nix/process-compose/start-redis.sh >"$NIX_BUILD_TOP/redis.log" 2>&1 &
 export REDIS_PID=$!
 
 # Wait for Redis to be ready


### PR DESCRIPTION
Bot-based backport to `release-0.7`, triggered by a label in #636.

Building the ncps package requires MinIO, MariaDB, PostgreSQL and Redis. All dependencies were started without redirecting logs so it became quite noisy un-necessarily making it hard to see what is happening.