### PR TITLE
fix: avoid MySQL deadlocks in migrate-nar-to-chunks tests

### DIFF
--- a/pkg/ncps/migrate_nar_to_chunks_test.go
+++ b/pkg/ncps/migrate_nar_to_chunks_test.go
@@ -177,10 +177,12 @@ func testMigrateNarToChunksDryRun(factory narToChunksMigrationFactory) func(*tes
 		require.NoError(t, err)
 
 		// Migrate NarInfo to DB first
+		// Use --concurrency=1 to avoid MySQL deadlocks when migrating multiple narinfos in parallel
 		migrateNarInfoArgs := []string{
 			"ncps", "migrate-narinfo",
 			"--cache-database-url", dbURL,
 			"--cache-storage-local", dir,
+			"--concurrency", "1",
 		}
 		require.NoError(t, app.Run(ctx, migrateNarInfoArgs))
 
@@ -229,10 +231,12 @@ func testMigrateNarToChunksIdempotency(factory narToChunksMigrationFactory) func
 		require.NoError(t, err)
 
 		// Migrate NarInfo to DB first
+		// Use --concurrency=1 to avoid MySQL deadlocks when migrating multiple narinfos in parallel
 		migrateNarInfoArgs := []string{
 			"ncps", "migrate-narinfo",
 			"--cache-database-url", dbURL,
 			"--cache-storage-local", dir,
+			"--concurrency", "1",
 		}
 		require.NoError(t, app.Run(ctx, migrateNarInfoArgs))
 
@@ -294,10 +298,12 @@ func testMigrateNarToChunksMultipleNARs(factory narToChunksMigrationFactory) fun
 		require.NoError(t, err)
 
 		// Migrate NarInfo to DB first
+		// Use --concurrency=1 to avoid MySQL deadlocks when migrating multiple narinfos in parallel
 		migrateNarInfoArgs := []string{
 			"ncps", "migrate-narinfo",
 			"--cache-database-url", dbURL,
 			"--cache-storage-local", dir,
+			"--concurrency", "1",
 		}
 		require.NoError(t, app.Run(ctx, migrateNarInfoArgs))
 


### PR DESCRIPTION
The test was failing with MySQL deadlock errors (Error 1213) when
migrating multiple narinfos concurrently. This is caused by concurrent
INSERT ... ON DUPLICATE KEY UPDATE operations on the nar_files table,
which can trigger deadlocks in InnoDB even when inserting different rows.

The fix sets --concurrency=1 for the migrate-narinfo command in tests
that process multiple NARs, forcing sequential processing and preventing
the race condition that causes deadlocks. This approach is similar to
the fix in commit 17d41233 for the CDC flaky test.

The deadlock only occurred with MySQL; SQLite and PostgreSQL tests were
unaffected.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>