### PR TITLE
fix: allow the NAR hash to be 32 chars (Nix32) and 52 chars (Base16) [backport #869]

### DIFF
--- a/pkg/nar/hash.go
+++ b/pkg/nar/hash.go
@@ -7,11 +7,13 @@ import (
 	"github.com/kalbasit/ncps/pkg/narinfo"
 )
 
-// NormalizedHashPattern defines the valid characters for a Nix32 encoded hash.
-// Nix32 uses a 32-character alphabet excluding 'e', 'o', 'u', and 't'.
-// Valid characters: 0-9, a-d, f-n, p-s, v-z
-// Hashes must be exactly 52 characters long.
-const NormalizedHashPattern = `[0-9a-df-np-sv-z]{52}`
+// NormalizedHashPattern defines the valid patterns for Nix store hashes.
+// It supports two primary formats:
+//  1. Nix32 (Base32): A custom 32-character alphabet (0-9, a-z excluding 'e', 'o', 'u', 't').
+//     Used for truncated SHA-256 (52 chars).
+//  2. Hexadecimal (Base16): Standard 0-9, a-f.
+//     Used for full SHA-256 digests (64 chars).
+const NormalizedHashPattern = `[0-9a-df-np-sv-z]{52}|[0-9a-f]{64}`
 
 // HashPattern is the strict validation pattern for complete nar hashes.
 // It matches an optional prefix (narinfo hash + separator) followed by exactly

--- a/testdata/entries.go
+++ b/testdata/entries.go
@@ -10,4 +10,5 @@ var Entries = []Entry{
 	Nar6,
 	Nar7, // Nar7 must not be the last entry or tests will break.
 	Nar8,
+	Nar9,
 }

--- a/testdata/nar9.go
+++ b/testdata/nar9.go
@@ -1,0 +1,34 @@
+package testdata
+
+import (
+	"path/filepath"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// Nar9 is the nar replicating #868.
+//
+//nolint:gochecknoglobals
+var Nar9 = Entry{
+	NarInfoHash: "yj1wxm9hh8610iyzqnz75kvs6xl8j3my",
+	NarInfoPath: filepath.Join("y", "yj", "yj1wxm9hh8610iyzqnz75kvs6xl8j3my.narinfo"),
+	//nolint:lll
+	NarInfoText: `StorePath: /nix/store/yj1wxm9hh8610iyzqnz75kvs6xl8j3my-source
+URL: nar/504dd9a697cdfa0ddc22552ca66b3322afd52beee44642419d0fff83bb9071e2.nar.zst
+Compression: zstd
+FileHash: sha256:504dd9a697cdfa0ddc22552ca66b3322afd52beee44642419d0fff83bb9071e2
+FileSize: 1126
+NarHash: sha256:1bzg89hgcr2gvza35vqi4n1jbb2gz1yg4b8p7gry4ihsj2mnnbap
+NarSize: 2440
+Sig: nix-community.cachix.org-1:wKpIFGNnM2hyGkGUaX+qhMhYzEwMio7o4RayDDD/BUF0eOOzp2aRzFWFSgRoqyJf7DygEIGFHPuk1gFDbhyJBQ==`,
+
+	NarHash:        "504dd9a697cdfa0ddc22552ca66b3322afd52beee44642419d0fff83bb9071e2",
+	NarCompression: nar.CompressionTypeZstd,
+	NarPath: filepath.Join(
+		"5",
+		"50",
+		"504dd9a697cdfa0ddc22552ca66b3322afd52beee44642419d0fff83bb9071e2.nar.zst",
+	),
+	NarText: testhelper.MustRandString(1126),
+}

--- a/testdata/upstream_public_keys.go
+++ b/testdata/upstream_public_keys.go
@@ -3,5 +3,6 @@ package testdata
 func PublicKeys() []string {
 	return []string{
 		"cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=",
+		"nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=",
 	}
 }


### PR DESCRIPTION
Bot-based backport to `release-0.8`, triggered by a label in #869.

The NAR hashes come in two primary formats:
1. Nix32 (Base32): A custom 32-character alphabet (0-9, a-z excluding 'e', 'o', 'u', 't').
   Used for truncated SHA-256 (52 chars).
2. Hexadecimal (Base16): Standard 0-9, a-f.
   Used for full SHA-256 digests (64 chars).

closes #806