### PR TITLE
feat: add database queries for NAR chunking and compression tracking

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -348,3 +348,18 @@ ORDER BY id;
 SELECT COUNT(*)
 FROM nar_files
 WHERE total_chunks = 0;
+
+-- name: GetCompressedNarInfos :many
+SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, `system`, ca
+FROM narinfos
+WHERE compression NOT IN ('', 'none')
+ORDER BY id
+LIMIT ? OFFSET ?;
+
+-- name: GetOldCompressedNarFiles :many
+SELECT id, hash, compression, file_size, `query`, created_at, updated_at, last_accessed_at, total_chunks
+FROM nar_files
+WHERE compression NOT IN ('', 'none')
+  AND created_at < ?
+ORDER BY id
+LIMIT ? OFFSET ?;

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -368,3 +368,18 @@ ORDER BY id;
 SELECT COUNT(*)
 FROM nar_files
 WHERE total_chunks = 0;
+
+-- name: GetCompressedNarInfos :many
+SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+FROM narinfos
+WHERE compression NOT IN ('', 'none')
+ORDER BY id
+LIMIT $1 OFFSET $2;
+
+-- name: GetOldCompressedNarFiles :many
+SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks
+FROM nar_files
+WHERE compression NOT IN ('', 'none')
+  AND created_at < $1
+ORDER BY id
+LIMIT $2 OFFSET $3;

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -355,3 +355,18 @@ ORDER BY id;
 SELECT COUNT(*)
 FROM nar_files
 WHERE total_chunks = 0;
+
+-- name: GetCompressedNarInfos :many
+SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+FROM narinfos
+WHERE compression NOT IN ('', 'none')
+ORDER BY id
+LIMIT ? OFFSET ?;
+
+-- name: GetOldCompressedNarFiles :many
+SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks
+FROM nar_files
+WHERE compression NOT IN ('', 'none')
+  AND created_at < ?
+ORDER BY id
+LIMIT ? OFFSET ?;

--- a/pkg/database/generated_models.go
+++ b/pkg/database/generated_models.go
@@ -85,6 +85,11 @@ type GetChunkByNarFileIDAndIndexParams struct {
 	ChunkIndex int64
 }
 
+type GetCompressedNarInfosParams struct {
+	Limit  int32
+	Offset int32
+}
+
 type GetLeastUsedNarFilesRow struct {
 	ID             int64
 	Hash           string
@@ -129,6 +134,12 @@ type GetNarFilesToChunkRow struct {
 type GetNarInfoHashesToChunkRow struct {
 	Hash string
 	URL  sql.NullString
+}
+
+type GetOldCompressedNarFilesParams struct {
+	CreatedAt time.Time
+	Limit     int32
+	Offset    int32
 }
 
 type GetOrphanedNarFilesRow struct {

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -165,6 +165,14 @@ type Querier interface {
 	//  WHERE nfc.nar_file_id = $1
 	//  ORDER BY nfc.chunk_index
 	GetChunksByNarFileID(ctx context.Context, narFileID int64) ([]Chunk, error)
+	//GetCompressedNarInfos
+	//
+	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+	//  FROM narinfos
+	//  WHERE compression NOT IN ('', 'none')
+	//  ORDER BY id
+	//  LIMIT $1 OFFSET $2
+	GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error)
 	//GetConfigByID
 	//
 	//  SELECT id, key, value, created_at, updated_at
@@ -317,6 +325,15 @@ type Querier interface {
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS BIGINT) AS total_size
 	//  FROM nar_files
 	GetNarTotalSize(ctx context.Context) (int64, error)
+	//GetOldCompressedNarFiles
+	//
+	//  SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks
+	//  FROM nar_files
+	//  WHERE compression NOT IN ('', 'none')
+	//    AND created_at < $1
+	//  ORDER BY id
+	//  LIMIT $2 OFFSET $3
+	GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]NarFile, error)
 	//GetOrphanedChunks
 	//
 	//  SELECT c.id, c.hash, c.size, c.created_at, c.updated_at

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -378,6 +378,55 @@ func (w *mysqlWrapper) GetChunksByNarFileID(ctx context.Context, narFileID int64
 	return items, nil
 }
 
+func (w *mysqlWrapper) GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetCompressedNarInfos(ctx, mysqldb.GetCompressedNarInfosParams{
+		Limit:  arg.Limit,
+		Offset: arg.Offset,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]NarInfo, len(res))
+	for i, v := range res {
+		items[i] = NarInfo{
+			ID: v.ID,
+
+			Hash: v.Hash,
+
+			CreatedAt: v.CreatedAt,
+
+			UpdatedAt: v.UpdatedAt,
+
+			LastAccessedAt: v.LastAccessedAt,
+
+			StorePath: v.StorePath,
+
+			URL: v.URL,
+
+			Compression: v.Compression,
+
+			FileHash: v.FileHash,
+
+			FileSize: v.FileSize,
+
+			NarHash: v.NarHash,
+
+			NarSize: v.NarSize,
+
+			Deriver: v.Deriver,
+
+			System: v.System,
+
+			Ca: v.Ca,
+		}
+	}
+	return items, nil
+}
+
 func (w *mysqlWrapper) GetConfigByID(ctx context.Context, id int64) (Config, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -889,6 +938,44 @@ func (w *mysqlWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {
 	// Return Primitive / *sql.DB / etc
 
 	return res, nil
+}
+
+func (w *mysqlWrapper) GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]NarFile, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetOldCompressedNarFiles(ctx, mysqldb.GetOldCompressedNarFilesParams{
+		CreatedAt: arg.CreatedAt,
+		Limit:     arg.Limit,
+		Offset:    arg.Offset,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]NarFile, len(res))
+	for i, v := range res {
+		items[i] = NarFile{
+			ID: v.ID,
+
+			Hash: v.Hash,
+
+			Compression: v.Compression,
+
+			FileSize: v.FileSize,
+
+			Query: v.Query,
+
+			CreatedAt: v.CreatedAt,
+
+			UpdatedAt: v.UpdatedAt,
+
+			LastAccessedAt: v.LastAccessedAt,
+
+			TotalChunks: v.TotalChunks,
+		}
+	}
+	return items, nil
 }
 
 func (w *mysqlWrapper) GetOrphanedChunks(ctx context.Context) ([]Chunk, error) {

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -428,6 +428,55 @@ func (w *postgresWrapper) GetChunksByNarFileID(ctx context.Context, narFileID in
 	return items, nil
 }
 
+func (w *postgresWrapper) GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetCompressedNarInfos(ctx, postgresdb.GetCompressedNarInfosParams{
+		Limit:  arg.Limit,
+		Offset: arg.Offset,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]NarInfo, len(res))
+	for i, v := range res {
+		items[i] = NarInfo{
+			ID: v.ID,
+
+			Hash: v.Hash,
+
+			CreatedAt: v.CreatedAt,
+
+			UpdatedAt: v.UpdatedAt,
+
+			LastAccessedAt: v.LastAccessedAt,
+
+			StorePath: v.StorePath,
+
+			URL: v.URL,
+
+			Compression: v.Compression,
+
+			FileHash: v.FileHash,
+
+			FileSize: v.FileSize,
+
+			NarHash: v.NarHash,
+
+			NarSize: v.NarSize,
+
+			Deriver: v.Deriver,
+
+			System: v.System,
+
+			Ca: v.Ca,
+		}
+	}
+	return items, nil
+}
+
 func (w *postgresWrapper) GetConfigByID(ctx context.Context, id int64) (Config, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -939,6 +988,44 @@ func (w *postgresWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {
 	// Return Primitive / *sql.DB / etc
 
 	return res, nil
+}
+
+func (w *postgresWrapper) GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]NarFile, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetOldCompressedNarFiles(ctx, postgresdb.GetOldCompressedNarFilesParams{
+		CreatedAt: arg.CreatedAt,
+		Limit:     arg.Limit,
+		Offset:    arg.Offset,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]NarFile, len(res))
+	for i, v := range res {
+		items[i] = NarFile{
+			ID: v.ID,
+
+			Hash: v.Hash,
+
+			Compression: v.Compression,
+
+			FileSize: v.FileSize,
+
+			Query: v.Query,
+
+			CreatedAt: v.CreatedAt,
+
+			UpdatedAt: v.UpdatedAt,
+
+			LastAccessedAt: v.LastAccessedAt,
+
+			TotalChunks: v.TotalChunks,
+		}
+	}
+	return items, nil
 }
 
 func (w *postgresWrapper) GetOrphanedChunks(ctx context.Context) ([]Chunk, error) {

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -446,6 +446,55 @@ func (w *sqliteWrapper) GetChunksByNarFileID(ctx context.Context, narFileID int6
 	return items, nil
 }
 
+func (w *sqliteWrapper) GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetCompressedNarInfos(ctx, sqlitedb.GetCompressedNarInfosParams{
+		Limit:  int64(arg.Limit),
+		Offset: int64(arg.Offset),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]NarInfo, len(res))
+	for i, v := range res {
+		items[i] = NarInfo{
+			ID: v.ID,
+
+			Hash: v.Hash,
+
+			CreatedAt: v.CreatedAt,
+
+			UpdatedAt: v.UpdatedAt,
+
+			LastAccessedAt: v.LastAccessedAt,
+
+			StorePath: v.StorePath,
+
+			URL: v.URL,
+
+			Compression: v.Compression,
+
+			FileHash: v.FileHash,
+
+			FileSize: v.FileSize,
+
+			NarHash: v.NarHash,
+
+			NarSize: v.NarSize,
+
+			Deriver: v.Deriver,
+
+			System: v.System,
+
+			Ca: v.Ca,
+		}
+	}
+	return items, nil
+}
+
 func (w *sqliteWrapper) GetConfigByID(ctx context.Context, id int64) (Config, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -957,6 +1006,44 @@ func (w *sqliteWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {
 	// Return Primitive / *sql.DB / etc
 
 	return res, nil
+}
+
+func (w *sqliteWrapper) GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]NarFile, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetOldCompressedNarFiles(ctx, sqlitedb.GetOldCompressedNarFilesParams{
+		CreatedAt: arg.CreatedAt,
+		Limit:     int64(arg.Limit),
+		Offset:    int64(arg.Offset),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]NarFile, len(res))
+	for i, v := range res {
+		items[i] = NarFile{
+			ID: v.ID,
+
+			Hash: v.Hash,
+
+			Compression: v.Compression,
+
+			FileSize: v.FileSize,
+
+			Query: v.Query,
+
+			CreatedAt: v.CreatedAt,
+
+			UpdatedAt: v.UpdatedAt,
+
+			LastAccessedAt: v.LastAccessedAt,
+
+			TotalChunks: v.TotalChunks,
+		}
+	}
+	return items, nil
 }
 
 func (w *sqliteWrapper) GetOrphanedChunks(ctx context.Context) ([]Chunk, error) {

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -150,6 +150,14 @@ type Querier interface {
 	//  WHERE nfc.nar_file_id = ?
 	//  ORDER BY nfc.chunk_index
 	GetChunksByNarFileID(ctx context.Context, narFileID int64) ([]Chunk, error)
+	//GetCompressedNarInfos
+	//
+	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, `system`, ca
+	//  FROM narinfos
+	//  WHERE compression NOT IN ('', 'none')
+	//  ORDER BY id
+	//  LIMIT ? OFFSET ?
+	GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error)
 	//GetConfigByID
 	//
 	//  SELECT id, `key`, value, created_at, updated_at
@@ -302,6 +310,15 @@ type Querier interface {
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS SIGNED) AS total_size
 	//  FROM nar_files
 	GetNarTotalSize(ctx context.Context) (int64, error)
+	//GetOldCompressedNarFiles
+	//
+	//  SELECT id, hash, compression, file_size, `query`, created_at, updated_at, last_accessed_at, total_chunks
+	//  FROM nar_files
+	//  WHERE compression NOT IN ('', 'none')
+	//    AND created_at < ?
+	//  ORDER BY id
+	//  LIMIT ? OFFSET ?
+	GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]GetOldCompressedNarFilesRow, error)
 	//GetOrphanedChunks
 	//
 	//  SELECT c.id, c.hash, c.size, c.created_at, c.updated_at

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -168,6 +168,14 @@ type Querier interface {
 	//  WHERE nfc.nar_file_id = $1
 	//  ORDER BY nfc.chunk_index
 	GetChunksByNarFileID(ctx context.Context, narFileID int64) ([]Chunk, error)
+	//GetCompressedNarInfos
+	//
+	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+	//  FROM narinfos
+	//  WHERE compression NOT IN ('', 'none')
+	//  ORDER BY id
+	//  LIMIT $1 OFFSET $2
+	GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error)
 	//GetConfigByID
 	//
 	//  SELECT id, key, value, created_at, updated_at
@@ -320,6 +328,15 @@ type Querier interface {
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS BIGINT) AS total_size
 	//  FROM nar_files
 	GetNarTotalSize(ctx context.Context) (int64, error)
+	//GetOldCompressedNarFiles
+	//
+	//  SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks
+	//  FROM nar_files
+	//  WHERE compression NOT IN ('', 'none')
+	//    AND created_at < $1
+	//  ORDER BY id
+	//  LIMIT $2 OFFSET $3
+	GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]NarFile, error)
 	//GetOrphanedChunks
 	//
 	//  SELECT c.id, c.hash, c.size, c.created_at, c.updated_at

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -604,6 +604,65 @@ func (q *Queries) GetChunksByNarFileID(ctx context.Context, narFileID int64) ([]
 	return items, nil
 }
 
+const getCompressedNarInfos = `-- name: GetCompressedNarInfos :many
+SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+FROM narinfos
+WHERE compression NOT IN ('', 'none')
+ORDER BY id
+LIMIT $1 OFFSET $2
+`
+
+type GetCompressedNarInfosParams struct {
+	Limit  int32
+	Offset int32
+}
+
+// GetCompressedNarInfos
+//
+//	SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+//	FROM narinfos
+//	WHERE compression NOT IN ('', 'none')
+//	ORDER BY id
+//	LIMIT $1 OFFSET $2
+func (q *Queries) GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error) {
+	rows, err := q.db.QueryContext(ctx, getCompressedNarInfos, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []NarInfo
+	for rows.Next() {
+		var i NarInfo
+		if err := rows.Scan(
+			&i.ID,
+			&i.Hash,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.LastAccessedAt,
+			&i.StorePath,
+			&i.URL,
+			&i.Compression,
+			&i.FileHash,
+			&i.FileSize,
+			&i.NarHash,
+			&i.NarSize,
+			&i.Deriver,
+			&i.System,
+			&i.Ca,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getConfigByID = `-- name: GetConfigByID :one
 SELECT id, key, value, created_at, updated_at
 FROM config
@@ -1337,6 +1396,62 @@ func (q *Queries) GetNarTotalSize(ctx context.Context) (int64, error) {
 	var total_size int64
 	err := row.Scan(&total_size)
 	return total_size, err
+}
+
+const getOldCompressedNarFiles = `-- name: GetOldCompressedNarFiles :many
+SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks
+FROM nar_files
+WHERE compression NOT IN ('', 'none')
+  AND created_at < $1
+ORDER BY id
+LIMIT $2 OFFSET $3
+`
+
+type GetOldCompressedNarFilesParams struct {
+	CreatedAt time.Time
+	Limit     int32
+	Offset    int32
+}
+
+// GetOldCompressedNarFiles
+//
+//	SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks
+//	FROM nar_files
+//	WHERE compression NOT IN ('', 'none')
+//	  AND created_at < $1
+//	ORDER BY id
+//	LIMIT $2 OFFSET $3
+func (q *Queries) GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]NarFile, error) {
+	rows, err := q.db.QueryContext(ctx, getOldCompressedNarFiles, arg.CreatedAt, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []NarFile
+	for rows.Next() {
+		var i NarFile
+		if err := rows.Scan(
+			&i.ID,
+			&i.Hash,
+			&i.Compression,
+			&i.FileSize,
+			&i.Query,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.LastAccessedAt,
+			&i.TotalChunks,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getOrphanedChunks = `-- name: GetOrphanedChunks :many

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -154,6 +154,14 @@ type Querier interface {
 	//  WHERE nfc.nar_file_id = ?
 	//  ORDER BY nfc.chunk_index
 	GetChunksByNarFileID(ctx context.Context, narFileID int64) ([]Chunk, error)
+	//GetCompressedNarInfos
+	//
+	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+	//  FROM narinfos
+	//  WHERE compression NOT IN ('', 'none')
+	//  ORDER BY id
+	//  LIMIT ? OFFSET ?
+	GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error)
 	//GetConfigByID
 	//
 	//  SELECT id, "key", value, created_at, updated_at
@@ -306,6 +314,15 @@ type Querier interface {
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS INTEGER) AS total_size
 	//  FROM nar_files
 	GetNarTotalSize(ctx context.Context) (int64, error)
+	//GetOldCompressedNarFiles
+	//
+	//  SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks
+	//  FROM nar_files
+	//  WHERE compression NOT IN ('', 'none')
+	//    AND created_at < ?
+	//  ORDER BY id
+	//  LIMIT ? OFFSET ?
+	GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]NarFile, error)
 	//GetOrphanedChunks
 	//
 	//  SELECT c.id, c.hash, c.size, c.created_at, c.updated_at

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -556,6 +556,65 @@ func (q *Queries) GetChunksByNarFileID(ctx context.Context, narFileID int64) ([]
 	return items, nil
 }
 
+const getCompressedNarInfos = `-- name: GetCompressedNarInfos :many
+SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+FROM narinfos
+WHERE compression NOT IN ('', 'none')
+ORDER BY id
+LIMIT ? OFFSET ?
+`
+
+type GetCompressedNarInfosParams struct {
+	Limit  int64
+	Offset int64
+}
+
+// GetCompressedNarInfos
+//
+//	SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+//	FROM narinfos
+//	WHERE compression NOT IN ('', 'none')
+//	ORDER BY id
+//	LIMIT ? OFFSET ?
+func (q *Queries) GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error) {
+	rows, err := q.db.QueryContext(ctx, getCompressedNarInfos, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []NarInfo
+	for rows.Next() {
+		var i NarInfo
+		if err := rows.Scan(
+			&i.ID,
+			&i.Hash,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.LastAccessedAt,
+			&i.StorePath,
+			&i.URL,
+			&i.Compression,
+			&i.FileHash,
+			&i.FileSize,
+			&i.NarHash,
+			&i.NarSize,
+			&i.Deriver,
+			&i.System,
+			&i.Ca,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getConfigByID = `-- name: GetConfigByID :one
 SELECT id, "key", value, created_at, updated_at
 FROM config
@@ -1289,6 +1348,62 @@ func (q *Queries) GetNarTotalSize(ctx context.Context) (int64, error) {
 	var total_size int64
 	err := row.Scan(&total_size)
 	return total_size, err
+}
+
+const getOldCompressedNarFiles = `-- name: GetOldCompressedNarFiles :many
+SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks
+FROM nar_files
+WHERE compression NOT IN ('', 'none')
+  AND created_at < ?
+ORDER BY id
+LIMIT ? OFFSET ?
+`
+
+type GetOldCompressedNarFilesParams struct {
+	CreatedAt time.Time
+	Limit     int64
+	Offset    int64
+}
+
+// GetOldCompressedNarFiles
+//
+//	SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks
+//	FROM nar_files
+//	WHERE compression NOT IN ('', 'none')
+//	  AND created_at < ?
+//	ORDER BY id
+//	LIMIT ? OFFSET ?
+func (q *Queries) GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]NarFile, error) {
+	rows, err := q.db.QueryContext(ctx, getOldCompressedNarFiles, arg.CreatedAt, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []NarFile
+	for rows.Next() {
+		var i NarFile
+		if err := rows.Scan(
+			&i.ID,
+			&i.Hash,
+			&i.Compression,
+			&i.FileSize,
+			&i.Query,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.LastAccessedAt,
+			&i.TotalChunks,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getOrphanedChunks = `-- name: GetOrphanedChunks :many


### PR DESCRIPTION
This commit adds several new database queries to support background jobs for NAR file chunking and compression migration. Specifically, it adds queries to:
- Update the total chunk count for a NAR file.
- Retrieve migrated NarInfo hashes that haven't been chunked yet.
- Retrieve and count NAR files that require chunking.
- Identify NarInfo and NAR files with compression for migration purposes.