### PR TITLE
fix: make database password optional for postgresql and mysql [backport #697]

### DIFF
--- a/charts/ncps/templates/_helpers.tpl
+++ b/charts/ncps/templates/_helpers.tpl
@@ -123,7 +123,7 @@ Returns the CACHE_DATABASE_URL env var config - either from value or secretKeyRe
       {{- $dbConfig := index .Values.config.database $dbType -}}
       {{- if $dbConfig.existingSecret }}
       name: {{ $dbConfig.existingSecret }}
-      {{- else if $dbConfig.password }}
+      {{- else }}
       name: {{ include "ncps.fullname" . }}
       {{- end }}
       key: database-url
@@ -145,7 +145,7 @@ Returns the DATABASE_URL env var config - either from value or secretKeyRef
       {{- $dbConfig := index .Values.config.database $dbType -}}
       {{- if $dbConfig.existingSecret }}
       name: {{ $dbConfig.existingSecret }}
-      {{- else if $dbConfig.password }}
+      {{- else }}
       name: {{ include "ncps.fullname" . }}
       {{- end }}
       key: database-url

--- a/charts/ncps/templates/secret.yaml
+++ b/charts/ncps/templates/secret.yaml
@@ -1,7 +1,7 @@
 {{- if or
   (and (eq .Values.config.storage.type "s3") (not .Values.config.storage.s3.existingSecret) .Values.config.storage.s3.accessKeyId .Values.config.storage.s3.secretAccessKey)
-  (and (eq .Values.config.database.type "postgresql") (not .Values.config.database.postgresql.existingSecret) .Values.config.database.postgresql.password)
-  (and (eq .Values.config.database.type "mysql") (not .Values.config.database.mysql.existingSecret) .Values.config.database.mysql.password)
+  (and (eq .Values.config.database.type "postgresql") (not .Values.config.database.postgresql.existingSecret))
+  (and (eq .Values.config.database.type "mysql") (not .Values.config.database.mysql.existingSecret))
   (and .Values.config.redis.enabled (not .Values.config.redis.existingSecret) (or .Values.config.redis.password .Values.config.redis.username))
   (and .Values.config.upstream.netrcFile (not .Values.config.upstream.existingNetrcSecret))
 -}}
@@ -23,13 +23,27 @@ data:
   s3-access-key-id: {{ .Values.config.storage.s3.accessKeyId | b64enc | quote }}
   s3-secret-access-key: {{ .Values.config.storage.s3.secretAccessKey | b64enc | quote }}
   {{- end }}
-  {{- if and (eq .Values.config.database.type "postgresql") (not .Values.config.database.postgresql.existingSecret) .Values.config.database.postgresql.password }}
-  postgres-password: {{ .Values.config.database.postgresql.password | b64enc | quote }}
-  database-url: {{ printf "postgresql://%s:%s@%s:%d/%s?sslmode=%s%s" (.Values.config.database.postgresql.username | urlquery) (.Values.config.database.postgresql.password | urlquery) .Values.config.database.postgresql.host (.Values.config.database.postgresql.port | int) .Values.config.database.postgresql.database .Values.config.database.postgresql.sslMode (ternary (printf "&%s" .Values.config.database.postgresql.extraParams) "" (ne .Values.config.database.postgresql.extraParams "")) | b64enc | quote }}
+  {{- if and (eq .Values.config.database.type "postgresql") (not .Values.config.database.postgresql.existingSecret) }}
+  {{- $pg := .Values.config.database.postgresql -}}
+  {{- if $pg.password }}
+  postgres-password: {{ $pg.password | b64enc | quote }}
   {{- end }}
-  {{- if and (eq .Values.config.database.type "mysql") (not .Values.config.database.mysql.existingSecret) .Values.config.database.mysql.password }}
-  mysql-password: {{ .Values.config.database.mysql.password | b64enc | quote }}
-  database-url: {{ printf "mysql://%s:%s@%s:%d/%s%s" (.Values.config.database.mysql.username | urlquery) (.Values.config.database.mysql.password | urlquery) .Values.config.database.mysql.host (.Values.config.database.mysql.port | int) .Values.config.database.mysql.database (ternary (printf "?%s" .Values.config.database.mysql.extraParams) "" (ne .Values.config.database.mysql.extraParams "")) | b64enc | quote }}
+  {{- $auth := $pg.username | urlquery }}
+  {{- if $pg.password }}
+  {{- $auth = printf "%s:%s" $auth ($pg.password | urlquery) }}
+  {{- end }}
+  database-url: {{ printf "postgresql://%s@%s:%d/%s?sslmode=%s%s" $auth $pg.host ($pg.port | int) $pg.database $pg.sslMode (ternary (printf "&%s" $pg.extraParams) "" (ne $pg.extraParams "")) | b64enc | quote }}
+  {{- end }}
+  {{- if and (eq .Values.config.database.type "mysql") (not .Values.config.database.mysql.existingSecret) }}
+  {{- $mysql := .Values.config.database.mysql -}}
+  {{- if $mysql.password }}
+  mysql-password: {{ $mysql.password | b64enc | quote }}
+  {{- end }}
+  {{- $auth := $mysql.username | urlquery }}
+  {{- if $mysql.password }}
+  {{- $auth = printf "%s:%s" $auth ($mysql.password | urlquery) }}
+  {{- end }}
+  database-url: {{ printf "mysql://%s@%s:%d/%s%s" $auth $mysql.host ($mysql.port | int) $mysql.database (ternary (printf "?%s" $mysql.extraParams) "" (ne $mysql.extraParams "")) | b64enc | quote }}
   {{- end }}
   {{- if and .Values.config.redis.enabled (not .Values.config.redis.existingSecret) }}
   {{- if .Values.config.redis.password }}

--- a/charts/ncps/tests/validation/mysql-no-password-positive.yaml
+++ b/charts/ncps/tests/validation/mysql-no-password-positive.yaml
@@ -1,0 +1,34 @@
+# Positive test: MySQL without password
+# Secret should NOT contain mysql-password and database-url should NOT have :@ format
+mode: deployment
+replicaCount: 1
+
+config:
+  hostname: "test.example.com"
+
+  cdc:
+    enabled: true
+
+  storage:
+    type: s3
+    s3:
+      bucket: test-bucket
+      endpoint: https://s3.amazonaws.com
+      region: us-east-1
+      accessKeyId: test-key
+      secretAccessKey: test-secret
+
+  database:
+    type: mysql
+    mysql:
+      host: mysql.default.svc
+      username: ncps
+      database: ncps
+
+  redis:
+    enabled: true
+    addresses:
+      - redis:6379
+
+migration:
+  mode: job

--- a/charts/ncps/tests/validation/postgres-no-password-positive.yaml
+++ b/charts/ncps/tests/validation/postgres-no-password-positive.yaml
@@ -1,0 +1,35 @@
+# Positive test: PostgreSQL without password
+# Secret should NOT contain postgres-password and database-url should NOT have :@ format
+mode: deployment
+replicaCount: 1
+
+config:
+  hostname: "test.example.com"
+
+  cdc:
+    enabled: true
+
+  storage:
+    type: s3
+    s3:
+      bucket: test-bucket
+      endpoint: https://s3.amazonaws.com
+      region: us-east-1
+      accessKeyId: test-key
+      secretAccessKey: test-secret
+
+  database:
+    type: postgresql
+    postgresql:
+      host: postgres.default.svc
+      username: postgres
+      database: ncps
+      sslMode: disable
+
+  redis:
+    enabled: true
+    addresses:
+      - redis:6379
+
+migration:
+  mode: job


### PR DESCRIPTION
Bot-based backport to `release-0.8`, triggered by a label in #697.

This change makes the database password optional in the Helm chart for
PostgreSQL and MySQL/MariaDB. This allows using these database types even
when no password is required (e.g., local development or specific proxy
setups). Previously, the chart would only create or reference the database
secret if a password was explicitly provided, leading to missing
configuration when passwords were omitted.

- Updated _helpers.tpl to use the release-named secret for database-url
  even if no password is set.
- Updated secret.yaml to ensure the Secret and database-url key are
  generated based on the database type, regardless of whether a password
  is provided.
- Added conditional logic in secret.yaml to only include
  postgres-password or mysql-password keys if they are actually set.