### PR TITLE
chore: stop creating the narinfo path in the store [backport #758]

### DIFF
--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -531,7 +531,6 @@ func (s *Store) setupDirs() error {
 	allPaths := []string{
 		s.configPath(),
 		s.storePath(),
-		s.storeNarInfoPath(),
 		s.storeNarPath(),
 		s.storeTMPPath(),
 	}

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -101,7 +101,6 @@ func TestNew(t *testing.T) {
 		dirs := []string{
 			"config",
 			"store",
-			filepath.Join("store", "narinfo"),
 			filepath.Join("store", "nar"),
 			filepath.Join("store", "tmp"),
 		}


### PR DESCRIPTION
Bot-based backport to `release-0.8`, triggered by a label in #758.

The store path in the local storage for narinfo is still being created
even though it's no longer being used. Stop creating it.