### PR TITLE
feat: add support for code coverage reporting

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -18,3 +18,12 @@ jobs:
       - uses: DeterminateSystems/magic-nix-cache-action@v13
       - uses: DeterminateSystems/flake-checker-action@main
       - run: nix flake check -L
+      - id: build-coverage
+        if: github.event.pull_request.head.repo.fork == false
+        run: nix build .#ncps.coverage -L
+      - name: Upload coverage reports to Codecov
+        if: steps.build-coverage.outcome == 'success'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: result-coverage

--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -16,9 +16,13 @@
         packages
         // devShells
         // {
-          golangci-lint = config.packages.ncps.overrideAttrs (oa: {
-            name = "golangci-lint";
+          # TODO: Simplify this to not use buildGoModule as it seems to be a
+          # waste of time. This could be a simple stdenvNoCC.mkDerviation.
+          golangci-lint-check = config.packages.ncps.overrideAttrs (oa: {
+            name = "golangci-lint-check";
             src = ../../.;
+            # ensure the output is only out since it's the only thing this package does.
+            outputs = [ "out" ];
             nativeBuildInputs = oa.nativeBuildInputs ++ [ pkgs.golangci-lint ];
             buildPhase = ''
               HOME=$TMPDIR

--- a/nix/packages/docker.nix
+++ b/nix/packages/docker.nix
@@ -7,9 +7,18 @@
       ...
     }:
     let
+
       package-ncps = config.packages.ncps.overrideAttrs (oa: {
-        # Remove race-condition testing as it does not work on all platforms
-        checkFlags = lib.remove "-race" (oa.checkFlags or [ ]);
+        checkFlags = lib.subtractLists [
+          # Remove coverage since it's not going to test everything (see preCheck disabling below).
+          "-coverprofile=coverage.txt"
+
+          # Remove race-condition testing as it does not work on all platforms.
+          "-race"
+        ] (oa.checkFlags or [ ]);
+
+        # Since we are not running the coverage tests, disable coverage output
+        outputs = lib.remove "coverage" (oa.outputs or [ ]);
 
         # No need to run integration tests for the docker image, they are
         # covered by the other tests. Additionally, there seems to be a

--- a/nix/packages/ncps/default.nix
+++ b/nix/packages/ncps/default.nix
@@ -61,9 +61,6 @@
             "-X github.com/kalbasit/ncps/pkg/ncps.Version=${version}"
           ];
 
-          doCheck = true;
-          checkFlags = [ "-race" ];
-
           nativeBuildInputs = [
             pkgs.curl # used for checking MinIO health check
             pkgs.dbmate # used for testing
@@ -76,7 +73,12 @@
             pkgs.redis # Redis for distributed locking integration tests
           ];
 
-          # pre and post checks
+          doCheck = true;
+          checkFlags = [
+            "-race"
+            "-coverprofile=coverage.txt"
+          ];
+
           preCheck = ''
             # Set up cleanup trap to ensure background processes are killed even if tests fail
             cleanup() {
@@ -91,6 +93,15 @@
             source $src/nix/packages/ncps/pre-check-mysql.sh
             source $src/nix/packages/ncps/pre-check-postgres.sh
             source $src/nix/packages/ncps/pre-check-redis.sh
+          '';
+
+          outputs = [
+            "out"
+            "coverage"
+          ];
+
+          postCheck = ''
+            mv coverage.txt $coverage
           '';
 
           postInstall = ''


### PR DESCRIPTION
This change introduces code coverage reporting by:
1. Adding a 'coverage' output to the 'ncps' Nix package.
2. Configuring 'checkFlags' in the Nix build to generate a coverage profile.
3. Updating the GitHub Actions workflow to build the coverage output and upload it to Codecov.
4. Filtering out coverage flags in 'nix/packages/docker.nix' to avoid unnecessary work in the Docker image build.