### PR TITLE
fix: harden NAR hash validation and improve URL parsing [backport #842]

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1050,21 +1050,21 @@ func TestDeadlock_NarInfo_Triggers_Nar_Refetch(t *testing.T) {
 	// NarInfoHash is 32 chars.
 	// narURL.Hash comes from URL.
 	// We want narURL.Hash == NarInfoHash.
-	collisionHash := "11111111111111111111111111111111"
+	collisionHash := "1111111111111111111111111111111111111111111111111111"
 
 	entry := testdata.Entry{
 		NarInfoHash:    collisionHash,
 		NarHash:        collisionHash,
 		NarCompression: "none",
-		NarInfoText: `StorePath: /nix/store/11111111111111111111111111111111-test-1.0
-URL: nar/11111111111111111111111111111111.nar
+		NarInfoText: `StorePath: /nix/store/1111111111111111111111111111111111111111111111111111-test-1.0
+URL: nar/1111111111111111111111111111111111111111111111111111.nar
 Compression: none
 FileHash: sha256:1111111111111111111111111111111111111111111111111111
 FileSize: 123
 NarHash: sha256:1111111111111111111111111111111111111111111111111111
 NarSize: 123
-References: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-dummy
-Deriver: dddddddddddddddddddddddddddddddd-test-1.0.drv
+References: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-dummy
+Deriver: dddddddddddddddddddddddddddddddddddddddddddddddddddd-test-1.0.drv
 Sig: cache.nixos.org-1:MadTCU1OSFCGUw4aqCKpLCZJpqBc7AbLvO7wgdlls0eq1DwaSnF/82SZE+wJGEiwlHbnZR+14daSaec0W3XoBQ==
 `,
 		NarText: "content-of-the-nar",

--- a/pkg/nar/filepath_test.go
+++ b/pkg/nar/filepath_test.go
@@ -19,8 +19,16 @@ func TestNarFilePath(t *testing.T) {
 		compression string
 		path        string
 	}{
-		{hash: "abc123", compression: "", path: filepath.Join("a", "ab", "abc123.nar")},
-		{hash: "def456", compression: "xz", path: filepath.Join("d", "de", "def456.nar.xz")},
+		{
+			hash:        "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+			compression: "",
+			path:        filepath.Join("1", "1m", "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar"),
+		},
+		{
+			hash:        "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps",
+			compression: "xz",
+			path:        filepath.Join("1", "1m", "1mb5fxh7nzbx1b2q40bgzwjnjh8xqfap9mfnfqxlvvgvdyv8xwps.nar.xz"),
+		},
 	}
 
 	for _, test := range []string{"", "a", "ab"} {

--- a/pkg/nar/hash.go
+++ b/pkg/nar/hash.go
@@ -3,17 +3,23 @@ package nar
 import (
 	"errors"
 	"regexp"
+
+	"github.com/kalbasit/ncps/pkg/narinfo"
 )
+
+// NormalizedHashPattern defines the valid characters for a Nix32 encoded hash.
+// Nix32 uses a 32-character alphabet excluding 'e', 'o', 'u', and 't'.
+// Valid characters: 0-9, a-d, f-n, p-s, v-z
+// Hashes must be exactly 52 characters long.
+const NormalizedHashPattern = `[0-9a-df-np-sv-z]{52}`
+
+const HashPattern = `(` + narinfo.HashPattern + `-)?` + NormalizedHashPattern
 
 var (
 	// ErrInvalidHash is returned if the hash is not valid.
 	ErrInvalidHash = errors.New("invalid nar hash")
 
-	// narHashPattern defines the valid characters for a nar hash.
-	//nolint:gochecknoglobals // This is used in other regexes to ensure they validate the same thing.
-	narHashPattern = `[a-z0-9_-]+`
-
-	narHashRegexp = regexp.MustCompile(`^(` + narHashPattern + `)$`)
+	narHashRegexp = regexp.MustCompile(`^(` + HashPattern + `)$`)
 )
 
 func ValidateHash(hash string) error {

--- a/pkg/nar/url_test.go
+++ b/pkg/nar/url_test.go
@@ -158,7 +158,7 @@ func TestParseURL(t *testing.T) {
 
 			narURL, err := nar.ParseURL(test.url)
 
-			if assert.ErrorIs(t, test.err, err) {
+			if assert.ErrorIs(t, err, test.err) {
 				assert.Equal(t, test.narURL, narURL)
 			}
 		})

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"path"
 	"strings"
 
@@ -66,6 +67,9 @@ type Config struct {
 	// Set to true for MinIO and other S3-compatible services
 	// Set to false for AWS S3 (default)
 	ForcePathStyle bool
+
+	// Transport is the HTTP transport to use for S3 requests.
+	Transport http.RoundTripper
 }
 
 // Store represents an S3 store and implements storage.Store.
@@ -96,6 +100,7 @@ func New(ctx context.Context, cfg Config) (*Store, error) {
 		Secure:       useSSL,
 		Region:       cfg.Region,
 		BucketLookup: bucketLookup,
+		Transport:    cfg.Transport,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating MinIO client: %w", err)


### PR DESCRIPTION
This change strengthens the validation of NAR hashes by enforcing a strict Nix32 format (52 characters) and optional narinfo hash prefix. The ParseURL function has been rewritten to be more robust, separating the hash and compression components more reliably and validating the hash before further processing.

Key improvements:
- Defined NormalizedHashPattern and HashPattern for precise hash validation.
- Enhanced ParseURL to correctly handle various NAR URL formats including those with query parameters.
- Improved the Normalize method in the URL struct to better handle narinfo hash prefixes and sanitize the hash against path traversal.
- Updated all relevant tests to use valid Nix32 hashes and removed redundant test cases.
- Ensured consistent URL construction in JoinURL by correctly handling paths and query parameters.

This hardening prevents potential security issues related to invalid or malicious NAR URLs and ensures consistent behavior across the application.

(cherry picked from commit 2bb8649e9ede4161b25b801fcffe5b795728aa2d)