### PR TITLE
refactor: extract shared migration logic and add distributed locking

### DIFF
--- a/docs/docs/User Guide/Operations/Upgrading.md
+++ b/docs/docs/User Guide/Operations/Upgrading.md
@@ -99,16 +99,23 @@ When upgrading from versions before database-backed narinfo metadata, you have t
 **Example CLI migration:**
 
 ```sh
-# Stop service
+# Without Redis (requires downtime)
 systemctl stop ncps
 
-# Run migration
 ncps migrate-narinfo \
   --cache-database-url="sqlite:/var/lib/ncps/db.sqlite" \
   --cache-storage-local="/var/lib/ncps"
 
-# Start service
 systemctl start ncps
+```
+
+```sh
+# With Redis (zero downtime - can run while serving)
+ncps migrate-narinfo \
+  --cache-database-url="sqlite:/var/lib/ncps/db.sqlite" \
+  --cache-storage-local="/var/lib/ncps" \
+  --cache-redis-addrs="redis1:6379,redis2:6379,redis3:6379" \
+  --cache-redis-password="..."
 ```
 
 See [NarInfo Migration Guide](NarInfo%20Migration.md) for comprehensive migration documentation.

--- a/docs/docs/User Guide/Usage/Cache Management.md
+++ b/docs/docs/User Guide/Usage/Cache Management.md
@@ -162,6 +162,17 @@ ncps migrate-narinfo \
   --concurrency=20
 ```
 
+**With Redis (for concurrent migration while serving):**
+
+```sh
+ncps migrate-narinfo \
+  --cache-database-url="sqlite:/var/lib/ncps/db.sqlite" \
+  --cache-storage-local="/var/lib/ncps" \
+  --cache-redis-addrs="redis1:6379,redis2:6379,redis3:6379" \
+  --cache-redis-password="..." \
+  --concurrency=20
+```
+
 **Dry run (preview):**
 
 ```sh


### PR DESCRIPTION
This refactors the migrate-narinfo command to eliminate code duplication by
extracting the core migration logic into pkg/cache where it can be shared
between the CLI command and the background migration process.

Key changes:

1. Added cache.MigrateNarInfo() - Standalone function containing the complete
   migration workflow with distributed locking support. This function properly
   handles UPSERT semantics for both new records and partial records (NULL URL).
2. Added storeNarInfoInDatabase() - Extracted the core UPSERT logic from
   Cache.storeInDatabase() to make it reusable without Cache dependencies.
3. Simplified backgroundMigrateNarInfo() - Now just calls MigrateNarInfoToDatabase()
   in a goroutine, eliminating ~90 lines of duplicate code.
4. Refactored migrate-narinfo command - Removed ~200 lines of duplicate
   migration logic (migrateOneToDatabase, getOrCreateNarInfo, getOrCreateNarFile)
   and replaced with direct call to cache.MigrateNarInfo().
5. Added Redis distributed locking - The migrate-narinfo command can now use
   Redis for distributed coordination when --cache-redis-addrs is provided.
   This enables safe migration while ncps is serving requests. Falls back to
   in-memory locking when Redis is not configured.

Benefits:
- Single source of truth for migration logic
- Consistent behavior between CLI and background migration
- Fixed UPSERT bug where partial records weren't being updated
- Supports multi-instance deployments with Redis coordination
- Better maintainability (bug fixes benefit both code paths)