### PR TITLE
test: add per-entry zstd encoding control to test server

### DIFF
--- a/testdata/nar7.go
+++ b/testdata/nar7.go
@@ -26,4 +26,5 @@ Sig: cache.nixos.org-1:oPqkkDFlniUh1BaGWwWd7LY2EfUh3r/GBxriDGE7vCfvJ3fKsnIDg1L4Q
 	NarCompression: nar.CompressionTypeNone,
 	NarPath:        filepath.Join("0", "09", "09xizkfyvigl5fqs0dhkn46nghfwwijbpdzzl4zg6kx90prjmsg0.nar"),
 	NarText:        testhelper.MustRandString(113256),
+	NoZstdEncoding: true,
 }

--- a/testdata/type.go
+++ b/testdata/type.go
@@ -11,4 +11,9 @@ type Entry struct {
 	NarCompression nar.CompressionType
 	NarPath        string
 	NarText        string
+
+	// NoZstdEncoding, when true, causes the test server to ignore
+	// Accept-Encoding: zstd and serve raw bytes without Content-Encoding.
+	// This simulates nix-serve behavior.
+	NoZstdEncoding bool
 }


### PR DESCRIPTION
This change introduces the NoZstdEncoding field to the testdata.Entry struct, allowing for more granular control over ZSTD compression in the test server.

Previously, the test server would always attempt ZSTD compression if requested by the client. By setting NoZstdEncoding to true, the server will now bypass ZSTD compression even when the Accept-Encoding: zstd header is present. This simulates the behavior of upstream servers like nix-serve that do not support ZSTD encoding for certain files.

Key changes:
- testdata/type.go: Added NoZstdEncoding field to the Entry struct.
- testdata/server.go: Updated the handler to respect the NoZstdEncoding flag when processing requests with Accept-Encoding: zstd.
- testdata/nar7.go: Enabled NoZstdEncoding for the Nar7 entry.
- testdata/nars_test.go: Updated TestNarsValid to handle cases where FileSize is 0, which occurs when using Compression: none in nix-serve style upstreams. In these cases, the NarText length is validated against NarSize instead.