### PR TITLE
fix: use int64 for the chunk index

### DIFF
--- a/db/migrations/mysql/20260131021850_add_chunks.sql
+++ b/db/migrations/mysql/20260131021850_add_chunks.sql
@@ -10,7 +10,7 @@ CREATE TABLE chunks (
 CREATE TABLE nar_file_chunks (
     nar_file_id BIGINT NOT NULL,
     chunk_id BIGINT NOT NULL,
-    chunk_index INT NOT NULL,
+    chunk_index BIGINT NOT NULL,
     PRIMARY KEY (nar_file_id, chunk_index),
     FOREIGN KEY (nar_file_id) REFERENCES nar_files (id) ON DELETE CASCADE,
     FOREIGN KEY (chunk_id) REFERENCES chunks (id) ON DELETE CASCADE

--- a/db/migrations/mysql/20260205063659_add_total_chunks_to_nar_files.sql
+++ b/db/migrations/mysql/20260205063659_add_total_chunks_to_nar_files.sql
@@ -1,5 +1,5 @@
 -- migrate:up
-ALTER TABLE nar_files ADD COLUMN total_chunks INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE nar_files ADD COLUMN total_chunks BIGINT(20) NOT NULL DEFAULT 0;
 
 -- migrate:down
 ALTER TABLE nar_files DROP COLUMN total_chunks;

--- a/db/migrations/postgres/20260131021850_add_chunks.sql
+++ b/db/migrations/postgres/20260131021850_add_chunks.sql
@@ -10,7 +10,7 @@ CREATE TABLE chunks (
 CREATE TABLE nar_file_chunks (
     nar_file_id BIGINT NOT NULL REFERENCES nar_files (id) ON DELETE CASCADE,
     chunk_id BIGINT NOT NULL REFERENCES chunks (id) ON DELETE CASCADE,
-    chunk_index INTEGER NOT NULL,
+    chunk_index BIGINT NOT NULL,
     PRIMARY KEY (nar_file_id, chunk_index)
 );
 CREATE INDEX idx_nar_file_chunks_chunk_id ON nar_file_chunks (chunk_id);

--- a/db/migrations/postgres/20260205063658_add_total_chunks_to_nar_files.sql
+++ b/db/migrations/postgres/20260205063658_add_total_chunks_to_nar_files.sql
@@ -1,5 +1,5 @@
 -- migrate:up
-ALTER TABLE nar_files ADD COLUMN total_chunks INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE nar_files ADD COLUMN total_chunks BIGINT NOT NULL DEFAULT 0;
 
 -- migrate:down
 ALTER TABLE nar_files DROP COLUMN total_chunks;

--- a/db/migrations/sqlite/20260205063651_add_total_chunks_to_nar_files.sql
+++ b/db/migrations/sqlite/20260205063651_add_total_chunks_to_nar_files.sql
@@ -1,5 +1,5 @@
 -- migrate:up
-ALTER TABLE nar_files ADD COLUMN total_chunks INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE nar_files ADD COLUMN total_chunks BIGINT NOT NULL DEFAULT 0;
 
 -- migrate:down
 ALTER TABLE nar_files DROP COLUMN total_chunks;

--- a/db/schema/mysql.sql
+++ b/db/schema/mysql.sql
@@ -59,7 +59,7 @@ CREATE TABLE `config` (
 CREATE TABLE `nar_file_chunks` (
   `nar_file_id` bigint(20) NOT NULL,
   `chunk_id` bigint(20) NOT NULL,
-  `chunk_index` int(11) NOT NULL,
+  `chunk_index` bigint(20) NOT NULL,
   PRIMARY KEY (`nar_file_id`,`chunk_index`),
   KEY `idx_nar_file_chunks_chunk_id` (`chunk_id`),
   CONSTRAINT `nar_file_chunks_ibfk_1` FOREIGN KEY (`nar_file_id`) REFERENCES `nar_files` (`id`) ON DELETE CASCADE,
@@ -82,7 +82,7 @@ CREATE TABLE `nar_files` (
   `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
   `updated_at` timestamp NULL DEFAULT NULL,
   `last_accessed_at` timestamp NULL DEFAULT current_timestamp(),
-  `total_chunks` int(11) NOT NULL DEFAULT 0,
+  `total_chunks` bigint(20) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_nar_files_hash_compression_query` (`hash`,`compression`,`query`) USING HASH,
   KEY `idx_nar_files_last_accessed_at` (`last_accessed_at`)

--- a/db/schema/postgres.sql
+++ b/db/schema/postgres.sql
@@ -86,7 +86,7 @@ ALTER SEQUENCE public.config_id_seq OWNED BY public.config.id;
 CREATE TABLE public.nar_file_chunks (
     nar_file_id bigint NOT NULL,
     chunk_id bigint NOT NULL,
-    chunk_index integer NOT NULL
+    chunk_index bigint NOT NULL
 );
 
 
@@ -103,7 +103,7 @@ CREATE TABLE public.nar_files (
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at timestamp with time zone,
     last_accessed_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
-    total_chunks integer DEFAULT 0 NOT NULL,
+    total_chunks bigint DEFAULT 0 NOT NULL,
     CONSTRAINT nar_files_file_size_check CHECK ((file_size >= 0))
 );
 

--- a/db/schema/sqlite.sql
+++ b/db/schema/sqlite.sql
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS "nar_files" (
     "query" TEXT NOT NULL DEFAULT '',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at TIMESTAMP,
-    last_accessed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, total_chunks INTEGER NOT NULL DEFAULT 0,
+    last_accessed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, total_chunks BIGINT NOT NULL DEFAULT 0,
     UNIQUE (hash, compression, "query")
 );
 CREATE INDEX idx_nar_files_last_accessed_at ON nar_files (last_accessed_at);

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1259,7 +1259,7 @@ func (c *Cache) storeNarWithCDC(ctx context.Context, tempPath string, narURL *na
 
 	var (
 		totalSize  int64
-		chunkCount int32
+		chunkCount int64
 	)
 
 	for {
@@ -4120,7 +4120,7 @@ func (c *Cache) getNarFromChunks(ctx context.Context, narURL *nar.URL) (int64, i
 	var (
 		narFileID   int64
 		totalSize   int64
-		totalChunks int32
+		totalChunks int64
 	)
 
 	err := c.withTransaction(ctx, "getNarFromChunks.init", func(qtx database.Querier) error {
@@ -4183,7 +4183,7 @@ func (c *Cache) getNarFromChunks(ctx context.Context, narURL *nar.URL) (int64, i
 
 // streamCompleteChunks streams all chunks for a NAR that has completed chunking.
 // This is the fast path where all chunks are available immediately.
-func (c *Cache) streamCompleteChunks(ctx context.Context, w io.Writer, narFileID int64, totalChunks int32) error {
+func (c *Cache) streamCompleteChunks(ctx context.Context, w io.Writer, narFileID int64, totalChunks int64) error {
 	// Get all chunks at once
 	chunkHashes := make([]string, 0, totalChunks)
 
@@ -4222,7 +4222,7 @@ func (c *Cache) streamCompleteChunks(ctx context.Context, w io.Writer, narFileID
 // streamProgressiveChunks streams chunks as they become available during an in-progress chunking operation.
 // This allows concurrent downloads while another instance is still chunking the NAR.
 func (c *Cache) streamProgressiveChunks(ctx context.Context, w io.Writer, narFileID int64) error {
-	chunkIndex := int32(0)
+	chunkIndex := int64(0)
 	pollInterval := 200 * time.Millisecond
 	maxWaitPerChunk := 30 * time.Second
 
@@ -4230,7 +4230,7 @@ func (c *Cache) streamProgressiveChunks(ctx context.Context, w io.Writer, narFil
 		// Try to get chunk at current index
 		var chunkHash string
 
-		var totalChunks int32
+		var totalChunks int64
 
 		chunkWaitStart := time.Now()
 

--- a/pkg/database/generated_models.go
+++ b/pkg/database/generated_models.go
@@ -57,7 +57,7 @@ type CreateNarFileParams struct {
 	Compression string
 	Query       string
 	FileSize    uint64
-	TotalChunks int32
+	TotalChunks int64
 }
 
 type CreateNarInfoParams struct {
@@ -82,7 +82,7 @@ type DeleteNarFileByHashParams struct {
 
 type GetChunkByNarFileIDAndIndexParams struct {
 	NarFileID  int64
-	ChunkIndex int32
+	ChunkIndex int64
 }
 
 type GetLeastUsedNarFilesRow struct {
@@ -132,7 +132,7 @@ type GetOrphanedNarFilesRow struct {
 type LinkNarFileToChunkParams struct {
 	NarFileID  int64
 	ChunkID    int64
-	ChunkIndex int32
+	ChunkIndex int64
 }
 
 type LinkNarInfoToNarFileParams struct {
@@ -149,7 +149,7 @@ type NarFile struct {
 	CreatedAt      time.Time
 	UpdatedAt      sql.NullTime
 	LastAccessedAt sql.NullTime
-	TotalChunks    int32
+	TotalChunks    int64
 }
 
 type NarInfo struct {
@@ -182,7 +182,7 @@ type TouchNarFileParams struct {
 }
 
 type UpdateNarFileTotalChunksParams struct {
-	TotalChunks int32
+	TotalChunks int64
 	ID          int64
 }
 

--- a/pkg/database/mysqldb/models.go
+++ b/pkg/database/mysqldb/models.go
@@ -34,13 +34,13 @@ type NarFile struct {
 	UpdatedAt      sql.NullTime
 	LastAccessedAt sql.NullTime
 	Query          string
-	TotalChunks    int32
+	TotalChunks    int64
 }
 
 type NarFileChunk struct {
 	NarFileID  int64
 	ChunkID    int64
-	ChunkIndex int32
+	ChunkIndex int64
 }
 
 type NarInfo struct {

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -131,7 +131,7 @@ type CreateNarFileParams struct {
 	Compression string
 	Query       string
 	FileSize    uint64
-	TotalChunks int32
+	TotalChunks int64
 }
 
 // CreateNarFile
@@ -416,7 +416,7 @@ WHERE nfc.nar_file_id = ? AND nfc.chunk_index = ?
 
 type GetChunkByNarFileIDAndIndexParams struct {
 	NarFileID  int64
-	ChunkIndex int32
+	ChunkIndex int64
 }
 
 // GetChunkByNarFileIDAndIndex
@@ -783,7 +783,7 @@ type GetNarFileByHashAndCompressionAndQueryRow struct {
 	CreatedAt      time.Time
 	UpdatedAt      sql.NullTime
 	LastAccessedAt sql.NullTime
-	TotalChunks    int32
+	TotalChunks    int64
 }
 
 // GetNarFileByHashAndCompressionAndQuery
@@ -823,7 +823,7 @@ type GetNarFileByIDRow struct {
 	CreatedAt      time.Time
 	UpdatedAt      sql.NullTime
 	LastAccessedAt sql.NullTime
-	TotalChunks    int32
+	TotalChunks    int64
 }
 
 // GetNarFileByID
@@ -1323,7 +1323,7 @@ INSERT IGNORE INTO nar_file_chunks (
 type LinkNarFileToChunkParams struct {
 	NarFileID  int64
 	ChunkID    int64
-	ChunkIndex int32
+	ChunkIndex int64
 }
 
 // LinkNarFileToChunk
@@ -1455,7 +1455,7 @@ WHERE id = ?
 `
 
 type UpdateNarFileTotalChunksParams struct {
-	TotalChunks int32
+	TotalChunks int64
 	ID          int64
 }
 

--- a/pkg/database/postgresdb/models.go
+++ b/pkg/database/postgresdb/models.go
@@ -34,13 +34,13 @@ type NarFile struct {
 	CreatedAt      time.Time
 	UpdatedAt      sql.NullTime
 	LastAccessedAt sql.NullTime
-	TotalChunks    int32
+	TotalChunks    int64
 }
 
 type NarFileChunk struct {
 	NarFileID  int64
 	ChunkID    int64
-	ChunkIndex int32
+	ChunkIndex int64
 }
 
 type NarInfo struct {

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -199,7 +199,7 @@ type CreateNarFileParams struct {
 	Compression string
 	Query       string
 	FileSize    uint64
-	TotalChunks int32
+	TotalChunks int64
 }
 
 // CreateNarFile
@@ -518,7 +518,7 @@ WHERE nfc.nar_file_id = $1 AND nfc.chunk_index = $2
 
 type GetChunkByNarFileIDAndIndexParams struct {
 	NarFileID  int64
-	ChunkIndex int32
+	ChunkIndex int64
 }
 
 // GetChunkByNarFileIDAndIndex
@@ -1402,7 +1402,7 @@ ON CONFLICT (nar_file_id, chunk_index) DO NOTHING
 type LinkNarFileToChunkParams struct {
 	NarFileID  int64
 	ChunkID    int64
-	ChunkIndex int32
+	ChunkIndex int64
 }
 
 // LinkNarFileToChunk
@@ -1537,7 +1537,7 @@ WHERE id = $2
 `
 
 type UpdateNarFileTotalChunksParams struct {
-	TotalChunks int32
+	TotalChunks int64
 	ID          int64
 }
 

--- a/pkg/database/sqlitedb/models.go
+++ b/pkg/database/sqlitedb/models.go
@@ -34,13 +34,13 @@ type NarFile struct {
 	CreatedAt      time.Time
 	UpdatedAt      sql.NullTime
 	LastAccessedAt sql.NullTime
-	TotalChunks    int32
+	TotalChunks    int64
 }
 
 type NarFileChunk struct {
 	NarFileID  int64
 	ChunkID    int64
-	ChunkIndex int32
+	ChunkIndex int64
 }
 
 type NarInfo struct {

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -151,7 +151,7 @@ type CreateNarFileParams struct {
 	Compression string
 	Query       string
 	FileSize    uint64
-	TotalChunks int32
+	TotalChunks int64
 }
 
 // CreateNarFile
@@ -470,7 +470,7 @@ WHERE nfc.nar_file_id = ? AND nfc.chunk_index = ?
 
 type GetChunkByNarFileIDAndIndexParams struct {
 	NarFileID  int64
-	ChunkIndex int32
+	ChunkIndex int64
 }
 
 // GetChunkByNarFileIDAndIndex
@@ -1354,7 +1354,7 @@ ON CONFLICT (nar_file_id, chunk_index) DO NOTHING
 type LinkNarFileToChunkParams struct {
 	NarFileID  int64
 	ChunkID    int64
-	ChunkIndex int32
+	ChunkIndex int64
 }
 
 // LinkNarFileToChunk
@@ -1489,7 +1489,7 @@ WHERE id = ?
 `
 
 type UpdateNarFileTotalChunksParams struct {
-	TotalChunks int32
+	TotalChunks int64
 	ID          int64
 }
 

--- a/sqlc.yml
+++ b/sqlc.yml
@@ -15,10 +15,6 @@ sql:
             go_type: uint64
           - column: chunks.size
             go_type: uint32
-          - column: nar_file_chunks.chunk_index
-            go_type: int32
-          - column: nar_files.total_chunks
-            go_type: int32
         rename:
           narinfo_id: NarInfoID
           url: URL
@@ -37,10 +33,6 @@ sql:
             go_type: uint64
           - column: chunks.size
             go_type: uint32
-          - column: nar_file_chunks.chunk_index
-            go_type: int32
-          - column: nar_files.total_chunks
-            go_type: int32
         rename:
           narinfo_id: NarInfoID
           url: URL
@@ -59,10 +51,6 @@ sql:
             go_type: uint64
           - column: chunks.size
             go_type: uint32
-          - column: nar_file_chunks.chunk_index
-            go_type: int32
-          - column: nar_files.total_chunks
-            go_type: int32
         rename:
           narinfo_id: NarInfoID
           url: URL


### PR DESCRIPTION
While it's not a concern for one NAR to be chunked into more chunks than
an int32 can handle, the performance and storage gain is simply not
worth the special handling I had to do in order to support int32.
Convert to int64 to keep the code simpler and the database essentially
limitless in terms of number of chunks.