### PR TITLE
ci: refactor fuzz workflow to use matrix strategy

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,20 +7,48 @@ permissions:
   contents: read
   issues: write
 jobs:
-  fuzz-pkg-nixcacheinfo:
+  fuzz:
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pkg: pkg/nixcacheinfo
+            func: FuzzParse
+            fuzz_pattern: FuzzParse
+            time: 1h
+          - pkg: pkg/helper
+            func: FuzzParseSize
+            fuzz_pattern: FuzzParseSize
+            time: 1h
+          - pkg: pkg/nar
+            func: FuzzParseURL
+            fuzz_pattern: FuzzParseURL
+            time: 1h
+          - pkg: pkg/nar
+            func: FuzzJoinURL
+            fuzz_pattern: FuzzJoinURL
+            time: 1h
+          - pkg: pkg/golomb
+            func: FuzzDecode
+            fuzz_pattern: ^FuzzDecode$
+            time: 1h
+          - pkg: pkg/golomb
+            func: FuzzDecodeBig
+            fuzz_pattern: ^FuzzDecodeBig$
+            time: 1h
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
-      - name: Fuzz Parse (nixcacheinfo)
-        run: go test -fuzz=FuzzParse -fuzztime=1h ./pkg/nixcacheinfo
+      - name: Fuzz ${{ matrix.func }}
+        run: go test -fuzz=${{ matrix.fuzz_pattern }} -fuzztime=${{ matrix.time }} ./${{ matrix.pkg }}
       - name: Encrypt Fuzz Crash
         if: failure()
         run: |
           # Find the crash file
-          CRASH_FILE=$(find pkg/nixcacheinfo/testdata/fuzz/FuzzParse -name "crash-*" | head -n 1)
+          CRASH_FILE=$(find ${{ matrix.pkg }}/testdata/fuzz/${{ matrix.func }} -name "crash-*" | head -n 1)
           if [ -z "$CRASH_FILE" ]; then
             echo "No crash file found despite failure."
             exit 0
@@ -37,7 +65,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v6
         with:
-          name: crash-nixcacheinfo-${{ env.SHA256 }}
+          name: crash-${{ matrix.func }}-${{ env.SHA256 }}
           path: ${{ env.CRASH_FILE }}
       - name: Create Issue on Crash
         if: failure()
@@ -49,7 +77,7 @@ jobs:
             exit 0
           fi
 
-          TITLE="Fuzzing Crash: FuzzParse $SHA256"
+          TITLE="Fuzzing Crash: ${{ matrix.func }} $SHA256"
 
           # Check for existing issue
           EXISTING_ISSUE=$(gh issue list --search "$SHA256 in:title" --json number --jq '.[0].number')
@@ -60,227 +88,5 @@ jobs:
 
           gh issue create \
             --title "$TITLE" \
-            --body "Fuzzing test 'FuzzParse' crashed.\n\nCommit: ${{ github.sha }}\nInput SHA256: \`$SHA256\`\n\nSee artifact for reproduction." \
-            --label "fuzz-crash"
-  fuzz-pkg-helper:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: "go.mod"
-      - name: Fuzz ParseSize (helper)
-        run: go test -fuzz=FuzzParseSize -fuzztime=1h ./pkg/helper
-      - name: Encrypt Fuzz Crash
-        if: failure()
-        run: |
-          # Find the crash file
-          CRASH_FILE=$(find pkg/helper/testdata/fuzz/FuzzParseSize -name "crash-*" | head -n 1)
-          if [ -z "$CRASH_FILE" ]; then
-            echo "No crash file found despite failure."
-            exit 0
-          fi
-
-          # Calculate SHA256 of the crash file
-          SHA256=$(sha256sum "$CRASH_FILE" | awk '{print $1}')
-
-          # Report SHA256
-          echo "Crash file SHA256: $SHA256"
-          echo "SHA256=$SHA256" >> "$GITHUB_ENV"
-          echo "CRASH_FILE=$CRASH_FILE" >> "$GITHUB_ENV"
-      - name: Archive crash file
-        if: failure()
-        uses: actions/upload-artifact@v6
-        with:
-          name: crash-helper-${{ env.SHA256 }}
-          path: ${{ env.CRASH_FILE }}
-      - name: Create Issue on Crash
-        if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ -z "$SHA256" ]; then
-            echo "SHA256 not set, skipping issue creation."
-            exit 0
-          fi
-
-          TITLE="Fuzzing Crash: FuzzParseSize $SHA256"
-
-          # Check for existing issue
-          EXISTING_ISSUE=$(gh issue list --search "$SHA256 in:title" --json number --jq '.[0].number')
-          if [ -n "$EXISTING_ISSUE" ]; then
-            echo "Issue already exists: #$EXISTING_ISSUE"
-            exit 0
-          fi
-
-          gh issue create \
-            --title "$TITLE" \
-            --body "Fuzzing test 'FuzzParseSize' crashed.\n\nCommit: ${{ github.sha }}\nInput SHA256: \`$SHA256\`\n\nSee artifact for reproduction." \
-            --label "fuzz-crash"
-  fuzz-pkg-nar:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: "go.mod"
-      - name: Fuzz ParseURL (nar)
-        run: go test -fuzz=FuzzParseURL -fuzztime=1h ./pkg/nar
-      - name: Encrypt Fuzz Crash
-        if: failure()
-        run: |
-          # Find the crash file
-          CRASH_FILE=$(find pkg/nar/testdata/fuzz/FuzzParseURL -name "crash-*" | head -n 1)
-          if [ -z "$CRASH_FILE" ]; then
-            echo "No crash file found despite failure."
-            exit 0
-          fi
-
-          # Calculate SHA256 of the crash file
-          SHA256=$(sha256sum "$CRASH_FILE" | awk '{print $1}')
-
-          # Report SHA256
-          echo "Crash file SHA256: $SHA256"
-          echo "SHA256=$SHA256" >> "$GITHUB_ENV"
-          echo "CRASH_FILE=$CRASH_FILE" >> "$GITHUB_ENV"
-      - name: Archive crash file
-        if: failure()
-        uses: actions/upload-artifact@v6
-        with:
-          name: crash-nar-${{ env.SHA256 }}
-          path: ${{ env.CRASH_FILE }}
-      - name: Create Issue on Crash
-        if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ -z "$SHA256" ]; then
-            echo "SHA256 not set, skipping issue creation."
-            exit 0
-          fi
-
-          TITLE="Fuzzing Crash: FuzzParseURL $SHA256"
-
-          # Check for existing issue
-          EXISTING_ISSUE=$(gh issue list --search "$SHA256 in:title" --json number --jq '.[0].number')
-          if [ -n "$EXISTING_ISSUE" ]; then
-            echo "Issue already exists: #$EXISTING_ISSUE"
-            exit 0
-          fi
-
-          gh issue create \
-            --title "$TITLE" \
-            --body "Fuzzing test 'FuzzParseURL' crashed.\n\nCommit: ${{ github.sha }}\nInput SHA256: \`$SHA256\`\n\nSee artifact for reproduction." \
-            --label "fuzz-crash"
-  fuzz-pkg-nar-joinurl:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: "go.mod"
-      - name: Fuzz JoinURL (nar)
-        run: go test -fuzz=FuzzJoinURL -fuzztime=1h ./pkg/nar
-      - name: Encrypt Fuzz Crash
-        if: failure()
-        run: |
-          # Find the crash file
-          CRASH_FILE=$(find pkg/nar/testdata/fuzz/FuzzJoinURL -name "crash-*" | head -n 1)
-          if [ -z "$CRASH_FILE" ]; then
-            echo "No crash file found despite failure."
-            exit 0
-          fi
-
-          # Calculate SHA256 of the crash file
-          SHA256=$(sha256sum "$CRASH_FILE" | awk '{print $1}')
-
-          # Report SHA256
-          echo "Crash file SHA256: $SHA256"
-          echo "SHA256=$SHA256" >> "$GITHUB_ENV"
-          echo "CRASH_FILE=$CRASH_FILE" >> "$GITHUB_ENV"
-      - name: Archive crash file
-        if: failure()
-        uses: actions/upload-artifact@v6
-        with:
-          name: crash-nar-joinurl-${{ env.SHA256 }}
-          path: ${{ env.CRASH_FILE }}
-      - name: Create Issue on Crash
-        if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ -z "$SHA256" ]; then
-            echo "SHA256 not set, skipping issue creation."
-            exit 0
-          fi
-
-          TITLE="Fuzzing Crash: FuzzJoinURL $SHA256"
-
-          # Check for existing issue
-          EXISTING_ISSUE=$(gh issue list --search "$SHA256 in:title" --json number --jq '.[0].number')
-          if [ -n "$EXISTING_ISSUE" ]; then
-            echo "Issue already exists: #$EXISTING_ISSUE"
-            exit 0
-          fi
-
-          gh issue create \
-            --title "$TITLE" \
-            --body "Fuzzing test 'FuzzJoinURL' crashed.\n\nCommit: ${{ github.sha }}\nInput SHA256: \`$SHA256\`\n\nSee artifact for reproduction." \
-            --label "fuzz-crash"
-  fuzz-pkg-golomb:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: "go.mod"
-      - name: Fuzz Decode (golomb)
-        run: go test -fuzz=^FuzzDecode$ -fuzztime=30m ./pkg/golomb
-      - name: Fuzz DecodeBig (golomb)
-        run: go test -fuzz=^FuzzDecodeBig$ -fuzztime=30m ./pkg/golomb
-      - name: Encrypt Fuzz Crash
-        if: failure()
-        run: |
-          # Find the crash file (checks both)
-          CRASH_FILE=$(find pkg/golomb/testdata/fuzz -name "crash-*" | head -n 1)
-          if [ -z "$CRASH_FILE" ]; then
-            echo "No crash file found despite failure."
-            exit 0
-          fi
-
-          # Calculate SHA256 of the crash file
-          SHA256=$(sha256sum "$CRASH_FILE" | awk '{print $1}')
-
-          # Report SHA256
-          echo "Crash file SHA256: $SHA256"
-          echo "SHA256=$SHA256" >> "$GITHUB_ENV"
-          echo "CRASH_FILE=$CRASH_FILE" >> "$GITHUB_ENV"
-      - name: Archive crash file
-        if: failure()
-        uses: actions/upload-artifact@v6
-        with:
-          name: crash-golomb-${{ env.SHA256 }}
-          path: ${{ env.CRASH_FILE }}
-      - name: Create Issue on Crash
-        if: failure()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ -z "$SHA256" ]; then
-            echo "SHA256 not set, skipping issue creation."
-            exit 0
-          fi
-
-          TITLE="Fuzzing Crash: Golomb $SHA256"
-
-          # Check for existing issue
-          EXISTING_ISSUE=$(gh issue list --search "$SHA256 in:title" --json number --jq '.[0].number')
-          if [ -n "$EXISTING_ISSUE" ]; then
-            echo "Issue already exists: #$EXISTING_ISSUE"
-            exit 0
-          fi
-
-          gh issue create \
-            --title "$TITLE" \
-            --body "Fuzzing test crashed in pkg/golomb.\n\nCommit: ${{ github.sha }}\nInput SHA256: \`$SHA256\`\n\nSee artifact for reproduction." \
+            --body "Fuzzing test '${{ matrix.func }}' crashed.\n\nCommit: ${{ github.sha }}\nInput SHA256: \`$SHA256\`\n\nSee artifact for reproduction." \
             --label "fuzz-crash"


### PR DESCRIPTION
The fuzz workflow was previously running 5 separate jobs, which was duplicative and harder to maintain. This change consolidates them into a single `fuzz` job using a matrix strategy to iterate over the packages and functions.

This simplifies the workflow configuration while maintaining the same level of parallelism and specific runtime durations for each fuzz test. Crash reporting logic has been updated to use the matrix variables dynamically.