### PR TITLE
perf: avoid double-reading data during CDC

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1313,19 +1313,15 @@ func (c *Cache) storeNarWithCDC(ctx context.Context, tempPath string, narURL *na
 				return totalSize, nil
 			}
 
-			// Process chunk
-			data := make([]byte, chunkMetadata.Size)
-
-			_, err := f.ReadAt(data, chunkMetadata.Offset)
-			if err != nil {
-				return 0, fmt.Errorf("error reading chunk data: %w", err)
-			}
-
 			// Store in chunkStore if new
-			_, err = chunkStore.PutChunk(ctx, chunkMetadata.Hash, data)
+			_, err = chunkStore.PutChunk(ctx, chunkMetadata.Hash, chunkMetadata.Data)
 			if err != nil {
+				chunkMetadata.Free()
+
 				return 0, fmt.Errorf("error storing chunk: %w", err)
 			}
+
+			chunkMetadata.Free()
 
 			totalSize += int64(chunkMetadata.Size)
 

--- a/pkg/chunker/error_test.go
+++ b/pkg/chunker/error_test.go
@@ -45,7 +45,11 @@ func TestCDCChunker_Chunk_ErrorRace(t *testing.T) {
 			err:  errRead,
 		}
 
-		_, err := collectChunks(ctx, chr, reader)
+		chunks, err := collectChunks(ctx, t, chr, reader)
+		for _, c := range chunks {
+			c.Free()
+		}
+
 		if !errors.Is(err, errRead) {
 			t.Fatalf("at iteration %d: expected error %v, got %v", i, errRead, err)
 		}


### PR DESCRIPTION
The content-defined chunking (CDC) process was previously reading data from disk even though the data was already available in memory within the chunker. This change optimizes the process by passing the chunk data directly from the chunker to the cache layer using a sync.Pool to minimize allocations and ensure thread-safety.

How:
- Added Data field to chunker.Chunk.
- Implemented per-chunker sync.Pool for byte buffers in CDCChunker.
- Updated CDCChunker.Chunk to copy data to a pooled buffer before sending it on the channel.
- Updated storeNarWithCDC in pkg/cache to use the passed data instead of reading from file.
- Added Free() mechanism to return buffers to the pool.