### PR TITLE
refactor: improve gen-db-wrappers code generator formatting

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -84,14 +84,14 @@ SET file_size = ?, updated_at = CURRENT_TIMESTAMP
 WHERE hash = ?;
 
 -- name: AddNarInfoReference :exec
-INSERT INTO narinfo_references (
+INSERT IGNORE INTO narinfo_references (
     narinfo_id, reference
 ) VALUES (
     ?, ?
 );
 
 -- name: AddNarInfoSignature :exec
-INSERT INTO narinfo_signatures (
+INSERT IGNORE INTO narinfo_signatures (
     narinfo_id, signature
 ) VALUES (
     ?, ?

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -91,7 +91,8 @@ INSERT INTO narinfo_references (
     narinfo_id, reference
 ) VALUES (
     $1, $2
-);
+)
+ON CONFLICT (narinfo_id, reference) DO NOTHING;
 
 -- @bulk-for AddNarInfoReference
 -- name: AddNarInfoReferences :exec
@@ -105,7 +106,8 @@ INSERT INTO narinfo_signatures (
     narinfo_id, signature
 ) VALUES (
     $1, $2
-);
+)
+ON CONFLICT (narinfo_id, signature) DO NOTHING;
 
 -- @bulk-for AddNarInfoSignature
 -- name: AddNarInfoSignatures :exec

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -91,14 +91,16 @@ INSERT INTO narinfo_references (
     narinfo_id, reference
 ) VALUES (
     ?, ?
-);
+)
+ON CONFLICT (narinfo_id, reference) DO NOTHING;
 
 -- name: AddNarInfoSignature :exec
 INSERT INTO narinfo_signatures (
     narinfo_id, signature
 ) VALUES (
     ?, ?
-);
+)
+ON CONFLICT (narinfo_id, signature) DO NOTHING;
 
 -- name: GetNarInfoReferences :many
 SELECT reference

--- a/nix/gen-db-wrappers/flake-module.nix
+++ b/nix/gen-db-wrappers/flake-module.nix
@@ -6,7 +6,7 @@
         name = "gen-db-wrappers";
         src = ./src;
 
-        vendorHash = "sha256-EsZuN5MPT1bTImjkcyNd5sxy7srSS0JlDJiGGfpEhtM=";
+        vendorHash = "sha256-dWDZ7LJq5y9c34Pi/PluiIQ363a5Ph0bcLq7jv+7Pbc=";
 
         meta = {
           description = "Generate database wrappers based on the Querier interface";

--- a/nix/gen-db-wrappers/src/go.mod
+++ b/nix/gen-db-wrappers/src/go.mod
@@ -2,4 +2,12 @@ module gen-db-wrappers
 
 go 1.25.5
 
-require github.com/jinzhu/inflection v1.0.0
+require (
+	github.com/jinzhu/inflection v1.0.0
+	mvdan.cc/gofumpt v0.9.2
+)
+
+require (
+	github.com/google/go-cmp v0.7.0 // indirect
+	golang.org/x/tools v0.38.0 // indirect
+)

--- a/nix/gen-db-wrappers/src/go.sum
+++ b/nix/gen-db-wrappers/src/go.sum
@@ -1,2 +1,16 @@
+github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
+github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
+github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+golang.org/x/tools v0.38.0 h1:Hx2Xv8hISq8Lm16jvBZ2VQf+RLmbd7wVUsALibYI/IQ=
+golang.org/x/tools v0.38.0/go.mod h1:yEsQ/d/YK8cjh0L6rZlY8tgtlKiBNTL14pGDJPJpYQs=
+mvdan.cc/gofumpt v0.9.2 h1:zsEMWL8SVKGHNztrx6uZrXdp7AX8r421Vvp23sz7ik4=
+mvdan.cc/gofumpt v0.9.2/go.mod h1:iB7Hn+ai8lPvofHd9ZFGVg2GOr8sBUw1QUWjNbmIL/s=

--- a/nix/gen-db-wrappers/src/main_test.go
+++ b/nix/gen-db-wrappers/src/main_test.go
@@ -282,6 +282,13 @@ func TestWrapperTemplate(t *testing.T) {
 			return joinParamsCall(params, engPkg, targetMethod, structs, structs)
 		},
 		"hasSuffix": strings.HasSuffix,
+		"zeroReturn": func(m MethodInfo) string {
+			// simplified for test
+			if m.ReturnsSelf {
+				return "nil"
+			}
+			return "0"
+		},
 	}
 
 	tmpl, err := template.New("wrapper").Funcs(funcMap).Parse(wrapperTemplate)
@@ -359,10 +366,10 @@ func TestWrapperTemplate(t *testing.T) {
 	}
 
 	output = buf.String()
-	if !strings.Contains(output, "return nil, ErrNotFound") {
-		t.Errorf("expected output to contain 'return nil, ErrNotFound' for WithTx, but it didn't\n%s", output)
+	if !strings.Contains(output, "nil, ErrNotFound") {
+		t.Errorf("expected output to contain 'nil, ErrNotFound' for WithTx, but it didn't\n%s", output)
 	}
-	if !strings.Contains(output, "return nil, err") {
-		t.Errorf("expected output to contain 'return nil, err' for WithTx, but it didn't\n%s", output)
+	if !strings.Contains(output, "nil, err") {
+		t.Errorf("expected output to contain 'nil, err' for WithTx, but it didn't\n%s", output)
 	}
 }

--- a/pkg/database/contract_test.go
+++ b/pkg/database/contract_test.go
@@ -982,4 +982,352 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			assert.Equal(t, value2, conf.Value)
 		})
 	})
+
+	t.Run("AddNarInfoReference", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("successful insertion", func(t *testing.T) {
+			t.Parallel()
+
+			db := factory(t)
+
+			hash, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			ni, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
+			require.NoError(t, err)
+
+			reference, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			err = db.AddNarInfoReference(context.Background(), database.AddNarInfoReferenceParams{
+				NarInfoID: ni.ID,
+				Reference: reference,
+			})
+			require.NoError(t, err)
+
+			refs, err := db.GetNarInfoReferences(context.Background(), ni.ID)
+			require.NoError(t, err)
+
+			if assert.Len(t, refs, 1) {
+				assert.Equal(t, reference, refs[0])
+			}
+		})
+
+		t.Run("duplicate reference is idempotent", func(t *testing.T) {
+			t.Parallel()
+
+			db := factory(t)
+
+			hash, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			ni, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
+			require.NoError(t, err)
+
+			reference, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			// Insert first time
+			err = db.AddNarInfoReference(context.Background(), database.AddNarInfoReferenceParams{
+				NarInfoID: ni.ID,
+				Reference: reference,
+			})
+			require.NoError(t, err)
+
+			// Insert duplicate - should not error
+			err = db.AddNarInfoReference(context.Background(), database.AddNarInfoReferenceParams{
+				NarInfoID: ni.ID,
+				Reference: reference,
+			})
+			require.NoError(t, err, "duplicate reference insertion should be idempotent")
+
+			// Verify only one reference exists
+			refs, err := db.GetNarInfoReferences(context.Background(), ni.ID)
+			require.NoError(t, err)
+
+			if assert.Len(t, refs, 1) {
+				assert.Equal(t, reference, refs[0])
+			}
+		})
+	})
+
+	t.Run("AddNarInfoReferences", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("successful bulk insertion", func(t *testing.T) {
+			t.Parallel()
+
+			db := factory(t)
+
+			hash, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			ni, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
+			require.NoError(t, err)
+
+			references := make([]string, 3)
+			for i := range references {
+				ref, err := helper.RandString(32, nil)
+				require.NoError(t, err)
+
+				references[i] = ref
+			}
+
+			err = db.AddNarInfoReferences(context.Background(), database.AddNarInfoReferencesParams{
+				NarInfoID: ni.ID,
+				Reference: references,
+			})
+			require.NoError(t, err)
+
+			refs, err := db.GetNarInfoReferences(context.Background(), ni.ID)
+			require.NoError(t, err)
+
+			assert.Len(t, refs, 3)
+		})
+
+		t.Run("duplicate references in same batch are idempotent", func(t *testing.T) {
+			t.Parallel()
+
+			db := factory(t)
+
+			hash, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			ni, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
+			require.NoError(t, err)
+
+			reference, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			// Insert same reference multiple times in one batch
+			references := []string{reference, reference, reference}
+
+			err = db.AddNarInfoReferences(context.Background(), database.AddNarInfoReferencesParams{
+				NarInfoID: ni.ID,
+				Reference: references,
+			})
+			require.NoError(t, err, "duplicate references in batch should be idempotent")
+
+			// Verify only one reference exists
+			refs, err := db.GetNarInfoReferences(context.Background(), ni.ID)
+			require.NoError(t, err)
+
+			if assert.Len(t, refs, 1) {
+				assert.Equal(t, reference, refs[0])
+			}
+		})
+
+		t.Run("duplicate references across batches are idempotent", func(t *testing.T) {
+			t.Parallel()
+
+			db := factory(t)
+
+			hash, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			ni, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
+			require.NoError(t, err)
+
+			ref1, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			ref2, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			// First batch
+			err = db.AddNarInfoReferences(context.Background(), database.AddNarInfoReferencesParams{
+				NarInfoID: ni.ID,
+				Reference: []string{ref1, ref2},
+			})
+			require.NoError(t, err)
+
+			// Second batch with duplicates
+			err = db.AddNarInfoReferences(context.Background(), database.AddNarInfoReferencesParams{
+				NarInfoID: ni.ID,
+				Reference: []string{ref1, ref2},
+			})
+			require.NoError(t, err, "duplicate references across batches should be idempotent")
+
+			// Verify only two unique references exist
+			refs, err := db.GetNarInfoReferences(context.Background(), ni.ID)
+			require.NoError(t, err)
+
+			assert.Len(t, refs, 2)
+		})
+	})
+
+	t.Run("AddNarInfoSignature", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("successful insertion", func(t *testing.T) {
+			t.Parallel()
+
+			db := factory(t)
+
+			hash, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			ni, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
+			require.NoError(t, err)
+
+			signature, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			err = db.AddNarInfoSignature(context.Background(), database.AddNarInfoSignatureParams{
+				NarInfoID: ni.ID,
+				Signature: signature,
+			})
+			require.NoError(t, err)
+
+			sigs, err := db.GetNarInfoSignatures(context.Background(), ni.ID)
+			require.NoError(t, err)
+
+			if assert.Len(t, sigs, 1) {
+				assert.Equal(t, signature, sigs[0])
+			}
+		})
+
+		t.Run("duplicate signature is idempotent", func(t *testing.T) {
+			t.Parallel()
+
+			db := factory(t)
+
+			hash, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			ni, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
+			require.NoError(t, err)
+
+			signature, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			// Insert first time
+			err = db.AddNarInfoSignature(context.Background(), database.AddNarInfoSignatureParams{
+				NarInfoID: ni.ID,
+				Signature: signature,
+			})
+			require.NoError(t, err)
+
+			// Insert duplicate - should not error
+			err = db.AddNarInfoSignature(context.Background(), database.AddNarInfoSignatureParams{
+				NarInfoID: ni.ID,
+				Signature: signature,
+			})
+			require.NoError(t, err, "duplicate signature insertion should be idempotent")
+
+			// Verify only one signature exists
+			sigs, err := db.GetNarInfoSignatures(context.Background(), ni.ID)
+			require.NoError(t, err)
+
+			if assert.Len(t, sigs, 1) {
+				assert.Equal(t, signature, sigs[0])
+			}
+		})
+	})
+
+	t.Run("AddNarInfoSignatures", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("successful bulk insertion", func(t *testing.T) {
+			t.Parallel()
+
+			db := factory(t)
+
+			hash, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			ni, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
+			require.NoError(t, err)
+
+			signatures := make([]string, 3)
+			for i := range signatures {
+				sig, err := helper.RandString(32, nil)
+				require.NoError(t, err)
+
+				signatures[i] = sig
+			}
+
+			err = db.AddNarInfoSignatures(context.Background(), database.AddNarInfoSignaturesParams{
+				NarInfoID: ni.ID,
+				Signature: signatures,
+			})
+			require.NoError(t, err)
+
+			sigs, err := db.GetNarInfoSignatures(context.Background(), ni.ID)
+			require.NoError(t, err)
+
+			assert.Len(t, sigs, 3)
+		})
+
+		t.Run("duplicate signatures in same batch are idempotent", func(t *testing.T) {
+			t.Parallel()
+
+			db := factory(t)
+
+			hash, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			ni, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
+			require.NoError(t, err)
+
+			signature, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			// Insert same signature multiple times in one batch
+			signatures := []string{signature, signature, signature}
+
+			err = db.AddNarInfoSignatures(context.Background(), database.AddNarInfoSignaturesParams{
+				NarInfoID: ni.ID,
+				Signature: signatures,
+			})
+			require.NoError(t, err, "duplicate signatures in batch should be idempotent")
+
+			// Verify only one signature exists
+			sigs, err := db.GetNarInfoSignatures(context.Background(), ni.ID)
+			require.NoError(t, err)
+
+			if assert.Len(t, sigs, 1) {
+				assert.Equal(t, signature, sigs[0])
+			}
+		})
+
+		t.Run("duplicate signatures across batches are idempotent", func(t *testing.T) {
+			t.Parallel()
+
+			db := factory(t)
+
+			hash, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			ni, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
+			require.NoError(t, err)
+
+			sig1, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			sig2, err := helper.RandString(32, nil)
+			require.NoError(t, err)
+
+			// First batch
+			err = db.AddNarInfoSignatures(context.Background(), database.AddNarInfoSignaturesParams{
+				NarInfoID: ni.ID,
+				Signature: []string{sig1, sig2},
+			})
+			require.NoError(t, err)
+
+			// Second batch with duplicates
+			err = db.AddNarInfoSignatures(context.Background(), database.AddNarInfoSignaturesParams{
+				NarInfoID: ni.ID,
+				Signature: []string{sig1, sig2},
+			})
+			require.NoError(t, err, "duplicate signatures across batches should be idempotent")
+
+			// Verify only two unique signatures exist
+			sigs, err := db.GetNarInfoSignatures(context.Background(), ni.ID)
+			require.NoError(t, err)
+
+			assert.Len(t, sigs, 2)
+		})
+	})
 }

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -14,6 +14,7 @@ type Querier interface {
 	//  ) VALUES (
 	//      $1, $2
 	//  )
+	//  ON CONFLICT (narinfo_id, reference) DO NOTHING
 	AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error
 	// @bulk-for AddNarInfoReference
 	//
@@ -29,6 +30,7 @@ type Querier interface {
 	//  ) VALUES (
 	//      $1, $2
 	//  )
+	//  ON CONFLICT (narinfo_id, signature) DO NOTHING
 	AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error
 	// @bulk-for AddNarInfoSignature
 	//

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -15,33 +15,26 @@ type mysqlWrapper struct {
 }
 
 func (w *mysqlWrapper) AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error {
-	err := w.adapter.AddNarInfoReference(ctx, mysqldb.AddNarInfoReferenceParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.AddNarInfoReference(ctx, mysqldb.AddNarInfoReferenceParams{
 		NarInfoID: arg.NarInfoID,
 		Reference: arg.Reference,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *mysqlWrapper) AddNarInfoReferences(ctx context.Context, arg AddNarInfoReferencesParams) error {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	for i, v := range arg.Reference {
 		_ = i
 		err := w.adapter.AddNarInfoReference(ctx, mysqldb.AddNarInfoReferenceParams{
 			NarInfoID: arg.NarInfoID,
+
 			Reference: v,
 		},
 		)
 		if err != nil {
-			if IsDuplicateKeyError(err) {
-				continue
-			}
-			if errors.Is(err, sql.ErrNoRows) {
-				return ErrNotFound
-			}
 			return err
 		}
 	}
@@ -49,33 +42,26 @@ func (w *mysqlWrapper) AddNarInfoReferences(ctx context.Context, arg AddNarInfoR
 }
 
 func (w *mysqlWrapper) AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error {
-	err := w.adapter.AddNarInfoSignature(ctx, mysqldb.AddNarInfoSignatureParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.AddNarInfoSignature(ctx, mysqldb.AddNarInfoSignatureParams{
 		NarInfoID: arg.NarInfoID,
 		Signature: arg.Signature,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *mysqlWrapper) AddNarInfoSignatures(ctx context.Context, arg AddNarInfoSignaturesParams) error {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	for i, v := range arg.Signature {
 		_ = i
 		err := w.adapter.AddNarInfoSignature(ctx, mysqldb.AddNarInfoSignatureParams{
 			NarInfoID: arg.NarInfoID,
+
 			Signature: v,
 		},
 		)
 		if err != nil {
-			if IsDuplicateKeyError(err) {
-				continue
-			}
-			if errors.Is(err, sql.ErrNoRows) {
-				return ErrNotFound
-			}
 			return err
 		}
 	}
@@ -83,6 +69,8 @@ func (w *mysqlWrapper) AddNarInfoSignatures(ctx context.Context, arg AddNarInfoS
 }
 
 func (w *mysqlWrapper) CreateChunk(ctx context.Context, arg CreateChunkParams) (Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	// MySQL does not support RETURNING for INSERTs.
 	// We insert, get LastInsertId, and then fetch the object.
 	res, err := w.adapter.CreateChunk(ctx, mysqldb.CreateChunkParams{
@@ -102,6 +90,8 @@ func (w *mysqlWrapper) CreateChunk(ctx context.Context, arg CreateChunkParams) (
 }
 
 func (w *mysqlWrapper) CreateConfig(ctx context.Context, arg CreateConfigParams) (Config, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	// MySQL does not support RETURNING for INSERTs.
 	// We insert, get LastInsertId, and then fetch the object.
 	res, err := w.adapter.CreateConfig(ctx, mysqldb.CreateConfigParams{
@@ -121,6 +111,8 @@ func (w *mysqlWrapper) CreateConfig(ctx context.Context, arg CreateConfigParams)
 }
 
 func (w *mysqlWrapper) CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	// MySQL does not support RETURNING for INSERTs.
 	// We insert, get LastInsertId, and then fetch the object.
 	res, err := w.adapter.CreateNarFile(ctx, mysqldb.CreateNarFileParams{
@@ -143,6 +135,8 @@ func (w *mysqlWrapper) CreateNarFile(ctx context.Context, arg CreateNarFileParam
 }
 
 func (w *mysqlWrapper) CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	// MySQL does not support RETURNING for INSERTs.
 	// We insert, get LastInsertId, and then fetch the object.
 	res, err := w.adapter.CreateNarInfo(ctx, mysqldb.CreateNarInfoParams{
@@ -171,156 +165,198 @@ func (w *mysqlWrapper) CreateNarInfo(ctx context.Context, arg CreateNarInfoParam
 }
 
 func (w *mysqlWrapper) DeleteChunkByID(ctx context.Context, id int64) error {
-	err := w.adapter.DeleteChunkByID(ctx, id)
-	if err != nil {
-		return err
-	}
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	// No return value (void)
-	return nil
+	return w.adapter.DeleteChunkByID(ctx, id)
 }
 
 func (w *mysqlWrapper) DeleteNarFileByHash(ctx context.Context, arg DeleteNarFileByHashParams) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteNarFileByHash(ctx, mysqldb.DeleteNarFileByHashParams{
 		Hash:        arg.Hash,
 		Compression: arg.Compression,
 		Query:       arg.Query,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *mysqlWrapper) DeleteNarFileByID(ctx context.Context, id int64) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteNarFileByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *mysqlWrapper) DeleteNarInfoByHash(ctx context.Context, hash string) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteNarInfoByHash(ctx, hash)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *mysqlWrapper) DeleteNarInfoByID(ctx context.Context, id int64) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteNarInfoByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *mysqlWrapper) DeleteOrphanedNarFiles(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteOrphanedNarFiles(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *mysqlWrapper) DeleteOrphanedNarInfos(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteOrphanedNarInfos(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *mysqlWrapper) GetChunkByHash(ctx context.Context, hash string) (Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetChunkByHash(ctx, hash)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Chunk{}, ErrNotFound
 		}
+
 		return Chunk{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Chunk(res), nil
 }
 
 func (w *mysqlWrapper) GetChunkByID(ctx context.Context, id int64) (Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetChunkByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Chunk{}, ErrNotFound
 		}
+
 		return Chunk{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Chunk(res), nil
 }
 
 func (w *mysqlWrapper) GetChunkByNarFileIDAndIndex(ctx context.Context, arg GetChunkByNarFileIDAndIndexParams) (Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetChunkByNarFileIDAndIndex(ctx, mysqldb.GetChunkByNarFileIDAndIndexParams{
 		NarFileID:  arg.NarFileID,
 		ChunkIndex: arg.ChunkIndex,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Chunk{}, ErrNotFound
 		}
+
 		return Chunk{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Chunk(res), nil
 }
 
 func (w *mysqlWrapper) GetChunkCount(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetChunkCount(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *mysqlWrapper) GetChunksByNarFileID(ctx context.Context, narFileID int64) ([]Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetChunksByNarFileID(ctx, narFileID)
 	if err != nil {
 		return nil, err
@@ -331,39 +367,46 @@ func (w *mysqlWrapper) GetChunksByNarFileID(ctx context.Context, narFileID int64
 	for i, v := range res {
 		items[i] = Chunk(v)
 	}
-
 	return items, nil
 }
 
 func (w *mysqlWrapper) GetConfigByID(ctx context.Context, id int64) (Config, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetConfigByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Config{}, ErrNotFound
 		}
+
 		return Config{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Config(res), nil
 }
 
 func (w *mysqlWrapper) GetConfigByKey(ctx context.Context, key string) (Config, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetConfigByKey(ctx, key)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Config{}, ErrNotFound
 		}
+
 		return Config{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Config(res), nil
 }
 
 func (w *mysqlWrapper) GetLeastUsedNarFiles(ctx context.Context, fileSize uint64) ([]GetLeastUsedNarFilesRow, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetLeastUsedNarFiles(ctx, fileSize)
 	if err != nil {
 		return nil, err
@@ -374,11 +417,12 @@ func (w *mysqlWrapper) GetLeastUsedNarFiles(ctx context.Context, fileSize uint64
 	for i, v := range res {
 		items[i] = GetLeastUsedNarFilesRow(v)
 	}
-
 	return items, nil
 }
 
 func (w *mysqlWrapper) GetLeastUsedNarInfos(ctx context.Context, fileSize uint64) ([]NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetLeastUsedNarInfos(ctx, fileSize)
 	if err != nil {
 		return nil, err
@@ -389,11 +433,12 @@ func (w *mysqlWrapper) GetLeastUsedNarInfos(ctx context.Context, fileSize uint64
 	for i, v := range res {
 		items[i] = NarInfo(v)
 	}
-
 	return items, nil
 }
 
 func (w *mysqlWrapper) GetMigratedNarInfoHashes(ctx context.Context) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetMigratedNarInfoHashes(ctx)
 	if err != nil {
 		return nil, err
@@ -404,6 +449,8 @@ func (w *mysqlWrapper) GetMigratedNarInfoHashes(ctx context.Context) ([]string, 
 }
 
 func (w *mysqlWrapper) GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetMigratedNarInfoHashesPaginated(ctx, mysqldb.GetMigratedNarInfoHashesPaginatedParams{
 		Limit:  arg.Limit,
 		Offset: arg.Offset,
@@ -417,106 +464,133 @@ func (w *mysqlWrapper) GetMigratedNarInfoHashesPaginated(ctx context.Context, ar
 }
 
 func (w *mysqlWrapper) GetNarFileByHashAndCompressionAndQuery(ctx context.Context, arg GetNarFileByHashAndCompressionAndQueryParams) (NarFile, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarFileByHashAndCompressionAndQuery(ctx, mysqldb.GetNarFileByHashAndCompressionAndQueryParams{
 		Hash:        arg.Hash,
 		Compression: arg.Compression,
 		Query:       arg.Query,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarFile{}, ErrNotFound
 		}
+
 		return NarFile{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarFile(res), nil
 }
 
 func (w *mysqlWrapper) GetNarFileByID(ctx context.Context, id int64) (NarFile, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarFileByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarFile{}, ErrNotFound
 		}
+
 		return NarFile{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarFile(res), nil
 }
 
 func (w *mysqlWrapper) GetNarFileByNarInfoID(ctx context.Context, narinfoID int64) (GetNarFileByNarInfoIDRow, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarFileByNarInfoID(ctx, narinfoID)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return GetNarFileByNarInfoIDRow{}, ErrNotFound
 		}
+
 		return GetNarFileByNarInfoIDRow{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return GetNarFileByNarInfoIDRow(res), nil
 }
 
 func (w *mysqlWrapper) GetNarFileCount(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarFileCount(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *mysqlWrapper) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoByHash(ctx, hash)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarInfo{}, ErrNotFound
 		}
+
 		return NarInfo{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarInfo(res), nil
 }
 
 func (w *mysqlWrapper) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarInfo{}, ErrNotFound
 		}
+
 		return NarInfo{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarInfo(res), nil
 }
 
 func (w *mysqlWrapper) GetNarInfoCount(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoCount(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *mysqlWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoHashesByNarFileID(ctx, narFileID)
 	if err != nil {
 		return nil, err
@@ -527,6 +601,8 @@ func (w *mysqlWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileI
 }
 
 func (w *mysqlWrapper) GetNarInfoHashesByURL(ctx context.Context, url sql.NullString) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoHashesByURL(ctx, url)
 	if err != nil {
 		return nil, err
@@ -537,6 +613,8 @@ func (w *mysqlWrapper) GetNarInfoHashesByURL(ctx context.Context, url sql.NullSt
 }
 
 func (w *mysqlWrapper) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoHashesToChunk(ctx)
 	if err != nil {
 		return nil, err
@@ -547,11 +625,12 @@ func (w *mysqlWrapper) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInf
 	for i, v := range res {
 		items[i] = GetNarInfoHashesToChunkRow(v)
 	}
-
 	return items, nil
 }
 
 func (w *mysqlWrapper) GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoReferences(ctx, narinfoID)
 	if err != nil {
 		return nil, err
@@ -562,6 +641,8 @@ func (w *mysqlWrapper) GetNarInfoReferences(ctx context.Context, narinfoID int64
 }
 
 func (w *mysqlWrapper) GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoSignatures(ctx, narinfoID)
 	if err != nil {
 		return nil, err
@@ -572,19 +653,26 @@ func (w *mysqlWrapper) GetNarInfoSignatures(ctx context.Context, narinfoID int64
 }
 
 func (w *mysqlWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarTotalSize(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *mysqlWrapper) GetOrphanedChunks(ctx context.Context) ([]Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetOrphanedChunks(ctx)
 	if err != nil {
 		return nil, err
@@ -595,11 +683,12 @@ func (w *mysqlWrapper) GetOrphanedChunks(ctx context.Context) ([]Chunk, error) {
 	for i, v := range res {
 		items[i] = Chunk(v)
 	}
-
 	return items, nil
 }
 
 func (w *mysqlWrapper) GetOrphanedNarFiles(ctx context.Context) ([]GetOrphanedNarFilesRow, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetOrphanedNarFiles(ctx)
 	if err != nil {
 		return nil, err
@@ -610,24 +699,30 @@ func (w *mysqlWrapper) GetOrphanedNarFiles(ctx context.Context) ([]GetOrphanedNa
 	for i, v := range res {
 		items[i] = GetOrphanedNarFilesRow(v)
 	}
-
 	return items, nil
 }
 
 func (w *mysqlWrapper) GetTotalChunkSize(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetTotalChunkSize(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *mysqlWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetUnmigratedNarInfoHashes(ctx)
 	if err != nil {
 		return nil, err
@@ -638,112 +733,107 @@ func (w *mysqlWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string
 }
 
 func (w *mysqlWrapper) IsNarInfoMigrated(ctx context.Context, hash string) (bool, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.IsNarInfoMigrated(ctx, hash)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, ErrNotFound
 		}
+
 		return false, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *mysqlWrapper) LinkNarFileToChunk(ctx context.Context, arg LinkNarFileToChunkParams) error {
-	err := w.adapter.LinkNarFileToChunk(ctx, mysqldb.LinkNarFileToChunkParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.LinkNarFileToChunk(ctx, mysqldb.LinkNarFileToChunkParams{
 		NarFileID:  arg.NarFileID,
 		ChunkID:    arg.ChunkID,
 		ChunkIndex: arg.ChunkIndex,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *mysqlWrapper) LinkNarInfoToNarFile(ctx context.Context, arg LinkNarInfoToNarFileParams) error {
-	err := w.adapter.LinkNarInfoToNarFile(ctx, mysqldb.LinkNarInfoToNarFileParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.LinkNarInfoToNarFile(ctx, mysqldb.LinkNarInfoToNarFileParams{
 		NarInfoID: arg.NarInfoID,
 		NarFileID: arg.NarFileID,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *mysqlWrapper) SetConfig(ctx context.Context, arg SetConfigParams) error {
-	err := w.adapter.SetConfig(ctx, mysqldb.SetConfigParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.SetConfig(ctx, mysqldb.SetConfigParams{
 		Key:   arg.Key,
 		Value: arg.Value,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *mysqlWrapper) TouchNarFile(ctx context.Context, arg TouchNarFileParams) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.TouchNarFile(ctx, mysqldb.TouchNarFileParams{
 		Hash:        arg.Hash,
 		Compression: arg.Compression,
 		Query:       arg.Query,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *mysqlWrapper) TouchNarInfo(ctx context.Context, hash string) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.TouchNarInfo(ctx, hash)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *mysqlWrapper) UpdateNarFileTotalChunks(ctx context.Context, arg UpdateNarFileTotalChunksParams) error {
-	err := w.adapter.UpdateNarFileTotalChunks(ctx, mysqldb.UpdateNarFileTotalChunksParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.UpdateNarFileTotalChunks(ctx, mysqldb.UpdateNarFileTotalChunksParams{
 		TotalChunks: arg.TotalChunks,
 		ID:          arg.ID,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *mysqlWrapper) UpdateNarInfoFileSize(ctx context.Context, arg UpdateNarInfoFileSizeParams) error {
-	err := w.adapter.UpdateNarInfoFileSize(ctx, mysqldb.UpdateNarInfoFileSizeParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.UpdateNarInfoFileSize(ctx, mysqldb.UpdateNarInfoFileSizeParams{
 		FileSize: arg.FileSize,
 		Hash:     arg.Hash,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *mysqlWrapper) WithTx(tx *sql.Tx) Querier {

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -15,92 +15,84 @@ type postgresWrapper struct {
 }
 
 func (w *postgresWrapper) AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error {
-	err := w.adapter.AddNarInfoReference(ctx, postgresdb.AddNarInfoReferenceParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.AddNarInfoReference(ctx, postgresdb.AddNarInfoReferenceParams{
 		NarInfoID: arg.NarInfoID,
 		Reference: arg.Reference,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *postgresWrapper) AddNarInfoReferences(ctx context.Context, arg AddNarInfoReferencesParams) error {
-	err := w.adapter.AddNarInfoReferences(ctx, postgresdb.AddNarInfoReferencesParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.AddNarInfoReferences(ctx, postgresdb.AddNarInfoReferencesParams{
 		NarInfoID: arg.NarInfoID,
 		Reference: arg.Reference,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *postgresWrapper) AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error {
-	err := w.adapter.AddNarInfoSignature(ctx, postgresdb.AddNarInfoSignatureParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.AddNarInfoSignature(ctx, postgresdb.AddNarInfoSignatureParams{
 		NarInfoID: arg.NarInfoID,
 		Signature: arg.Signature,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *postgresWrapper) AddNarInfoSignatures(ctx context.Context, arg AddNarInfoSignaturesParams) error {
-	err := w.adapter.AddNarInfoSignatures(ctx, postgresdb.AddNarInfoSignaturesParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.AddNarInfoSignatures(ctx, postgresdb.AddNarInfoSignaturesParams{
 		NarInfoID: arg.NarInfoID,
 		Signature: arg.Signature,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *postgresWrapper) CreateChunk(ctx context.Context, arg CreateChunkParams) (Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.CreateChunk(ctx, postgresdb.CreateChunkParams{
 		Hash: arg.Hash,
 		Size: arg.Size,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Chunk{}, ErrNotFound
 		}
+
 		return Chunk{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Chunk(res), nil
 }
 
 func (w *postgresWrapper) CreateConfig(ctx context.Context, arg CreateConfigParams) (Config, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.CreateConfig(ctx, postgresdb.CreateConfigParams{
 		Key:   arg.Key,
 		Value: arg.Value,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Config{}, ErrNotFound
 		}
+
 		return Config{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Config(res), nil
 }
 
 func (w *postgresWrapper) CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.CreateNarFile(ctx, postgresdb.CreateNarFileParams{
 		Hash:        arg.Hash,
 		Compression: arg.Compression,
@@ -109,18 +101,21 @@ func (w *postgresWrapper) CreateNarFile(ctx context.Context, arg CreateNarFilePa
 		TotalChunks: arg.TotalChunks,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarFile{}, ErrNotFound
 		}
+
 		return NarFile{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarFile(res), nil
 }
 
 func (w *postgresWrapper) CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.CreateNarInfo(ctx, postgresdb.CreateNarInfoParams{
 		Hash:        arg.Hash,
 		StorePath:   arg.StorePath,
@@ -135,168 +130,211 @@ func (w *postgresWrapper) CreateNarInfo(ctx context.Context, arg CreateNarInfoPa
 		Ca:          arg.Ca,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarInfo{}, ErrNotFound
 		}
+
 		return NarInfo{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarInfo(res), nil
 }
 
 func (w *postgresWrapper) DeleteChunkByID(ctx context.Context, id int64) error {
-	err := w.adapter.DeleteChunkByID(ctx, id)
-	if err != nil {
-		return err
-	}
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	// No return value (void)
-	return nil
+	return w.adapter.DeleteChunkByID(ctx, id)
 }
 
 func (w *postgresWrapper) DeleteNarFileByHash(ctx context.Context, arg DeleteNarFileByHashParams) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteNarFileByHash(ctx, postgresdb.DeleteNarFileByHashParams{
 		Hash:        arg.Hash,
 		Compression: arg.Compression,
 		Query:       arg.Query,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *postgresWrapper) DeleteNarFileByID(ctx context.Context, id int64) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteNarFileByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *postgresWrapper) DeleteNarInfoByHash(ctx context.Context, hash string) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteNarInfoByHash(ctx, hash)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *postgresWrapper) DeleteNarInfoByID(ctx context.Context, id int64) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteNarInfoByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *postgresWrapper) DeleteOrphanedNarFiles(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteOrphanedNarFiles(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *postgresWrapper) DeleteOrphanedNarInfos(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteOrphanedNarInfos(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *postgresWrapper) GetChunkByHash(ctx context.Context, hash string) (Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetChunkByHash(ctx, hash)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Chunk{}, ErrNotFound
 		}
+
 		return Chunk{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Chunk(res), nil
 }
 
 func (w *postgresWrapper) GetChunkByID(ctx context.Context, id int64) (Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetChunkByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Chunk{}, ErrNotFound
 		}
+
 		return Chunk{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Chunk(res), nil
 }
 
 func (w *postgresWrapper) GetChunkByNarFileIDAndIndex(ctx context.Context, arg GetChunkByNarFileIDAndIndexParams) (Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetChunkByNarFileIDAndIndex(ctx, postgresdb.GetChunkByNarFileIDAndIndexParams{
 		NarFileID:  arg.NarFileID,
 		ChunkIndex: arg.ChunkIndex,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Chunk{}, ErrNotFound
 		}
+
 		return Chunk{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Chunk(res), nil
 }
 
 func (w *postgresWrapper) GetChunkCount(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetChunkCount(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *postgresWrapper) GetChunksByNarFileID(ctx context.Context, narFileID int64) ([]Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetChunksByNarFileID(ctx, narFileID)
 	if err != nil {
 		return nil, err
@@ -307,39 +345,46 @@ func (w *postgresWrapper) GetChunksByNarFileID(ctx context.Context, narFileID in
 	for i, v := range res {
 		items[i] = Chunk(v)
 	}
-
 	return items, nil
 }
 
 func (w *postgresWrapper) GetConfigByID(ctx context.Context, id int64) (Config, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetConfigByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Config{}, ErrNotFound
 		}
+
 		return Config{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Config(res), nil
 }
 
 func (w *postgresWrapper) GetConfigByKey(ctx context.Context, key string) (Config, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetConfigByKey(ctx, key)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Config{}, ErrNotFound
 		}
+
 		return Config{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Config(res), nil
 }
 
 func (w *postgresWrapper) GetLeastUsedNarFiles(ctx context.Context, fileSize uint64) ([]GetLeastUsedNarFilesRow, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetLeastUsedNarFiles(ctx, fileSize)
 	if err != nil {
 		return nil, err
@@ -350,11 +395,12 @@ func (w *postgresWrapper) GetLeastUsedNarFiles(ctx context.Context, fileSize uin
 	for i, v := range res {
 		items[i] = GetLeastUsedNarFilesRow(v)
 	}
-
 	return items, nil
 }
 
 func (w *postgresWrapper) GetLeastUsedNarInfos(ctx context.Context, fileSize uint64) ([]NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetLeastUsedNarInfos(ctx, fileSize)
 	if err != nil {
 		return nil, err
@@ -365,11 +411,12 @@ func (w *postgresWrapper) GetLeastUsedNarInfos(ctx context.Context, fileSize uin
 	for i, v := range res {
 		items[i] = NarInfo(v)
 	}
-
 	return items, nil
 }
 
 func (w *postgresWrapper) GetMigratedNarInfoHashes(ctx context.Context) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetMigratedNarInfoHashes(ctx)
 	if err != nil {
 		return nil, err
@@ -380,6 +427,8 @@ func (w *postgresWrapper) GetMigratedNarInfoHashes(ctx context.Context) ([]strin
 }
 
 func (w *postgresWrapper) GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetMigratedNarInfoHashesPaginated(ctx, postgresdb.GetMigratedNarInfoHashesPaginatedParams{
 		Limit:  arg.Limit,
 		Offset: arg.Offset,
@@ -393,106 +442,133 @@ func (w *postgresWrapper) GetMigratedNarInfoHashesPaginated(ctx context.Context,
 }
 
 func (w *postgresWrapper) GetNarFileByHashAndCompressionAndQuery(ctx context.Context, arg GetNarFileByHashAndCompressionAndQueryParams) (NarFile, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarFileByHashAndCompressionAndQuery(ctx, postgresdb.GetNarFileByHashAndCompressionAndQueryParams{
 		Hash:        arg.Hash,
 		Compression: arg.Compression,
 		Query:       arg.Query,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarFile{}, ErrNotFound
 		}
+
 		return NarFile{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarFile(res), nil
 }
 
 func (w *postgresWrapper) GetNarFileByID(ctx context.Context, id int64) (NarFile, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarFileByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarFile{}, ErrNotFound
 		}
+
 		return NarFile{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarFile(res), nil
 }
 
 func (w *postgresWrapper) GetNarFileByNarInfoID(ctx context.Context, narinfoID int64) (GetNarFileByNarInfoIDRow, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarFileByNarInfoID(ctx, narinfoID)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return GetNarFileByNarInfoIDRow{}, ErrNotFound
 		}
+
 		return GetNarFileByNarInfoIDRow{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return GetNarFileByNarInfoIDRow(res), nil
 }
 
 func (w *postgresWrapper) GetNarFileCount(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarFileCount(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *postgresWrapper) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoByHash(ctx, hash)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarInfo{}, ErrNotFound
 		}
+
 		return NarInfo{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarInfo(res), nil
 }
 
 func (w *postgresWrapper) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarInfo{}, ErrNotFound
 		}
+
 		return NarInfo{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarInfo(res), nil
 }
 
 func (w *postgresWrapper) GetNarInfoCount(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoCount(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *postgresWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoHashesByNarFileID(ctx, narFileID)
 	if err != nil {
 		return nil, err
@@ -503,6 +579,8 @@ func (w *postgresWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFi
 }
 
 func (w *postgresWrapper) GetNarInfoHashesByURL(ctx context.Context, url sql.NullString) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoHashesByURL(ctx, url)
 	if err != nil {
 		return nil, err
@@ -513,6 +591,8 @@ func (w *postgresWrapper) GetNarInfoHashesByURL(ctx context.Context, url sql.Nul
 }
 
 func (w *postgresWrapper) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoHashesToChunk(ctx)
 	if err != nil {
 		return nil, err
@@ -523,11 +603,12 @@ func (w *postgresWrapper) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNar
 	for i, v := range res {
 		items[i] = GetNarInfoHashesToChunkRow(v)
 	}
-
 	return items, nil
 }
 
 func (w *postgresWrapper) GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoReferences(ctx, narinfoID)
 	if err != nil {
 		return nil, err
@@ -538,6 +619,8 @@ func (w *postgresWrapper) GetNarInfoReferences(ctx context.Context, narinfoID in
 }
 
 func (w *postgresWrapper) GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoSignatures(ctx, narinfoID)
 	if err != nil {
 		return nil, err
@@ -548,19 +631,26 @@ func (w *postgresWrapper) GetNarInfoSignatures(ctx context.Context, narinfoID in
 }
 
 func (w *postgresWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarTotalSize(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *postgresWrapper) GetOrphanedChunks(ctx context.Context) ([]Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetOrphanedChunks(ctx)
 	if err != nil {
 		return nil, err
@@ -571,11 +661,12 @@ func (w *postgresWrapper) GetOrphanedChunks(ctx context.Context) ([]Chunk, error
 	for i, v := range res {
 		items[i] = Chunk(v)
 	}
-
 	return items, nil
 }
 
 func (w *postgresWrapper) GetOrphanedNarFiles(ctx context.Context) ([]GetOrphanedNarFilesRow, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetOrphanedNarFiles(ctx)
 	if err != nil {
 		return nil, err
@@ -586,24 +677,30 @@ func (w *postgresWrapper) GetOrphanedNarFiles(ctx context.Context) ([]GetOrphane
 	for i, v := range res {
 		items[i] = GetOrphanedNarFilesRow(v)
 	}
-
 	return items, nil
 }
 
 func (w *postgresWrapper) GetTotalChunkSize(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetTotalChunkSize(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *postgresWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetUnmigratedNarInfoHashes(ctx)
 	if err != nil {
 		return nil, err
@@ -614,112 +711,107 @@ func (w *postgresWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]str
 }
 
 func (w *postgresWrapper) IsNarInfoMigrated(ctx context.Context, hash string) (bool, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.IsNarInfoMigrated(ctx, hash)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, ErrNotFound
 		}
+
 		return false, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *postgresWrapper) LinkNarFileToChunk(ctx context.Context, arg LinkNarFileToChunkParams) error {
-	err := w.adapter.LinkNarFileToChunk(ctx, postgresdb.LinkNarFileToChunkParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.LinkNarFileToChunk(ctx, postgresdb.LinkNarFileToChunkParams{
 		NarFileID:  arg.NarFileID,
 		ChunkID:    arg.ChunkID,
 		ChunkIndex: arg.ChunkIndex,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *postgresWrapper) LinkNarInfoToNarFile(ctx context.Context, arg LinkNarInfoToNarFileParams) error {
-	err := w.adapter.LinkNarInfoToNarFile(ctx, postgresdb.LinkNarInfoToNarFileParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.LinkNarInfoToNarFile(ctx, postgresdb.LinkNarInfoToNarFileParams{
 		NarInfoID: arg.NarInfoID,
 		NarFileID: arg.NarFileID,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *postgresWrapper) SetConfig(ctx context.Context, arg SetConfigParams) error {
-	err := w.adapter.SetConfig(ctx, postgresdb.SetConfigParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.SetConfig(ctx, postgresdb.SetConfigParams{
 		Key:   arg.Key,
 		Value: arg.Value,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *postgresWrapper) TouchNarFile(ctx context.Context, arg TouchNarFileParams) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.TouchNarFile(ctx, postgresdb.TouchNarFileParams{
 		Hash:        arg.Hash,
 		Compression: arg.Compression,
 		Query:       arg.Query,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *postgresWrapper) TouchNarInfo(ctx context.Context, hash string) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.TouchNarInfo(ctx, hash)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *postgresWrapper) UpdateNarFileTotalChunks(ctx context.Context, arg UpdateNarFileTotalChunksParams) error {
-	err := w.adapter.UpdateNarFileTotalChunks(ctx, postgresdb.UpdateNarFileTotalChunksParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.UpdateNarFileTotalChunks(ctx, postgresdb.UpdateNarFileTotalChunksParams{
 		TotalChunks: arg.TotalChunks,
 		ID:          arg.ID,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *postgresWrapper) UpdateNarInfoFileSize(ctx context.Context, arg UpdateNarInfoFileSizeParams) error {
-	err := w.adapter.UpdateNarInfoFileSize(ctx, postgresdb.UpdateNarInfoFileSizeParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.UpdateNarInfoFileSize(ctx, postgresdb.UpdateNarInfoFileSizeParams{
 		Hash:     arg.Hash,
 		FileSize: arg.FileSize,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *postgresWrapper) WithTx(tx *sql.Tx) Querier {

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -15,33 +15,26 @@ type sqliteWrapper struct {
 }
 
 func (w *sqliteWrapper) AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error {
-	err := w.adapter.AddNarInfoReference(ctx, sqlitedb.AddNarInfoReferenceParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.AddNarInfoReference(ctx, sqlitedb.AddNarInfoReferenceParams{
 		NarInfoID: arg.NarInfoID,
 		Reference: arg.Reference,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *sqliteWrapper) AddNarInfoReferences(ctx context.Context, arg AddNarInfoReferencesParams) error {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	for i, v := range arg.Reference {
 		_ = i
 		err := w.adapter.AddNarInfoReference(ctx, sqlitedb.AddNarInfoReferenceParams{
 			NarInfoID: arg.NarInfoID,
+
 			Reference: v,
 		},
 		)
 		if err != nil {
-			if IsDuplicateKeyError(err) {
-				continue
-			}
-			if errors.Is(err, sql.ErrNoRows) {
-				return ErrNotFound
-			}
 			return err
 		}
 	}
@@ -49,33 +42,26 @@ func (w *sqliteWrapper) AddNarInfoReferences(ctx context.Context, arg AddNarInfo
 }
 
 func (w *sqliteWrapper) AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error {
-	err := w.adapter.AddNarInfoSignature(ctx, sqlitedb.AddNarInfoSignatureParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.AddNarInfoSignature(ctx, sqlitedb.AddNarInfoSignatureParams{
 		NarInfoID: arg.NarInfoID,
 		Signature: arg.Signature,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *sqliteWrapper) AddNarInfoSignatures(ctx context.Context, arg AddNarInfoSignaturesParams) error {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	for i, v := range arg.Signature {
 		_ = i
 		err := w.adapter.AddNarInfoSignature(ctx, sqlitedb.AddNarInfoSignatureParams{
 			NarInfoID: arg.NarInfoID,
+
 			Signature: v,
 		},
 		)
 		if err != nil {
-			if IsDuplicateKeyError(err) {
-				continue
-			}
-			if errors.Is(err, sql.ErrNoRows) {
-				return ErrNotFound
-			}
 			return err
 		}
 	}
@@ -83,40 +69,48 @@ func (w *sqliteWrapper) AddNarInfoSignatures(ctx context.Context, arg AddNarInfo
 }
 
 func (w *sqliteWrapper) CreateChunk(ctx context.Context, arg CreateChunkParams) (Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.CreateChunk(ctx, sqlitedb.CreateChunkParams{
 		Hash: arg.Hash,
 		Size: arg.Size,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Chunk{}, ErrNotFound
 		}
+
 		return Chunk{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Chunk(res), nil
 }
 
 func (w *sqliteWrapper) CreateConfig(ctx context.Context, arg CreateConfigParams) (Config, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.CreateConfig(ctx, sqlitedb.CreateConfigParams{
 		Key:   arg.Key,
 		Value: arg.Value,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Config{}, ErrNotFound
 		}
+
 		return Config{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Config(res), nil
 }
 
 func (w *sqliteWrapper) CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.CreateNarFile(ctx, sqlitedb.CreateNarFileParams{
 		Hash:        arg.Hash,
 		Compression: arg.Compression,
@@ -125,18 +119,21 @@ func (w *sqliteWrapper) CreateNarFile(ctx context.Context, arg CreateNarFilePara
 		TotalChunks: arg.TotalChunks,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarFile{}, ErrNotFound
 		}
+
 		return NarFile{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarFile(res), nil
 }
 
 func (w *sqliteWrapper) CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.CreateNarInfo(ctx, sqlitedb.CreateNarInfoParams{
 		Hash:        arg.Hash,
 		StorePath:   arg.StorePath,
@@ -151,168 +148,211 @@ func (w *sqliteWrapper) CreateNarInfo(ctx context.Context, arg CreateNarInfoPara
 		Ca:          arg.Ca,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarInfo{}, ErrNotFound
 		}
+
 		return NarInfo{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarInfo(res), nil
 }
 
 func (w *sqliteWrapper) DeleteChunkByID(ctx context.Context, id int64) error {
-	err := w.adapter.DeleteChunkByID(ctx, id)
-	if err != nil {
-		return err
-	}
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	// No return value (void)
-	return nil
+	return w.adapter.DeleteChunkByID(ctx, id)
 }
 
 func (w *sqliteWrapper) DeleteNarFileByHash(ctx context.Context, arg DeleteNarFileByHashParams) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteNarFileByHash(ctx, sqlitedb.DeleteNarFileByHashParams{
 		Hash:        arg.Hash,
 		Compression: arg.Compression,
 		Query:       arg.Query,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *sqliteWrapper) DeleteNarFileByID(ctx context.Context, id int64) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteNarFileByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *sqliteWrapper) DeleteNarInfoByHash(ctx context.Context, hash string) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteNarInfoByHash(ctx, hash)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *sqliteWrapper) DeleteNarInfoByID(ctx context.Context, id int64) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteNarInfoByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *sqliteWrapper) DeleteOrphanedNarFiles(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteOrphanedNarFiles(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *sqliteWrapper) DeleteOrphanedNarInfos(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.DeleteOrphanedNarInfos(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *sqliteWrapper) GetChunkByHash(ctx context.Context, hash string) (Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetChunkByHash(ctx, hash)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Chunk{}, ErrNotFound
 		}
+
 		return Chunk{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Chunk(res), nil
 }
 
 func (w *sqliteWrapper) GetChunkByID(ctx context.Context, id int64) (Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetChunkByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Chunk{}, ErrNotFound
 		}
+
 		return Chunk{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Chunk(res), nil
 }
 
 func (w *sqliteWrapper) GetChunkByNarFileIDAndIndex(ctx context.Context, arg GetChunkByNarFileIDAndIndexParams) (Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetChunkByNarFileIDAndIndex(ctx, sqlitedb.GetChunkByNarFileIDAndIndexParams{
 		NarFileID:  arg.NarFileID,
 		ChunkIndex: arg.ChunkIndex,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Chunk{}, ErrNotFound
 		}
+
 		return Chunk{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Chunk(res), nil
 }
 
 func (w *sqliteWrapper) GetChunkCount(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetChunkCount(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *sqliteWrapper) GetChunksByNarFileID(ctx context.Context, narFileID int64) ([]Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetChunksByNarFileID(ctx, narFileID)
 	if err != nil {
 		return nil, err
@@ -323,39 +363,46 @@ func (w *sqliteWrapper) GetChunksByNarFileID(ctx context.Context, narFileID int6
 	for i, v := range res {
 		items[i] = Chunk(v)
 	}
-
 	return items, nil
 }
 
 func (w *sqliteWrapper) GetConfigByID(ctx context.Context, id int64) (Config, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetConfigByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Config{}, ErrNotFound
 		}
+
 		return Config{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Config(res), nil
 }
 
 func (w *sqliteWrapper) GetConfigByKey(ctx context.Context, key string) (Config, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetConfigByKey(ctx, key)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return Config{}, ErrNotFound
 		}
+
 		return Config{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return Config(res), nil
 }
 
 func (w *sqliteWrapper) GetLeastUsedNarFiles(ctx context.Context, fileSize uint64) ([]GetLeastUsedNarFilesRow, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetLeastUsedNarFiles(ctx, fileSize)
 	if err != nil {
 		return nil, err
@@ -366,11 +413,12 @@ func (w *sqliteWrapper) GetLeastUsedNarFiles(ctx context.Context, fileSize uint6
 	for i, v := range res {
 		items[i] = GetLeastUsedNarFilesRow(v)
 	}
-
 	return items, nil
 }
 
 func (w *sqliteWrapper) GetLeastUsedNarInfos(ctx context.Context, fileSize uint64) ([]NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetLeastUsedNarInfos(ctx, fileSize)
 	if err != nil {
 		return nil, err
@@ -381,11 +429,12 @@ func (w *sqliteWrapper) GetLeastUsedNarInfos(ctx context.Context, fileSize uint6
 	for i, v := range res {
 		items[i] = NarInfo(v)
 	}
-
 	return items, nil
 }
 
 func (w *sqliteWrapper) GetMigratedNarInfoHashes(ctx context.Context) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetMigratedNarInfoHashes(ctx)
 	if err != nil {
 		return nil, err
@@ -396,6 +445,8 @@ func (w *sqliteWrapper) GetMigratedNarInfoHashes(ctx context.Context) ([]string,
 }
 
 func (w *sqliteWrapper) GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetMigratedNarInfoHashesPaginated(ctx, sqlitedb.GetMigratedNarInfoHashesPaginatedParams{
 		Limit:  int64(arg.Limit),
 		Offset: int64(arg.Offset),
@@ -409,106 +460,133 @@ func (w *sqliteWrapper) GetMigratedNarInfoHashesPaginated(ctx context.Context, a
 }
 
 func (w *sqliteWrapper) GetNarFileByHashAndCompressionAndQuery(ctx context.Context, arg GetNarFileByHashAndCompressionAndQueryParams) (NarFile, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarFileByHashAndCompressionAndQuery(ctx, sqlitedb.GetNarFileByHashAndCompressionAndQueryParams{
 		Hash:        arg.Hash,
 		Compression: arg.Compression,
 		Query:       arg.Query,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarFile{}, ErrNotFound
 		}
+
 		return NarFile{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarFile(res), nil
 }
 
 func (w *sqliteWrapper) GetNarFileByID(ctx context.Context, id int64) (NarFile, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarFileByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarFile{}, ErrNotFound
 		}
+
 		return NarFile{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarFile(res), nil
 }
 
 func (w *sqliteWrapper) GetNarFileByNarInfoID(ctx context.Context, narinfoID int64) (GetNarFileByNarInfoIDRow, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarFileByNarInfoID(ctx, narinfoID)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return GetNarFileByNarInfoIDRow{}, ErrNotFound
 		}
+
 		return GetNarFileByNarInfoIDRow{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return GetNarFileByNarInfoIDRow(res), nil
 }
 
 func (w *sqliteWrapper) GetNarFileCount(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarFileCount(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *sqliteWrapper) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoByHash(ctx, hash)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarInfo{}, ErrNotFound
 		}
+
 		return NarInfo{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarInfo(res), nil
 }
 
 func (w *sqliteWrapper) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoByID(ctx, id)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarInfo{}, ErrNotFound
 		}
+
 		return NarInfo{}, err
 	}
 
 	// Convert Single Domain Struct
-
 	return NarInfo(res), nil
 }
 
 func (w *sqliteWrapper) GetNarInfoCount(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoCount(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *sqliteWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoHashesByNarFileID(ctx, narFileID)
 	if err != nil {
 		return nil, err
@@ -519,6 +597,8 @@ func (w *sqliteWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFile
 }
 
 func (w *sqliteWrapper) GetNarInfoHashesByURL(ctx context.Context, url sql.NullString) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoHashesByURL(ctx, url)
 	if err != nil {
 		return nil, err
@@ -529,6 +609,8 @@ func (w *sqliteWrapper) GetNarInfoHashesByURL(ctx context.Context, url sql.NullS
 }
 
 func (w *sqliteWrapper) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoHashesToChunk(ctx)
 	if err != nil {
 		return nil, err
@@ -539,11 +621,12 @@ func (w *sqliteWrapper) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarIn
 	for i, v := range res {
 		items[i] = GetNarInfoHashesToChunkRow(v)
 	}
-
 	return items, nil
 }
 
 func (w *sqliteWrapper) GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoReferences(ctx, narinfoID)
 	if err != nil {
 		return nil, err
@@ -554,6 +637,8 @@ func (w *sqliteWrapper) GetNarInfoReferences(ctx context.Context, narinfoID int6
 }
 
 func (w *sqliteWrapper) GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarInfoSignatures(ctx, narinfoID)
 	if err != nil {
 		return nil, err
@@ -564,19 +649,26 @@ func (w *sqliteWrapper) GetNarInfoSignatures(ctx context.Context, narinfoID int6
 }
 
 func (w *sqliteWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetNarTotalSize(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *sqliteWrapper) GetOrphanedChunks(ctx context.Context) ([]Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetOrphanedChunks(ctx)
 	if err != nil {
 		return nil, err
@@ -587,11 +679,12 @@ func (w *sqliteWrapper) GetOrphanedChunks(ctx context.Context) ([]Chunk, error) 
 	for i, v := range res {
 		items[i] = Chunk(v)
 	}
-
 	return items, nil
 }
 
 func (w *sqliteWrapper) GetOrphanedNarFiles(ctx context.Context) ([]GetOrphanedNarFilesRow, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetOrphanedNarFiles(ctx)
 	if err != nil {
 		return nil, err
@@ -602,24 +695,30 @@ func (w *sqliteWrapper) GetOrphanedNarFiles(ctx context.Context) ([]GetOrphanedN
 	for i, v := range res {
 		items[i] = GetOrphanedNarFilesRow(v)
 	}
-
 	return items, nil
 }
 
 func (w *sqliteWrapper) GetTotalChunkSize(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetTotalChunkSize(ctx)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *sqliteWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.GetUnmigratedNarInfoHashes(ctx)
 	if err != nil {
 		return nil, err
@@ -630,112 +729,107 @@ func (w *sqliteWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]strin
 }
 
 func (w *sqliteWrapper) IsNarInfoMigrated(ctx context.Context, hash string) (bool, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.IsNarInfoMigrated(ctx, hash)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, ErrNotFound
 		}
+
 		return false, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res != 0, nil
 }
 
 func (w *sqliteWrapper) LinkNarFileToChunk(ctx context.Context, arg LinkNarFileToChunkParams) error {
-	err := w.adapter.LinkNarFileToChunk(ctx, sqlitedb.LinkNarFileToChunkParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.LinkNarFileToChunk(ctx, sqlitedb.LinkNarFileToChunkParams{
 		NarFileID:  arg.NarFileID,
 		ChunkID:    arg.ChunkID,
 		ChunkIndex: arg.ChunkIndex,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *sqliteWrapper) LinkNarInfoToNarFile(ctx context.Context, arg LinkNarInfoToNarFileParams) error {
-	err := w.adapter.LinkNarInfoToNarFile(ctx, sqlitedb.LinkNarInfoToNarFileParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.LinkNarInfoToNarFile(ctx, sqlitedb.LinkNarInfoToNarFileParams{
 		NarInfoID: arg.NarInfoID,
 		NarFileID: arg.NarFileID,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *sqliteWrapper) SetConfig(ctx context.Context, arg SetConfigParams) error {
-	err := w.adapter.SetConfig(ctx, sqlitedb.SetConfigParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.SetConfig(ctx, sqlitedb.SetConfigParams{
 		Key:   arg.Key,
 		Value: arg.Value,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *sqliteWrapper) TouchNarFile(ctx context.Context, arg TouchNarFileParams) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.TouchNarFile(ctx, sqlitedb.TouchNarFileParams{
 		Hash:        arg.Hash,
 		Compression: arg.Compression,
 		Query:       arg.Query,
 	})
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *sqliteWrapper) TouchNarInfo(ctx context.Context, hash string) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
 	res, err := w.adapter.TouchNarInfo(ctx, hash)
 	if err != nil {
+
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
+
 		return 0, err
 	}
 
 	// Return Primitive / *sql.DB / etc
+
 	return res, nil
 }
 
 func (w *sqliteWrapper) UpdateNarFileTotalChunks(ctx context.Context, arg UpdateNarFileTotalChunksParams) error {
-	err := w.adapter.UpdateNarFileTotalChunks(ctx, sqlitedb.UpdateNarFileTotalChunksParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.UpdateNarFileTotalChunks(ctx, sqlitedb.UpdateNarFileTotalChunksParams{
 		TotalChunks: arg.TotalChunks,
 		ID:          arg.ID,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *sqliteWrapper) UpdateNarInfoFileSize(ctx context.Context, arg UpdateNarInfoFileSizeParams) error {
-	err := w.adapter.UpdateNarInfoFileSize(ctx, sqlitedb.UpdateNarInfoFileSizeParams{
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.UpdateNarInfoFileSize(ctx, sqlitedb.UpdateNarInfoFileSizeParams{
 		FileSize: arg.FileSize,
 		Hash:     arg.Hash,
 	})
-	if err != nil {
-		return err
-	}
-
-	// No return value (void)
-	return nil
 }
 
 func (w *sqliteWrapper) WithTx(tx *sql.Tx) Querier {

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -12,7 +12,7 @@ import (
 type Querier interface {
 	//AddNarInfoReference
 	//
-	//  INSERT INTO narinfo_references (
+	//  INSERT IGNORE INTO narinfo_references (
 	//      narinfo_id, reference
 	//  ) VALUES (
 	//      ?, ?
@@ -20,7 +20,7 @@ type Querier interface {
 	AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error
 	//AddNarInfoSignature
 	//
-	//  INSERT INTO narinfo_signatures (
+	//  INSERT IGNORE INTO narinfo_signatures (
 	//      narinfo_id, signature
 	//  ) VALUES (
 	//      ?, ?

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const addNarInfoReference = `-- name: AddNarInfoReference :exec
-INSERT INTO narinfo_references (
+INSERT IGNORE INTO narinfo_references (
     narinfo_id, reference
 ) VALUES (
     ?, ?
@@ -26,7 +26,7 @@ type AddNarInfoReferenceParams struct {
 
 // AddNarInfoReference
 //
-//	INSERT INTO narinfo_references (
+//	INSERT IGNORE INTO narinfo_references (
 //	    narinfo_id, reference
 //	) VALUES (
 //	    ?, ?
@@ -37,7 +37,7 @@ func (q *Queries) AddNarInfoReference(ctx context.Context, arg AddNarInfoReferen
 }
 
 const addNarInfoSignature = `-- name: AddNarInfoSignature :exec
-INSERT INTO narinfo_signatures (
+INSERT IGNORE INTO narinfo_signatures (
     narinfo_id, signature
 ) VALUES (
     ?, ?
@@ -51,7 +51,7 @@ type AddNarInfoSignatureParams struct {
 
 // AddNarInfoSignature
 //
-//	INSERT INTO narinfo_signatures (
+//	INSERT IGNORE INTO narinfo_signatures (
 //	    narinfo_id, signature
 //	) VALUES (
 //	    ?, ?

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -17,6 +17,7 @@ type Querier interface {
 	//  ) VALUES (
 	//      $1, $2
 	//  )
+	//  ON CONFLICT (narinfo_id, reference) DO NOTHING
 	AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error
 	// @bulk-for AddNarInfoReference
 	//
@@ -32,6 +33,7 @@ type Querier interface {
 	//  ) VALUES (
 	//      $1, $2
 	//  )
+	//  ON CONFLICT (narinfo_id, signature) DO NOTHING
 	AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error
 	// @bulk-for AddNarInfoSignature
 	//

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -19,6 +19,7 @@ INSERT INTO narinfo_references (
 ) VALUES (
     $1, $2
 )
+ON CONFLICT (narinfo_id, reference) DO NOTHING
 `
 
 type AddNarInfoReferenceParams struct {
@@ -33,6 +34,7 @@ type AddNarInfoReferenceParams struct {
 //	) VALUES (
 //	    $1, $2
 //	)
+//	ON CONFLICT (narinfo_id, reference) DO NOTHING
 func (q *Queries) AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error {
 	_, err := q.db.ExecContext(ctx, addNarInfoReference, arg.NarInfoID, arg.Reference)
 	return err
@@ -67,6 +69,7 @@ INSERT INTO narinfo_signatures (
 ) VALUES (
     $1, $2
 )
+ON CONFLICT (narinfo_id, signature) DO NOTHING
 `
 
 type AddNarInfoSignatureParams struct {
@@ -81,6 +84,7 @@ type AddNarInfoSignatureParams struct {
 //	) VALUES (
 //	    $1, $2
 //	)
+//	ON CONFLICT (narinfo_id, signature) DO NOTHING
 func (q *Queries) AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error {
 	_, err := q.db.ExecContext(ctx, addNarInfoSignature, arg.NarInfoID, arg.Signature)
 	return err

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -17,6 +17,7 @@ type Querier interface {
 	//  ) VALUES (
 	//      ?, ?
 	//  )
+	//  ON CONFLICT (narinfo_id, reference) DO NOTHING
 	AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error
 	//AddNarInfoSignature
 	//
@@ -25,6 +26,7 @@ type Querier interface {
 	//  ) VALUES (
 	//      ?, ?
 	//  )
+	//  ON CONFLICT (narinfo_id, signature) DO NOTHING
 	AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error
 	//CreateChunk
 	//

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -17,6 +17,7 @@ INSERT INTO narinfo_references (
 ) VALUES (
     ?, ?
 )
+ON CONFLICT (narinfo_id, reference) DO NOTHING
 `
 
 type AddNarInfoReferenceParams struct {
@@ -31,6 +32,7 @@ type AddNarInfoReferenceParams struct {
 //	) VALUES (
 //	    ?, ?
 //	)
+//	ON CONFLICT (narinfo_id, reference) DO NOTHING
 func (q *Queries) AddNarInfoReference(ctx context.Context, arg AddNarInfoReferenceParams) error {
 	_, err := q.db.ExecContext(ctx, addNarInfoReference, arg.NarInfoID, arg.Reference)
 	return err
@@ -42,6 +44,7 @@ INSERT INTO narinfo_signatures (
 ) VALUES (
     ?, ?
 )
+ON CONFLICT (narinfo_id, signature) DO NOTHING
 `
 
 type AddNarInfoSignatureParams struct {
@@ -56,6 +59,7 @@ type AddNarInfoSignatureParams struct {
 //	) VALUES (
 //	    ?, ?
 //	)
+//	ON CONFLICT (narinfo_id, signature) DO NOTHING
 func (q *Queries) AddNarInfoSignature(ctx context.Context, arg AddNarInfoSignatureParams) error {
 	_, err := q.db.ExecContext(ctx, addNarInfoSignature, arg.NarInfoID, arg.Signature)
 	return err


### PR DESCRIPTION
Switch from go/format to gofumpt for consistent formatting with the
rest of the codebase. This ensures generated wrapper files follow the
same strict formatting rules as hand-written code.

The change also simplifies the template code by removing redundant
helper functions and improving the readability of the bulk insert
auto-loop logic for non-Postgres database engines.