### PR TITLE
fix: server must allow nar hashes with base16 as well as nix32

### DIFF
--- a/pkg/server/security_test.go
+++ b/pkg/server/security_test.go
@@ -119,11 +119,11 @@ L:
 			shouldReachUpstream: false,
 		},
 		{
-			name:                "Valid NAR hash (32 chars)",
+			name:                "Invalid NAR hash (32 chars - should be 52 or 64)",
 			method:              http.MethodGet,
 			path:                "/nar/1lid9xrpirkzcpqsxfq02qwiq0yd70ch.nar.xz",
 			expectedStatus:      http.StatusNotFound,
-			shouldReachUpstream: true,
+			shouldReachUpstream: false,
 		},
 		{
 			name:                "Valid NAR hash (52 chars)",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -35,8 +35,8 @@ import (
 
 const (
 	routeIndex          = "/"
-	routeNar            = "/nar/{hash:[a-z0-9]{32,52}}.nar"
-	routeNarCompression = "/nar/{hash:[a-z0-9]{32,52}}.nar.{compression:*}"
+	routeNar            = "/nar/{hash:" + nar.NormalizedHashPattern + "}.nar"
+	routeNarCompression = "/nar/{hash:" + nar.NormalizedHashPattern + "}.nar.{compression:*}"
 	routeNarInfo        = "/{hash:" + narinfo.HashPattern + "}.narinfo"
 	routeCacheInfo      = "/nix-cache-info"
 	routeCachePublicKey = "/pubkey"


### PR DESCRIPTION
The server is currently only allowing nix32 (specialized base32),
however, nar hashes can also be of base16 made up of 64 characters.

fixes #870