### PR TITLE
docs: update helm chart documentation link

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -68,4 +68,4 @@ jobs:
 
             ### Documentation
 
-            See [Helm Chart README](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/charts/ncps/README.md) for detailed documentation and examples.
+            See [Helm Chart Documentation](https://docs.ncps.dev/user-guide/installation/helm-chart) for detailed documentation and examples.


### PR DESCRIPTION
Updated the documentation link in the releases workflow to point to the canonical Helm Chart documentation on docs.ncps.dev instead of the repository's README.md. This ensures users are directed to the most up-to-date and comprehensive documentation.