### PR TITLE
test: refactor cache tests to use backend factory

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -2252,9 +2252,6 @@ func testGetNarInfoMultipleConcurrentPutsDuringMigration(factory cacheFactory) f
 		hash := testdata.Nar1.NarInfoHash
 		entry := testdata.Nar1
 
-		t.Cleanup(c.Close)
-		t.Cleanup(func() { db.DB().Close() })
-
 		// Pre-populate storage
 		narInfoPath := filepath.Join(tmpDir, "store", "narinfo", entry.NarInfoPath)
 		narPath := filepath.Join(tmpDir, "store", "nar", entry.NarPath)
@@ -2494,7 +2491,6 @@ func testGetNarInfoRaceConditionDuringMigrationDeletion(factory cacheFactory) fu
 		require.NoError(t, os.WriteFile(narPath, []byte(entry.NarText), 0o600))
 
 		// Channel to coordinate the race
-		migrationCalled := make(chan struct{})
 		migrationComplete := make(chan struct{})
 
 		var (
@@ -2510,8 +2506,6 @@ func testGetNarInfoRaceConditionDuringMigrationDeletion(factory cacheFactory) fu
 			beforeGetNarInfo: func(h string) {
 				if h == hash {
 					migrationOnce.Do(func() {
-						close(migrationCalled)
-
 						// This is the critical race window:
 						// GetNarInfo has checked HasNarInfo (returned true)
 						// Now it's about to call GetNarInfo on storage


### PR DESCRIPTION
Refactored tests in pkg/cache/cache_test.go to utilize the cacheFactory
pattern instead of being hardcoded to SQLite. This allows the test suite
to correctly verify PostgreSQL and MySQL backends in CI.

Specifically:
- Updated multiple test functions to use the provided factory for setup.
- Fixed a race condition in GetNarInfoRaceConditionDuringMigrationDeletion
  by ensuring the test hook uses the cache's own locker.
- Improved synchronization and coordination in race condition tests.
- Resolved build and linting errors arising from the refactoring.

This change ensures that all cache backends are properly tested and
fixes CI failures caused by incorrect test configuration.