### PR TITLE
perf: optimize chunk recording by using bulk LinkNarFileToChunks

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -287,6 +287,14 @@ INSERT IGNORE INTO nar_file_chunks (
     ?, ?, ?
 );
 
+-- @bulk-for LinkNarFileToChunk
+-- name: LinkNarFileToChunks :exec
+INSERT IGNORE INTO nar_file_chunks (
+    nar_file_id, chunk_id, chunk_index
+) VALUES (
+    ?, ?, ?
+);
+
 
 
 -- name: GetTotalChunkSize :one

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -307,6 +307,14 @@ INSERT INTO nar_file_chunks (
 )
 ON CONFLICT (nar_file_id, chunk_index) DO NOTHING;
 
+-- @bulk-for LinkNarFileToChunk
+-- name: LinkNarFileToChunks :exec
+INSERT INTO nar_file_chunks (
+    nar_file_id, chunk_id, chunk_index
+)
+SELECT $1, unnest(sqlc.arg(chunk_id)::bigint[]), unnest(sqlc.arg(chunk_index)::bigint[])
+ON CONFLICT (nar_file_id, chunk_index) DO NOTHING;
+
 
 
 -- name: GetTotalChunkSize :one

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -293,6 +293,15 @@ INSERT INTO nar_file_chunks (
 )
 ON CONFLICT (nar_file_id, chunk_index) DO NOTHING;
 
+-- @bulk-for LinkNarFileToChunk
+-- name: LinkNarFileToChunks :exec
+INSERT INTO nar_file_chunks (
+    nar_file_id, chunk_id, chunk_index
+) VALUES (
+    ?, ?, ?
+)
+ON CONFLICT (nar_file_id, chunk_index) DO NOTHING;
+
 
 
 -- name: GetTotalChunkSize :one

--- a/pkg/database/generated_models.go
+++ b/pkg/database/generated_models.go
@@ -140,6 +140,12 @@ type LinkNarFileToChunkParams struct {
 	ChunkIndex int64
 }
 
+type LinkNarFileToChunksParams struct {
+	NarFileID  int64
+	ChunkID    []int64
+	ChunkIndex []int64
+}
+
 type LinkNarInfoToNarFileParams struct {
 	NarInfoID int64
 	NarFileID int64

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -346,6 +346,14 @@ type Querier interface {
 	//  )
 	//  ON CONFLICT (nar_file_id, chunk_index) DO NOTHING
 	LinkNarFileToChunk(ctx context.Context, arg LinkNarFileToChunkParams) error
+	// @bulk-for LinkNarFileToChunk
+	//
+	//  INSERT INTO nar_file_chunks (
+	//      nar_file_id, chunk_id, chunk_index
+	//  )
+	//  SELECT $1, unnest($2::bigint[]), unnest($3::bigint[])
+	//  ON CONFLICT (nar_file_id, chunk_index) DO NOTHING
+	LinkNarFileToChunks(ctx context.Context, arg LinkNarFileToChunksParams) error
 	//LinkNarInfoToNarFile
 	//
 	//  INSERT INTO narinfo_nar_files (

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -760,6 +760,26 @@ func (w *mysqlWrapper) LinkNarFileToChunk(ctx context.Context, arg LinkNarFileTo
 	})
 }
 
+func (w *mysqlWrapper) LinkNarFileToChunks(ctx context.Context, arg LinkNarFileToChunksParams) error {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	for i, v := range arg.ChunkID {
+		_ = i
+		err := w.adapter.LinkNarFileToChunk(ctx, mysqldb.LinkNarFileToChunkParams{
+			NarFileID: arg.NarFileID,
+
+			ChunkID: v,
+
+			ChunkIndex: arg.ChunkIndex[i],
+		},
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (w *mysqlWrapper) LinkNarInfoToNarFile(ctx context.Context, arg LinkNarInfoToNarFileParams) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -738,6 +738,16 @@ func (w *postgresWrapper) LinkNarFileToChunk(ctx context.Context, arg LinkNarFil
 	})
 }
 
+func (w *postgresWrapper) LinkNarFileToChunks(ctx context.Context, arg LinkNarFileToChunksParams) error {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.LinkNarFileToChunks(ctx, postgresdb.LinkNarFileToChunksParams{
+		NarFileID:  arg.NarFileID,
+		ChunkID:    arg.ChunkID,
+		ChunkIndex: arg.ChunkIndex,
+	})
+}
+
 func (w *postgresWrapper) LinkNarInfoToNarFile(ctx context.Context, arg LinkNarInfoToNarFileParams) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -756,6 +756,26 @@ func (w *sqliteWrapper) LinkNarFileToChunk(ctx context.Context, arg LinkNarFileT
 	})
 }
 
+func (w *sqliteWrapper) LinkNarFileToChunks(ctx context.Context, arg LinkNarFileToChunksParams) error {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	for i, v := range arg.ChunkID {
+		_ = i
+		err := w.adapter.LinkNarFileToChunk(ctx, sqlitedb.LinkNarFileToChunkParams{
+			NarFileID: arg.NarFileID,
+
+			ChunkID: v,
+
+			ChunkIndex: arg.ChunkIndex[i],
+		},
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (w *sqliteWrapper) LinkNarInfoToNarFile(ctx context.Context, arg LinkNarInfoToNarFileParams) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -330,6 +330,14 @@ type Querier interface {
 	//      ?, ?, ?
 	//  )
 	LinkNarFileToChunk(ctx context.Context, arg LinkNarFileToChunkParams) error
+	// @bulk-for LinkNarFileToChunk
+	//
+	//  INSERT IGNORE INTO nar_file_chunks (
+	//      nar_file_id, chunk_id, chunk_index
+	//  ) VALUES (
+	//      ?, ?, ?
+	//  )
+	LinkNarFileToChunks(ctx context.Context, arg LinkNarFileToChunksParams) error
 	//LinkNarInfoToNarFile
 	//
 	//  INSERT INTO narinfo_nar_files (

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -1385,6 +1385,32 @@ func (q *Queries) LinkNarFileToChunk(ctx context.Context, arg LinkNarFileToChunk
 	return err
 }
 
+const linkNarFileToChunks = `-- name: LinkNarFileToChunks :exec
+INSERT IGNORE INTO nar_file_chunks (
+    nar_file_id, chunk_id, chunk_index
+) VALUES (
+    ?, ?, ?
+)
+`
+
+type LinkNarFileToChunksParams struct {
+	NarFileID  int64
+	ChunkID    int64
+	ChunkIndex int64
+}
+
+// @bulk-for LinkNarFileToChunk
+//
+//	INSERT IGNORE INTO nar_file_chunks (
+//	    nar_file_id, chunk_id, chunk_index
+//	) VALUES (
+//	    ?, ?, ?
+//	)
+func (q *Queries) LinkNarFileToChunks(ctx context.Context, arg LinkNarFileToChunksParams) error {
+	_, err := q.db.ExecContext(ctx, linkNarFileToChunks, arg.NarFileID, arg.ChunkID, arg.ChunkIndex)
+	return err
+}
+
 const linkNarInfoToNarFile = `-- name: LinkNarInfoToNarFile :exec
 INSERT INTO narinfo_nar_files (
     narinfo_id, nar_file_id

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -349,6 +349,14 @@ type Querier interface {
 	//  )
 	//  ON CONFLICT (nar_file_id, chunk_index) DO NOTHING
 	LinkNarFileToChunk(ctx context.Context, arg LinkNarFileToChunkParams) error
+	// @bulk-for LinkNarFileToChunk
+	//
+	//  INSERT INTO nar_file_chunks (
+	//      nar_file_id, chunk_id, chunk_index
+	//  )
+	//  SELECT $1, unnest($2::bigint[]), unnest($3::bigint[])
+	//  ON CONFLICT (nar_file_id, chunk_index) DO NOTHING
+	LinkNarFileToChunks(ctx context.Context, arg LinkNarFileToChunksParams) error
 	//LinkNarInfoToNarFile
 	//
 	//  INSERT INTO narinfo_nar_files (

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -335,6 +335,15 @@ type Querier interface {
 	//  )
 	//  ON CONFLICT (nar_file_id, chunk_index) DO NOTHING
 	LinkNarFileToChunk(ctx context.Context, arg LinkNarFileToChunkParams) error
+	// @bulk-for LinkNarFileToChunk
+	//
+	//  INSERT INTO nar_file_chunks (
+	//      nar_file_id, chunk_id, chunk_index
+	//  ) VALUES (
+	//      ?, ?, ?
+	//  )
+	//  ON CONFLICT (nar_file_id, chunk_index) DO NOTHING
+	LinkNarFileToChunks(ctx context.Context, arg LinkNarFileToChunksParams) error
 	//LinkNarInfoToNarFile
 	//
 	//  INSERT INTO narinfo_nar_files (

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -1421,6 +1421,34 @@ func (q *Queries) LinkNarFileToChunk(ctx context.Context, arg LinkNarFileToChunk
 	return err
 }
 
+const linkNarFileToChunks = `-- name: LinkNarFileToChunks :exec
+INSERT INTO nar_file_chunks (
+    nar_file_id, chunk_id, chunk_index
+) VALUES (
+    ?, ?, ?
+)
+ON CONFLICT (nar_file_id, chunk_index) DO NOTHING
+`
+
+type LinkNarFileToChunksParams struct {
+	NarFileID  int64
+	ChunkID    int64
+	ChunkIndex int64
+}
+
+// @bulk-for LinkNarFileToChunk
+//
+//	INSERT INTO nar_file_chunks (
+//	    nar_file_id, chunk_id, chunk_index
+//	) VALUES (
+//	    ?, ?, ?
+//	)
+//	ON CONFLICT (nar_file_id, chunk_index) DO NOTHING
+func (q *Queries) LinkNarFileToChunks(ctx context.Context, arg LinkNarFileToChunksParams) error {
+	_, err := q.db.ExecContext(ctx, linkNarFileToChunks, arg.NarFileID, arg.ChunkID, arg.ChunkIndex)
+	return err
+}
+
 const linkNarInfoToNarFile = `-- name: LinkNarInfoToNarFile :exec
 INSERT INTO narinfo_nar_files (
     narinfo_id, nar_file_id


### PR DESCRIPTION
Optimized the chunk recording process by separating the CreateChunk and LinkNarFileToChunk operations and batching the linking operation into a single bulk query. This addresses the PR feedback regarding reducing the number of queries within a transaction.

Also fixed a bug in the gen-db-wrappers tool where scalar fields were incorrectly mapped to the loop variable if their types matched, and added support for multiple slice parameters in bulk loops by using an indexed loop.