### PR TITLE
feat: add test helpers to generate random NarInfo/Nar hashes [backport #846]

### DIFF
--- a/testhelper/export_test.go
+++ b/testhelper/export_test.go
@@ -2,8 +2,13 @@ package testhelper
 
 import "io"
 
-// AllChars refers to unexported chars constant.
-const AllChars = allChars
+const (
+	// AllChars refers to unexported chars constant.
+	AllChars = allChars
+
+	// Nix32Chars refers to unexported nix32Chars constant.
+	Nix32Chars = nix32Chars
+)
 
 // RandChars is a test-only export of the unexported randChars method.
 func RandChars(n int, charSet string, r io.Reader) (string, error) {

--- a/testhelper/rand.go
+++ b/testhelper/rand.go
@@ -6,7 +6,10 @@ import (
 	"math/big"
 )
 
-const allChars = "abcdefghijklmnopqrstuvwxyz0123456789"
+const (
+	allChars   = "abcdefghijklmnopqrstuvwxyz0123456789"
+	nix32Chars = "abcdfghijklmnpqrsvwxyz0123456789"
+)
 
 func randChars(n int, charSet string, r io.Reader) (string, error) {
 	ret := make([]byte, n)
@@ -31,6 +34,32 @@ func RandString(n int) (string, error) { return randChars(n, allChars, rand.Read
 // returns an error, it will panic.
 func MustRandString(n int) string {
 	str, err := RandString(n)
+	if err != nil {
+		panic(err)
+	}
+
+	return str
+}
+
+func RandNarInfoHash() (string, error) {
+	return randChars(32, nix32Chars, rand.Reader)
+}
+
+func MustRandNarInfoHash() string {
+	str, err := RandNarInfoHash()
+	if err != nil {
+		panic(err)
+	}
+
+	return str
+}
+
+func RandNarHash() (string, error) {
+	return randChars(52, nix32Chars, rand.Reader)
+}
+
+func MustRandNarHash() string {
+	str, err := RandNarHash()
 	if err != nil {
 		panic(err)
 	}

--- a/testhelper/rand_test.go
+++ b/testhelper/rand_test.go
@@ -34,3 +34,115 @@ func TestRandChars(t *testing.T) {
 		assert.Equal(t, "a2lzq", s)
 	})
 }
+
+func TestRandNarInfoHash(t *testing.T) {
+	t.Run("validate length", func(t *testing.T) {
+		t.Parallel()
+
+		s, err := testhelper.RandNarInfoHash()
+		require.NoError(t, err)
+
+		assert.Len(t, s, 32)
+	})
+
+	t.Run("validate character set", func(t *testing.T) {
+		t.Parallel()
+
+		s, err := testhelper.RandNarInfoHash()
+		require.NoError(t, err)
+
+		for _, ch := range s {
+			assert.Contains(t, testhelper.Nix32Chars, string(ch))
+		}
+	})
+
+	t.Run("returns different values", func(t *testing.T) {
+		t.Parallel()
+
+		s1, err := testhelper.RandNarInfoHash()
+		require.NoError(t, err)
+
+		s2, err := testhelper.RandNarInfoHash()
+		require.NoError(t, err)
+
+		assert.NotEqual(t, s1, s2)
+	})
+}
+
+func TestMustRandNarInfoHash(t *testing.T) {
+	t.Run("returns valid hash", func(t *testing.T) {
+		t.Parallel()
+
+		s := testhelper.MustRandNarInfoHash()
+
+		assert.Len(t, s, 32)
+
+		for _, ch := range s {
+			assert.Contains(t, testhelper.Nix32Chars, string(ch))
+		}
+	})
+
+	t.Run("does not panic", func(t *testing.T) {
+		t.Parallel()
+
+		assert.NotPanics(t, func() {
+			testhelper.MustRandNarInfoHash()
+		})
+	})
+}
+
+func TestRandNarHash(t *testing.T) {
+	t.Run("validate length", func(t *testing.T) {
+		t.Parallel()
+
+		s, err := testhelper.RandNarHash()
+		require.NoError(t, err)
+
+		assert.Len(t, s, 52)
+	})
+
+	t.Run("validate character set", func(t *testing.T) {
+		t.Parallel()
+
+		s, err := testhelper.RandNarHash()
+		require.NoError(t, err)
+
+		for _, ch := range s {
+			assert.Contains(t, testhelper.Nix32Chars, string(ch))
+		}
+	})
+
+	t.Run("returns different values", func(t *testing.T) {
+		t.Parallel()
+
+		s1, err := testhelper.RandNarHash()
+		require.NoError(t, err)
+
+		s2, err := testhelper.RandNarHash()
+		require.NoError(t, err)
+
+		assert.NotEqual(t, s1, s2)
+	})
+}
+
+func TestMustRandNarHash(t *testing.T) {
+	t.Run("returns valid hash", func(t *testing.T) {
+		t.Parallel()
+
+		s := testhelper.MustRandNarHash()
+
+		assert.Len(t, s, 52)
+
+		for _, ch := range s {
+			assert.Contains(t, testhelper.Nix32Chars, string(ch))
+		}
+	})
+
+	t.Run("does not panic", func(t *testing.T) {
+		t.Parallel()
+
+		assert.NotPanics(t, func() {
+			testhelper.MustRandNarHash()
+		})
+	})
+}


### PR DESCRIPTION
Bot-based backport to `release-0.8`, triggered by a label in #846.

Add `RandNarInfoHash() (string, error)`, `MustRandNarInfoHash() string`,
`RandNarHash() (string, error)`, and `MustRandNarHash() string` to the
testhelper package to help with testing when a random hash is needed.