### PR TITLE
feat: Add special handling for MySQL UPDATE Statements

### DIFF
--- a/nix/gen-db-wrappers/src/main_test.go
+++ b/nix/gen-db-wrappers/src/main_test.go
@@ -228,6 +228,8 @@ func TestWrapperTemplate(t *testing.T) {
 
 	// Helper functions as defined in main.go
 	funcMap := template.FuncMap{
+		"hasParam":            hasParam,
+		"paramHasField":       paramHasField,
 		"joinParamsSignature": joinParamsSignature,
 		"joinReturns":         joinReturns,
 		"isSlice":             isSlice,


### PR DESCRIPTION
MySQL does not support RETURNING for UPDATEs. We update, and then fetch
the object by its unique key (assumed to be the first param after
context, or we try by Hash if it exists).

Part of #805