### PR TITLE
fix: repair narinfo migration logic for invalid URLs

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -62,7 +62,20 @@ INSERT INTO narinfos (
     hash, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 ) VALUES (
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
-);
+)
+ON DUPLICATE KEY UPDATE
+    id = LAST_INSERT_ID(id),
+    store_path = IF(url IS NULL, VALUES(store_path), store_path),
+    url = IF(url IS NULL, VALUES(url), url),
+    compression = IF(url IS NULL, VALUES(compression), compression),
+    file_hash = IF(url IS NULL, VALUES(file_hash), file_hash),
+    file_size = IF(url IS NULL, VALUES(file_size), file_size),
+    nar_hash = IF(url IS NULL, VALUES(nar_hash), nar_hash),
+    nar_size = IF(url IS NULL, VALUES(nar_size), nar_size),
+    deriver = IF(url IS NULL, VALUES(deriver), deriver),
+    system = IF(url IS NULL, VALUES(system), system),
+    ca = IF(url IS NULL, VALUES(ca), ca),
+    updated_at = IF(url IS NULL, CURRENT_TIMESTAMP, updated_at);
 
 -- name: AddNarInfoReference :exec
 INSERT INTO narinfo_references (
@@ -103,7 +116,8 @@ INSERT INTO narinfo_nar_files (
     narinfo_id, nar_file_id
 ) VALUES (
     ?, ?
-);
+)
+ON DUPLICATE KEY UPDATE narinfo_id = narinfo_id;
 
 -- name: TouchNarInfo :execrows
 UPDATE narinfos

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -65,6 +65,19 @@ INSERT INTO narinfos (
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
+ON CONFLICT (hash) DO UPDATE SET
+    store_path = EXCLUDED.store_path,
+    url = EXCLUDED.url,
+    compression = EXCLUDED.compression,
+    file_hash = EXCLUDED.file_hash,
+    file_size = EXCLUDED.file_size,
+    nar_hash = EXCLUDED.nar_hash,
+    nar_size = EXCLUDED.nar_size,
+    deriver = EXCLUDED.deriver,
+    system = EXCLUDED.system,
+    ca = EXCLUDED.ca,
+    updated_at = CURRENT_TIMESTAMP
+WHERE narinfos.url IS NULL
 RETURNING *;
 
 -- name: AddNarInfoReference :exec
@@ -120,7 +133,8 @@ INSERT INTO narinfo_nar_files (
     narinfo_id, nar_file_id
 ) VALUES (
     $1, $2
-);
+)
+ON CONFLICT (narinfo_id, nar_file_id) DO NOTHING;
 
 -- name: TouchNarInfo :execrows
 UPDATE narinfos

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -65,6 +65,19 @@ INSERT INTO narinfos (
 ) VALUES (
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 )
+ON CONFLICT(hash) DO UPDATE SET
+    store_path = excluded.store_path,
+    url = excluded.url,
+    compression = excluded.compression,
+    file_hash = excluded.file_hash,
+    file_size = excluded.file_size,
+    nar_hash = excluded.nar_hash,
+    nar_size = excluded.nar_size,
+    deriver = excluded.deriver,
+    system = excluded.system,
+    ca = excluded.ca,
+    updated_at = CURRENT_TIMESTAMP
+WHERE narinfos.url IS NULL
 RETURNING *;
 
 -- name: AddNarInfoReference :exec
@@ -106,7 +119,8 @@ INSERT INTO narinfo_nar_files (
     narinfo_id, nar_file_id
 ) VALUES (
     ?, ?
-);
+)
+ON CONFLICT (narinfo_id, nar_file_id) DO NOTHING;
 
 -- name: TouchNarInfo :execrows
 UPDATE narinfos

--- a/pkg/database/contract_test.go
+++ b/pkg/database/contract_test.go
@@ -143,11 +143,13 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			hash, err := helper.RandString(32, nil)
 			require.NoError(t, err)
 
-			_, err = db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
+			ni1, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
 			require.NoError(t, err)
 
-			_, err = db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
-			assert.True(t, database.IsDuplicateKeyError(err))
+			ni2, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
+			require.NoError(t, err)
+
+			assert.Equal(t, ni1.ID, ni2.ID)
 		})
 
 		t.Run("can write many narinfos", func(t *testing.T) {

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -64,6 +64,19 @@ type Querier interface {
 	//  ) VALUES (
 	//      $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 	//  )
+	//  ON CONFLICT (hash) DO UPDATE SET
+	//      store_path = EXCLUDED.store_path,
+	//      url = EXCLUDED.url,
+	//      compression = EXCLUDED.compression,
+	//      file_hash = EXCLUDED.file_hash,
+	//      file_size = EXCLUDED.file_size,
+	//      nar_hash = EXCLUDED.nar_hash,
+	//      nar_size = EXCLUDED.nar_size,
+	//      deriver = EXCLUDED.deriver,
+	//      system = EXCLUDED.system,
+	//      ca = EXCLUDED.ca,
+	//      updated_at = CURRENT_TIMESTAMP
+	//  WHERE narinfos.url IS NULL
 	//  RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (NarInfo, error)
 	//DeleteNarFileByHash
@@ -253,6 +266,7 @@ type Querier interface {
 	//  ) VALUES (
 	//      $1, $2
 	//  )
+	//  ON CONFLICT (narinfo_id, nar_file_id) DO NOTHING
 	LinkNarInfoToNarFile(ctx context.Context, arg LinkNarInfoToNarFileParams) error
 	//SetConfig
 	//

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -52,6 +52,19 @@ type Querier interface {
 	//  ) VALUES (
 	//      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 	//  )
+	//  ON DUPLICATE KEY UPDATE
+	//      id = LAST_INSERT_ID(id),
+	//      store_path = IF(url IS NULL, VALUES(store_path), store_path),
+	//      url = IF(url IS NULL, VALUES(url), url),
+	//      compression = IF(url IS NULL, VALUES(compression), compression),
+	//      file_hash = IF(url IS NULL, VALUES(file_hash), file_hash),
+	//      file_size = IF(url IS NULL, VALUES(file_size), file_size),
+	//      nar_hash = IF(url IS NULL, VALUES(nar_hash), nar_hash),
+	//      nar_size = IF(url IS NULL, VALUES(nar_size), nar_size),
+	//      deriver = IF(url IS NULL, VALUES(deriver), deriver),
+	//      system = IF(url IS NULL, VALUES(system), system),
+	//      ca = IF(url IS NULL, VALUES(ca), ca),
+	//      updated_at = IF(url IS NULL, CURRENT_TIMESTAMP, updated_at)
 	CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (sql.Result, error)
 	//DeleteNarFileByHash
 	//
@@ -240,6 +253,7 @@ type Querier interface {
 	//  ) VALUES (
 	//      ?, ?
 	//  )
+	//  ON DUPLICATE KEY UPDATE narinfo_id = narinfo_id
 	LinkNarInfoToNarFile(ctx context.Context, arg LinkNarInfoToNarFileParams) error
 	//SetConfig
 	//

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -127,6 +127,19 @@ INSERT INTO narinfos (
 ) VALUES (
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 )
+ON DUPLICATE KEY UPDATE
+    id = LAST_INSERT_ID(id),
+    store_path = IF(url IS NULL, VALUES(store_path), store_path),
+    url = IF(url IS NULL, VALUES(url), url),
+    compression = IF(url IS NULL, VALUES(compression), compression),
+    file_hash = IF(url IS NULL, VALUES(file_hash), file_hash),
+    file_size = IF(url IS NULL, VALUES(file_size), file_size),
+    nar_hash = IF(url IS NULL, VALUES(nar_hash), nar_hash),
+    nar_size = IF(url IS NULL, VALUES(nar_size), nar_size),
+    deriver = IF(url IS NULL, VALUES(deriver), deriver),
+    system = IF(url IS NULL, VALUES(system), system),
+    ca = IF(url IS NULL, VALUES(ca), ca),
+    updated_at = IF(url IS NULL, CURRENT_TIMESTAMP, updated_at)
 `
 
 type CreateNarInfoParams struct {
@@ -150,6 +163,19 @@ type CreateNarInfoParams struct {
 //	) VALUES (
 //	    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 //	)
+//	ON DUPLICATE KEY UPDATE
+//	    id = LAST_INSERT_ID(id),
+//	    store_path = IF(url IS NULL, VALUES(store_path), store_path),
+//	    url = IF(url IS NULL, VALUES(url), url),
+//	    compression = IF(url IS NULL, VALUES(compression), compression),
+//	    file_hash = IF(url IS NULL, VALUES(file_hash), file_hash),
+//	    file_size = IF(url IS NULL, VALUES(file_size), file_size),
+//	    nar_hash = IF(url IS NULL, VALUES(nar_hash), nar_hash),
+//	    nar_size = IF(url IS NULL, VALUES(nar_size), nar_size),
+//	    deriver = IF(url IS NULL, VALUES(deriver), deriver),
+//	    system = IF(url IS NULL, VALUES(system), system),
+//	    ca = IF(url IS NULL, VALUES(ca), ca),
+//	    updated_at = IF(url IS NULL, CURRENT_TIMESTAMP, updated_at)
 func (q *Queries) CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (sql.Result, error) {
 	return q.db.ExecContext(ctx, createNarInfo,
 		arg.Hash,
@@ -943,6 +969,7 @@ INSERT INTO narinfo_nar_files (
 ) VALUES (
     ?, ?
 )
+ON DUPLICATE KEY UPDATE narinfo_id = narinfo_id
 `
 
 type LinkNarInfoToNarFileParams struct {
@@ -957,6 +984,7 @@ type LinkNarInfoToNarFileParams struct {
 //	) VALUES (
 //	    ?, ?
 //	)
+//	ON DUPLICATE KEY UPDATE narinfo_id = narinfo_id
 func (q *Queries) LinkNarInfoToNarFile(ctx context.Context, arg LinkNarInfoToNarFileParams) error {
 	_, err := q.db.ExecContext(ctx, linkNarInfoToNarFile, arg.NarInfoID, arg.NarFileID)
 	return err

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -66,6 +66,19 @@ type Querier interface {
 	//  ) VALUES (
 	//      $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 	//  )
+	//  ON CONFLICT (hash) DO UPDATE SET
+	//      store_path = EXCLUDED.store_path,
+	//      url = EXCLUDED.url,
+	//      compression = EXCLUDED.compression,
+	//      file_hash = EXCLUDED.file_hash,
+	//      file_size = EXCLUDED.file_size,
+	//      nar_hash = EXCLUDED.nar_hash,
+	//      nar_size = EXCLUDED.nar_size,
+	//      deriver = EXCLUDED.deriver,
+	//      system = EXCLUDED.system,
+	//      ca = EXCLUDED.ca,
+	//      updated_at = CURRENT_TIMESTAMP
+	//  WHERE narinfos.url IS NULL
 	//  RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (NarInfo, error)
 	//DeleteNarFileByHash
@@ -255,6 +268,7 @@ type Querier interface {
 	//  ) VALUES (
 	//      $1, $2
 	//  )
+	//  ON CONFLICT (narinfo_id, nar_file_id) DO NOTHING
 	LinkNarInfoToNarFile(ctx context.Context, arg LinkNarInfoToNarFileParams) error
 	//SetConfig
 	//

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -198,6 +198,19 @@ INSERT INTO narinfos (
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 )
+ON CONFLICT (hash) DO UPDATE SET
+    store_path = EXCLUDED.store_path,
+    url = EXCLUDED.url,
+    compression = EXCLUDED.compression,
+    file_hash = EXCLUDED.file_hash,
+    file_size = EXCLUDED.file_size,
+    nar_hash = EXCLUDED.nar_hash,
+    nar_size = EXCLUDED.nar_size,
+    deriver = EXCLUDED.deriver,
+    system = EXCLUDED.system,
+    ca = EXCLUDED.ca,
+    updated_at = CURRENT_TIMESTAMP
+WHERE narinfos.url IS NULL
 RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 `
 
@@ -222,6 +235,19 @@ type CreateNarInfoParams struct {
 //	) VALUES (
 //	    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
 //	)
+//	ON CONFLICT (hash) DO UPDATE SET
+//	    store_path = EXCLUDED.store_path,
+//	    url = EXCLUDED.url,
+//	    compression = EXCLUDED.compression,
+//	    file_hash = EXCLUDED.file_hash,
+//	    file_size = EXCLUDED.file_size,
+//	    nar_hash = EXCLUDED.nar_hash,
+//	    nar_size = EXCLUDED.nar_size,
+//	    deriver = EXCLUDED.deriver,
+//	    system = EXCLUDED.system,
+//	    ca = EXCLUDED.ca,
+//	    updated_at = CURRENT_TIMESTAMP
+//	WHERE narinfos.url IS NULL
 //	RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 func (q *Queries) CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (NarInfo, error) {
 	row := q.db.QueryRowContext(ctx, createNarInfo,
@@ -1035,6 +1061,7 @@ INSERT INTO narinfo_nar_files (
 ) VALUES (
     $1, $2
 )
+ON CONFLICT (narinfo_id, nar_file_id) DO NOTHING
 `
 
 type LinkNarInfoToNarFileParams struct {
@@ -1049,6 +1076,7 @@ type LinkNarInfoToNarFileParams struct {
 //	) VALUES (
 //	    $1, $2
 //	)
+//	ON CONFLICT (narinfo_id, nar_file_id) DO NOTHING
 func (q *Queries) LinkNarInfoToNarFile(ctx context.Context, arg LinkNarInfoToNarFileParams) error {
 	_, err := q.db.ExecContext(ctx, linkNarInfoToNarFile, arg.NarInfoID, arg.NarFileID)
 	return err

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -52,6 +52,19 @@ type Querier interface {
 	//  ) VALUES (
 	//      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 	//  )
+	//  ON CONFLICT(hash) DO UPDATE SET
+	//      store_path = excluded.store_path,
+	//      url = excluded.url,
+	//      compression = excluded.compression,
+	//      file_hash = excluded.file_hash,
+	//      file_size = excluded.file_size,
+	//      nar_hash = excluded.nar_hash,
+	//      nar_size = excluded.nar_size,
+	//      deriver = excluded.deriver,
+	//      system = excluded.system,
+	//      ca = excluded.ca,
+	//      updated_at = CURRENT_TIMESTAMP
+	//  WHERE narinfos.url IS NULL
 	//  RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (NarInfo, error)
 	//DeleteNarFileByHash
@@ -241,6 +254,7 @@ type Querier interface {
 	//  ) VALUES (
 	//      ?, ?
 	//  )
+	//  ON CONFLICT (narinfo_id, nar_file_id) DO NOTHING
 	LinkNarInfoToNarFile(ctx context.Context, arg LinkNarInfoToNarFileParams) error
 	//SetConfig
 	//

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -150,6 +150,19 @@ INSERT INTO narinfos (
 ) VALUES (
     ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 )
+ON CONFLICT(hash) DO UPDATE SET
+    store_path = excluded.store_path,
+    url = excluded.url,
+    compression = excluded.compression,
+    file_hash = excluded.file_hash,
+    file_size = excluded.file_size,
+    nar_hash = excluded.nar_hash,
+    nar_size = excluded.nar_size,
+    deriver = excluded.deriver,
+    system = excluded.system,
+    ca = excluded.ca,
+    updated_at = CURRENT_TIMESTAMP
+WHERE narinfos.url IS NULL
 RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 `
 
@@ -174,6 +187,19 @@ type CreateNarInfoParams struct {
 //	) VALUES (
 //	    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 //	)
+//	ON CONFLICT(hash) DO UPDATE SET
+//	    store_path = excluded.store_path,
+//	    url = excluded.url,
+//	    compression = excluded.compression,
+//	    file_hash = excluded.file_hash,
+//	    file_size = excluded.file_size,
+//	    nar_hash = excluded.nar_hash,
+//	    nar_size = excluded.nar_size,
+//	    deriver = excluded.deriver,
+//	    system = excluded.system,
+//	    ca = excluded.ca,
+//	    updated_at = CURRENT_TIMESTAMP
+//	WHERE narinfos.url IS NULL
 //	RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 func (q *Queries) CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (NarInfo, error) {
 	row := q.db.QueryRowContext(ctx, createNarInfo,
@@ -987,6 +1013,7 @@ INSERT INTO narinfo_nar_files (
 ) VALUES (
     ?, ?
 )
+ON CONFLICT (narinfo_id, nar_file_id) DO NOTHING
 `
 
 type LinkNarInfoToNarFileParams struct {
@@ -1001,6 +1028,7 @@ type LinkNarInfoToNarFileParams struct {
 //	) VALUES (
 //	    ?, ?
 //	)
+//	ON CONFLICT (narinfo_id, nar_file_id) DO NOTHING
 func (q *Queries) LinkNarInfoToNarFile(ctx context.Context, arg LinkNarInfoToNarFileParams) error {
 	_, err := q.db.ExecContext(ctx, linkNarInfoToNarFile, arg.NarInfoID, arg.NarFileID)
 	return err

--- a/testhelper/sqlite.go
+++ b/testhelper/sqlite.go
@@ -234,3 +234,26 @@ func getOrCreateNarFile(
 
 	return narFile, nil
 }
+
+// SetupSQLite sets up a new temporary SQLite database for testing.
+// It returns a database connection and a cleanup function.
+// This function has the same signature as SetupPostgres and SetupMySQL for consistency.
+func SetupSQLite(t *testing.T) (database.Querier, func()) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "sqlite-test-")
+	require.NoError(t, err)
+
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	CreateMigrateDatabase(t, dbFile)
+
+	db, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		db.DB().Close()
+		os.RemoveAll(dir)
+	}
+
+	return db, cleanup
+}


### PR DESCRIPTION
This commit restores and fixes the logic where a NarInfo with an invalid (NULL) URL in the database is treated as a signal that the record has not yet been fully migrated from storage. The `migrate-narinfo` command and other parts of the system rely on this `url IS NULL` condition to identify pending migrations.

Specifically, this change:
1. Re-enables the background migration trigger in `GetNarInfo` when it encounters a database record with an invalid URL.
2. Updates `storeInDatabase` to properly handle upserts when such a placeholder record exists. Instead of failing with a duplicate key error, it deletes the existing partial record and recreates it with the full details, ensuring the migration can complete successfully.
3. Adds a regression test `TestGetNarInfo_MigratesInvalidURL` to verify this behavior.