### PR TITLE
chore: remove PAGER management requirement

### DIFF
--- a/.agent/skills/graphite/SKILL.md
+++ b/.agent/skills/graphite/SKILL.md
@@ -87,29 +87,6 @@ Many Graphite commands (`gt modify`, `gt move`, `gt split`, `gt restack`) are in
 2.  **Automatic Restacking**: Descendant branches are automatically updated if you change a parent branch.
 3.  **Visual Clarity**: Graphite's CLI output stays accurate and helpful.
 
-### Pager Interference
-
-**The Problem**: Commands like `git diff`, `git status`, or `gt ls` may produce empty output or stall if the `PAGER` environment variable is set to an interactive tool like `less` or `more`.
-
-**The Solution**: Always ensure the environment variable `PAGER` is set to `cat` or empty, OR use the tool-specific flag to disable the pager.
-
-**Best Practices**:
-
-1. **Per-command**: Prefix commands with `PAGER=cat`:
-
-   ```bash
-   PAGER=cat git status
-   PAGER=cat gt ls
-   ```
-
-2. **Git Specific**: Use `--no-pager` before the sub-command:
-
-   ```bash
-   git --no-pager diff
-   ```
-
-3. **Scripting**: If writing or modifying helper scripts, include `export PAGER=""` at the top of the script to protect future runs.
-
 ### Misplaced Commits
 
 If you accidentally commit a change to the wrong branch in a stack:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,14 +168,6 @@ The project uses "Skills" to provide detailed instructions and best practices fo
 
 When working with these tools, you SHOULD read the corresponding `SKILL.md` to ensure compliance with project-specific rules.
 
-### Agent Workflow (Important)
-
-**PAGER Management**: To avoid stalls and empty output during CLI command execution, agents MUST ensure that interactive pagers are disabled.
-
-- Prefix commands with `PAGER=cat` (e.g., `PAGER=cat git status`).
-- Use command-specific flags to disable pagers (e.g., `git --no-pager diff`).
-- When creating or modifying scripts, include `export PAGER=""` at the top.
-
 ### CI/CD and GitHub Actions
 
 - **CI/CD**: GitHub Actions optimized for Graphite-style stacked PRs.

--- a/dev-scripts/get-unresolved-comments.sh
+++ b/dev-scripts/get-unresolved-comments.sh
@@ -4,12 +4,9 @@ set -eo pipefail
 # get-unresolved-comments.sh: Fetches unresolved PR comments using GitHub GraphQL API.
 # Usage: ./get-unresolved-comments.sh <pr-number>
 
-# Ensure no pager interfers with any of the commands
-export PAGER=""
-
 PR_NUMBER=$1
 if [ -z "$PR_NUMBER" ]; then
-  PR_NUMBER=$(PAGER= gh pr view --json number --jq '.number' || true)
+  PR_NUMBER=$(gh pr view --json number --jq '.number' || true)
   if [ -z "$PR_NUMBER" ]; then
     echo "Error: No PR number provided and could not find a PR for the current branch." >&2
     echo "Usage: $0 <pr-number>" >&2

--- a/dev-scripts/resolve-pr-comment.sh
+++ b/dev-scripts/resolve-pr-comment.sh
@@ -4,9 +4,6 @@ set -eo pipefail
 # resolve-pr-comment.sh: Resolves a GitHub PR review thread.
 # Usage: ./resolve-pr-comment.sh <thread-id>
 
-# Ensure no pager interfers with any of the commands
-export PAGER=""
-
 THREAD_ID=$1
 if [ -z "$THREAD_ID" ]; then
   echo "Usage: $0 <thread-id>" >&2


### PR DESCRIPTION
This change removes the requirement for agents to prefix commands with
PAGER="" or PAGER=cat, and removes the export PAGER="" from maintenance
scripts. This is because the underlying terminal issue that caused
stalls and empty output has been fixed.

- Removed PAGER management instructions from CLAUDE.md
- Removed Pager Interference section from graphite SKILL.md
- Removed export PAGER="" and PAGER prefix from dev-scripts