### PR TITLE
feat: optimize migrate-nar-to-chunks and add safety checks

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -317,3 +317,13 @@ WHERE nfc.nar_file_id = ? AND nfc.chunk_index = ?;
 UPDATE nar_files
 SET total_chunks = ?, updated_at = CURRENT_TIMESTAMP
 WHERE id = ?;
+
+-- name: GetNarInfoHashesToChunk :many
+-- Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
+SELECT ni.hash, ni.url
+FROM narinfos ni
+LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
+WHERE ni.url IS NOT NULL
+  AND (nf.id IS NULL OR nf.total_chunks = 0)
+ORDER BY ni.hash;

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -335,3 +335,13 @@ WHERE nfc.nar_file_id = $1 AND nfc.chunk_index = $2;
 UPDATE nar_files
 SET total_chunks = $1, updated_at = CURRENT_TIMESTAMP
 WHERE id = $2;
+
+-- name: GetNarInfoHashesToChunk :many
+-- Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
+SELECT ni.hash, ni.url
+FROM narinfos ni
+LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
+WHERE ni.url IS NOT NULL
+  AND (nf.id IS NULL OR nf.total_chunks = 0)
+ORDER BY ni.hash;

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -321,3 +321,13 @@ WHERE nfc.nar_file_id = ? AND nfc.chunk_index = ?;
 UPDATE nar_files
 SET total_chunks = ?, updated_at = CURRENT_TIMESTAMP
 WHERE id = ?;
+
+-- name: GetNarInfoHashesToChunk :many
+-- Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
+SELECT ni.hash, ni.url
+FROM narinfos ni
+LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
+WHERE ni.url IS NOT NULL
+  AND (nf.id IS NULL OR nf.total_chunks = 0)
+ORDER BY ni.hash;

--- a/pkg/database/generated_models.go
+++ b/pkg/database/generated_models.go
@@ -118,6 +118,11 @@ type GetNarFileByNarInfoIDRow struct {
 	LastAccessedAt sql.NullTime
 }
 
+type GetNarInfoHashesToChunkRow struct {
+	Hash string
+	URL  sql.NullString
+}
+
 type GetOrphanedNarFilesRow struct {
 	ID             int64
 	Hash           string

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -275,6 +275,16 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url = $1
 	GetNarInfoHashesByURL(ctx context.Context, url sql.NullString) ([]string, error)
+	// Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
+	//
+	//  SELECT ni.hash, ni.url
+	//  FROM narinfos ni
+	//  LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+	//  LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
+	//  WHERE ni.url IS NOT NULL
+	//    AND (nf.id IS NULL OR nf.total_chunks = 0)
+	//  ORDER BY ni.hash
+	GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error)
 	//GetNarInfoReferences
 	//
 	//  SELECT reference

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -534,6 +534,21 @@ func (w *mysqlWrapper) GetNarInfoHashesByURL(ctx context.Context, url sql.NullSt
 	return res, nil
 }
 
+func (w *mysqlWrapper) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error) {
+	res, err := w.adapter.GetNarInfoHashesToChunk(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]GetNarInfoHashesToChunkRow, len(res))
+	for i, v := range res {
+		items[i] = GetNarInfoHashesToChunkRow(v)
+	}
+
+	return items, nil
+}
+
 func (w *mysqlWrapper) GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error) {
 	res, err := w.adapter.GetNarInfoReferences(ctx, narinfoID)
 	if err != nil {

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -512,6 +512,21 @@ func (w *postgresWrapper) GetNarInfoHashesByURL(ctx context.Context, url sql.Nul
 	return res, nil
 }
 
+func (w *postgresWrapper) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error) {
+	res, err := w.adapter.GetNarInfoHashesToChunk(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]GetNarInfoHashesToChunkRow, len(res))
+	for i, v := range res {
+		items[i] = GetNarInfoHashesToChunkRow(v)
+	}
+
+	return items, nil
+}
+
 func (w *postgresWrapper) GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error) {
 	res, err := w.adapter.GetNarInfoReferences(ctx, narinfoID)
 	if err != nil {

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -526,6 +526,21 @@ func (w *sqliteWrapper) GetNarInfoHashesByURL(ctx context.Context, url sql.NullS
 	return res, nil
 }
 
+func (w *sqliteWrapper) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error) {
+	res, err := w.adapter.GetNarInfoHashesToChunk(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]GetNarInfoHashesToChunkRow, len(res))
+	for i, v := range res {
+		items[i] = GetNarInfoHashesToChunkRow(v)
+	}
+
+	return items, nil
+}
+
 func (w *sqliteWrapper) GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error) {
 	res, err := w.adapter.GetNarInfoReferences(ctx, narinfoID)
 	if err != nil {

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -262,6 +262,16 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url = ?
 	GetNarInfoHashesByURL(ctx context.Context, url sql.NullString) ([]string, error)
+	// Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
+	//
+	//  SELECT ni.hash, ni.url
+	//  FROM narinfos ni
+	//  LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+	//  LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
+	//  WHERE ni.url IS NOT NULL
+	//    AND (nf.id IS NULL OR nf.total_chunks = 0)
+	//  ORDER BY ni.hash
+	GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error)
 	//GetNarInfoReferences
 	//
 	//  SELECT reference

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -1058,6 +1058,53 @@ func (q *Queries) GetNarInfoHashesByURL(ctx context.Context, url sql.NullString)
 	return items, nil
 }
 
+const getNarInfoHashesToChunk = `-- name: GetNarInfoHashesToChunk :many
+SELECT ni.hash, ni.url
+FROM narinfos ni
+LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
+WHERE ni.url IS NOT NULL
+  AND (nf.id IS NULL OR nf.total_chunks = 0)
+ORDER BY ni.hash
+`
+
+type GetNarInfoHashesToChunkRow struct {
+	Hash string
+	URL  sql.NullString
+}
+
+// Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
+//
+//	SELECT ni.hash, ni.url
+//	FROM narinfos ni
+//	LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+//	LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
+//	WHERE ni.url IS NOT NULL
+//	  AND (nf.id IS NULL OR nf.total_chunks = 0)
+//	ORDER BY ni.hash
+func (q *Queries) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error) {
+	rows, err := q.db.QueryContext(ctx, getNarInfoHashesToChunk)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetNarInfoHashesToChunkRow
+	for rows.Next() {
+		var i GetNarInfoHashesToChunkRow
+		if err := rows.Scan(&i.Hash, &i.URL); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getNarInfoReferences = `-- name: GetNarInfoReferences :many
 SELECT reference
 FROM narinfo_references

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -278,6 +278,16 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url = $1
 	GetNarInfoHashesByURL(ctx context.Context, url sql.NullString) ([]string, error)
+	// Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
+	//
+	//  SELECT ni.hash, ni.url
+	//  FROM narinfos ni
+	//  LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+	//  LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
+	//  WHERE ni.url IS NOT NULL
+	//    AND (nf.id IS NULL OR nf.total_chunks = 0)
+	//  ORDER BY ni.hash
+	GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error)
 	//GetNarInfoReferences
 	//
 	//  SELECT reference

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -1136,6 +1136,53 @@ func (q *Queries) GetNarInfoHashesByURL(ctx context.Context, url sql.NullString)
 	return items, nil
 }
 
+const getNarInfoHashesToChunk = `-- name: GetNarInfoHashesToChunk :many
+SELECT ni.hash, ni.url
+FROM narinfos ni
+LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
+WHERE ni.url IS NOT NULL
+  AND (nf.id IS NULL OR nf.total_chunks = 0)
+ORDER BY ni.hash
+`
+
+type GetNarInfoHashesToChunkRow struct {
+	Hash string
+	URL  sql.NullString
+}
+
+// Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
+//
+//	SELECT ni.hash, ni.url
+//	FROM narinfos ni
+//	LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+//	LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
+//	WHERE ni.url IS NOT NULL
+//	  AND (nf.id IS NULL OR nf.total_chunks = 0)
+//	ORDER BY ni.hash
+func (q *Queries) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error) {
+	rows, err := q.db.QueryContext(ctx, getNarInfoHashesToChunk)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetNarInfoHashesToChunkRow
+	for rows.Next() {
+		var i GetNarInfoHashesToChunkRow
+		if err := rows.Scan(&i.Hash, &i.URL); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getNarInfoReferences = `-- name: GetNarInfoReferences :many
 SELECT reference
 FROM narinfo_references

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -264,6 +264,16 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url = ?
 	GetNarInfoHashesByURL(ctx context.Context, url sql.NullString) ([]string, error)
+	// Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
+	//
+	//  SELECT ni.hash, ni.url
+	//  FROM narinfos ni
+	//  LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+	//  LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
+	//  WHERE ni.url IS NOT NULL
+	//    AND (nf.id IS NULL OR nf.total_chunks = 0)
+	//  ORDER BY ni.hash
+	GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error)
 	//GetNarInfoReferences
 	//
 	//  SELECT reference

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -55,6 +55,9 @@ type NarInfoStore interface {
 
 	// DeleteNarInfo deletes the narinfo from the store.
 	DeleteNarInfo(ctx context.Context, hash string) error
+
+	// WalkNarInfos walks all narinfos in the store and calls fn for each one.
+	WalkNarInfos(ctx context.Context, fn func(hash string) error) error
 }
 
 // NarStore represents a store capable of storing nars.


### PR DESCRIPTION
This change improves the performance and reliability of the migrate-nar-to-chunks command.

Key improvements:
- Updated GetNarInfoHashesToChunk database query to return the URL along with the hash, eliminating an extra database lookup per item in the migration loop.
- Added a safety check at the start of migrate-nar-to-chunks to ensure all narinfos have been migrated (using migrate-narinfo) before proceeding with NAR-to-chunks migration.
- Implemented WalkNarInfos in the NarInfoStore interface to support the new safety check.
- Refactored GetNar in the cache component to reduce nesting complexity, addressing linting recommendations.
- Updated tests to include the required migrate-narinfo step before running migrate-nar-to-chunks.
- Added a sentinel error ErrUnmigratedNarinfosFound for better error reporting.