### PR TITLE
refactor: remove unused error

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -89,9 +89,6 @@ var (
 	// errNarInfoPurged is returned if the narinfo was purged.
 	errNarInfoPurged = errors.New("the narinfo was purged")
 
-	// ErrInconsistentState is returned when the database is in an inconsistent state (e.g., nar exists without narinfo).
-	ErrInconsistentState = errors.New("inconsistent database state")
-
 	// ErrCDCDisabled is returned when CDC is required but not enabled.
 	ErrCDCDisabled = errors.New("CDC must be enabled and chunk store configured for migration")
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -401,21 +401,12 @@ func (s *Server) putNarInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.cache.PutNarInfo(r.Context(), hash, r.Body); err != nil {
-		if errors.Is(err, cache.ErrInconsistentState) {
-			http.Error(w, err.Error(), http.StatusConflict)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 
-			zerolog.Ctx(r.Context()).
-				Warn().
-				Err(err).
-				Msg("conflict storing narinfo in cache")
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-
-			zerolog.Ctx(r.Context()).
-				Error().
-				Err(err).
-				Msg("error putting the NAR in cache")
-		}
+		zerolog.Ctx(r.Context()).
+			Error().
+			Err(err).
+			Msg("error putting the NAR in cache")
 
 		return
 	}


### PR DESCRIPTION
ErrInconsistentState is no longer being used ever since #662 landed and
can be removed.