### PR TITLE
fix: race condition when serving normalized nar urls

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -41,6 +41,14 @@ FROM narinfos ni
 INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
 WHERE nnf.nar_file_id = ?;
 
+-- name: GetNarInfoURLByNarFileHash :one
+SELECT ni.url
+FROM narinfos ni
+INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+WHERE nf.hash = ? AND nf.compression = ? AND nf.query = ?
+LIMIT 1;
+
 -- name: CreateConfig :execresult
 INSERT INTO config (
     `key`, value

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -41,6 +41,14 @@ FROM narinfos ni
 INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
 WHERE nnf.nar_file_id = $1;
 
+-- name: GetNarInfoURLByNarFileHash :one
+SELECT ni.url
+FROM narinfos ni
+INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+WHERE nf.hash = $1 AND nf.compression = $2 AND nf.query = $3
+LIMIT 1;
+
 -- name: CreateConfig :one
 INSERT INTO config (
     key, value

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -41,6 +41,14 @@ FROM narinfos ni
 INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
 WHERE nnf.nar_file_id = ?;
 
+-- name: GetNarInfoURLByNarFileHash :one
+SELECT ni.url
+FROM narinfos ni
+INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+WHERE nf.hash = ? AND nf.compression = ? AND nf."query" = ?
+LIMIT 1;
+
 -- name: CreateConfig :one
 INSERT INTO config (
     key, value

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -836,6 +836,11 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadClose
 			Debug().
 			Msg("pulling nar in a go-routine and will stream the file back to the client")
 
+		// Look up the original NAR URL from the narinfo in the database.
+		// The client requests the normalized hash, but the upstream may require
+		// the original (prefixed) hash (e.g., nix-serve style upstreams).
+		narURL = c.lookupOriginalNarURL(ctx, narURL)
+
 		// create a detachedCtx that has the same span and logger as the main
 		// context but with the baseContext as parent; This context will not cancel
 		// when ctx is canceled allowing us to continue pulling the nar in the
@@ -1038,6 +1043,38 @@ func (c *Cache) GetNarFileSize(ctx context.Context, nu nar.URL) (int64, error) {
 
 	//nolint:gosec // G115: File size is non-negative
 	return int64(nr.FileSize), nil
+}
+
+// lookupOriginalNarURL looks up the original (potentially prefixed) NAR URL from the database
+// by matching the narinfo that references a nar_file with the given hash.
+// This is used to recover the original upstream URL (with prefix) when fetching from
+// nix-serve style upstreams that use prefixed URLs (e.g., narinfohash-narhash).
+func (c *Cache) lookupOriginalNarURL(ctx context.Context, normalizedNarURL nar.URL) nar.URL {
+	urlStr, err := c.db.GetNarInfoURLByNarFileHash(ctx, database.GetNarInfoURLByNarFileHashParams{
+		Hash:        normalizedNarURL.Hash,
+		Compression: normalizedNarURL.Compression.String(),
+		Query:       normalizedNarURL.Query.Encode(),
+	})
+	if err != nil {
+		// Not found is an expected case. We should log any other database errors.
+		if !database.IsNotFoundError(err) && !errors.Is(err, sql.ErrNoRows) {
+			zerolog.Ctx(ctx).Warn().Err(err).Msg("Failed to lookup original nar URL")
+		}
+
+		return normalizedNarURL
+	}
+
+	if urlStr.Valid && urlStr.String != "" {
+		originalURL, parseErr := nar.ParseURL(urlStr.String)
+		if parseErr == nil {
+			return originalURL
+		}
+		// Log if we have a URL in the DB but can't parse it.
+		zerolog.Ctx(ctx).Warn().Err(parseErr).Str("url", urlStr.String).Msg("Failed to parse original nar URL from DB")
+	}
+
+	// If parsing fails or URL is invalid/empty, return the normalized URL unchanged
+	return normalizedNarURL
 }
 
 // PutNar records the NAR (given as an io.Reader) into the store.

--- a/pkg/database/generated_models.go
+++ b/pkg/database/generated_models.go
@@ -146,6 +146,12 @@ type GetNarInfoHashesToChunkRow struct {
 	URL  sql.NullString
 }
 
+type GetNarInfoURLByNarFileHashParams struct {
+	Hash        string
+	Compression string
+	Query       string
+}
+
 type GetOldCompressedNarFilesParams struct {
 	CreatedAt time.Time
 	Limit     int32

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -320,6 +320,15 @@ type Querier interface {
 	//  FROM narinfo_signatures
 	//  WHERE narinfo_id = $1
 	GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error)
+	//GetNarInfoURLByNarFileHash
+	//
+	//  SELECT ni.url
+	//  FROM narinfos ni
+	//  INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+	//  INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+	//  WHERE nf.hash = $1 AND nf.compression = $2 AND nf.query = $3
+	//  LIMIT 1
+	GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error)
 	//GetNarTotalSize
 	//
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS BIGINT) AS total_size

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -934,6 +934,23 @@ func (w *mysqlWrapper) GetNarInfoSignatures(ctx context.Context, narinfoID int64
 	return res, nil
 }
 
+func (w *mysqlWrapper) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetNarInfoURLByNarFileHash(ctx, mysqldb.GetNarInfoURLByNarFileHashParams{
+		Hash:        arg.Hash,
+		Compression: arg.Compression,
+		Query:       arg.Query,
+	})
+	if err != nil {
+		return sql.NullString{}, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *mysqlWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -986,6 +986,23 @@ func (w *postgresWrapper) GetNarInfoSignatures(ctx context.Context, narinfoID in
 	return res, nil
 }
 
+func (w *postgresWrapper) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetNarInfoURLByNarFileHash(ctx, postgresdb.GetNarInfoURLByNarFileHashParams{
+		Hash:        arg.Hash,
+		Compression: arg.Compression,
+		Query:       arg.Query,
+	})
+	if err != nil {
+		return sql.NullString{}, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *postgresWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -1004,6 +1004,23 @@ func (w *sqliteWrapper) GetNarInfoSignatures(ctx context.Context, narinfoID int6
 	return res, nil
 }
 
+func (w *sqliteWrapper) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetNarInfoURLByNarFileHash(ctx, sqlitedb.GetNarInfoURLByNarFileHashParams{
+		Hash:        arg.Hash,
+		Compression: arg.Compression,
+		Query:       arg.Query,
+	})
+	if err != nil {
+		return sql.NullString{}, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *sqliteWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -305,6 +305,15 @@ type Querier interface {
 	//  FROM narinfo_signatures
 	//  WHERE narinfo_id = ?
 	GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error)
+	//GetNarInfoURLByNarFileHash
+	//
+	//  SELECT ni.url
+	//  FROM narinfos ni
+	//  INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+	//  INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+	//  WHERE nf.hash = ? AND nf.compression = ? AND nf.query = ?
+	//  LIMIT 1
+	GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error)
 	//GetNarTotalSize
 	//
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS SIGNED) AS total_size

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -1312,6 +1312,36 @@ func (q *Queries) GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]
 	return items, nil
 }
 
+const getNarInfoURLByNarFileHash = `-- name: GetNarInfoURLByNarFileHash :one
+SELECT ni.url
+FROM narinfos ni
+INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+WHERE nf.hash = ? AND nf.compression = ? AND nf.query = ?
+LIMIT 1
+`
+
+type GetNarInfoURLByNarFileHashParams struct {
+	Hash        string
+	Compression string
+	Query       string
+}
+
+// GetNarInfoURLByNarFileHash
+//
+//	SELECT ni.url
+//	FROM narinfos ni
+//	INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+//	INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+//	WHERE nf.hash = ? AND nf.compression = ? AND nf.query = ?
+//	LIMIT 1
+func (q *Queries) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error) {
+	row := q.db.QueryRowContext(ctx, getNarInfoURLByNarFileHash, arg.Hash, arg.Compression, arg.Query)
+	var url sql.NullString
+	err := row.Scan(&url)
+	return url, err
+}
+
 const getNarTotalSize = `-- name: GetNarTotalSize :one
 SELECT CAST(COALESCE(SUM(file_size), 0) AS SIGNED) AS total_size
 FROM nar_files

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -323,6 +323,15 @@ type Querier interface {
 	//  FROM narinfo_signatures
 	//  WHERE narinfo_id = $1
 	GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error)
+	//GetNarInfoURLByNarFileHash
+	//
+	//  SELECT ni.url
+	//  FROM narinfos ni
+	//  INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+	//  INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+	//  WHERE nf.hash = $1 AND nf.compression = $2 AND nf.query = $3
+	//  LIMIT 1
+	GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error)
 	//GetNarTotalSize
 	//
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS BIGINT) AS total_size

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -1395,6 +1395,36 @@ func (q *Queries) GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]
 	return items, nil
 }
 
+const getNarInfoURLByNarFileHash = `-- name: GetNarInfoURLByNarFileHash :one
+SELECT ni.url
+FROM narinfos ni
+INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+WHERE nf.hash = $1 AND nf.compression = $2 AND nf.query = $3
+LIMIT 1
+`
+
+type GetNarInfoURLByNarFileHashParams struct {
+	Hash        string
+	Compression string
+	Query       string
+}
+
+// GetNarInfoURLByNarFileHash
+//
+//	SELECT ni.url
+//	FROM narinfos ni
+//	INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+//	INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+//	WHERE nf.hash = $1 AND nf.compression = $2 AND nf.query = $3
+//	LIMIT 1
+func (q *Queries) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error) {
+	row := q.db.QueryRowContext(ctx, getNarInfoURLByNarFileHash, arg.Hash, arg.Compression, arg.Query)
+	var url sql.NullString
+	err := row.Scan(&url)
+	return url, err
+}
+
 const getNarTotalSize = `-- name: GetNarTotalSize :one
 SELECT CAST(COALESCE(SUM(file_size), 0) AS BIGINT) AS total_size
 FROM nar_files

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -309,6 +309,15 @@ type Querier interface {
 	//  FROM narinfo_signatures
 	//  WHERE narinfo_id = ?
 	GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error)
+	//GetNarInfoURLByNarFileHash
+	//
+	//  SELECT ni.url
+	//  FROM narinfos ni
+	//  INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+	//  INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+	//  WHERE nf.hash = ? AND nf.compression = ? AND nf."query" = ?
+	//  LIMIT 1
+	GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error)
 	//GetNarTotalSize
 	//
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS INTEGER) AS total_size

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -1347,6 +1347,36 @@ func (q *Queries) GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]
 	return items, nil
 }
 
+const getNarInfoURLByNarFileHash = `-- name: GetNarInfoURLByNarFileHash :one
+SELECT ni.url
+FROM narinfos ni
+INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+WHERE nf.hash = ? AND nf.compression = ? AND nf."query" = ?
+LIMIT 1
+`
+
+type GetNarInfoURLByNarFileHashParams struct {
+	Hash        string
+	Compression string
+	Query       string
+}
+
+// GetNarInfoURLByNarFileHash
+//
+//	SELECT ni.url
+//	FROM narinfos ni
+//	INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+//	INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+//	WHERE nf.hash = ? AND nf.compression = ? AND nf."query" = ?
+//	LIMIT 1
+func (q *Queries) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error) {
+	row := q.db.QueryRowContext(ctx, getNarInfoURLByNarFileHash, arg.Hash, arg.Compression, arg.Query)
+	var url sql.NullString
+	err := row.Scan(&url)
+	return url, err
+}
+
 const getNarTotalSize = `-- name: GetNarTotalSize :one
 SELECT CAST(COALESCE(SUM(file_size), 0) AS INTEGER) AS total_size
 FROM nar_files

--- a/testdata/type.go
+++ b/testdata/type.go
@@ -16,4 +16,9 @@ type Entry struct {
 	// Accept-Encoding: zstd and serve raw bytes without Content-Encoding.
 	// This simulates nix-serve behavior.
 	NoZstdEncoding bool
+
+	// NarInfoNarHash is the NAR hash as it appears in the upstream narinfo URL.
+	// For nix-serve upstreams, this includes the narinfo hash prefix (e.g., "narinfohash-narhash").
+	// When empty, NarHash is used directly.
+	NarInfoNarHash string
 }


### PR DESCRIPTION
When using upstreams that use prefixed NAR URLs (like nix-serve), a request for a normalized NAR URL would not be correctly mapped to existing storage or active download jobs if they were using the prefixed hash. This resulted in redundant downloads and potential race conditions.

This change fixes this by:
1. Adding a database query to look up the original upstream URL for a given NAR file hash by checking associated narinfos.
2. Using this original URL in `Cache.GetNar` to canonicalize the NAR URL before download coordination.
3. Ensuring that both normalized and prefixed requests for the same content use the same lock key and `downloadState`.
4. Updating the mock server in tests to support both original and normalized NAR URL formats.