### PR TITLE
fix: ensure CI job accurately reflects the status of all dependent jobs

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	os.Exit(realYaMain())
+	os.Exit(realMain())
 }
 
 func realMain() int {


### PR DESCRIPTION
The CI job was previously using a simplified check that might not have
accounted for all job statuses correctly, especially when jobs were
skipped or failed in complex ways.

This change:
- Updates the `ci` job to depend on all relevant jobs explicitly.
- Uses `if: always()` to ensure the job runs regardless of dependency outcomes.
- Uses a bash script to parse `toJSON(needs)` and explicitly check for
  any "failure" or "cancelled" results among dependencies.
- Considers "success" or "skipped" as valid passing states.