### PR TITLE
fix: trim narinfo hash prefix from NarURL in upstream cache [backport #831]

### DIFF
--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -333,7 +333,7 @@ func TestRunLRU(t *testing.T) {
 	// pull the nars except for the last entry to get their last_accessed_at updated
 	sizePulled = 0
 
-	for _, narEntry := range entries {
+	for i, narEntry := range entries {
 		_, err := c.GetNarInfo(context.Background(), narEntry.NarInfoHash)
 		require.NoError(t, err)
 
@@ -356,14 +356,15 @@ func TestRunLRU(t *testing.T) {
 			require.NoError(t, err)
 		}
 
+		t.Logf("Entry %d (%s): reported size=%d, NarText size=%d, diff=%d",
+			i, narEntry.NarInfoHash, size, len(narEntry.NarText), size-int64(len(narEntry.NarText)))
+
 		sizePulled += size
 	}
 
-	// Note: In phase 2, we pull the same entries again, so the size should equal maxSize.
-	// However, due to how GetNar returns sizes (may be different from phase 1 due to caching),
-	// we allow a small tolerance.
-	//nolint:gosec
-	assert.InDelta(t, int64(maxSize), sizePulled, 100, "confirm size pulled is approximately maxSize")
+	assert.Equal(t,
+		int64(maxSize), //nolint:gosec
+		sizePulled, "confirm size pulled is exactly maxSize")
 
 	// all narinfo records are in the database
 	for _, narEntry := range allEntries {

--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -381,6 +381,10 @@ func (c *Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, 
 		ni.FileSize = ni.NarSize
 	}
 
+	// nix-serve serves the NarURL with the narinfo hash included in the URL as
+	// prefix to the NAR Hash. Trim that out, we don't need it.
+	ni.URL = strings.ReplaceAll(ni.URL, hash+"-", "")
+
 	return ni, nil
 }
 

--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -176,6 +176,15 @@ func TestGetNarInfo(t *testing.T) {
 
 						assert.EqualValues(t, len(narEntry.NarText), ni.FileSize)
 					})
+
+					if narEntry.NarInfoHash == "c12lxpykv6sld7a0sakcnr3y0la70x8w" {
+						t.Run("narinfo is removed from nar url", func(t *testing.T) {
+							ni, err := c.GetNarInfo(context.Background(), narEntry.NarInfoHash)
+							require.NoError(t, err)
+
+							assert.Equal(t, "nar/09xizkfyvigl5fqs0dhkn46nghfwwijbpdzzl4zg6kx90prjmsg0.nar", ni.URL)
+						})
+					}
 				})
 			}
 

--- a/testdata/entries.go
+++ b/testdata/entries.go
@@ -8,5 +8,6 @@ var Entries = []Entry{
 	Nar4,
 	Nar5,
 	Nar6,
-	Nar7,
+	Nar7, // Nar7 must not be the last entry or tests will break.
+	Nar8,
 }

--- a/testdata/nar7.go
+++ b/testdata/nar7.go
@@ -14,7 +14,7 @@ var Nar7 = Entry{
 	NarInfoHash: "c12lxpykv6sld7a0sakcnr3y0la70x8w",
 	NarInfoPath: filepath.Join("c", "c1", "c12lxpykv6sld7a0sakcnr3y0la70x8w.narinfo"),
 	NarInfoText: `StorePath: /nix/store/c12lxpykv6sld7a0sakcnr3y0la70x8w-hello-2.12.2
-URL: nar/09xizkfyvigl5fqs0dhkn46nghfwwijbpdzzl4zg6kx90prjmsg0.nar
+URL: nar/c12lxpykv6sld7a0sakcnr3y0la70x8w-09xizkfyvigl5fqs0dhkn46nghfwwijbpdzzl4zg6kx90prjmsg0.nar
 Compression: none
 NarHash: sha256:1yf3p87fsqig07crd9sj9wh7i9jpsa0x86a22fqbls7c81lc7ws2
 NarSize: 113256

--- a/testdata/nar8.go
+++ b/testdata/nar8.go
@@ -1,0 +1,31 @@
+package testdata
+
+import (
+	"path/filepath"
+
+	"github.com/kalbasit/ncps/pkg/helper"
+	"github.com/kalbasit/ncps/pkg/nar"
+)
+
+// Nar8 is the nar representing hello from release-25.05.
+//
+//nolint:gochecknoglobals
+var Nar8 = Entry{
+	NarInfoHash: "swxfvpa96x0qc9v2g7jvil2301dflvhg",
+	NarInfoPath: filepath.Join("s", "sw", "swxfvpa96x0qc9v2g7jvil2301dflvhg.narinfo"),
+	NarInfoText: `StorePath: /nix/store/swxfvpa96x0qc9v2g7jvil2301dflvhg-hello-2.12.1
+URL: nar/1hng5pfbqi227z363yjr73rrk3v4064yx6b0c6vn9z6b4px032y3.nar.xz
+Compression: xz
+FileHash: sha256:1hng5pfbqi227z363yjr73rrk3v4064yx6b0c6vn9z6b4px032y3
+FileSize: 25484
+NarHash: sha256:0ps9ym8hmi59q2dah0hgmaqh8k5d7xw67ncn6m78q7ar4pvh48v5
+NarSize: 112712
+References: 6ib8qg0filxrwsghdpm04f6i7hlvp482-libiconv-109
+Deriver: 4pfsbms43j6iqbhjn7j8xzgvjgnrbqkm-hello-2.12.1.drv
+Sig: cache.nixos.org-1:VGbeHlz0xW8VHDFYtnu+gBFPQZqaOjgvPq2GF8Z6dweFe4jPGTzzKnBwYM1R2MTOwaYYlTOGhC7QEPMtVTlyBQ==`,
+
+	NarHash:        "1hng5pfbqi227z363yjr73rrk3v4064yx6b0c6vn9z6b4px032y3",
+	NarCompression: nar.CompressionTypeXz,
+	NarPath:        filepath.Join("1", "1h", "1hng5pfbqi227z363yjr73rrk3v4064yx6b0c6vn9z6b4px032y3.nar.xz"),
+	NarText:        helper.MustRandString(25484, nil),
+}


### PR DESCRIPTION
Nix-serve sometimes serves the NarURL with the narinfo hash included as a prefix to the NAR hash (e.g., "nar/<hash>-<narhash>.nar"). This causes issues for ncps which expects the NarURL to point directly to the NAR file.

Modified GetNarInfo in the upstream cache to remove the narinfo hash and the subsequent hyphen from the URL using strings.ReplaceAll.

Added new test entries (Nar7 and Nar8) to testdata to cover this scenario and updated the upstream cache tests to verify that the narinfo hash is correctly removed from the URL.

Also updated internal cache tests to better log sizes and handle transparent zstd compression when calculating expected sizes during LRU testing.

fixes #806
closes #820

(cherry picked from commit 3beaceb49a6a9779dbb5a9c1422b7d62436b1d19)