### PR TITLE
test: isolate distributed lock failover keys

### DIFF
--- a/pkg/cache/cache_distributed_test.go
+++ b/pkg/cache/cache_distributed_test.go
@@ -446,7 +446,7 @@ func testDistributedLockFailover(_ distributedDBFactory) func(*testing.T) {
 
 		redisCfg := redis.Config{
 			Addrs:     redisAddrs,
-			KeyPrefix: "ncps:test:failover:",
+			KeyPrefix: fmt.Sprintf("ncps:test:failover:%s:", t.Name()),
 		}
 
 		retryCfg := lock.RetryConfig{


### PR DESCRIPTION
Update KeyPrefix in TestDistributedBackends/PostgreSQL/LockFailover to include the test name. This prevents key collisions between different test runs ensuring test isolation.