### PR TITLE
fix: MySQL CreateNarInfo upsert logic and refactor cache tests [backport #791]

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -67,7 +67,6 @@ INSERT INTO narinfos (
 ON DUPLICATE KEY UPDATE
     id = LAST_INSERT_ID(id),
     store_path = IF(url IS NULL, VALUES(store_path), store_path),
-    url = IF(url IS NULL, VALUES(url), url),
     compression = IF(url IS NULL, VALUES(compression), compression),
     file_hash = IF(url IS NULL, VALUES(file_hash), file_hash),
     file_size = IF(url IS NULL, VALUES(file_size), file_size),
@@ -76,6 +75,7 @@ ON DUPLICATE KEY UPDATE
     deriver = IF(url IS NULL, VALUES(deriver), deriver),
     system = IF(url IS NULL, VALUES(system), system),
     ca = IF(url IS NULL, VALUES(ca), ca),
+    url = IF(url IS NULL, VALUES(url), url),
     updated_at = IF(url IS NULL, CURRENT_TIMESTAMP, updated_at);
 
 -- name: AddNarInfoReference :exec

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -55,7 +55,6 @@ type Querier interface {
 	//  ON DUPLICATE KEY UPDATE
 	//      id = LAST_INSERT_ID(id),
 	//      store_path = IF(url IS NULL, VALUES(store_path), store_path),
-	//      url = IF(url IS NULL, VALUES(url), url),
 	//      compression = IF(url IS NULL, VALUES(compression), compression),
 	//      file_hash = IF(url IS NULL, VALUES(file_hash), file_hash),
 	//      file_size = IF(url IS NULL, VALUES(file_size), file_size),
@@ -64,6 +63,7 @@ type Querier interface {
 	//      deriver = IF(url IS NULL, VALUES(deriver), deriver),
 	//      system = IF(url IS NULL, VALUES(system), system),
 	//      ca = IF(url IS NULL, VALUES(ca), ca),
+	//      url = IF(url IS NULL, VALUES(url), url),
 	//      updated_at = IF(url IS NULL, CURRENT_TIMESTAMP, updated_at)
 	CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (sql.Result, error)
 	//DeleteNarFileByHash

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -131,7 +131,6 @@ INSERT INTO narinfos (
 ON DUPLICATE KEY UPDATE
     id = LAST_INSERT_ID(id),
     store_path = IF(url IS NULL, VALUES(store_path), store_path),
-    url = IF(url IS NULL, VALUES(url), url),
     compression = IF(url IS NULL, VALUES(compression), compression),
     file_hash = IF(url IS NULL, VALUES(file_hash), file_hash),
     file_size = IF(url IS NULL, VALUES(file_size), file_size),
@@ -140,6 +139,7 @@ ON DUPLICATE KEY UPDATE
     deriver = IF(url IS NULL, VALUES(deriver), deriver),
     system = IF(url IS NULL, VALUES(system), system),
     ca = IF(url IS NULL, VALUES(ca), ca),
+    url = IF(url IS NULL, VALUES(url), url),
     updated_at = IF(url IS NULL, CURRENT_TIMESTAMP, updated_at)
 `
 
@@ -167,7 +167,6 @@ type CreateNarInfoParams struct {
 //	ON DUPLICATE KEY UPDATE
 //	    id = LAST_INSERT_ID(id),
 //	    store_path = IF(url IS NULL, VALUES(store_path), store_path),
-//	    url = IF(url IS NULL, VALUES(url), url),
 //	    compression = IF(url IS NULL, VALUES(compression), compression),
 //	    file_hash = IF(url IS NULL, VALUES(file_hash), file_hash),
 //	    file_size = IF(url IS NULL, VALUES(file_size), file_size),
@@ -176,6 +175,7 @@ type CreateNarInfoParams struct {
 //	    deriver = IF(url IS NULL, VALUES(deriver), deriver),
 //	    system = IF(url IS NULL, VALUES(system), system),
 //	    ca = IF(url IS NULL, VALUES(ca), ca),
+//	    url = IF(url IS NULL, VALUES(url), url),
 //	    updated_at = IF(url IS NULL, CURRENT_TIMESTAMP, updated_at)
 func (q *Queries) CreateNarInfo(ctx context.Context, arg CreateNarInfoParams) (sql.Result, error) {
 	return q.db.ExecContext(ctx, createNarInfo,


### PR DESCRIPTION
Bot-based backport to `release-0.8`, triggered by a label in #791.

This commit includes a fix for the MySQL CreateNarInfo upsert logic.
The ON DUPLICATE KEY UPDATE clause was incorrectly updating the url
column before other columns that depended on its previous NULL value.
Assignments were reordered to ensure url and updated_at are
evaluated last.

Changes:
- Modified db/query.mysql.sql to reorder assignments in CreateNarInfo.
- Added a new compliance test CreateNarInfoUpdateFromPlaceholder in
  pkg/database/contract_test.go to verify upsert behavior across all backends.
- Regenerated database wrappers using sqlc and gen-db-wrappers.
- Refactored several race condition tests in pkg/cache/cache_test.go to use
  local SQLite instead of the backend factory, as manually adjusted by the user.

Verified the fix with:
- TestBackends/MySQL/InsertNarInfo/CreateNarInfoUpdateFromPlaceholder
- Original TestCacheBackends/MySQL/GetNarInfoRaceConditionDuringMigrationDeletion (before refactor)