### PR TITLE
feat: implement background migration and cleanup for compressed NARs

### DIFF
--- a/pkg/cache/cache_distributed_test.go
+++ b/pkg/cache/cache_distributed_test.go
@@ -758,7 +758,7 @@ func testLargeNARConcurrentDownloadScenario(t *testing.T, factory distributedDBF
 			downloadLocker,
 			cacheLocker,
 			5*time.Minute,
-			30*time.Second, // downloadPollTimeout
+			60*time.Second, // downloadPollTimeout
 			30*time.Minute,
 		)
 		require.NoError(t, err)
@@ -799,7 +799,7 @@ func testLargeNARConcurrentDownloadScenario(t *testing.T, factory distributedDBF
 			// Create a context with timeout for each request (simulates HTTP request timeout)
 			// This should be longer than the download delay (2s) plus chunking time
 			// For CDC-enabled tests, progressive streaming may take longer
-			requestCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+			requestCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
 			defer cancel()
 
 			// All instances request the same NAR concurrently
@@ -998,7 +998,7 @@ func testCDCProgressiveStreamingDuringChunking(factory distributedDBFactory) fun
 				downloadLocker,
 				cacheLocker,
 				5*time.Minute,
-				30*time.Second, // downloadPollTimeout
+				60*time.Second, // downloadPollTimeout
 				30*time.Minute,
 			)
 			require.NoError(t, err)
@@ -1036,7 +1036,7 @@ func testCDCProgressiveStreamingDuringChunking(factory distributedDBFactory) fun
 				defer wg.Done()
 
 				// Create a context with timeout (give enough time for CDC chunking)
-				requestCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+				requestCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
 				defer cancel()
 
 				// Measure TTFB (time to first byte)


### PR DESCRIPTION
This commit adds background jobs to the cache system to manage the lifecycle of compressed NAR files.
NARs are now processed in two stages:
1. Migration: Compressed NARs (e.g., .zstd) are asynchronously decompressed and stored in an
   uncompressed format. The corresponding narinfo is updated to reflect the new compression type
   (none) and the correct uncompressed file size, while maintaining the same NAR hash.
2. Cleanup: Old compressed NAR files are automatically removed from storage and the database
   after a configurable TTL (default 48 hours).

Key changes:
- Added MigrateCompressedToUncompressed and CleanupCompressedNars methods to the Cache struct.
- Integrated these methods into the cron scheduler with configurable schedules.
- Added compressedNarTTL to allow customization of how long compressed files are retained.
- Added UpdateNarInfo logic to safely transition narinfo records during migration.
- Implemented comprehensive tests in pkg/cache/compression_test.go verifying the migration
  and cleanup workflows.
- Improved test reliability by increasing timeouts in distributed tests to account for
  CDC processing overhead.

Part of #805