### PR TITLE
feat: Add UpdateNarInfo query to all engines

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -78,6 +78,22 @@ ON DUPLICATE KEY UPDATE
     url = IF(url IS NULL, VALUES(url), url),
     updated_at = IF(url IS NULL, CURRENT_TIMESTAMP, updated_at);
 
+-- name: UpdateNarInfo :execresult
+UPDATE narinfos
+SET
+    store_path = ?,
+    url = ?,
+    compression = ?,
+    file_hash = ?,
+    file_size = ?,
+    nar_hash = ?,
+    nar_size = ?,
+    deriver = ?,
+    system = ?,
+    ca = ?,
+    updated_at = CURRENT_TIMESTAMP
+WHERE hash = ?;
+
 -- name: UpdateNarInfoFileSize :exec
 UPDATE narinfos
 SET file_size = ?, updated_at = CURRENT_TIMESTAMP

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -81,6 +81,23 @@ ON CONFLICT (hash) DO UPDATE SET
 WHERE narinfos.url IS NULL
 RETURNING *;
 
+-- name: UpdateNarInfo :one
+UPDATE narinfos
+SET
+    store_path = $2,
+    url = $3,
+    compression = $4,
+    file_hash = $5,
+    file_size = $6,
+    nar_hash = $7,
+    nar_size = $8,
+    deriver = $9,
+    system = $10,
+    ca = $11,
+    updated_at = CURRENT_TIMESTAMP
+WHERE hash = $1
+RETURNING *;
+
 -- name: UpdateNarInfoFileSize :exec
 UPDATE narinfos
 SET file_size = $2, updated_at = CURRENT_TIMESTAMP

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -81,6 +81,23 @@ ON CONFLICT(hash) DO UPDATE SET
 WHERE narinfos.url IS NULL
 RETURNING *;
 
+-- name: UpdateNarInfo :one
+UPDATE narinfos
+SET
+    store_path = ?,
+    url = ?,
+    compression = ?,
+    file_hash = ?,
+    file_size = ?,
+    nar_hash = ?,
+    nar_size = ?,
+    deriver = ?,
+    system = ?,
+    ca = ?,
+    updated_at = CURRENT_TIMESTAMP
+WHERE hash = ?
+RETURNING *;
+
 -- name: UpdateNarInfoFileSize :exec
 UPDATE narinfos
 SET file_size = ?, updated_at = CURRENT_TIMESTAMP

--- a/pkg/database/generated_models.go
+++ b/pkg/database/generated_models.go
@@ -220,3 +220,17 @@ type UpdateNarInfoFileSizeParams struct {
 	Hash     string
 	FileSize sql.NullInt64
 }
+
+type UpdateNarInfoParams struct {
+	Hash        string
+	StorePath   sql.NullString
+	URL         sql.NullString
+	Compression sql.NullString
+	FileHash    sql.NullString
+	FileSize    sql.NullInt64
+	NarHash     sql.NullString
+	NarSize     sql.NullInt64
+	Deriver     sql.NullString
+	System      sql.NullString
+	Ca          sql.NullString
+}

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -427,6 +427,24 @@ type Querier interface {
 	//  SET total_chunks = $1, updated_at = CURRENT_TIMESTAMP
 	//  WHERE id = $2
 	UpdateNarFileTotalChunks(ctx context.Context, arg UpdateNarFileTotalChunksParams) error
+	//UpdateNarInfo
+	//
+	//  UPDATE narinfos
+	//  SET
+	//      store_path = $2,
+	//      url = $3,
+	//      compression = $4,
+	//      file_hash = $5,
+	//      file_size = $6,
+	//      nar_hash = $7,
+	//      nar_size = $8,
+	//      deriver = $9,
+	//      system = $10,
+	//      ca = $11,
+	//      updated_at = CURRENT_TIMESTAMP
+	//  WHERE hash = $1
+	//  RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+	UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (NarInfo, error)
 	//UpdateNarInfoFileSize
 	//
 	//  UPDATE narinfos

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -1205,6 +1205,66 @@ func (w *postgresWrapper) UpdateNarFileTotalChunks(ctx context.Context, arg Upda
 	})
 }
 
+func (w *postgresWrapper) UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.UpdateNarInfo(ctx, postgresdb.UpdateNarInfoParams{
+		Hash:        arg.Hash,
+		StorePath:   arg.StorePath,
+		URL:         arg.URL,
+		Compression: arg.Compression,
+		FileHash:    arg.FileHash,
+		FileSize:    arg.FileSize,
+		NarHash:     arg.NarHash,
+		NarSize:     arg.NarSize,
+		Deriver:     arg.Deriver,
+		System:      arg.System,
+		Ca:          arg.Ca,
+	})
+	if err != nil {
+
+		if errors.Is(err, sql.ErrNoRows) {
+			return NarInfo{}, ErrNotFound
+		}
+
+		return NarInfo{}, err
+	}
+
+	// Convert Single Domain Struct
+
+	return NarInfo{
+		ID: res.ID,
+
+		Hash: res.Hash,
+
+		CreatedAt: res.CreatedAt,
+
+		UpdatedAt: res.UpdatedAt,
+
+		LastAccessedAt: res.LastAccessedAt,
+
+		StorePath: res.StorePath,
+
+		URL: res.URL,
+
+		Compression: res.Compression,
+
+		FileHash: res.FileHash,
+
+		FileSize: res.FileSize,
+
+		NarHash: res.NarHash,
+
+		NarSize: res.NarSize,
+
+		Deriver: res.Deriver,
+
+		System: res.System,
+
+		Ca: res.Ca,
+	}, nil
+}
+
 func (w *postgresWrapper) UpdateNarInfoFileSize(ctx context.Context, arg UpdateNarInfoFileSizeParams) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -1232,6 +1232,66 @@ func (w *sqliteWrapper) UpdateNarFileTotalChunks(ctx context.Context, arg Update
 	})
 }
 
+func (w *sqliteWrapper) UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.UpdateNarInfo(ctx, sqlitedb.UpdateNarInfoParams{
+		StorePath:   arg.StorePath,
+		URL:         arg.URL,
+		Compression: arg.Compression,
+		FileHash:    arg.FileHash,
+		FileSize:    arg.FileSize,
+		NarHash:     arg.NarHash,
+		NarSize:     arg.NarSize,
+		Deriver:     arg.Deriver,
+		System:      arg.System,
+		Ca:          arg.Ca,
+		Hash:        arg.Hash,
+	})
+	if err != nil {
+
+		if errors.Is(err, sql.ErrNoRows) {
+			return NarInfo{}, ErrNotFound
+		}
+
+		return NarInfo{}, err
+	}
+
+	// Convert Single Domain Struct
+
+	return NarInfo{
+		ID: res.ID,
+
+		Hash: res.Hash,
+
+		CreatedAt: res.CreatedAt,
+
+		UpdatedAt: res.UpdatedAt,
+
+		LastAccessedAt: res.LastAccessedAt,
+
+		StorePath: res.StorePath,
+
+		URL: res.URL,
+
+		Compression: res.Compression,
+
+		FileHash: res.FileHash,
+
+		FileSize: res.FileSize,
+
+		NarHash: res.NarHash,
+
+		NarSize: res.NarSize,
+
+		Deriver: res.Deriver,
+
+		System: res.System,
+
+		Ca: res.Ca,
+	}, nil
+}
+
 func (w *sqliteWrapper) UpdateNarInfoFileSize(ctx context.Context, arg UpdateNarInfoFileSizeParams) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -410,6 +410,23 @@ type Querier interface {
 	//  SET total_chunks = ?, updated_at = CURRENT_TIMESTAMP
 	//  WHERE id = ?
 	UpdateNarFileTotalChunks(ctx context.Context, arg UpdateNarFileTotalChunksParams) error
+	//UpdateNarInfo
+	//
+	//  UPDATE narinfos
+	//  SET
+	//      store_path = ?,
+	//      url = ?,
+	//      compression = ?,
+	//      file_hash = ?,
+	//      file_size = ?,
+	//      nar_hash = ?,
+	//      nar_size = ?,
+	//      deriver = ?,
+	//      system = ?,
+	//      ca = ?,
+	//      updated_at = CURRENT_TIMESTAMP
+	//  WHERE hash = ?
+	UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (sql.Result, error)
 	//UpdateNarInfoFileSize
 	//
 	//  UPDATE narinfos

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -1737,6 +1737,69 @@ func (q *Queries) UpdateNarFileTotalChunks(ctx context.Context, arg UpdateNarFil
 	return err
 }
 
+const updateNarInfo = `-- name: UpdateNarInfo :execresult
+UPDATE narinfos
+SET
+    store_path = ?,
+    url = ?,
+    compression = ?,
+    file_hash = ?,
+    file_size = ?,
+    nar_hash = ?,
+    nar_size = ?,
+    deriver = ?,
+    system = ?,
+    ca = ?,
+    updated_at = CURRENT_TIMESTAMP
+WHERE hash = ?
+`
+
+type UpdateNarInfoParams struct {
+	StorePath   sql.NullString
+	URL         sql.NullString
+	Compression sql.NullString
+	FileHash    sql.NullString
+	FileSize    sql.NullInt64
+	NarHash     sql.NullString
+	NarSize     sql.NullInt64
+	Deriver     sql.NullString
+	System      sql.NullString
+	Ca          sql.NullString
+	Hash        string
+}
+
+// UpdateNarInfo
+//
+//	UPDATE narinfos
+//	SET
+//	    store_path = ?,
+//	    url = ?,
+//	    compression = ?,
+//	    file_hash = ?,
+//	    file_size = ?,
+//	    nar_hash = ?,
+//	    nar_size = ?,
+//	    deriver = ?,
+//	    system = ?,
+//	    ca = ?,
+//	    updated_at = CURRENT_TIMESTAMP
+//	WHERE hash = ?
+func (q *Queries) UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (sql.Result, error) {
+	return q.db.ExecContext(ctx, updateNarInfo,
+		arg.StorePath,
+		arg.URL,
+		arg.Compression,
+		arg.FileHash,
+		arg.FileSize,
+		arg.NarHash,
+		arg.NarSize,
+		arg.Deriver,
+		arg.System,
+		arg.Ca,
+		arg.Hash,
+	)
+}
+
 const updateNarInfoFileSize = `-- name: UpdateNarInfoFileSize :exec
 UPDATE narinfos
 SET file_size = ?, updated_at = CURRENT_TIMESTAMP

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -430,6 +430,24 @@ type Querier interface {
 	//  SET total_chunks = $1, updated_at = CURRENT_TIMESTAMP
 	//  WHERE id = $2
 	UpdateNarFileTotalChunks(ctx context.Context, arg UpdateNarFileTotalChunksParams) error
+	//UpdateNarInfo
+	//
+	//  UPDATE narinfos
+	//  SET
+	//      store_path = $2,
+	//      url = $3,
+	//      compression = $4,
+	//      file_hash = $5,
+	//      file_size = $6,
+	//      nar_hash = $7,
+	//      nar_size = $8,
+	//      deriver = $9,
+	//      system = $10,
+	//      ca = $11,
+	//      updated_at = CURRENT_TIMESTAMP
+	//  WHERE hash = $1
+	//  RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+	UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (NarInfo, error)
 	//UpdateNarInfoFileSize
 	//
 	//  UPDATE narinfos

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -1811,6 +1811,90 @@ func (q *Queries) UpdateNarFileTotalChunks(ctx context.Context, arg UpdateNarFil
 	return err
 }
 
+const updateNarInfo = `-- name: UpdateNarInfo :one
+UPDATE narinfos
+SET
+    store_path = $2,
+    url = $3,
+    compression = $4,
+    file_hash = $5,
+    file_size = $6,
+    nar_hash = $7,
+    nar_size = $8,
+    deriver = $9,
+    system = $10,
+    ca = $11,
+    updated_at = CURRENT_TIMESTAMP
+WHERE hash = $1
+RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+`
+
+type UpdateNarInfoParams struct {
+	Hash        string
+	StorePath   sql.NullString
+	URL         sql.NullString
+	Compression sql.NullString
+	FileHash    sql.NullString
+	FileSize    sql.NullInt64
+	NarHash     sql.NullString
+	NarSize     sql.NullInt64
+	Deriver     sql.NullString
+	System      sql.NullString
+	Ca          sql.NullString
+}
+
+// UpdateNarInfo
+//
+//	UPDATE narinfos
+//	SET
+//	    store_path = $2,
+//	    url = $3,
+//	    compression = $4,
+//	    file_hash = $5,
+//	    file_size = $6,
+//	    nar_hash = $7,
+//	    nar_size = $8,
+//	    deriver = $9,
+//	    system = $10,
+//	    ca = $11,
+//	    updated_at = CURRENT_TIMESTAMP
+//	WHERE hash = $1
+//	RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+func (q *Queries) UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (NarInfo, error) {
+	row := q.db.QueryRowContext(ctx, updateNarInfo,
+		arg.Hash,
+		arg.StorePath,
+		arg.URL,
+		arg.Compression,
+		arg.FileHash,
+		arg.FileSize,
+		arg.NarHash,
+		arg.NarSize,
+		arg.Deriver,
+		arg.System,
+		arg.Ca,
+	)
+	var i NarInfo
+	err := row.Scan(
+		&i.ID,
+		&i.Hash,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.LastAccessedAt,
+		&i.StorePath,
+		&i.URL,
+		&i.Compression,
+		&i.FileHash,
+		&i.FileSize,
+		&i.NarHash,
+		&i.NarSize,
+		&i.Deriver,
+		&i.System,
+		&i.Ca,
+	)
+	return i, err
+}
+
 const updateNarInfoFileSize = `-- name: UpdateNarInfoFileSize :exec
 UPDATE narinfos
 SET file_size = $2, updated_at = CURRENT_TIMESTAMP

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -417,6 +417,24 @@ type Querier interface {
 	//  SET total_chunks = ?, updated_at = CURRENT_TIMESTAMP
 	//  WHERE id = ?
 	UpdateNarFileTotalChunks(ctx context.Context, arg UpdateNarFileTotalChunksParams) error
+	//UpdateNarInfo
+	//
+	//  UPDATE narinfos
+	//  SET
+	//      store_path = ?,
+	//      url = ?,
+	//      compression = ?,
+	//      file_hash = ?,
+	//      file_size = ?,
+	//      nar_hash = ?,
+	//      nar_size = ?,
+	//      deriver = ?,
+	//      system = ?,
+	//      ca = ?,
+	//      updated_at = CURRENT_TIMESTAMP
+	//  WHERE hash = ?
+	//  RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+	UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (NarInfo, error)
 	//UpdateNarInfoFileSize
 	//
 	//  UPDATE narinfos

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -1765,6 +1765,90 @@ func (q *Queries) UpdateNarFileTotalChunks(ctx context.Context, arg UpdateNarFil
 	return err
 }
 
+const updateNarInfo = `-- name: UpdateNarInfo :one
+UPDATE narinfos
+SET
+    store_path = ?,
+    url = ?,
+    compression = ?,
+    file_hash = ?,
+    file_size = ?,
+    nar_hash = ?,
+    nar_size = ?,
+    deriver = ?,
+    system = ?,
+    ca = ?,
+    updated_at = CURRENT_TIMESTAMP
+WHERE hash = ?
+RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+`
+
+type UpdateNarInfoParams struct {
+	StorePath   sql.NullString
+	URL         sql.NullString
+	Compression sql.NullString
+	FileHash    sql.NullString
+	FileSize    sql.NullInt64
+	NarHash     sql.NullString
+	NarSize     sql.NullInt64
+	Deriver     sql.NullString
+	System      sql.NullString
+	Ca          sql.NullString
+	Hash        string
+}
+
+// UpdateNarInfo
+//
+//	UPDATE narinfos
+//	SET
+//	    store_path = ?,
+//	    url = ?,
+//	    compression = ?,
+//	    file_hash = ?,
+//	    file_size = ?,
+//	    nar_hash = ?,
+//	    nar_size = ?,
+//	    deriver = ?,
+//	    system = ?,
+//	    ca = ?,
+//	    updated_at = CURRENT_TIMESTAMP
+//	WHERE hash = ?
+//	RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
+func (q *Queries) UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (NarInfo, error) {
+	row := q.db.QueryRowContext(ctx, updateNarInfo,
+		arg.StorePath,
+		arg.URL,
+		arg.Compression,
+		arg.FileHash,
+		arg.FileSize,
+		arg.NarHash,
+		arg.NarSize,
+		arg.Deriver,
+		arg.System,
+		arg.Ca,
+		arg.Hash,
+	)
+	var i NarInfo
+	err := row.Scan(
+		&i.ID,
+		&i.Hash,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.LastAccessedAt,
+		&i.StorePath,
+		&i.URL,
+		&i.Compression,
+		&i.FileHash,
+		&i.FileSize,
+		&i.NarHash,
+		&i.NarSize,
+		&i.Deriver,
+		&i.System,
+		&i.Ca,
+	)
+	return i, err
+}
+
 const updateNarInfoFileSize = `-- name: UpdateNarInfoFileSize :exec
 UPDATE narinfos
 SET file_size = ?, updated_at = CURRENT_TIMESTAMP


### PR DESCRIPTION
The query will be used by the cache package to update narinfo after
compression/chunking.

Part of #805