### PR TITLE
fix: server must allow nar hashes with base16 as well as nix32

### DIFF
--- a/pkg/helper/url_path.go
+++ b/pkg/helper/url_path.go
@@ -2,7 +2,7 @@ package helper
 
 import "regexp"
 
-var isValidHashRegexp = regexp.MustCompile(`^([a-z0-9]{32}|[a-z0-9]{52})$`)
+var isValidHashRegexp = regexp.MustCompile(`^([a-z0-9]{32,64})$`)
 
 // NarInfoURLPath returns the path of the narinfo file given a hash.
 func NarInfoURLPath(hash string) string { return "/" + hash + ".narinfo" }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -32,8 +32,8 @@ import (
 
 const (
 	routeIndex          = "/"
-	routeNar            = "/nar/{hash:[a-z0-9]{32,52}}.nar"
-	routeNarCompression = "/nar/{hash:[a-z0-9]{32,52}}.nar.{compression:*}"
+	routeNar            = "/nar/{hash:[a-z0-9]{32,64}}.nar"
+	routeNarCompression = "/nar/{hash:[a-z0-9]{32,64}}.nar.{compression:*}"
 	routeNarInfo        = "/{hash:" + narinfo.HashPattern + "}.narinfo"
 	routeCacheInfo      = "/nix-cache-info"
 	routeCachePublicKey = "/pubkey"


### PR DESCRIPTION
The server is currently only allowing nix32 (specialized base32),
however, nar hashes can also be of base16 made up of 64 characters.

fixes #870

(cherry picked from pr #882)