### PR TITLE
fix: enhance NAR URL normalization and fix potential path traversal

### DIFF
--- a/pkg/nar/hash.go
+++ b/pkg/nar/hash.go
@@ -13,13 +13,23 @@ import (
 // Hashes must be exactly 52 characters long.
 const NormalizedHashPattern = `[0-9a-df-np-sv-z]{52}`
 
-const HashPattern = `(` + narinfo.HashPattern + `-)?` + NormalizedHashPattern
+// HashPattern is the strict validation pattern for complete nar hashes.
+// It matches an optional prefix (narinfo hash + separator) followed by exactly
+// a 52-character normalized hash. Used with anchors (^...$) to validate the full input.
+// For extraction and lenient parsing, use HashPatternLenient instead.
+const HashPattern = `(?:(` + narinfo.HashPattern + `[-_]))?` + NormalizedHashPattern
+
+// HashPatternLenient is used for parsing/extraction. It matches optional prefix
+// followed by anything, allowing us to extract and validate parts separately.
+const HashPatternLenient = `(?:(` + narinfo.HashPattern + `[-_]))?(.+)`
 
 var (
 	// ErrInvalidHash is returned if the hash is not valid.
 	ErrInvalidHash = errors.New("invalid nar hash")
 
-	narHashRegexp = regexp.MustCompile(`^(` + HashPattern + `)$`)
+	narHashRegexp           = regexp.MustCompile(`^` + HashPattern + `$`)
+	narNormalizedHashRegexp = regexp.MustCompile(`^` + NormalizedHashPattern + `$`)
+	narHashLenientRegexp    = regexp.MustCompile(`^` + HashPatternLenient + `$`)
 )
 
 func ValidateHash(hash string) error {

--- a/pkg/nar/url_test.go
+++ b/pkg/nar/url_test.go
@@ -138,6 +138,7 @@ func TestNormalize(t *testing.T) {
 	tests := []struct {
 		input  nar.URL
 		output nar.URL
+		errStr string
 	}{
 		{
 			input: nar.URL{
@@ -178,19 +179,19 @@ func TestNormalize(t *testing.T) {
 		{
 			// Valid hash with separator but no prefix
 			input: nar.URL{
-				Hash: "my-hash",
+				Hash: "1m9phnql68mxrnjc7ssxcvjrxxwcx0fzc849w025mkanwgsy1bpy",
 			},
 			output: nar.URL{
-				Hash: "my-hash",
+				Hash: "1m9phnql68mxrnjc7ssxcvjrxxwcx0fzc849w025mkanwgsy1bpy",
 			},
 		},
 		{
 			// Valid prefix and multiple separators in the suffix
 			input: nar.URL{
-				Hash: "c12lxpykv6sld7a0sakcnr3y0la70x8w-part1-part2",
+				Hash: "c12lxpykv6sld7a0sakcnr3y0la70x8w-1m9phnql68mxrnjc7ssxcvjrxxwcx0fzc849w025mkanwgsy1bpy",
 			},
 			output: nar.URL{
-				Hash: "part1-part2",
+				Hash: "1m9phnql68mxrnjc7ssxcvjrxxwcx0fzc849w025mkanwgsy1bpy",
 			},
 		},
 		{
@@ -198,9 +199,7 @@ func TestNormalize(t *testing.T) {
 			input: nar.URL{
 				Hash: "c12lxpykv6sld7a0sakcnr3y0la70x8w-../../etc/passwd",
 			},
-			output: nar.URL{
-				Hash: "c12lxpykv6sld7a0sakcnr3y0la70x8w-../../etc/passwd",
-			},
+			errStr: "invalid nar hash: ../../etc/passwd",
 		},
 	}
 
@@ -213,8 +212,13 @@ func TestNormalize(t *testing.T) {
 		t.Run(tname, func(t *testing.T) {
 			t.Parallel()
 
-			result := test.input.Normalize()
-			assert.Equal(t, test.output, result)
+			result, err := test.input.Normalize()
+			if test.errStr != "" {
+				assert.EqualError(t, err, test.errStr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.output, result)
+			}
 		})
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -359,7 +359,19 @@ func (s *Server) getNarInfo(withBody bool) http.HandlerFunc {
 				return
 			}
 
-			narInfoCopy.URL = narURL.Normalize().String()
+			normalizedURL, err := narURL.Normalize()
+			if err != nil {
+				zerolog.Ctx(r.Context()).
+					Error().
+					Err(err).
+					Msg("error normalizing the NAR URL")
+
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+
+				return
+			}
+
+			narInfoCopy.URL = normalizedURL.String()
 		}
 
 		narInfoBytes := []byte(narInfoCopy.String())

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -330,7 +330,12 @@ func (s *Store) DeleteNarInfo(ctx context.Context, hash string) error {
 
 // HasNar returns true if the store has the nar.
 func (s *Store) HasNar(ctx context.Context, narURL nar.URL) bool {
-	tfp, err := narURL.Normalize().ToFilePath()
+	normalizedURL, err := narURL.Normalize()
+	if err != nil {
+		return false
+	}
+
+	tfp, err := normalizedURL.ToFilePath()
 	if err != nil {
 		return false
 	}
@@ -357,7 +362,10 @@ func (s *Store) HasNar(ctx context.Context, narURL nar.URL) bool {
 // NOTE: The caller must close the returned io.ReadCloser!
 func (s *Store) GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadCloser, error) {
 	// Normalize the NAR URL to handle URLs with embedded narinfo hash prefix
-	normalizedURL := narURL.Normalize()
+	normalizedURL, err := narURL.Normalize()
+	if err != nil {
+		return 0, nil, err
+	}
 
 	tfp, err := normalizedURL.ToFilePath()
 	if err != nil {
@@ -397,7 +405,10 @@ func (s *Store) GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadClose
 // PutNar puts the nar in the store.
 func (s *Store) PutNar(ctx context.Context, narURL nar.URL, body io.Reader) (int64, error) {
 	// Normalize the NAR URL to handle URLs with embedded narinfo hash prefix
-	normalizedURL := narURL.Normalize()
+	normalizedURL, err := narURL.Normalize()
+	if err != nil {
+		return 0, err
+	}
 
 	tfp, err := normalizedURL.ToFilePath()
 	if err != nil {
@@ -457,7 +468,10 @@ func (s *Store) PutNar(ctx context.Context, narURL nar.URL, body io.Reader) (int
 // DeleteNar deletes the nar from the store.
 func (s *Store) DeleteNar(ctx context.Context, narURL nar.URL) error {
 	// Normalize the NAR URL to handle URLs with embedded narinfo hash prefix
-	normalizedURL := narURL.Normalize()
+	normalizedURL, err := narURL.Normalize()
+	if err != nil {
+		return err
+	}
 
 	tfp, err := normalizedURL.ToFilePath()
 	if err != nil {

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -566,7 +566,12 @@ func (s *Store) narInfoPath(hash string) (string, error) {
 }
 
 func (s *Store) narPath(narURL nar.URL) (string, error) {
-	tfp, err := narURL.Normalize().ToFilePath()
+	normalizedURL, err := narURL.Normalize()
+	if err != nil {
+		return "", err
+	}
+
+	tfp, err := normalizedURL.ToFilePath()
 	if err != nil {
 		return "", err
 	}

--- a/testdata/server.go
+++ b/testdata/server.go
@@ -143,7 +143,15 @@ func (s *Server) handler() http.Handler {
 			}
 
 			// Support fetching by normalized hash (with prefix stripped)
-			normalizedHash := (&nar.URL{Hash: entry.NarHash}).Normalize().Hash
+			normalizedURL, err := (&nar.URL{Hash: entry.NarHash}).Normalize()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+
+				return
+			}
+
+			normalizedHash := normalizedURL.Hash
+
 			if normalizedHash != entry.NarHash {
 				if r.URL.Path == "/nar/"+normalizedHash+".nar" {
 					bs = []byte(entry.NarText)


### PR DESCRIPTION
The previous implementation of Normalize() was vulnerable to path
traversal if the NAR hash contained ".." or other malicious sequences.
This change refactors Normalize() to use stricter regular expressions
for hash validation and returns an error if the hash is invalid.

Additionally, it refactors ensureNarFile in pkg/cache/cache.go to use a
new helper createOrUpdateNarFile, reducing code duplication.

Key changes:
- Introduced narHashLenientRegexp and narNormalizedHashRegexp for robust hash validation.
- Modified nar.URL.Normalize() to return (URL, error).
- Updated all callers in pkg/server, pkg/storage, and testdata to handle the new error return.
- Added filepath.Base() to temp file creation in pkg/cache/cache.go for enhanced security.