### PR TITLE
feat: improve the run.py and add nix-isolated-build.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ charts/ncps/test-values/
 
 # Websites
 /public
+
+# Python Cache
+__pycache__/
+*.pyc
+*.pyo

--- a/dev-scripts/nix-isolated-build.py
+++ b/dev-scripts/nix-isolated-build.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from typing import List, Tuple
+
+def get_physical_temp_dir() -> str:
+    """Creates a temp dir and resolves symlinks (crucial for macOS /var)."""
+    tmp = tempfile.mkdtemp(prefix="nix-store.")
+    return os.path.realpath(tmp)
+
+def probe_caches(urls: List[str]) -> List[Tuple[str, str]]:
+    """Determines which caches are online and fetches their public keys."""
+    active_caches = []
+    for url in urls:
+        url = url.rstrip('/')
+        try:
+            # Check if cache is alive
+            with urllib.request.urlopen(f"{url}/nix-cache-info", timeout=2):
+                # Fetch pubkey
+                with urllib.request.urlopen(f"{url}/pubkey", timeout=2) as r:
+                    pubkey = r.read().decode('utf-8').strip()
+                    active_caches.append((url, pubkey))
+                    print(f"✅ Found active cache: {url}")
+        except Exception:
+            print(f"── Ignoring offline cache: {url}")
+    return active_caches
+
+def main():
+    parser = argparse.ArgumentParser(description="Multi-cache Nix build reproduction script")
+    parser.add_argument("packages", nargs="+", help="Nix flakeref packages to build")
+    parser.add_argument("--leave-nix-store", action="store_true", help="Do not delete the temp store on exit")
+    args = parser.parse_args()
+
+    default_urls = ["http://localhost:8501", "http://localhost:8502", "http://localhost:8503"]
+    active_configs = probe_caches(default_urls)
+
+    if not active_configs:
+        print("error: No active caches found.")
+        sys.exit(1)
+
+    # 1. Define temp_store before using it
+    temp_store = get_physical_temp_dir()
+    print(f"Nix store directory: {temp_store}")
+
+    substituters = " ".join([c[0] for c in active_configs])
+
+    # We only use the keys from the active caches we found.
+    # We deliberately exclude cache.nixos.org keys to test strict isolation.
+    pubkeys = " ".join([c[1] for c in active_configs])
+
+    cmd = [
+        "nix", "run", "nixpkgs#nixVersions.stable", "--",
+        "build",
+        "--store", temp_store,
+        "--no-link",
+        # OVERRIDE: This replaces the default https://cache.nixos.org
+        "--substituters", substituters,
+        # OVERRIDE: This empties any global extra substituters (like flake settings)
+        "--option", "extra-substituters", "",
+        "--trusted-public-keys", pubkeys
+    ] + args.packages
+
+    try:
+        print(f"Running: {' '.join(cmd)}")
+        # 2. Actually run the command!
+        subprocess.run(cmd, check=True)
+
+    except subprocess.CalledProcessError as e:
+        print(f"\nBuild failed with exit code {e.returncode}")
+        sys.exit(e.returncode)
+    finally:
+        if not args.leave_nix_store:
+            print(f"Cleaning up {temp_store}...")
+            shutil.rmtree(temp_store, ignore_errors=True)
+        else:
+            print(f"Leaving Nix store at: {temp_store}")
+
+if __name__ == "__main__":
+    main()

--- a/dev-scripts/run.py
+++ b/dev-scripts/run.py
@@ -2,10 +2,13 @@
 
 import argparse
 import os
+import gzip
+import shutil
 import signal
 import subprocess
 import sys
 import time
+import shlex
 from urllib.parse import urlparse
 
 # --- Configuration Constants ---
@@ -35,6 +38,34 @@ BLUE = "\033[0;34m"
 NC = "\033[0m"
 
 processes = []
+extra_panes = [] # Track tmux panes created by this script
+
+
+class TmuxManager:
+    @staticmethod
+    def is_in_tmux():
+        return "TMUX" in os.environ
+
+    @staticmethod
+    def get_pane_id():
+        return subprocess.check_output(["tmux", "display-message", "-p", "#{pane_id}"], text=True).strip()
+
+    @staticmethod
+    def split_window(target_pane, command=None):
+        # Split vertically (even layout will be applied later)
+        args = ["tmux", "split-window", "-d", "-t", target_pane, "-P", "-F", "#{pane_id}"]
+        if command:
+            args.append(command)
+        return subprocess.check_output(args, text=True).strip()
+
+    @staticmethod
+    def select_layout(layout):
+        subprocess.run(["tmux", "select-layout", layout], check=True)
+
+    @staticmethod
+    def kill_pane(pane_id):
+        subprocess.run(["tmux", "kill-pane", "-t", pane_id], check=True)
+
 
 
 def log(msg, color=NC):
@@ -55,8 +86,92 @@ def cleanup(signum, frame):
             log(f"Force killing process {p.pid}", RED)
             p.kill()
 
+    # Kill extra tmux panes
+    for pane_id in extra_panes:
+        try:
+            TmuxManager.kill_pane(pane_id)
+        except subprocess.CalledProcessError:
+            pass # Pane might already be gone
+
     log("All instances stopped.", GREEN)
     sys.exit(0)
+
+
+def rotate_logs(log_path, max_backups=5):
+    """
+    Rotates the log file at log_path.
+    Existing log is moved to log_path.1.gz, log_path.1.gz to log_path.2.gz, etc.
+    """
+    if not os.path.exists(log_path):
+        return
+
+    # Rotate existing backups
+    for i in range(max_backups - 1, 0, -1):
+        s = f"{log_path}.{i}.gz"
+        d = f"{log_path}.{i+1}.gz"
+        if os.path.exists(s):
+            os.rename(s, d)
+
+    # Rotate current log
+    if os.path.exists(log_path):
+        dest = f"{log_path}.1.gz"
+        with open(log_path, "rb") as f_in:
+            with gzip.open(dest, "wb") as f_out:
+                shutil.copyfileobj(f_in, f_out)
+        os.remove(log_path)
+
+
+def internal_start_instance(args):
+    """
+    Internal function to run the actual process and pipe output to log file.
+    This is what watchexec calls.
+    """
+    log_path = args.log_file
+    rotate_logs(log_path)
+
+    # Reconstruct the command to run the actual app
+    # We stripped the wrapper args, now run 'go run .' with the rest
+    cmd = ["go", "run", "."] + args.rest_args
+
+    # Ensure log directory exists
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+
+    log(f"Starting instance, logging to {log_path}", GREEN)
+
+    # Use line buffering and text mode for real-time output processing
+    p = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=os.getcwd(),
+        bufsize=1,
+        universal_newlines=True,
+    )
+
+    def handler(signum, frame):
+        p.terminate()
+        try:
+            p.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            p.kill()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
+
+    with open(log_path, "w") as f_log:
+        while True:
+            line = p.stdout.readline()
+            if not line and p.poll() is not None:
+                break
+            if line:
+                f_log.write(line)
+                f_log.flush()
+                if args.log_to_stdout:
+                    sys.stdout.write(line)
+                    sys.stdout.flush()
+
+    sys.exit(p.poll())
 
 
 def check_dependencies(args):
@@ -208,6 +323,30 @@ def main():
         help="Public key for cache validation (can be specified multiple times)",
     )
 
+    parser.add_argument(
+        "--internal-start-instance",
+        action="store_true",
+        help=argparse.SUPPRESS,  # Hidden flag for internal wrapper use
+    )
+    parser.add_argument(
+        "--log-file",
+        help=argparse.SUPPRESS,  # Hidden flag for internal wrapper use
+    )
+    parser.add_argument(
+        "--log-to-stdout",
+        action="store_true",
+        help="Also print logs to stdout (in addition to log file)",
+    )
+
+    # We use parse_known_args because when running internally, we have
+    # a bunch of flags for the Go app that we don't define here.
+    if "--internal-start-instance" in sys.argv:
+        # Initial parse to check for the internal flag
+        args, rest = parser.parse_known_args()
+        args.rest_args = rest
+        internal_start_instance(args)
+        return
+
     args = parser.parse_args()
 
     # --- Guard Rails ---
@@ -273,22 +412,46 @@ def main():
     log(f"  Locker:  {args.locker}", BLUE)
     print("")
 
+    use_tmux_split = args.mode == "ha" and TmuxManager.is_in_tmux()
+    if use_tmux_split:
+        current_pane = TmuxManager.get_pane_id()
+
     for i in range(1, num_instances + 1):
         port = BASE_PORT + (i - 1)
 
-        cmd = [
-            "watchexec",
+        # Instead of calling 'go run .' directly, we call ourselves with the internal flag
+        # This wrapper handles log rotation and redirection.
+        # We need the absolute path to this script and the executables to be safe.
+        script_path = os.path.abspath(__file__)
+        log_file = os.path.abspath(f"var/log/ncps-{port}.log")
+        watchexec_path = shutil.which("watchexec") or "watchexec"
+        python_path = sys.executable
+
+        # Chunk 1: Watchexec arguments
+        cmd_watchexec = [
+            watchexec_path,
             "-e",
             "go",
             "-c",
             "clear",
             "-r",
-            "go",
-            "run",
-            ".",
+            "--",
+        ]
+
+        # Chunk 2: Python wrapper arguments
+        cmd_wrapper = [
+            python_path,
+            script_path,
+            "--internal-start-instance",
+            f"--log-file={log_file}",
+        ]
+
+        if args.log_to_stdout:
+            cmd_wrapper.append("--log-to-stdout")
+
+        # Chunk 3: Go application arguments
+        cmd_app = [
             "--analytics-reporting-enabled=false",
-            "--log-console-writer-enabled",
-            f"--log-console-writer-prefix=localhost:{port}",
             "serve",
             "--cache-allow-put-verb",
             f"--cache-hostname=cache-{i}.example.com",
@@ -304,24 +467,24 @@ def main():
 
         urls = args.cache_url or ["https://cache.nixos.org"]
         for url in urls:
-            cmd.append(f"--cache-upstream-url={url}")
+            cmd_app.append(f"--cache-upstream-url='{url}'")
 
         keys = args.cache_public_key or [
             "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
         ]
         for key in keys:
-            cmd.append(f"--cache-upstream-public-key={key}")
+            cmd_app.append(f"--cache-upstream-public-key={key}")
 
         if args.analytics_reporting_samples:
-            cmd.append("--analytics-reporting-samples")
+            cmd_app.append("--analytics-reporting-samples")
 
         # Storage Args
         if args.enable_cdc:
-            cmd.append("--cache-cdc-enabled")
+            cmd_app.append("--cache-cdc-enabled")
         if args.storage == "local":
-            cmd.extend(["--cache-storage-local", local_storage_path])
+            cmd_app.extend(["--cache-storage-local", local_storage_path])
         else:
-            cmd.extend(
+            cmd_app.extend(
                 [
                     f"--cache-storage-s3-bucket={S3_CONFIG['bucket']}",
                     f"--cache-storage-s3-endpoint={S3_CONFIG['endpoint']}",
@@ -334,28 +497,32 @@ def main():
 
         # Locker Args
         if args.locker == "redis":
-            cmd.extend(
+            cmd_app.extend(
                 [
                     "--cache-lock-backend=redis",
                     f"--cache-redis-addrs={REDIS_ADDR}",
-                    "--cache-lock-download-ttl=5m",
-                    "--cache-lock-lru-ttl=30m",
+                    f"--cache-lock-download-ttl=5m",
+                    f"--cache-lock-lru-ttl=30m",
                 ]
             )
+
+        # Combine all parts
+        cmd = cmd_watchexec + cmd_wrapper + cmd_app
 
         # Start Process
         log(f"Starting Instance {i} on port {port}...", GREEN)
 
-        # Use a shell pipe to prefix output, similar to the bash script
-        # Note: We are not piping through sed in python to keep signal handling simple,
-        # but you could add a pipe handler if strictly required.
-        # Standard Popen here for reliability.
-        p = subprocess.Popen(cmd)
-        processes.append(p)
-
-        # Stagger start for HA
-        if num_instances > 1:
-            time.sleep(1)
+        if use_tmux_split:
+            # Construct shell command
+            cmd_str = shlex.join(cmd)
+            # Use atomic split-and-run to avoid timing issues with send-keys
+            new_pane = TmuxManager.split_window(current_pane, command=cmd_str)
+            extra_panes.append(new_pane)
+            TmuxManager.select_layout("tiled")
+        else:
+            # Run locally (Instance 1 or single mode)
+            p = subprocess.Popen(cmd)
+            processes.append(p)
 
     # Wait for interrupts
     signal.signal(signal.SIGINT, cleanup)


### PR DESCRIPTION
The run.py now keep logs in files instead of stdout because stdout is
quite messy and hard to parse. With --log-to-stdout flag, you get the
previous behavior and the log file. Additionally, the script
auto-detects tmux and if it's running, it will create one split per
cache server.

The nix-isolated-build.py automatically discovers servers started by
run.py and uses them and only them as substiture to build the package(s)
given as argument to the script.