### PR TITLE
refactor(metrics): make background migration metrics generic [backport #691]

### DIFF
--- a/docs/docs/User Guide/Configuration/Observability.md
+++ b/docs/docs/User Guide/Configuration/Observability.md
@@ -80,19 +80,24 @@ Note: Upstream health metrics are collected as part of analytics reporting. See 
 
 **Migration Metrics** (during narinfo migration):
 
-- `ncps_migration_narinfos_total{operation,result}` - NarInfo migration operations
+- `ncps_migration_objects_total{migration_type,operation,result}` - Total number of objects processed during migration.
+  - `migration_type`: "narinfo-to-db"
   - `operation`: "migrate" or "delete"
   - `result`: "success", "failure", or "skipped"
-- `ncps_migration_duration_seconds{operation}` - Migration operation duration histogram
+- `ncps_migration_duration_seconds{migration_type,operation}` - Migration operation duration histogram
+  - `migration_type`: "narinfo-to-db"
   - `operation`: "migrate" or "delete"
-- `ncps_migration_batch_size` - Migration batch size histogram
+- `ncps_migration_batch_size{migration_type}` - Migration batch size histogram
+  - `migration_type`: "narinfo-to-db"
 
 **Background Migration Metrics** (during on-the-fly migration):
 
-- `ncps_background_migration_narinfos_total{operation,result}` - Background NarInfo migration operations
+- `ncps_background_migration_objects_total{migration_type,operation,result}` - Total number of objects processed during background migration
+  - `migration_type`: "narinfo-to-db"
   - `operation`: "migrate" or "delete"
   - `result`: "success" or "failure"
-- `ncps_background_migration_duration_seconds{operation}` - Background migration operation duration histogram
+- `ncps_background_migration_duration_seconds{migration_type,operation}` - Background migration operation duration histogram
+  - `migration_type`: "narinfo-to-db"
   - `operation`: "migrate" or "delete"
 
 See [NarInfo Migration Guide](../Operations/NarInfo%20Migration.md) for migration documentation.

--- a/docs/docs/User Guide/Operations/Monitoring.md
+++ b/docs/docs/User Guide/Operations/Monitoring.md
@@ -36,18 +36,25 @@ Access metrics at: `http://your-ncps:8501/metrics` (for `serve`) or via stdout/O
 
 **Migration Metrics:**
 
-- `ncps_migration_narinfos_total{operation,result}` - NarInfos migrated
-  - Labels: `operation` (migrate/delete), `result` (success/failure/skipped)
-- `ncps_migration_duration_seconds{operation}` - Migration operation duration
-  - Label: `operation` (migrate/delete)
-- `ncps_migration_batch_size` - Migration batch sizes
+- `ncps_migration_objects_total{migration_type,operation,result}` - Total number of objects processed during migration.
+  - `migration_type`: "narinfo-to-db"
+  - `operation`: "migrate" or "delete"
+  - `result`: "success", "failure", or "skipped"
+- `ncps_migration_duration_seconds{migration_type,operation}` - Migration operation duration histogram
+  - `migration_type`: "narinfo-to-db"
+  - `operation`: "migrate" or "delete"
+- `ncps_migration_batch_size{migration_type}` - Migration batch size histogram
+  - `migration_type`: "narinfo-to-db"
 
 **Background Migration Metrics:**
 
-- `ncps_background_migration_narinfos_total{operation,result}` - Background NarInfos migrated
-  - Labels: `operation` (migrate/delete), `result` (success/failure)
-- `ncps_background_migration_duration_seconds{operation}` - Background migration operation duration
-  - Label: `operation` (migrate/delete)
+- `ncps_background_migration_objects_total{migration_type,operation,result}` - Total number of objects processed during background migration.
+  - `migration_type`: "narinfo-to-db"
+  - `operation`: "migrate" or "delete"
+  - `result`: "success" or "failure"
+- `ncps_background_migration_duration_seconds{migration_type,operation}` - Background migration operation duration histogram
+  - `migration_type`: "narinfo-to-db"
+  - `operation`: "migrate" or "delete"
 
 ## Prometheus Configuration
 

--- a/docs/docs/User Guide/Operations/NarInfo Migration.md
+++ b/docs/docs/User Guide/Operations/NarInfo Migration.md
@@ -221,15 +221,15 @@ ncps migrate-narinfo \
 
 If OpenTelemetry is enabled, monitor via metrics:
 
-**ncps_migration_narinfos_total**
+**ncps_migration_objects_total**
 
 ```
 # Total migrations
-sum(ncps_migration_narinfos_total)
+sum(ncps_migration_objects_total{migration_type="narinfo-to-db"})
 
 # Success rate
-sum(rate(ncps_migration_narinfos_total{result="success"}[5m])) /
-sum(rate(ncps_migration_narinfos_total[5m]))
+sum(rate(ncps_migration_objects_total{migration_type="narinfo-to-db", result="success"}[5m])) /
+sum(rate(ncps_migration_objects_total{migration_type="narinfo-to-db"}[5m]))
 ```
 
 **ncps_migration_duration_seconds**

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -46,6 +46,9 @@ const (
 	// Migration result constants for metrics.
 	migrationResultSuccess = "success"
 	migrationResultFailure = "failure"
+
+	// Migration type constants for metrics.
+	migrationTypeNarInfoToDB = "narinfo-to-db"
 )
 
 // narInfoJobKey returns the key used for tracking narinfo download jobs.
@@ -127,7 +130,7 @@ var (
 
 	// Background migration metrics
 	//nolint:gochecknoglobals
-	backgroundMigrationNarInfosTotal metric.Int64Counter
+	backgroundMigrationObjectsTotal metric.Int64Counter
 
 	//nolint:gochecknoglobals
 	backgroundMigrationDuration metric.Float64Histogram
@@ -270,10 +273,10 @@ func init() {
 		panic(err)
 	}
 
-	backgroundMigrationNarInfosTotal, err = meter.Int64Counter(
-		"ncps_background_migration_narinfos_total",
-		metric.WithDescription("Total number of narinfos processed during background migration"),
-		metric.WithUnit("{narinfo}"),
+	backgroundMigrationObjectsTotal, err = meter.Int64Counter(
+		"ncps_background_migration_objects_total",
+		metric.WithDescription("Total number of objects processed during background migration"),
+		metric.WithUnit("{object}"),
 	)
 	if err != nil {
 		panic(err)
@@ -281,7 +284,7 @@ func init() {
 
 	backgroundMigrationDuration, err = meter.Float64Histogram(
 		"ncps_background_migration_duration_seconds",
-		metric.WithDescription("Duration of background narinfo migration operations"),
+		metric.WithDescription("Duration of background object migration operations"),
 		metric.WithUnit("s"),
 	)
 	if err != nil {
@@ -2342,21 +2345,23 @@ func MigrateNarInfo(
 
 	opStartTime := time.Now()
 
+	migrateAttrs := []attribute.KeyValue{
+		attribute.String("migration_type", migrationTypeNarInfoToDB),
+		attribute.String("operation", migrationOperationMigrate),
+	}
+
 	// Store narinfo in database using the UPSERT logic from storeInDatabase
 	err = storeNarInfoInDatabase(ctx, db, hash, ni)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to migrate narinfo to database")
 
-		backgroundMigrationNarInfosTotal.Add(ctx, 1,
+		backgroundMigrationObjectsTotal.Add(ctx, 1,
 			metric.WithAttributes(
-				attribute.String("operation", migrationOperationMigrate),
-				attribute.String("result", migrationResultFailure),
+				append(migrateAttrs, attribute.String("result", migrationResultFailure))...,
 			),
 		)
 		backgroundMigrationDuration.Record(ctx, time.Since(opStartTime).Seconds(),
-			metric.WithAttributes(
-				attribute.String("operation", migrationOperationMigrate),
-			),
+			metric.WithAttributes(migrateAttrs...),
 		)
 
 		return fmt.Errorf("failed to store narinfo in database: %w", err)
@@ -2364,45 +2369,42 @@ func MigrateNarInfo(
 
 	log.Debug().Dur("duration", time.Since(opStartTime)).Msg("successfully migrated narinfo to database")
 
-	backgroundMigrationNarInfosTotal.Add(ctx, 1,
+	backgroundMigrationObjectsTotal.Add(ctx, 1,
 		metric.WithAttributes(
-			attribute.String("operation", migrationOperationMigrate),
-			attribute.String("result", migrationResultSuccess),
+			append(migrateAttrs, attribute.String("result", migrationResultSuccess))...,
 		),
 	)
 	backgroundMigrationDuration.Record(ctx, time.Since(opStartTime).Seconds(),
-		metric.WithAttributes(
-			attribute.String("operation", migrationOperationMigrate),
-		),
+		metric.WithAttributes(migrateAttrs...),
 	)
 
 	// Only delete from storage if narInfoStore is provided
 	if narInfoStore != nil {
 		deleteStartTime := time.Now()
+		deleteAttrs := []attribute.KeyValue{
+			attribute.String("migration_type", migrationTypeNarInfoToDB),
+			attribute.String("operation", migrationOperationDelete),
+		}
 
 		if err := narInfoStore.DeleteNarInfo(ctx, hash); err != nil {
 			log.Error().Err(err).Msg("failed to delete narinfo from store after migration")
-			backgroundMigrationNarInfosTotal.Add(ctx, 1,
+			backgroundMigrationObjectsTotal.Add(ctx, 1,
 				metric.WithAttributes(
-					attribute.String("operation", migrationOperationDelete),
-					attribute.String("result", migrationResultFailure),
+					append(deleteAttrs, attribute.String("result", migrationResultFailure))...,
 				),
 			)
 			// Don't return error - migration succeeded, only cleanup failed
 		} else {
 			log.Debug().Msg("deleted narinfo from storage after successful migration")
-			backgroundMigrationNarInfosTotal.Add(ctx, 1,
+			backgroundMigrationObjectsTotal.Add(ctx, 1,
 				metric.WithAttributes(
-					attribute.String("operation", migrationOperationDelete),
-					attribute.String("result", migrationResultSuccess),
+					append(deleteAttrs, attribute.String("result", migrationResultSuccess))...,
 				),
 			)
 		}
 
 		backgroundMigrationDuration.Record(ctx, time.Since(deleteStartTime).Seconds(),
-			metric.WithAttributes(
-				attribute.String("operation", migrationOperationDelete),
-			),
+			metric.WithAttributes(deleteAttrs...),
 		)
 	}
 

--- a/pkg/ncps/migrate_narinfo.go
+++ b/pkg/ncps/migrate_narinfo.go
@@ -360,7 +360,7 @@ to enable safe concurrent migration.`,
 						if dryRun {
 							log.Info().Msg("[DRY-RUN] would delete from storage")
 							atomic.AddInt32(&totalSucceeded, 1)
-							RecordMigrationNarInfo(ctxWithLog, MigrationOperationDelete, MigrationResultSuccess)
+							RecordMigrationObject(ctxWithLog, MigrationOperationDelete, MigrationResultSuccess)
 
 							return nil
 						}
@@ -368,10 +368,10 @@ to enable safe concurrent migration.`,
 						if err := narInfoStore.DeleteNarInfo(ctxWithLog, hash); err != nil {
 							log.Error().Err(err).Msg("failed to delete from store")
 							atomic.AddInt32(&totalFailed, 1)
-							RecordMigrationNarInfo(ctxWithLog, MigrationOperationDelete, MigrationResultFailure)
+							RecordMigrationObject(ctxWithLog, MigrationOperationDelete, MigrationResultFailure)
 						} else {
 							atomic.AddInt32(&totalSucceeded, 1)
-							RecordMigrationNarInfo(ctxWithLog, MigrationOperationDelete, MigrationResultSuccess)
+							RecordMigrationObject(ctxWithLog, MigrationOperationDelete, MigrationResultSuccess)
 						}
 
 						return nil
@@ -399,7 +399,7 @@ to enable safe concurrent migration.`,
 					if err != nil {
 						log.Error().Err(err).Msg("failed to get narinfo from store")
 						atomic.AddInt32(&totalFailed, 1)
-						RecordMigrationNarInfo(ctxWithLog, MigrationOperationMigrate, MigrationResultFailure)
+						RecordMigrationObject(ctxWithLog, MigrationOperationMigrate, MigrationResultFailure)
 
 						return nil
 					}
@@ -407,7 +407,7 @@ to enable safe concurrent migration.`,
 					if dryRun {
 						log.Info().Msg("[DRY-RUN] would migrate and delete")
 						atomic.AddInt32(&totalSucceeded, 1)
-						RecordMigrationNarInfo(ctxWithLog, MigrationOperationMigrate, MigrationResultSuccess)
+						RecordMigrationObject(ctxWithLog, MigrationOperationMigrate, MigrationResultSuccess)
 
 						return nil
 					}
@@ -417,13 +417,13 @@ to enable safe concurrent migration.`,
 					if err := cache.MigrateNarInfo(ctxWithLog, locker, db, narInfoStore, hash, ni); err != nil {
 						log.Error().Err(err).Msg("failed to migrate narinfo")
 						atomic.AddInt32(&totalFailed, 1)
-						RecordMigrationNarInfo(ctxWithLog, MigrationOperationMigrate, MigrationResultFailure)
+						RecordMigrationObject(ctxWithLog, MigrationOperationMigrate, MigrationResultFailure)
 
 						return nil
 					}
 
 					atomic.AddInt32(&totalSucceeded, 1)
-					RecordMigrationNarInfo(ctxWithLog, MigrationOperationMigrate, MigrationResultSuccess)
+					RecordMigrationObject(ctxWithLog, MigrationOperationMigrate, MigrationResultSuccess)
 
 					return nil
 				})


### PR DESCRIPTION
Bot-based backport to `release-0.8`, triggered by a label in #691.

Rename backgroundMigrationNarInfosTotal to backgroundMigrationObjectsTotal to genericize it for use with other object types (like chunks).

Update descriptions and units for migration-related metrics to use '{object}' instead of '{narinfo}'.

Add 'migration_type' attribute to background migration metrics to distinguish between 'narinfo-to-db' and other future types.