### PR TITLE
refactor: simplify golangci-lint check in nix/checks

### DIFF
--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -13,7 +13,11 @@
           golangci-lint-check = pkgs.stdenvNoCC.mkDerivation {
             name = "golangci-lint-check";
             src = ../../.;
-            nativeBuildInputs = [ pkgs.golangci-lint ];
+            nativeBuildInputs = [
+              pkgs.go
+              pkgs.golangci-lint
+            ];
+            CGO_ENABLED = 0;
             buildPhase = ''
               HOME=$NIX_BUILD_TOP
               golangci-lint run --timeout 10m


### PR DESCRIPTION
refactor: simplify golangci-lint check in nix/checks

This simplifies the golangci-lint check by using pkgs.stdenvNoCC.mkDerivation
instead of overriding config.packages.ncps. This is more efficient as it
avoids unnecessary build steps from buildGoModule. It also updates HOME
to $NIX_BUILD_TOP for consistency in the build environment.

not working yet