### PR TITLE
fix: Add support for missing FileSize and FileHash [backport #823]

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2174,13 +2174,19 @@ func (c *Cache) storeInDatabase(
 			StorePath:   sql.NullString{String: narInfo.StorePath, Valid: narInfo.StorePath != ""},
 			URL:         sql.NullString{String: narInfo.URL, Valid: narInfo.URL != ""},
 			Compression: sql.NullString{String: narInfo.Compression, Valid: narInfo.Compression != ""},
-			FileHash:    sql.NullString{String: narInfo.FileHash.String(), Valid: narInfo.FileHash != nil},
 			FileSize:    sql.NullInt64{Int64: int64(narInfo.FileSize), Valid: true}, //nolint:gosec
-			NarHash:     sql.NullString{String: narInfo.NarHash.String(), Valid: narInfo.NarHash != nil},
-			NarSize:     sql.NullInt64{Int64: int64(narInfo.NarSize), Valid: true}, //nolint:gosec
+			NarSize:     sql.NullInt64{Int64: int64(narInfo.NarSize), Valid: true},  //nolint:gosec
 			Deriver:     sql.NullString{String: narInfo.Deriver, Valid: narInfo.Deriver != ""},
 			System:      sql.NullString{String: narInfo.System, Valid: narInfo.System != ""},
 			Ca:          sql.NullString{String: narInfo.CA, Valid: narInfo.CA != ""},
+		}
+
+		if narInfo.FileHash != nil {
+			createNarInfoParams.FileHash = sql.NullString{String: narInfo.FileHash.String(), Valid: true}
+		}
+
+		if narInfo.NarHash != nil {
+			createNarInfoParams.NarHash = sql.NullString{String: narInfo.NarHash.String(), Valid: true}
 		}
 
 		nir, err := qtx.CreateNarInfo(ctx, createNarInfoParams)
@@ -2434,13 +2440,19 @@ func storeNarInfoInDatabase(ctx context.Context, db database.Querier, hash strin
 		StorePath:   sql.NullString{String: narInfo.StorePath, Valid: narInfo.StorePath != ""},
 		URL:         sql.NullString{String: narInfo.URL, Valid: narInfo.URL != ""},
 		Compression: sql.NullString{String: narInfo.Compression, Valid: narInfo.Compression != ""},
-		FileHash:    sql.NullString{String: narInfo.FileHash.String(), Valid: narInfo.FileHash != nil},
 		FileSize:    sql.NullInt64{Int64: int64(narInfo.FileSize), Valid: true}, //nolint:gosec
-		NarHash:     sql.NullString{String: narInfo.NarHash.String(), Valid: narInfo.NarHash != nil},
-		NarSize:     sql.NullInt64{Int64: int64(narInfo.NarSize), Valid: true}, //nolint:gosec
+		NarSize:     sql.NullInt64{Int64: int64(narInfo.NarSize), Valid: true},  //nolint:gosec
 		Deriver:     sql.NullString{String: narInfo.Deriver, Valid: narInfo.Deriver != ""},
 		System:      sql.NullString{String: narInfo.System, Valid: narInfo.System != ""},
 		Ca:          sql.NullString{String: narInfo.CA, Valid: narInfo.CA != ""},
+	}
+
+	if narInfo.FileHash != nil {
+		createNarInfoParams.FileHash = sql.NullString{String: narInfo.FileHash.String(), Valid: true}
+	}
+
+	if narInfo.NarHash != nil {
+		createNarInfoParams.NarHash = sql.NullString{String: narInfo.NarHash.String(), Valid: true}
 	}
 
 	nir, err := qtx.CreateNarInfo(ctx, createNarInfoParams)

--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -47,6 +47,9 @@ var (
 	// ErrNotFound is returned if the nar or narinfo were not found.
 	ErrNotFound = errors.New("not found")
 
+	// ErrInvalidNarInfo is returned if the given narinfo is invalid.
+	ErrInvalidNarInfo = errors.New("invalid narinfo")
+
 	// ErrUnexpectedHTTPStatusCode is returned if the response has an unexpected status code.
 	ErrUnexpectedHTTPStatusCode = errors.New("unexpected HTTP status code")
 
@@ -365,6 +368,17 @@ func (c *Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, 
 		if !signature.VerifyFirst(ni.Fingerprint(), ni.Signatures, c.publicKeys) {
 			return ni, ErrSignatureValidationFailed
 		}
+	}
+
+	if ni.FileSize == 0 {
+		if ni.Compression != nar.CompressionTypeNone.String() {
+			// TODO: Realistically this can be determined by looking at the NAR
+			// when it arrives but ncps is undergoing a lot of changes currently
+			// and since this is async it breaks a lot of tests.
+			return nil, fmt.Errorf("%w: FileSize is missing for a compressed NAR", ErrInvalidNarInfo)
+		}
+
+		ni.FileSize = ni.NarSize
 	}
 
 	return ni, nil

--- a/testdata/nar7.go
+++ b/testdata/nar7.go
@@ -16,8 +16,6 @@ var Nar7 = Entry{
 	NarInfoText: `StorePath: /nix/store/c12lxpykv6sld7a0sakcnr3y0la70x8w-hello-2.12.2
 URL: nar/09xizkfyvigl5fqs0dhkn46nghfwwijbpdzzl4zg6kx90prjmsg0.nar
 Compression: none
-FileHash: sha256:1yf3p87fsqig07crd9sj9wh7i9jpsa0x86a22fqbls7c81lc7ws2
-FileSize: 113256
 NarHash: sha256:1yf3p87fsqig07crd9sj9wh7i9jpsa0x86a22fqbls7c81lc7ws2
 NarSize: 113256
 References: 7h6icyvqv6lqd0bcx41c8h3615rjcqb2-libiconv-109.100.2

--- a/testdata/upstream_public_keys.go
+++ b/testdata/upstream_public_keys.go
@@ -1,5 +1,7 @@
 package testdata
 
 func PublicKeys() []string {
-	return []string{"cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="}
+	return []string{
+		"cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=",
+	}
 }


### PR DESCRIPTION
Bot-based backport to `release-0.8`, triggered by a label in #823.

This change allows ncps to work correctly when FileSize and/or FileHash
are missing. It computes the FileSize if it's missing and Compression is
none but returns an error for invalid narinfo otherwise. FileHash is not
computed at this time.

part of fixing #806 