### PR TITLE
fix(cdc): update narinfo compression and URL after MigrateNarToChunks

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -379,3 +379,9 @@ WHERE compression NOT IN ('', 'none')
   AND created_at < ?
 ORDER BY id
 LIMIT ? OFFSET ?;
+
+-- name: UpdateNarInfoCompressionAndURL :execrows
+-- Update narinfo compression and URL after CDC migration.
+UPDATE narinfos
+SET compression = sqlc.arg(compression), url = sqlc.arg(new_url), updated_at = CURRENT_TIMESTAMP
+WHERE url = sqlc.arg(old_url);

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -400,3 +400,9 @@ WHERE compression NOT IN ('', 'none')
   AND created_at < $1
 ORDER BY id
 LIMIT $2 OFFSET $3;
+
+-- name: UpdateNarInfoCompressionAndURL :execrows
+-- Update narinfo compression and URL after CDC migration.
+UPDATE narinfos
+SET compression = sqlc.arg(compression), url = sqlc.arg(new_url), updated_at = CURRENT_TIMESTAMP
+WHERE url = sqlc.arg(old_url);

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -387,3 +387,9 @@ WHERE compression NOT IN ('', 'none')
   AND created_at < ?
 ORDER BY id
 LIMIT ? OFFSET ?;
+
+-- name: UpdateNarInfoCompressionAndURL :execrows
+-- Update narinfo compression and URL after CDC migration.
+UPDATE narinfos
+SET compression = sqlc.arg(compression), url = sqlc.arg(new_url), updated_at = CURRENT_TIMESTAMP
+WHERE url = sqlc.arg(old_url);

--- a/pkg/database/generated_models.go
+++ b/pkg/database/generated_models.go
@@ -235,6 +235,12 @@ type UpdateNarFileTotalChunksParams struct {
 	ID          int64
 }
 
+type UpdateNarInfoCompressionAndURLParams struct {
+	Compression sql.NullString
+	NewUrl      sql.NullString
+	OldUrl      sql.NullString
+}
+
 type UpdateNarInfoFileSizeParams struct {
 	Hash     string
 	FileSize sql.NullInt64

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -445,6 +445,12 @@ type Querier interface {
 	//  WHERE hash = $1
 	//  RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (NarInfo, error)
+	// Update narinfo compression and URL after CDC migration.
+	//
+	//  UPDATE narinfos
+	//  SET compression = $1, url = $2, updated_at = CURRENT_TIMESTAMP
+	//  WHERE url = $3
+	UpdateNarInfoCompressionAndURL(ctx context.Context, arg UpdateNarInfoCompressionAndURLParams) (int64, error)
 	//UpdateNarInfoFileSize
 	//
 	//  UPDATE narinfos

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -1205,6 +1205,23 @@ func (w *mysqlWrapper) UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParam
 	return w.GetNarInfoByHash(ctx, arg.Hash)
 }
 
+func (w *mysqlWrapper) UpdateNarInfoCompressionAndURL(ctx context.Context, arg UpdateNarInfoCompressionAndURLParams) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.UpdateNarInfoCompressionAndURL(ctx, mysqldb.UpdateNarInfoCompressionAndURLParams{
+		Compression: arg.Compression,
+		NewUrl:      arg.NewUrl,
+		OldUrl:      arg.OldUrl,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *mysqlWrapper) UpdateNarInfoFileSize(ctx context.Context, arg UpdateNarInfoFileSizeParams) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -1275,6 +1275,23 @@ func (w *postgresWrapper) UpdateNarInfo(ctx context.Context, arg UpdateNarInfoPa
 	}, nil
 }
 
+func (w *postgresWrapper) UpdateNarInfoCompressionAndURL(ctx context.Context, arg UpdateNarInfoCompressionAndURLParams) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.UpdateNarInfoCompressionAndURL(ctx, postgresdb.UpdateNarInfoCompressionAndURLParams{
+		Compression: arg.Compression,
+		NewUrl:      arg.NewUrl,
+		OldUrl:      arg.OldUrl,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *postgresWrapper) UpdateNarInfoFileSize(ctx context.Context, arg UpdateNarInfoFileSizeParams) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -1302,6 +1302,23 @@ func (w *sqliteWrapper) UpdateNarInfo(ctx context.Context, arg UpdateNarInfoPara
 	}, nil
 }
 
+func (w *sqliteWrapper) UpdateNarInfoCompressionAndURL(ctx context.Context, arg UpdateNarInfoCompressionAndURLParams) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.UpdateNarInfoCompressionAndURL(ctx, sqlitedb.UpdateNarInfoCompressionAndURLParams{
+		Compression: arg.Compression,
+		NewUrl:      arg.NewUrl,
+		OldUrl:      arg.OldUrl,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *sqliteWrapper) UpdateNarInfoFileSize(ctx context.Context, arg UpdateNarInfoFileSizeParams) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -427,6 +427,12 @@ type Querier interface {
 	//      updated_at = CURRENT_TIMESTAMP
 	//  WHERE hash = ?
 	UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (sql.Result, error)
+	// Update narinfo compression and URL after CDC migration.
+	//
+	//  UPDATE narinfos
+	//  SET compression = ?, url = ?, updated_at = CURRENT_TIMESTAMP
+	//  WHERE url = ?
+	UpdateNarInfoCompressionAndURL(ctx context.Context, arg UpdateNarInfoCompressionAndURLParams) (int64, error)
 	//UpdateNarInfoFileSize
 	//
 	//  UPDATE narinfos

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -1821,6 +1821,31 @@ func (q *Queries) UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (s
 	)
 }
 
+const updateNarInfoCompressionAndURL = `-- name: UpdateNarInfoCompressionAndURL :execrows
+UPDATE narinfos
+SET compression = ?, url = ?, updated_at = CURRENT_TIMESTAMP
+WHERE url = ?
+`
+
+type UpdateNarInfoCompressionAndURLParams struct {
+	Compression sql.NullString
+	NewUrl      sql.NullString
+	OldUrl      sql.NullString
+}
+
+// Update narinfo compression and URL after CDC migration.
+//
+//	UPDATE narinfos
+//	SET compression = ?, url = ?, updated_at = CURRENT_TIMESTAMP
+//	WHERE url = ?
+func (q *Queries) UpdateNarInfoCompressionAndURL(ctx context.Context, arg UpdateNarInfoCompressionAndURLParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateNarInfoCompressionAndURL, arg.Compression, arg.NewUrl, arg.OldUrl)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const updateNarInfoFileSize = `-- name: UpdateNarInfoFileSize :exec
 UPDATE narinfos
 SET file_size = ?, updated_at = CURRENT_TIMESTAMP

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -448,6 +448,12 @@ type Querier interface {
 	//  WHERE hash = $1
 	//  RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (NarInfo, error)
+	// Update narinfo compression and URL after CDC migration.
+	//
+	//  UPDATE narinfos
+	//  SET compression = $1, url = $2, updated_at = CURRENT_TIMESTAMP
+	//  WHERE url = $3
+	UpdateNarInfoCompressionAndURL(ctx context.Context, arg UpdateNarInfoCompressionAndURLParams) (int64, error)
 	//UpdateNarInfoFileSize
 	//
 	//  UPDATE narinfos

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -1917,6 +1917,31 @@ func (q *Queries) UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (N
 	return i, err
 }
 
+const updateNarInfoCompressionAndURL = `-- name: UpdateNarInfoCompressionAndURL :execrows
+UPDATE narinfos
+SET compression = $1, url = $2, updated_at = CURRENT_TIMESTAMP
+WHERE url = $3
+`
+
+type UpdateNarInfoCompressionAndURLParams struct {
+	Compression sql.NullString
+	NewUrl      sql.NullString
+	OldUrl      sql.NullString
+}
+
+// Update narinfo compression and URL after CDC migration.
+//
+//	UPDATE narinfos
+//	SET compression = $1, url = $2, updated_at = CURRENT_TIMESTAMP
+//	WHERE url = $3
+func (q *Queries) UpdateNarInfoCompressionAndURL(ctx context.Context, arg UpdateNarInfoCompressionAndURLParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateNarInfoCompressionAndURL, arg.Compression, arg.NewUrl, arg.OldUrl)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const updateNarInfoFileSize = `-- name: UpdateNarInfoFileSize :exec
 UPDATE narinfos
 SET file_size = $2, updated_at = CURRENT_TIMESTAMP

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -435,6 +435,12 @@ type Querier interface {
 	//  WHERE hash = ?
 	//  RETURNING id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
 	UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (NarInfo, error)
+	// Update narinfo compression and URL after CDC migration.
+	//
+	//  UPDATE narinfos
+	//  SET compression = ?1, url = ?2, updated_at = CURRENT_TIMESTAMP
+	//  WHERE url = ?3
+	UpdateNarInfoCompressionAndURL(ctx context.Context, arg UpdateNarInfoCompressionAndURLParams) (int64, error)
 	//UpdateNarInfoFileSize
 	//
 	//  UPDATE narinfos

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -1871,6 +1871,31 @@ func (q *Queries) UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (N
 	return i, err
 }
 
+const updateNarInfoCompressionAndURL = `-- name: UpdateNarInfoCompressionAndURL :execrows
+UPDATE narinfos
+SET compression = ?1, url = ?2, updated_at = CURRENT_TIMESTAMP
+WHERE url = ?3
+`
+
+type UpdateNarInfoCompressionAndURLParams struct {
+	Compression sql.NullString
+	NewUrl      sql.NullString
+	OldUrl      sql.NullString
+}
+
+// Update narinfo compression and URL after CDC migration.
+//
+//	UPDATE narinfos
+//	SET compression = ?1, url = ?2, updated_at = CURRENT_TIMESTAMP
+//	WHERE url = ?3
+func (q *Queries) UpdateNarInfoCompressionAndURL(ctx context.Context, arg UpdateNarInfoCompressionAndURLParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateNarInfoCompressionAndURL, arg.Compression, arg.NewUrl, arg.OldUrl)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const updateNarInfoFileSize = `-- name: UpdateNarInfoFileSize :exec
 UPDATE narinfos
 SET file_size = ?, updated_at = CURRENT_TIMESTAMP


### PR DESCRIPTION
When migrating a whole-file NAR to CDC chunks, the narinfo records in the
database were left with their original compression (e.g., xz) and URL
(e.g., nar/hash.nar.xz). This caused inconsistency since the NAR is now
stored as raw uncompressed chunks.

Added UpdateNarInfoCompressionAndURL query (all 3 SQL engines) and use it
in MigrateNarToChunks to update narinfo records to Compression: none and
remove the compression extension from the URL after successful migration.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>