### PR TITLE
fix: harden NAR hash validation and improve URL parsing

### DIFF
--- a/pkg/cache/cdc_test.go
+++ b/pkg/cache/cdc_test.go
@@ -152,14 +152,14 @@ func testCDCMixedMode(factory cacheFactory) func(*testing.T) {
 		require.NoError(t, c.SetCDCConfiguration(false, 0, 0, 0))
 
 		blobContent := "traditional blob content"
-		nuBlob := nar.URL{Hash: "blob1", Compression: nar.CompressionTypeNone}
+		nuBlob := nar.URL{Hash: "1s8p1kgdms8rmxkq24q51wc7zpn0aqcwgzvc473v9cii7z2qyxq0", Compression: nar.CompressionTypeNone}
 		require.NoError(t, c.PutNar(ctx, nuBlob, io.NopCloser(strings.NewReader(blobContent))))
 
 		// 2. Store chunks with CDC enabled
 		require.NoError(t, c.SetCDCConfiguration(true, 1024, 4096, 8192))
 
 		chunkContent := "chunked content"
-		nuChunk := nar.URL{Hash: "chunk1", Compression: nar.CompressionTypeNone}
+		nuChunk := nar.URL{Hash: "00ji9synj1r6h6sjw27wwv8fw98myxsg92q5ma1pvrbmh451kc27", Compression: nar.CompressionTypeNone}
 		require.NoError(t, c.PutNar(ctx, nuChunk, io.NopCloser(strings.NewReader(chunkContent))))
 
 		// 3. Retrieve both
@@ -203,7 +203,7 @@ func testCDCGetNarInfo(factory cacheFactory) func(*testing.T) {
 
 		// Create and store a NAR with CDC enabled
 		content := "this is test content for GetNarInfo with CDC enabled"
-		nu := nar.URL{Hash: "testnarinfo1", Compression: nar.CompressionTypeNone}
+		nu := nar.URL{Hash: "1s8p1kgdms8rmxkq24q51wc7zpn0aqcwgzvc473v9cii7z2qyxq0", Compression: nar.CompressionTypeNone}
 
 		err = c.PutNar(ctx, nu, io.NopCloser(strings.NewReader(content)))
 		require.NoError(t, err)
@@ -214,24 +214,24 @@ func testCDCGetNarInfo(factory cacheFactory) func(*testing.T) {
 		assert.Positive(t, count, "chunks should exist in database")
 
 		// Store a narinfo that references this NAR
-		niText := `StorePath: /nix/store/test-path
-URL: nar/testnarinfo1.nar
+		niText := `StorePath: /nix/store/0amzzlz5w7ihknr59cn0q56pvp17bqqz-test-path
+URL: nar/1s8p1kgdms8rmxkq24q51wc7zpn0aqcwgzvc473v9cii7z2qyxq0.nar
 Compression: none
-FileHash: sha256:0000000000000000000000000000000000000000000000000000000000000000
+FileHash: sha256:1s8p1kgdms8rmxkq24q51wc7zpn0aqcwgzvc473v9cii7z2qyxq0
 FileSize: 52
-NarHash: sha256:0000000000000000000000000000000000000000000000000000000000000000
+NarHash: sha256:1s8p1kgdms8rmxkq24q51wc7zpn0aqcwgzvc473v9cii7z2qyxq0
 NarSize: 52
 `
-		err = c.PutNarInfo(ctx, "testnarinfohash", io.NopCloser(strings.NewReader(niText)))
+		err = c.PutNarInfo(ctx, "0amzzlz5w7ihknr59cn0q56pvp17bqqz", io.NopCloser(strings.NewReader(niText)))
 		require.NoError(t, err)
 
 		// Now call GetNarInfo. Since the NAR is stored as chunks and NOT as a whole file,
 		// the old version of getNarInfoFromDatabase would fail to find it and purge the narinfo.
-		_, err = c.GetNarInfo(ctx, "testnarinfohash")
+		_, err = c.GetNarInfo(ctx, "0amzzlz5w7ihknr59cn0q56pvp17bqqz")
 		require.NoError(t, err, "GetNarInfo should succeed even if NAR is only in chunks")
 
 		// Verify that the narinfo still exists in the database
-		_, err = c.GetNarInfo(ctx, "testnarinfohash")
+		_, err = c.GetNarInfo(ctx, "0amzzlz5w7ihknr59cn0q56pvp17bqqz")
 		require.NoError(t, err, "GetNarInfo should still succeed (not purged)")
 	}
 }

--- a/pkg/nar/filepath_test.go
+++ b/pkg/nar/filepath_test.go
@@ -19,8 +19,16 @@ func TestNarFilePath(t *testing.T) {
 		compression string
 		path        string
 	}{
-		{hash: "abc123", compression: "", path: filepath.Join("a", "ab", "abc123.nar")},
-		{hash: "def456", compression: "xz", path: filepath.Join("d", "de", "def456.nar.xz")},
+		{
+			hash:        "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+			compression: "",
+			path:        filepath.Join("1", "1m", "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar"),
+		},
+		{
+			hash:        "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+			compression: "xz",
+			path:        filepath.Join("1", "1m", "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.xz"),
+		},
 	}
 
 	for _, test := range []string{"", "a", "ab"} {

--- a/pkg/nar/hash.go
+++ b/pkg/nar/hash.go
@@ -3,17 +3,23 @@ package nar
 import (
 	"errors"
 	"regexp"
+
+	"github.com/kalbasit/ncps/pkg/narinfo"
 )
+
+// NormalizedHashPattern defines the valid characters for a Nix32 encoded hash.
+// Nix32 uses a 32-character alphabet excluding 'e', 'o', 'u', and 't'.
+// Valid characters: 0-9, a-d, f-n, p-s, v-z
+// Hashes must be exactly 52 characters long.
+const NormalizedHashPattern = `[0-9a-df-np-sv-z]{52}`
+
+const HashPattern = `(` + narinfo.HashPattern + `-)?` + NormalizedHashPattern
 
 var (
 	// ErrInvalidHash is returned if the hash is not valid.
 	ErrInvalidHash = errors.New("invalid nar hash")
 
-	// narHashPattern defines the valid characters for a nar hash.
-	//nolint:gochecknoglobals // This is used in other regexes to ensure they validate the same thing.
-	narHashPattern = `[a-z0-9_-]+`
-
-	narHashRegexp = regexp.MustCompile(`^(` + narHashPattern + `)$`)
+	narHashRegexp = regexp.MustCompile(`^(` + HashPattern + `)$`)
 )
 
 func ValidateHash(hash string) error {

--- a/pkg/nar/url_test.go
+++ b/pkg/nar/url_test.go
@@ -125,7 +125,7 @@ func TestParseURL(t *testing.T) {
 
 			narURL, err := nar.ParseURL(test.url)
 
-			if assert.ErrorIs(t, test.err, err) {
+			if assert.ErrorIs(t, err, test.err) {
 				assert.Equal(t, test.narURL, narURL)
 			}
 		})

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -918,7 +918,7 @@ func TestGetNar_ZstdCompression(t *testing.T) {
 
 	// 1. Put an uncompressed Nar into the cache.
 	narData := strings.Repeat("uncompressed nar data ", 1000)
-	narHash := "00000000000000000000000000000001" // dummy 32-char hash
+	narHash := "0000000000000000000000000000000000000000000000000001" // dummy 52-char hash
 	narURL := ts.URL + "/nar/" + narHash + ".nar"
 
 	req, err := http.NewRequestWithContext(
@@ -991,7 +991,7 @@ func TestGetNar_NoZstdCompression(t *testing.T) {
 
 	// 1. Put an uncompressed Nar into the cache.
 	narData := uncompressedNarData
-	narHash := "00000000000000000000000000000002" // dummy 32-char hash
+	narHash := "0000000000000000000000000000000000000000000000000002" // dummy 52-char hash
 	narURL := ts.URL + "/nar/" + narHash + ".nar"
 
 	req, err := http.NewRequestWithContext(
@@ -1057,7 +1057,7 @@ func TestGetNar_ZstdCompression_Head(t *testing.T) {
 
 	// 1. Put an uncompressed Nar into the cache.
 	narData := uncompressedNarData
-	narHash := "00000000000000000000000000000003" // dummy 32-char hash
+	narHash := "0000000000000000000000000000000000000000000000000003" // dummy 52-char hash
 	narURL := ts.URL + "/nar/" + narHash + ".nar"
 
 	req, err := http.NewRequestWithContext(
@@ -1145,7 +1145,7 @@ func TestGetNar_HeaderSettingSequence(t *testing.T) {
 
 	// Put an uncompressed Nar into the cache.
 	narData := uncompressedNarData
-	narHash := "00000000000000000000000000000004"
+	narHash := "0000000000000000000000000000000000000000000000000004"
 	narURL := "/nar/" + narHash + ".nar"
 
 	req := httptest.NewRequest(http.MethodPut, narURL, strings.NewReader(narData))

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -526,7 +526,7 @@ func TestHasNarInfo_ErrorPaths(t *testing.T) {
 		store, err := storage_s3.New(ctx, cfgWithMock)
 		require.NoError(t, err)
 
-		exists := store.HasNarInfo(ctx, "hash")
+		exists := store.HasNarInfo(ctx, "00ji9synj1r6h6sjw27wwv8fw98myxsg92q5ma1pvrbmh451kc27")
 		assert.False(t, exists)
 	})
 
@@ -783,7 +783,7 @@ func TestHasNar_ErrorPaths(t *testing.T) {
 		store, err := storage_s3.New(ctx, cfgWithMock)
 		require.NoError(t, err)
 
-		narURL := nar.URL{Hash: "hash", Compression: "none"}
+		narURL := nar.URL{Hash: "00ji9synj1r6h6sjw27wwv8fw98myxsg92q5ma1pvrbmh451kc27", Compression: "none"}
 		exists := store.HasNar(ctx, narURL)
 		assert.False(t, exists)
 	})
@@ -841,7 +841,7 @@ func TestPutNar_ErrorPaths(t *testing.T) {
 		store, err := storage_s3.New(ctx, cfgWithMock)
 		require.NoError(t, err)
 
-		narURL := nar.URL{Hash: "hash", Compression: "none"}
+		narURL := nar.URL{Hash: "00ji9synj1r6h6sjw27wwv8fw98myxsg92q5ma1pvrbmh451kc27", Compression: "none"}
 		_, err = store.PutNar(ctx, narURL, strings.NewReader("content"))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "error checking if nar exists")
@@ -873,7 +873,7 @@ func TestPutNar_ErrorPaths(t *testing.T) {
 		store, err := storage_s3.New(ctx, cfgWithMock)
 		require.NoError(t, err)
 
-		narURL := nar.URL{Hash: "hash", Compression: "none"}
+		narURL := nar.URL{Hash: "00ji9synj1r6h6sjw27wwv8fw98myxsg92q5ma1pvrbmh451kc27", Compression: "none"}
 		_, err = store.PutNar(ctx, narURL, strings.NewReader("content"))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "error putting nar to S3")
@@ -935,7 +935,7 @@ func TestNar_ErrorPaths(t *testing.T) {
 		store, err := storage_s3.New(ctx, cfgWithMock)
 		require.NoError(t, err)
 
-		narURL := nar.URL{Hash: "hash", Compression: "none"}
+		narURL := nar.URL{Hash: "00ji9synj1r6h6sjw27wwv8fw98myxsg92q5ma1pvrbmh451kc27", Compression: "none"}
 		_, _, err = store.GetNar(ctx, narURL)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "get failed")
@@ -962,7 +962,7 @@ func TestNar_ErrorPaths(t *testing.T) {
 		store, err := storage_s3.New(ctx, cfgWithMock)
 		require.NoError(t, err)
 
-		narURL := nar.URL{Hash: "hash", Compression: "none"}
+		narURL := nar.URL{Hash: "00ji9synj1r6h6sjw27wwv8fw98myxsg92q5ma1pvrbmh451kc27", Compression: "none"}
 		err = store.DeleteNar(ctx, narURL)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "error checking if nar exists")
@@ -993,7 +993,7 @@ func TestNar_ErrorPaths(t *testing.T) {
 		store, err := storage_s3.New(ctx, cfgWithMock)
 		require.NoError(t, err)
 
-		narURL := nar.URL{Hash: "hash", Compression: "none"}
+		narURL := nar.URL{Hash: "00ji9synj1r6h6sjw27wwv8fw98myxsg92q5ma1pvrbmh451kc27", Compression: "none"}
 		err = store.DeleteNar(ctx, narURL)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "delete failed")


### PR DESCRIPTION
This change strengthens the validation of NAR hashes by enforcing a
strict Nix32 format (52 characters) and optional narinfo hash prefix.
The ParseURL function has been rewritten to be more robust, separating
the hash and compression components more reliably and validating the
hash before further processing.

Key improvements:
- Defined NormalizedHashPattern and HashPattern for precise hash validation.
- Enhanced ParseURL to correctly handle various NAR URL formats including those with query parameters.
- Improved the Normalize method in the URL struct to better handle
  narinfo hash prefixes and sanitize the hash against path traversal.
- Updated all relevant tests to use valid Nix32 hashes and removed redundant test cases.
- Ensured consistent URL construction in JoinURL by correctly handling paths and query parameters.

This hardening prevents potential security issues related to invalid or
malicious NAR URLs and ensures consistent behavior across the
application.