### PR TITLE
refactor: remove redundant ErrAlreadyExists checks

### DIFF
--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -678,7 +678,7 @@ func TestPutNarInfoConcurrentSameHash(t *testing.T) {
 	}
 
 	// All PutNarInfo calls should succeed (PUT should be idempotent)
-	// Bug: without proper ErrAlreadyExists handling in PutNarInfo, some may return errors
+	// Bug: without proper duplicate detection in PutNarInfo, some may return errors
 	require.Equal(t, numGoroutines, successCount, "all PutNarInfo calls should succeed (PUT should be idempotent)")
 
 	// Verify the narinfo exists in database (narinfos are no longer stored in storage)

--- a/pkg/ncps/migrate_narinfo_test.go
+++ b/pkg/ncps/migrate_narinfo_test.go
@@ -212,7 +212,7 @@ func TestMigrateNarInfo_Idempotency(t *testing.T) {
 		// This should handle duplicate key gracefully
 		err = testhelper.MigrateNarInfoToDatabase(ctx, db, hash, ni)
 
-		// Should either succeed or return ErrAlreadyExists
+		// Should either succeed or succeed if multiple concurrently handled the same hash
 		if err != nil && !database.IsDuplicateKeyError(err) {
 			return err
 		}


### PR DESCRIPTION
Remove redundant ErrAlreadyExists checks in store operations.
The storeNarInfoInDatabase function uses UPSERT logic which handles
duplicate keys internally and returns nil on success. Therefore,
checking for ErrAlreadyExists after calling it is redundant.
Additionally, ErrAlreadyExists was removed from the cache package
as it is no longer used or returned.

Fix unresolved comment in #651.