### PR TITLE
fix: harden the narinfo hash validation [backport #840]

### DIFF
--- a/pkg/narinfo/hash.go
+++ b/pkg/narinfo/hash.go
@@ -1,0 +1,32 @@
+package narinfo
+
+import (
+	"errors"
+	"regexp"
+)
+
+// narInfoHashPattern defines the valid characters for a Nix32 encoded hash.
+// Nix32 uses a 32-character alphabet excluding 'e', 'o', 'u', and 't'.
+// Valid characters: 0-9, a-d, f-n, p-s, v-z
+// Hashes must be exactly 32 characters long.
+const HashPattern = `[0-9a-df-np-sv-z]{32}`
+
+var (
+	// ErrInvalidHash is returned if the hash is invalid.
+	ErrInvalidHash = errors.New("invalid narinfo hash")
+
+	// hashRegexp is used to validate hashes.
+	hashRegexp = regexp.MustCompile(`^` + HashPattern + `$`)
+)
+
+// ValidateHash validates the given hash according to Nix32 encoding requirements.
+// A valid hash must:
+// - Be exactly 32 characters long
+// - Contain only characters from the Nix32 alphabet ('0'-'9', 'a'-'z' excluding 'e', 'o', 'u', 't').
+func ValidateHash(hash string) error {
+	if !hashRegexp.MatchString(hash) {
+		return ErrInvalidHash
+	}
+
+	return nil
+}

--- a/pkg/narinfo/hash_test.go
+++ b/pkg/narinfo/hash_test.go
@@ -1,0 +1,131 @@
+package narinfo_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kalbasit/ncps/pkg/narinfo"
+)
+
+func TestValidateHash(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		hash      string
+		shouldErr bool
+	}{
+		// Valid Nix32 hashes (32 characters from the allowed alphabet)
+		{
+			name:      "valid hash with all allowed characters",
+			hash:      "n5glp21rsz314qssw9fbvfswgy3kc68f",
+			shouldErr: false,
+		},
+		{
+			name:      "valid hash with numbers",
+			hash:      "01234567890123456789012345678901",
+			shouldErr: false,
+		},
+		{
+			name:      "valid hash with mixed characters",
+			hash:      "abcdfghijklmnpqrsvwxyzabcdfghijk",
+			shouldErr: false,
+		},
+
+		// Invalid: contains forbidden letters (e, o, u, t)
+		{
+			name:      "invalid hash contains 'e'",
+			hash:      "n5glp21rsz314qssw9fbvfswgy3kc68e",
+			shouldErr: true,
+		},
+		{
+			name:      "invalid hash contains 'o'",
+			hash:      "n5glp21rsz314qssw9fbvfswgy3kc68o",
+			shouldErr: true,
+		},
+		{
+			name:      "invalid hash contains 'u'",
+			hash:      "n5glp21rsz314qssw9fbvfswgy3kc68u",
+			shouldErr: true,
+		},
+		{
+			name:      "invalid hash contains 't'",
+			hash:      "n5glp21rsz314qssw9fbvfswgy3kc68t",
+			shouldErr: true,
+		},
+
+		// Invalid: contains uppercase letters
+		{
+			name:      "invalid hash contains uppercase",
+			hash:      "N5glp21rsz314qssw9fbvfswgy3kc68f",
+			shouldErr: true,
+		},
+		{
+			name:      "invalid hash all uppercase",
+			hash:      "N5GLP21RSZ314QSSW9FBVFSWGY3KC68F",
+			shouldErr: true,
+		},
+
+		// Invalid: contains special characters
+		{
+			name:      "invalid hash with exclamation mark",
+			hash:      "n5glp21rsz314qssw9fbvfswgy3kc68!",
+			shouldErr: true,
+		},
+		{
+			name:      "invalid hash with hyphen",
+			hash:      "n5glp21rsz314qssw9fbvfswgy3kc-8f",
+			shouldErr: true,
+		},
+		{
+			name:      "invalid hash with underscore",
+			hash:      "n5glp21rsz314qssw9fbvfswgy3kc_8f",
+			shouldErr: true,
+		},
+		{
+			name:      "invalid hash with space",
+			hash:      "n5glp21rsz314qssw9fbvfswgy3kc 8f",
+			shouldErr: true,
+		},
+
+		// Invalid: wrong length
+		{
+			name:      "invalid hash too short",
+			hash:      "n5glp21rsz314qssw9fbvfswgy3kc68",
+			shouldErr: true,
+		},
+		{
+			name:      "invalid hash too long",
+			hash:      "n5glp21rsz314qssw9fbvfswgy3kc68ff",
+			shouldErr: true,
+		},
+
+		// Invalid: empty string
+		{
+			name:      "invalid hash empty string",
+			hash:      "",
+			shouldErr: true,
+		},
+
+		// Invalid: only one character
+		{
+			name:      "invalid hash single character",
+			hash:      "a",
+			shouldErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := narinfo.ValidateHash(test.hash)
+			if test.shouldErr {
+				assert.ErrorIs(t, err, narinfo.ErrInvalidHash)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/narinfo/narinfo.go
+++ b/pkg/narinfo/narinfo.go
@@ -1,29 +1,10 @@
 package narinfo
 
 import (
-	"errors"
 	"fmt"
-	"regexp"
 
 	"github.com/kalbasit/ncps/pkg/helper"
 )
-
-var (
-	// ErrInvalidHash is returned if the hash is invalid.
-	ErrInvalidHash = errors.New("invalid narinfo hash")
-
-	// hashRegexp is used to validate hashes.
-	hashRegexp = regexp.MustCompile(`^[a-z0-9]+$`)
-)
-
-// ValidateHash validates the given hash.
-func ValidateHash(hash string) error {
-	if !hashRegexp.MatchString(hash) {
-		return ErrInvalidHash
-	}
-
-	return nil
-}
 
 // FilePath returns the path of the narinfo file given a hash.
 func FilePath(hash string) (string, error) {

--- a/pkg/narinfo/narinfo_test.go
+++ b/pkg/narinfo/narinfo_test.go
@@ -18,7 +18,10 @@ func TestNarInfoFilePath(t *testing.T) {
 		hash string
 		path string
 	}{
-		{hash: "abc123", path: filepath.Join("a", "ab", "abc123.narinfo")},
+		{
+			hash: "n5glp21rsz314qssw9fbvfswgy3kc68f",
+			path: filepath.Join("n", "n5", "n5glp21rsz314qssw9fbvfswgy3kc68f.narinfo"),
+		},
 	}
 
 	for _, test := range []string{"", "a", "ab"} {

--- a/pkg/ncps/migrate_narinfo_test.go
+++ b/pkg/ncps/migrate_narinfo_test.go
@@ -870,8 +870,8 @@ func TestMigrateNarInfo_LargeNarInfo(t *testing.T) {
 
 	const numSignatures = 50
 
-	hash := "largenarinfo1234567890abcdef1234567890abcdef"
-	narHash := "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+	hash := "0a90gw9sdyz3680wfncd5xf0qg6zh27w"
+	narHash := "024wilh5y46xqqjnwp159s13kgvsh8zfr6g6znb8ix2vlyf61rwp"
 
 	// Build references string
 	var referencesBuilder strings.Builder


### PR DESCRIPTION
This commit hardens the narinfo hash validation to strictly enforce the Nix32 encoding specification:

- Enforce exactly 32-character hash length (previously allowed any length)
- Restrict to valid Nix32 alphabet: 0-9, a-d, f-n, p-s, v-z (previously allowed any lowercase letter and digit)
- Explicitly reject forbidden characters: e, o, u, t
- Reject uppercase letters and special characters

Added 18 comprehensive test cases covering:
- Valid hashes with different character combinations
- Invalid hashes with forbidden characters
- Invalid hashes with wrong lengths
- Invalid hashes with special characters and uppercase letters

This ensures that only valid Nix32 hashes are accepted, preventing potential data corruption or compatibility issues in the narinfo processing pipeline.

(cherry picked from commit 91945f3df2fadd881c7dc0cc883b327458ee88a0)