### PR TITLE
fix: binding a socket to localhost network interfaces

### DIFF
--- a/nix/k8s-tests/src/k8s_tests_tester.py
+++ b/nix/k8s-tests/src/k8s_tests_tester.py
@@ -955,7 +955,8 @@ class NCPSTester:
         import socket
 
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("", 0))
+            # Bind only to the loopback interface to avoid exposing a listening socket on all interfaces
+            s.bind(("127.0.0.1", 0))
             s.listen(1)
             port = s.getsockname()[1]
         return port


### PR DESCRIPTION
Potential fix for [https://github.com/kalbasit/ncps/security/code-scanning/4](https://github.com/kalbasit/ncps/security/code-scanning/4)

In general, the problem is fixed by binding the socket only to a specific interface (typically `127.0.0.1` for local-only helpers) instead of to all interfaces via `""` or `"0.0.0.0"`. When discovering a free port, there is no need to expose that temporary socket externally; binding to loopback preserves the behavior while limiting exposure.

The single best change here is to update `_find_free_port` so that it binds to `("127.0.0.1", 0)` rather than `("", 0)`. This still asks the OS to assign an ephemeral free port (because the port argument is `0`), but the listening socket will only be reachable from the local machine. No additional imports are required, and no other parts of the code need to change because callers of `_find_free_port` only care about the port number, not the interface used for the temporary bind.

Concretely, in `nix/k8s-tests/src/k8s_tests_tester.py`, within the `_find_free_port` method around lines 955–960, change the `s.bind(("", 0))` call to `s.bind(("127.0.0.1", 0))`. All other logic in that method (creating the socket, calling `listen`, reading `getsockname()[1]`, and returning the port) should remain as is.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
