### PR TITLE
fix: correct version detection and ldflags in Nix package [backport #655]

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,14 +66,18 @@ jobs:
       - uses: actions/checkout@v6
       - name: Build the docker image
         shell: bash
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          nix build -L .#packages.${{ matrix.system }}.docker
+          nix build -L --impure .#packages.${{ matrix.system }}.docker
       - name: Build the docker image pusher
         shell: bash
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          nix build -L .#packages.${{ matrix.system }}.push-docker-image
+          nix build -L --impure .#packages.${{ matrix.system }}.push-docker-image
       - name: Login to Docker Hub
         if: inputs.push_images
         uses: docker/login-action@v3

--- a/nix/packages/ncps/default.nix
+++ b/nix/packages/ncps/default.nix
@@ -11,22 +11,17 @@
         let
           version =
             let
-              tag =
-                let
-                  semverRegex = "v[0-9]+(\\.[0-9]+){0,2}(-[a-zA-Z0-9.-]+)?";
-                  tag' = self.tag or "";
-                in
-                if builtins.match semverRegex tag' != null then tag' else "";
-
               rev = self.rev or self.dirtyRev;
+              tag = builtins.getEnv "RELEASE_VERSION";
             in
             if tag != "" then tag else rev;
 
           vendorHash = "sha256-nnt4HIG4Fs7RhHjVb7mYJ39UgvFKc46Cu42cURMmr1s=";
         in
         pkgs.buildGoModule {
+          inherit version vendorHash;
+
           pname = "ncps";
-          inherit version;
 
           src = lib.fileset.toSource {
             fileset = lib.fileset.unions [
@@ -62,10 +57,8 @@
             root = ../../..;
           };
 
-          inherit vendorHash;
-
           ldflags = [
-            "-X github.com/kalbasit/ncps/cmd.Version=${version}"
+            "-X github.com/kalbasit/ncps/pkg/ncps.Version=${version}"
           ];
 
           doCheck = true;


### PR DESCRIPTION
Bot-based backport to `release-0.7`, triggered by a label in #655.

The version detection logic in the Nix package was unsuccessfully trying
to extract a tag from the self input. This has been simplified to use
the RELEASE_VERSION environment variable.

Additionally, the Go ldflags were targetting github.com/kalbasit/ncps/cmd.Version,
but the variable is actually defined in github.com/kalbasit/ncps/pkg/ncps.Version.