### PR TITLE
fix(ci): send the flake workflow the codecov secret

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
       contents: "read"
     with:
       systems: "['x86_64-linux', 'aarch64-linux']"
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
   docker:
     uses: ./.github/workflows/docker.yml
     needs: flake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
       contents: "read"
     with:
       systems: "['x86_64-linux', 'aarch64-linux']"
+    secrets:
+      codecov_token: ${{ secrets.CODECOV_TOKEN }}
   helm-tests:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -6,6 +6,10 @@ on:
         description: "The systems for which to add support for. JSON-formatted string."
         required: true
         type: string
+    secrets:
+      codecov_token:
+        description: "Codecov token"
+        required: true
 jobs:
   check:
     strategy:
@@ -25,5 +29,5 @@ jobs:
         if: steps.build-coverage.outcome == 'success'
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.codecov_token }}
           files: result-coverage


### PR DESCRIPTION
A shared workflow does not automatically get access to repository secrets, it needs to be passed in.