### PR TITLE
feat: switch chunk hashing to BLAKE3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/sysbot/go-netrc v0.0.0-20231214061310-8bb3fde9e2d4
 	github.com/urfave/cli-altsrc/v3 v3.1.0
 	github.com/urfave/cli/v3 v3.6.2
+	github.com/zeebo/blake3 v0.2.4
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0
 	go.opentelemetry.io/otel v1.40.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,12 @@ github.com/urfave/cli-altsrc/v3 v3.1.0 h1:6E5+kXeAWmRxXlPgdEVf9VqVoTJ2MJci0UMpUi
 github.com/urfave/cli-altsrc/v3 v3.1.0/go.mod h1:VcWVTGXcL3nrXUDJZagHAeUX702La3PKeWav7KpISqA=
 github.com/urfave/cli/v3 v3.6.2 h1:lQuqiPrZ1cIz8hz+HcrG0TNZFxU70dPZ3Yl+pSrH9A8=
 github.com/urfave/cli/v3 v3.6.2/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
+github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
+github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
+github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
+github.com/zeebo/pcg v1.0.1 h1:lyqfGeWiv4ahac6ttHs+I5hwtH/+1mrhlCtVNQM2kHo=
+github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 h1:7iP2uCb7sGddAr30RRS6xjKy7AZ2JtTOPA3oolgVSw8=

--- a/nix/packages/ncps/default.nix
+++ b/nix/packages/ncps/default.nix
@@ -16,7 +16,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-KsBZJG5l5lUKzPt+OlFENosQ3GZ1aCcS0yLbfWXLT1Q=";
+          vendorHash = "sha256-jfoJBQQ3q8//KMihdrBKGZBokHQYLdh9lYsmArGp32c=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/pkg/chunker/chunker.go
+++ b/pkg/chunker/chunker.go
@@ -2,18 +2,18 @@ package chunker
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"io"
 	"sync"
 
 	"github.com/kalbasit/fastcdc"
+	"github.com/zeebo/blake3"
 )
 
 // Chunk represents a single content-defined chunk.
 type Chunk struct {
-	Hash   string // SHA-256 hash of chunk content
+	Hash   string // BLAKE3 hash of chunk content
 	Offset int64  // Offset in original stream
 	Size   uint32 // Chunk size in bytes
 	Data   []byte // Chunk data
@@ -110,8 +110,8 @@ func (c *CDCChunker) Chunk(ctx context.Context, r io.Reader) (<-chan Chunk, <-ch
 					return
 				}
 
-				// Compute SHA-256 hash of the chunk data
-				h := sha256.Sum256(chunk.Data)
+				// Compute BLAKE3 hash of the chunk data
+				h := blake3.Sum256(chunk.Data)
 				hashStr := hex.EncodeToString(h[:])
 
 				// Copy data to a pooled buffer to avoid allocations and ensure thread-safety


### PR DESCRIPTION
This change replaces SHA256 with BLAKE3 for content-defined chunking to improve hashing performance. BLAKE3 is significantly faster than SHA256 while maintaining strong security properties for this use case.

The implementation updates pkg/chunker to use github.com/zeebo/blake3 and updates the nix vendorHash accordingly.