### PR TITLE
fix: fix bulk operations with multiple slices in gen-db-wrappers

### DIFF
--- a/nix/gen-db-wrappers/src/main_test.go
+++ b/nix/gen-db-wrappers/src/main_test.go
@@ -303,7 +303,7 @@ func TestWrapperTemplate(t *testing.T) {
 	output := buf.String()
 
 	// Verify auto-looping was triggered
-	if !strings.Contains(output, "for _, v := range arg.Usernames") {
+	if !strings.Contains(output, "for i, v := range arg.Usernames") {
 		t.Errorf("expected output to contain loop over arg.Usernames, but it didn't\n%s", output)
 	}
 

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -28,7 +28,8 @@ func (w *mysqlWrapper) AddNarInfoReference(ctx context.Context, arg AddNarInfoRe
 }
 
 func (w *mysqlWrapper) AddNarInfoReferences(ctx context.Context, arg AddNarInfoReferencesParams) error {
-	for _, v := range arg.Reference {
+	for i, v := range arg.Reference {
+		_ = i
 		err := w.adapter.AddNarInfoReference(ctx, mysqldb.AddNarInfoReferenceParams{
 			NarInfoID: arg.NarInfoID,
 			Reference: v,
@@ -61,7 +62,8 @@ func (w *mysqlWrapper) AddNarInfoSignature(ctx context.Context, arg AddNarInfoSi
 }
 
 func (w *mysqlWrapper) AddNarInfoSignatures(ctx context.Context, arg AddNarInfoSignaturesParams) error {
-	for _, v := range arg.Signature {
+	for i, v := range arg.Signature {
+		_ = i
 		err := w.adapter.AddNarInfoSignature(ctx, mysqldb.AddNarInfoSignatureParams{
 			NarInfoID: arg.NarInfoID,
 			Signature: v,

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -28,7 +28,8 @@ func (w *sqliteWrapper) AddNarInfoReference(ctx context.Context, arg AddNarInfoR
 }
 
 func (w *sqliteWrapper) AddNarInfoReferences(ctx context.Context, arg AddNarInfoReferencesParams) error {
-	for _, v := range arg.Reference {
+	for i, v := range arg.Reference {
+		_ = i
 		err := w.adapter.AddNarInfoReference(ctx, sqlitedb.AddNarInfoReferenceParams{
 			NarInfoID: arg.NarInfoID,
 			Reference: v,
@@ -61,7 +62,8 @@ func (w *sqliteWrapper) AddNarInfoSignature(ctx context.Context, arg AddNarInfoS
 }
 
 func (w *sqliteWrapper) AddNarInfoSignatures(ctx context.Context, arg AddNarInfoSignaturesParams) error {
-	for _, v := range arg.Signature {
+	for i, v := range arg.Signature {
+		_ = i
 		err := w.adapter.AddNarInfoSignature(ctx, sqlitedb.AddNarInfoSignatureParams{
 			NarInfoID: arg.NarInfoID,
 			Signature: v,


### PR DESCRIPTION
The bulk operation generator was failing when multiple slice parameters were present because it was using a range loop with a blank identifier for the index, which only allowed accessing the first slice's elements via the loop variable.

This change switches the loop to an indexed range loop (for i := range ...) which allows accessing elements from all slices using the same index. Additionally, it fixes a bug where scalar fields were incorrectly being mapped to the loop variable if their types happened to match, ensuring they are instead correctly mapped from the input argument.