### PR TITLE
feat: store and serve uncompressed NARs as zstd

### DIFF
--- a/pkg/cache/cache_distributed_test.go
+++ b/pkg/cache/cache_distributed_test.go
@@ -657,8 +657,8 @@ func testLargeNARConcurrentDownloadScenario(t *testing.T, factory distributedDBF
 	db, sharedDir, cleanup := factory(t)
 	t.Cleanup(cleanup)
 
-	// Generate a large NAR (12MB) to ensure CDC chunking can happen
-	const largeNARSize = 12 * 1024 * 1024
+	// Generate a large NAR (2MB) - enough for chunking but fast for tests
+	const largeNARSize = 2 * 1024 * 1024
 
 	narData := make([]byte, largeNARSize)
 	_, err := rand.Read(narData)
@@ -758,7 +758,7 @@ func testLargeNARConcurrentDownloadScenario(t *testing.T, factory distributedDBF
 			downloadLocker,
 			cacheLocker,
 			5*time.Minute,
-			60*time.Second, // downloadPollTimeout
+			120*time.Second, // downloadPollTimeout
 			30*time.Minute,
 		)
 		require.NoError(t, err)
@@ -799,7 +799,7 @@ func testLargeNARConcurrentDownloadScenario(t *testing.T, factory distributedDBF
 			// Create a context with timeout for each request (simulates HTTP request timeout)
 			// This should be longer than the download delay (2s) plus chunking time
 			// For CDC-enabled tests, progressive streaming may take longer
-			requestCtx, cancel := context.WithTimeout(ctx, 120*time.Second)
+			requestCtx, cancel := context.WithTimeout(ctx, 150*time.Second)
 			defer cancel()
 
 			// All instances request the same NAR concurrently

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -639,10 +639,12 @@ func testGetNarInfo(factory cacheFactory) func(*testing.T) {
 
 			for i, narEntry := range allEntries {
 				t.Run("nar idx"+strconv.Itoa(i)+" narInfoHash="+narEntry.NarInfoHash, func(t *testing.T) {
-					narInfo, err := c.GetNarInfo(context.Background(), narEntry.NarInfoHash)
+					_, err := c.GetNarInfo(context.Background(), narEntry.NarInfoHash)
 					require.NoError(t, err)
 
 					storePath := filepath.Join(dir, "store", "nar", narEntry.NarPath)
+					waitForFile(t, storePath)
+
 					if assert.FileExists(t, storePath) {
 						body, err := os.ReadFile(storePath)
 						require.NoError(t, err)
@@ -655,7 +657,6 @@ func testGetNarInfo(factory cacheFactory) func(*testing.T) {
 							require.NoError(t, err)
 
 							assert.Equal(t, narEntry.NarText, string(plain))
-							assert.Equal(t, narInfo.FileSize, uint64(len(body)))
 						}
 					}
 				})


### PR DESCRIPTION
Normalize NARs that are originally uncompressed (Compression: none) by storing them using ZSTD compression. This optimization reduces storage requirements while maintaining full compatibility with clients that expect uncompressed data by transparently decompressing upon retrieval.

Key implementation details:
- Storage normalization: storeNarFromTempFile now detects uncompressed NARs and uses an io.Pipe paired with a ZSTD encoder to compress the stream before it hits the store.
- Metadata normalization: pullNarInfo and PutNarInfo ensure that for uncompressed NARs, the FileSize and FileHash in the metadata correctly reflect the uncompressed NarSize and NarHash, preventing serialization inconsistencies.
- Transparent retrieval: Updated the loading logic (GetNar, getNarFromStore, etc.) to prioritize checking for .nar.zst files and performing on-the-fly decompression when Compression: none is indicated in the database.
- Test robustness: Updated test suites to handle asynchronous storage via waitForFile and added validation for correct size/hash calculations of normalized entries.