### PR TITLE
feat: add Base16 nar hash test helpers

### DIFF
--- a/pkg/storage/chunk/local_test.go
+++ b/pkg/storage/chunk/local_test.go
@@ -31,7 +31,7 @@ func TestLocalStore(t *testing.T) {
 	t.Run("put and get chunk", func(t *testing.T) {
 		t.Parallel()
 
-		hash := testhelper.MustRandNarHash()
+		hash := testhelper.MustRandBase32NarHash()
 		content := strings.Repeat("chunk content", 1024)
 
 		created, size, err := store.PutChunk(ctx, hash, []byte(content))
@@ -56,7 +56,7 @@ func TestLocalStore(t *testing.T) {
 	t.Run("duplicate put", func(t *testing.T) {
 		t.Parallel()
 
-		hash := testhelper.MustRandNarHash()
+		hash := testhelper.MustRandBase32NarHash()
 		content := strings.Repeat("chunk content", 1024)
 
 		created1, size1, err := store.PutChunk(ctx, hash, []byte(content))
@@ -73,7 +73,7 @@ func TestLocalStore(t *testing.T) {
 	t.Run("get non-existent chunk", func(t *testing.T) {
 		t.Parallel()
 
-		hash := testhelper.MustRandNarHash()
+		hash := testhelper.MustRandBase32NarHash()
 		_, err := store.GetChunk(ctx, hash)
 		require.ErrorIs(t, err, chunk.ErrNotFound)
 	})
@@ -81,7 +81,7 @@ func TestLocalStore(t *testing.T) {
 	t.Run("delete chunk cleans up directory", func(t *testing.T) {
 		t.Parallel()
 
-		hash := testhelper.MustRandNarHash()
+		hash := testhelper.MustRandBase32NarHash()
 		content := strings.Repeat("cleanup test", 1024)
 
 		_, _, err := store.PutChunk(ctx, hash, []byte(content))
@@ -112,7 +112,7 @@ func TestLocalStore(t *testing.T) {
 	t.Run("PutChunk concurrent", func(t *testing.T) {
 		t.Parallel()
 
-		hash := testhelper.MustRandNarHash()
+		hash := testhelper.MustRandBase32NarHash()
 		content := strings.Repeat("concurrent content", 1024)
 		numGoroutines := 10
 
@@ -164,7 +164,7 @@ func TestLocalStore(t *testing.T) {
 
 		// Use highly compressible data (repeated bytes)
 		data := bytes.Repeat([]byte("compressible"), 1024)
-		isNew, compressedSize, err := store.PutChunk(ctx, testhelper.MustRandNarHash(), data)
+		isNew, compressedSize, err := store.PutChunk(ctx, testhelper.MustRandBase32NarHash(), data)
 		require.NoError(t, err)
 		assert.True(t, isNew)
 		assert.Greater(t, int64(len(data)), compressedSize, "compressed size should be less than original")
@@ -175,7 +175,7 @@ func TestLocalStore(t *testing.T) {
 		t.Parallel()
 
 		data := []byte("hello, compressed world! hello, compressed world! hello, compressed world!")
-		hash := testhelper.MustRandNarHash()
+		hash := testhelper.MustRandBase32NarHash()
 		_, _, err := store.PutChunk(ctx, hash, data)
 		require.NoError(t, err)
 

--- a/pkg/storage/chunk/s3_test.go
+++ b/pkg/storage/chunk/s3_test.go
@@ -117,7 +117,7 @@ func TestS3Store_Integration(t *testing.T) {
 	t.Run("stored chunk is zstd-compressed in S3", func(t *testing.T) {
 		t.Parallel()
 
-		hash := testhelper.MustRandNarHash()
+		hash := testhelper.MustRandBase32NarHash()
 
 		data := bytes.Repeat([]byte("compressible"), 1024)
 		isNew, compressedSize, err := store.PutChunk(ctx, hash, data)
@@ -134,7 +134,7 @@ func TestS3Store_Integration(t *testing.T) {
 	t.Run("compressed chunk round-trips correctly via S3", func(t *testing.T) {
 		t.Parallel()
 
-		hash := testhelper.MustRandNarHash()
+		hash := testhelper.MustRandBase32NarHash()
 
 		data := []byte("hello from S3 compressed chunk! hello from S3 compressed chunk!")
 		_, _, err := store.PutChunk(ctx, hash, data)
@@ -192,7 +192,7 @@ func runRaceConditionTest(t *testing.T, distinctHashes bool) {
 	}()
 
 	content := []byte(strings.Repeat("race condition content", 1024))
-	sharedHash := testhelper.MustRandNarHash()
+	sharedHash := testhelper.MustRandBase32NarHash()
 
 	results := make(chan bool, numGoRoutines)
 	errs := make(chan error, numGoRoutines)
@@ -201,7 +201,7 @@ func runRaceConditionTest(t *testing.T, distinctHashes bool) {
 		go func() {
 			hash := sharedHash
 			if distinctHashes {
-				hash = testhelper.MustRandNarHash()
+				hash = testhelper.MustRandBase32NarHash()
 			}
 
 			hashes <- hash

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -1391,7 +1391,7 @@ func TestHasNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        testhelper.MustRandNarHash(),
+			Hash:        testhelper.MustRandBase32NarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 
@@ -1412,7 +1412,7 @@ func TestHasNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        testhelper.MustRandNarHash(),
+			Hash:        testhelper.MustRandBase32NarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 
@@ -1445,7 +1445,7 @@ func TestGetNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        testhelper.MustRandNarHash(),
+			Hash:        testhelper.MustRandBase32NarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 
@@ -1467,7 +1467,7 @@ func TestGetNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        testhelper.MustRandNarHash(),
+			Hash:        testhelper.MustRandBase32NarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 
@@ -1509,7 +1509,7 @@ func TestPutNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        testhelper.MustRandNarHash(),
+			Hash:        testhelper.MustRandBase32NarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 
@@ -1541,7 +1541,7 @@ func TestPutNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        testhelper.MustRandNarHash(),
+			Hash:        testhelper.MustRandBase32NarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 
@@ -1576,7 +1576,7 @@ func TestDeleteNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        testhelper.MustRandNarHash(),
+			Hash:        testhelper.MustRandBase32NarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 
@@ -1598,7 +1598,7 @@ func TestDeleteNar_Integration(t *testing.T) {
 		ctx := newContext()
 
 		narURL := nar.URL{
-			Hash:        testhelper.MustRandNarHash(),
+			Hash:        testhelper.MustRandBase32NarHash(),
 			Compression: testdata.Nar1.NarCompression,
 		}
 

--- a/testhelper/export_test.go
+++ b/testhelper/export_test.go
@@ -8,6 +8,9 @@ const (
 
 	// Nix32Chars refers to unexported nix32Chars constant.
 	Nix32Chars = nix32Chars
+
+	// Base16Chars refers to unexported base16Chars constant.
+	Base16Chars = base16Chars
 )
 
 // RandChars is a test-only export of the unexported randChars method.

--- a/testhelper/rand.go
+++ b/testhelper/rand.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	allChars   = "abcdefghijklmnopqrstuvwxyz0123456789"
-	nix32Chars = "abcdfghijklmnpqrsvwxyz0123456789"
+	allChars    = "abcdefghijklmnopqrstuvwxyz0123456789"
+	nix32Chars  = "abcdfghijklmnpqrsvwxyz0123456789"
+	base16Chars = "0123456789abcdef"
 )
 
 func randChars(n int, charSet string, r io.Reader) (string, error) {
@@ -54,12 +55,25 @@ func MustRandNarInfoHash() string {
 	return str
 }
 
-func RandNarHash() (string, error) {
+func RandBase32NarHash() (string, error) {
 	return randChars(52, nix32Chars, rand.Reader)
 }
 
-func MustRandNarHash() string {
-	str, err := RandNarHash()
+func MustRandBase32NarHash() string {
+	str, err := RandBase32NarHash()
+	if err != nil {
+		panic(err)
+	}
+
+	return str
+}
+
+func RandBase16NarHash() (string, error) {
+	return randChars(64, base16Chars, rand.Reader)
+}
+
+func MustRandBase16NarHash() string {
+	str, err := RandBase16NarHash()
 	if err != nil {
 		panic(err)
 	}

--- a/testhelper/rand_test.go
+++ b/testhelper/rand_test.go
@@ -91,11 +91,67 @@ func TestMustRandNarInfoHash(t *testing.T) {
 	})
 }
 
-func TestRandNarHash(t *testing.T) {
+func TestRandBase16NarHash(t *testing.T) {
 	t.Run("validate length", func(t *testing.T) {
 		t.Parallel()
 
-		s, err := testhelper.RandNarHash()
+		s, err := testhelper.RandBase16NarHash()
+		require.NoError(t, err)
+
+		assert.Len(t, s, 64)
+	})
+
+	t.Run("validate character set", func(t *testing.T) {
+		t.Parallel()
+
+		s, err := testhelper.RandBase16NarHash()
+		require.NoError(t, err)
+
+		for _, ch := range s {
+			assert.Contains(t, testhelper.Base16Chars, string(ch))
+		}
+	})
+
+	t.Run("returns different values", func(t *testing.T) {
+		t.Parallel()
+
+		s1, err := testhelper.RandBase16NarHash()
+		require.NoError(t, err)
+
+		s2, err := testhelper.RandBase16NarHash()
+		require.NoError(t, err)
+
+		assert.NotEqual(t, s1, s2)
+	})
+}
+
+func TestMustRandBase16NarHash(t *testing.T) {
+	t.Run("returns valid hash", func(t *testing.T) {
+		t.Parallel()
+
+		s := testhelper.MustRandBase16NarHash()
+
+		assert.Len(t, s, 64)
+
+		for _, ch := range s {
+			assert.Contains(t, testhelper.Base16Chars, string(ch))
+		}
+	})
+
+	t.Run("does not panic", func(t *testing.T) {
+		t.Parallel()
+
+		assert.NotPanics(t, func() {
+			testhelper.MustRandBase16NarHash()
+		})
+	})
+}
+
+func TestRandBase32NarHash(t *testing.T) {
+	t.Run("validate length", func(t *testing.T) {
+		t.Parallel()
+
+		s, err := testhelper.RandBase32NarHash()
 		require.NoError(t, err)
 
 		assert.Len(t, s, 52)
@@ -104,7 +160,7 @@ func TestRandNarHash(t *testing.T) {
 	t.Run("validate character set", func(t *testing.T) {
 		t.Parallel()
 
-		s, err := testhelper.RandNarHash()
+		s, err := testhelper.RandBase32NarHash()
 		require.NoError(t, err)
 
 		for _, ch := range s {
@@ -115,21 +171,21 @@ func TestRandNarHash(t *testing.T) {
 	t.Run("returns different values", func(t *testing.T) {
 		t.Parallel()
 
-		s1, err := testhelper.RandNarHash()
+		s1, err := testhelper.RandBase32NarHash()
 		require.NoError(t, err)
 
-		s2, err := testhelper.RandNarHash()
+		s2, err := testhelper.RandBase32NarHash()
 		require.NoError(t, err)
 
 		assert.NotEqual(t, s1, s2)
 	})
 }
 
-func TestMustRandNarHash(t *testing.T) {
+func TestMustRandBase32NarHash(t *testing.T) {
 	t.Run("returns valid hash", func(t *testing.T) {
 		t.Parallel()
 
-		s := testhelper.MustRandNarHash()
+		s := testhelper.MustRandBase32NarHash()
 
 		assert.Len(t, s, 52)
 
@@ -142,7 +198,7 @@ func TestMustRandNarHash(t *testing.T) {
 		t.Parallel()
 
 		assert.NotPanics(t, func() {
-			testhelper.MustRandNarHash()
+			testhelper.MustRandBase32NarHash()
 		})
 	})
 }


### PR DESCRIPTION
These helpers are useful for generating base16 nar hashes.