### PR TITLE
feat: setup OTel in migrate-narinfo

### DIFF
--- a/docs/docs/User Guide/Configuration/Observability.md
+++ b/docs/docs/User Guide/Configuration/Observability.md
@@ -22,6 +22,7 @@ ncps provides comprehensive observability through:
 **Command-line:**
 
 ```sh
+# For the server
 ncps serve --prometheus-enabled=true
 ```
 
@@ -152,7 +153,13 @@ See the [Monitoring Guide](../Operations/Monitoring.md) for dashboard examples.
 **Command-line:**
 
 ```sh
+# For the server
 ncps serve \
+  --otel-enabled=true \
+  --otel-grpc-url=http://otel-collector:4317
+
+# For narinfo migration
+ncps migrate-narinfo \
   --otel-enabled=true \
   --otel-grpc-url=http://otel-collector:4317
 ```

--- a/docs/docs/User Guide/Operations/Monitoring.md
+++ b/docs/docs/User Guide/Operations/Monitoring.md
@@ -6,14 +6,14 @@ Set up monitoring, metrics, and alerting for ncps.
 
 ## Enable Prometheus
 
-Enable the `/metrics` endpoint:
+Enable the `/metrics` endpoint (supported by `serve` and `migrate-narinfo` commands):
 
 ```yaml
 prometheus:
   enabled: true
 ```
 
-Access metrics at: `http://your-ncps:8501/metrics`
+Access metrics at: `http://your-ncps:8501/metrics` (for `serve`) or via stdout/OTel (for `migrate-narinfo`).
 
 ## Available Metrics
 

--- a/docs/docs/User Guide/Operations/NarInfo Migration.md
+++ b/docs/docs/User Guide/Operations/NarInfo Migration.md
@@ -116,6 +116,11 @@ ncps migrate-narinfo \
 - `--cache-redis-password` - Redis password (optional)
 - `--cache-redis-db` - Redis database number (default: 0)
 - `--cache-redis-use-tls` - Use TLS for Redis connections (optional)
+- `--cache-redis-pool-size` - Redis connection pool size (default: 10)
+- `--cache-lock-backend` - Lock backend to use: 'local', 'redis', or 'postgres' (default: 'local')
+- `--cache-lock-redis-key-prefix` - Prefix for Redis lock keys (default: 'ncps:lock:')
+- `--cache-lock-allow-degraded-mode` - Fallback to local locks if Redis is down
+- `--cache-lock-retry-max-attempts` - Max lock retry attempts (default: 3)
 
 ### Dry Run
 
@@ -203,9 +208,18 @@ INFO migration completed found=10000 processed=10000 succeeded=9987 failed=13 du
 - **failed**: Errors during migration
 - **rate**: Narinfos processed per second
 
-### Prometheus Metrics
+### OpenTelemetry
 
-If Prometheus is enabled, monitor via metrics:
+Migration metrics can be exported to an OpenTelemetry collector:
+
+```sh
+ncps migrate-narinfo \
+  --otel-enabled \
+  --otel-grpc-url="http://otel-collector:4317" \
+  ...
+```
+
+If OpenTelemetry is enabled, monitor via metrics:
 
 **ncps_migration_narinfos_total**
 
@@ -377,7 +391,7 @@ ncps migrate-narinfo \
 
 ### During Migration
 
-1. **Monitor progress** via console or Prometheus
+1. **Monitor progress** via console or OpenTelemetry
 1. **Watch error count** - some failures OK, many failures = investigate
 1. **Check database performance** - watch for resource constraints
 1. **Keep backups available** for quick rollback if needed

--- a/docs/docs/User Guide/Operations/Upgrading.md
+++ b/docs/docs/User Guide/Operations/Upgrading.md
@@ -94,7 +94,7 @@ When upgrading from versions before database-backed narinfo metadata, you have t
 - Faster bulk migration
 - Use during maintenance window
 - Deletion from storage (saves space)
-- Progress monitoring and metrics
+- Progress monitoring and metrics with OpenTelemetry
 
 **Example CLI migration:**
 

--- a/docs/docs/User Guide/Usage/Cache Management.md
+++ b/docs/docs/User Guide/Usage/Cache Management.md
@@ -186,7 +186,7 @@ ncps migrate-narinfo --dry-run \
 Monitor migration progress through:
 
 - **Console logs** - Progress updates every 5 seconds
-- **Prometheus metrics** - `ncps_migration_*` metrics
+- **OpenTelemetry** - Export traces and metrics (enable with `--otel-enabled`)
 - **Final summary** - Completion report with statistics
 
 **Example output:**

--- a/pkg/ncps/root.go
+++ b/pkg/ncps/root.go
@@ -151,7 +151,7 @@ func New() (*cli.Command, error) {
 		},
 		Commands: []*cli.Command{
 			serveCommand(userDirs, flagSources, registerShutdown),
-			migrateNarInfoCommand(flagSources),
+			migrateNarInfoCommand(flagSources, registerShutdown),
 		},
 	}
 

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -425,7 +425,7 @@ func serveAction(registerShutdown registerShutdownFn) cli.ActionFunc {
 			return err
 		}
 
-		extraResourceAttrs, err := serveDetectExtraResourceAttrs(ctx, cmd, db, rwLocker)
+		extraResourceAttrs, err := detectExtraResourceAttrs(ctx, cmd, db, rwLocker)
 		if err != nil {
 			logger.
 				Error().
@@ -920,7 +920,7 @@ func createCache(
 	return c, nil
 }
 
-func serveDetectExtraResourceAttrs(
+func detectExtraResourceAttrs(
 	ctx context.Context,
 	cmd *cli.Command,
 	db database.Querier,


### PR DESCRIPTION
This change sets up OpenTelemetry metrics in the migrate-narinfo command. It reuses the Otel setup logic from the serve command and adds missing lock configuration flags to migrate-narinfo to support full distributed locking configuration.
    
Summary of changes:
- Refactored detectExtraResourceAttrs in serve.go for reuse.
- Updated migrateNarInfoCommand to support shutdown registration.
- Integrated OTel setup in migrate_narinfo.go.
- Replaced custom createLocker with shared getLockers.
- Added missing lock flags to migrate-narinfo command.
- Updated documentation (User Guide, Monitoring, Upgrading) to reflect the new features.