### PR TITLE
refactor: use testhelper instead of custom hash generator

### DIFF
--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -1177,7 +1177,7 @@ func TestHasNarInfo_Integration(t *testing.T) {
 		}
 
 		ctx := newContext()
-		hash := getUniqueHash(t, testdata.Nar1.NarInfoHash)
+		hash := testhelper.MustRandNarInfoHash()
 
 		// Make sure it doesn't exist
 		_ = store.DeleteNarInfo(ctx, hash)
@@ -1194,7 +1194,7 @@ func TestHasNarInfo_Integration(t *testing.T) {
 		}
 
 		ctx := newContext()
-		hash := getUniqueHash(t, testdata.Nar1.NarInfoHash)
+		hash := testhelper.MustRandNarInfoHash()
 
 		ni, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
 		require.NoError(t, err)
@@ -1225,7 +1225,7 @@ func TestGetNarInfo_Integration(t *testing.T) {
 		}
 
 		ctx := newContext()
-		hash := getUniqueHash(t, testdata.Nar1.NarInfoHash)
+		hash := testhelper.MustRandNarInfoHash()
 
 		// Make sure it doesn't exist
 		_ = store.DeleteNarInfo(ctx, hash)
@@ -1243,7 +1243,7 @@ func TestGetNarInfo_Integration(t *testing.T) {
 		}
 
 		ctx := newContext()
-		hash := getUniqueHash(t, testdata.Nar1.NarInfoHash)
+		hash := testhelper.MustRandNarInfoHash()
 
 		ni, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
 		require.NoError(t, err)
@@ -1280,7 +1280,7 @@ func TestPutNarInfo_Integration(t *testing.T) {
 		}
 
 		ctx := newContext()
-		hash := getUniqueHash(t, testdata.Nar1.NarInfoHash)
+		hash := testhelper.MustRandNarInfoHash()
 
 		ni, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
 		require.NoError(t, err)
@@ -1309,7 +1309,7 @@ func TestPutNarInfo_Integration(t *testing.T) {
 		}
 
 		ctx := newContext()
-		hash := getUniqueHash(t, testdata.Nar1.NarInfoHash)
+		hash := testhelper.MustRandNarInfoHash()
 
 		ni, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
 		require.NoError(t, err)
@@ -1342,7 +1342,7 @@ func TestDeleteNarInfo_Integration(t *testing.T) {
 		}
 
 		ctx := newContext()
-		hash := getUniqueHash(t, testdata.Nar1.NarInfoHash)
+		hash := testhelper.MustRandNarInfoHash()
 
 		// Make sure it doesn't exist
 		_ = store.DeleteNarInfo(ctx, hash)
@@ -1360,7 +1360,7 @@ func TestDeleteNarInfo_Integration(t *testing.T) {
 		}
 
 		ctx := newContext()
-		hash := getUniqueHash(t, testdata.Nar1.NarInfoHash)
+		hash := testhelper.MustRandNarInfoHash()
 
 		ni, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
 		require.NoError(t, err)
@@ -1391,7 +1391,7 @@ func TestHasNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        getUniqueHash(t, testdata.Nar1.NarHash),
+			Hash:        testhelper.MustRandNarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 
@@ -1412,7 +1412,7 @@ func TestHasNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        getUniqueHash(t, testdata.Nar1.NarHash),
+			Hash:        testhelper.MustRandNarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 
@@ -1445,7 +1445,7 @@ func TestGetNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        getUniqueHash(t, testdata.Nar1.NarHash),
+			Hash:        testhelper.MustRandNarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 
@@ -1467,7 +1467,7 @@ func TestGetNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        getUniqueHash(t, testdata.Nar1.NarHash),
+			Hash:        testhelper.MustRandNarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 
@@ -1509,7 +1509,7 @@ func TestPutNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        getUniqueHash(t, testdata.Nar1.NarHash),
+			Hash:        testhelper.MustRandNarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 
@@ -1541,7 +1541,7 @@ func TestPutNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        getUniqueHash(t, testdata.Nar1.NarHash),
+			Hash:        testhelper.MustRandNarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 
@@ -1576,7 +1576,7 @@ func TestDeleteNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        getUniqueHash(t, testdata.Nar1.NarHash),
+			Hash:        testhelper.MustRandNarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 
@@ -1598,7 +1598,7 @@ func TestDeleteNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        getUniqueHash(t, testdata.Nar1.NarHash),
+			Hash:        testhelper.MustRandNarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 
@@ -1624,8 +1624,8 @@ func TestWalkNarInfos_Integration(t *testing.T) {
 	}
 
 	ctx := newContext()
-	hash1 := getUniqueHash(t, "hash1")
-	hash2 := getUniqueHash(t, "hash2")
+	hash1 := testhelper.MustRandNarInfoHash()
+	hash2 := testhelper.MustRandNarInfoHash()
 
 	ni, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
 	require.NoError(t, err)
@@ -1720,23 +1720,4 @@ func newContext() context.Context {
 	return zerolog.
 		New(io.Discard).
 		WithContext(context.Background())
-}
-
-// getUniqueHash generates a unique hash for testing based on the test name
-// This prevents parallel tests from interfering with each other.
-func getUniqueHash(t *testing.T, base string) string {
-	t.Helper()
-	// Use test name to create a unique hash prefix
-	// Ensure we only use characters allowed in nix hashes (a-z0-9)
-	s := strings.ToLower(t.Name())
-	s = strings.Map(func(r rune) rune {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
-			return r
-		}
-
-		return 'x'
-	}, s)
-
-	// Combine with base hash to create unique hash
-	return s + "x" + base
 }


### PR DESCRIPTION
The random generator was generating hashes that were possibly invalid
leading to invalid narinfo/nar hashes. Replace it with the proper random
generators from the testhelper package.