### PR TITLE
fix: race condition when serving normalized nar urls [backport #893]

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -41,6 +41,14 @@ FROM narinfos ni
 INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
 WHERE nnf.nar_file_id = ?;
 
+-- name: GetNarInfoURLByNarFileHash :one
+SELECT ni.url
+FROM narinfos ni
+INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+WHERE nf.hash = ? AND nf.compression = ? AND nf.query = ?
+LIMIT 1;
+
 -- name: CreateConfig :execresult
 INSERT INTO config (
     `key`, value

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -41,6 +41,14 @@ FROM narinfos ni
 INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
 WHERE nnf.nar_file_id = $1;
 
+-- name: GetNarInfoURLByNarFileHash :one
+SELECT ni.url
+FROM narinfos ni
+INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+WHERE nf.hash = $1 AND nf.compression = $2 AND nf.query = $3
+LIMIT 1;
+
 -- name: CreateConfig :one
 INSERT INTO config (
     key, value

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -41,6 +41,14 @@ FROM narinfos ni
 INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
 WHERE nnf.nar_file_id = ?;
 
+-- name: GetNarInfoURLByNarFileHash :one
+SELECT ni.url
+FROM narinfos ni
+INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+WHERE nf.hash = ? AND nf.compression = ? AND nf."query" = ?
+LIMIT 1;
+
 -- name: CreateConfig :one
 INSERT INTO config (
     key, value

--- a/pkg/database/generated_models.go
+++ b/pkg/database/generated_models.go
@@ -77,6 +77,12 @@ type GetNarFileByHashAndCompressionAndQueryParams struct {
 	Query       string
 }
 
+type GetNarInfoURLByNarFileHashParams struct {
+	Hash        string
+	Compression string
+	Query       string
+}
+
 type LinkNarInfoToNarFileParams struct {
 	NarInfoID int64
 	NarFileID int64

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -233,6 +233,15 @@ type Querier interface {
 	//  FROM narinfo_signatures
 	//  WHERE narinfo_id = $1
 	GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error)
+	//GetNarInfoURLByNarFileHash
+	//
+	//  SELECT ni.url
+	//  FROM narinfos ni
+	//  INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+	//  INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+	//  WHERE nf.hash = $1 AND nf.compression = $2 AND nf.query = $3
+	//  LIMIT 1
+	GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error)
 	//GetNarTotalSize
 	//
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS BIGINT) AS total_size

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -468,6 +468,23 @@ func (w *mysqlWrapper) GetNarInfoSignatures(ctx context.Context, narinfoID int64
 	return res, nil
 }
 
+func (w *mysqlWrapper) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error) {
+	res, err := w.adapter.GetNarInfoURLByNarFileHash(ctx, mysqldb.GetNarInfoURLByNarFileHashParams{
+		Hash:        arg.Hash,
+		Compression: arg.Compression,
+		Query:       arg.Query,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return sql.NullString{}, ErrNotFound
+		}
+		return sql.NullString{}, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+	return res, nil
+}
+
 func (w *mysqlWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {
 	res, err := w.adapter.GetNarTotalSize(ctx)
 	if err != nil {

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -454,6 +454,23 @@ func (w *postgresWrapper) GetNarInfoSignatures(ctx context.Context, narinfoID in
 	return res, nil
 }
 
+func (w *postgresWrapper) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error) {
+	res, err := w.adapter.GetNarInfoURLByNarFileHash(ctx, postgresdb.GetNarInfoURLByNarFileHashParams{
+		Hash:        arg.Hash,
+		Compression: arg.Compression,
+		Query:       arg.Query,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return sql.NullString{}, ErrNotFound
+		}
+		return sql.NullString{}, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+	return res, nil
+}
+
 func (w *postgresWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {
 	res, err := w.adapter.GetNarTotalSize(ctx)
 	if err != nil {

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -462,6 +462,23 @@ func (w *sqliteWrapper) GetNarInfoSignatures(ctx context.Context, narinfoID int6
 	return res, nil
 }
 
+func (w *sqliteWrapper) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error) {
+	res, err := w.adapter.GetNarInfoURLByNarFileHash(ctx, sqlitedb.GetNarInfoURLByNarFileHashParams{
+		Hash:        arg.Hash,
+		Compression: arg.Compression,
+		Query:       arg.Query,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return sql.NullString{}, ErrNotFound
+		}
+		return sql.NullString{}, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+	return res, nil
+}
+
 func (w *sqliteWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {
 	res, err := w.adapter.GetNarTotalSize(ctx)
 	if err != nil {

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -220,6 +220,15 @@ type Querier interface {
 	//  FROM narinfo_signatures
 	//  WHERE narinfo_id = ?
 	GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error)
+	//GetNarInfoURLByNarFileHash
+	//
+	//  SELECT ni.url
+	//  FROM narinfos ni
+	//  INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+	//  INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+	//  WHERE nf.hash = ? AND nf.compression = ? AND nf.query = ?
+	//  LIMIT 1
+	GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error)
 	//GetNarTotalSize
 	//
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS SIGNED) AS total_size

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -903,6 +903,36 @@ func (q *Queries) GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]
 	return items, nil
 }
 
+const getNarInfoURLByNarFileHash = `-- name: GetNarInfoURLByNarFileHash :one
+SELECT ni.url
+FROM narinfos ni
+INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+WHERE nf.hash = ? AND nf.compression = ? AND nf.query = ?
+LIMIT 1
+`
+
+type GetNarInfoURLByNarFileHashParams struct {
+	Hash        string
+	Compression string
+	Query       string
+}
+
+// GetNarInfoURLByNarFileHash
+//
+//	SELECT ni.url
+//	FROM narinfos ni
+//	INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+//	INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+//	WHERE nf.hash = ? AND nf.compression = ? AND nf.query = ?
+//	LIMIT 1
+func (q *Queries) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error) {
+	row := q.db.QueryRowContext(ctx, getNarInfoURLByNarFileHash, arg.Hash, arg.Compression, arg.Query)
+	var url sql.NullString
+	err := row.Scan(&url)
+	return url, err
+}
+
 const getNarTotalSize = `-- name: GetNarTotalSize :one
 SELECT CAST(COALESCE(SUM(file_size), 0) AS SIGNED) AS total_size
 FROM nar_files

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -6,6 +6,7 @@ package postgresdb
 
 import (
 	"context"
+	"database/sql"
 )
 
 type Querier interface {
@@ -235,6 +236,15 @@ type Querier interface {
 	//  FROM narinfo_signatures
 	//  WHERE narinfo_id = $1
 	GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error)
+	//GetNarInfoURLByNarFileHash
+	//
+	//  SELECT ni.url
+	//  FROM narinfos ni
+	//  INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+	//  INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+	//  WHERE nf.hash = $1 AND nf.compression = $2 AND nf.query = $3
+	//  LIMIT 1
+	GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error)
 	//GetNarTotalSize
 	//
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS BIGINT) AS total_size

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -950,6 +950,36 @@ func (q *Queries) GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]
 	return items, nil
 }
 
+const getNarInfoURLByNarFileHash = `-- name: GetNarInfoURLByNarFileHash :one
+SELECT ni.url
+FROM narinfos ni
+INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+WHERE nf.hash = $1 AND nf.compression = $2 AND nf.query = $3
+LIMIT 1
+`
+
+type GetNarInfoURLByNarFileHashParams struct {
+	Hash        string
+	Compression string
+	Query       string
+}
+
+// GetNarInfoURLByNarFileHash
+//
+//	SELECT ni.url
+//	FROM narinfos ni
+//	INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+//	INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+//	WHERE nf.hash = $1 AND nf.compression = $2 AND nf.query = $3
+//	LIMIT 1
+func (q *Queries) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error) {
+	row := q.db.QueryRowContext(ctx, getNarInfoURLByNarFileHash, arg.Hash, arg.Compression, arg.Query)
+	var url sql.NullString
+	err := row.Scan(&url)
+	return url, err
+}
+
 const getNarTotalSize = `-- name: GetNarTotalSize :one
 SELECT CAST(COALESCE(SUM(file_size), 0) AS BIGINT) AS total_size
 FROM nar_files

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -6,6 +6,7 @@ package sqlitedb
 
 import (
 	"context"
+	"database/sql"
 )
 
 type Querier interface {
@@ -221,6 +222,15 @@ type Querier interface {
 	//  FROM narinfo_signatures
 	//  WHERE narinfo_id = ?
 	GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]string, error)
+	//GetNarInfoURLByNarFileHash
+	//
+	//  SELECT ni.url
+	//  FROM narinfos ni
+	//  INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+	//  INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+	//  WHERE nf.hash = ? AND nf.compression = ? AND nf."query" = ?
+	//  LIMIT 1
+	GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error)
 	//GetNarTotalSize
 	//
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS INTEGER) AS total_size

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -902,6 +902,36 @@ func (q *Queries) GetNarInfoSignatures(ctx context.Context, narinfoID int64) ([]
 	return items, nil
 }
 
+const getNarInfoURLByNarFileHash = `-- name: GetNarInfoURLByNarFileHash :one
+SELECT ni.url
+FROM narinfos ni
+INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+WHERE nf.hash = ? AND nf.compression = ? AND nf."query" = ?
+LIMIT 1
+`
+
+type GetNarInfoURLByNarFileHashParams struct {
+	Hash        string
+	Compression string
+	Query       string
+}
+
+// GetNarInfoURLByNarFileHash
+//
+//	SELECT ni.url
+//	FROM narinfos ni
+//	INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
+//	INNER JOIN nar_files nf ON nf.id = nnf.nar_file_id
+//	WHERE nf.hash = ? AND nf.compression = ? AND nf."query" = ?
+//	LIMIT 1
+func (q *Queries) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error) {
+	row := q.db.QueryRowContext(ctx, getNarInfoURLByNarFileHash, arg.Hash, arg.Compression, arg.Query)
+	var url sql.NullString
+	err := row.Scan(&url)
+	return url, err
+}
+
 const getNarTotalSize = `-- name: GetNarTotalSize :one
 SELECT CAST(COALESCE(SUM(file_size), 0) AS INTEGER) AS total_size
 FROM nar_files

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -701,3 +701,128 @@ func newContext() context.Context {
 		New(io.Discard).
 		WithContext(context.Background())
 }
+
+// TestGetNar_NixServeUpstream_PrefixedNarURL tests that ncps correctly proxies NARs when
+// the nix-serve upstream uses prefixed URLs (narinfo-hash-nar-hash), and the test
+// server only serves the NAR at the prefixed path (not the normalized path).
+// This reproduces the race condition bug where GetNar tries to fetch from upstream
+// using the normalized URL (which the upstream doesn't recognize).
+func TestGetNar_NixServeUpstream_PrefixedNarURL(t *testing.T) {
+	t.Parallel()
+
+	hts := testdata.NewTestServer(t, 40)
+	t.Cleanup(hts.Close)
+
+	// Create a test entry with a prefixed NAR URL (nix-serve style)
+	// Based on Nar7 but with a prefixed URL
+	prefixedNarInfoHash := testdata.Nar7.NarInfoHash + "-" + testdata.Nar7.NarHash
+	prefixedNarInfoText := `StorePath: /nix/store/c12lxpykv6sld7a0sakcnr3y0la70x8w-hello-2.12.2
+URL: nar/` + prefixedNarInfoHash + `.nar
+Compression: none
+NarHash: sha256:1yf3p87fsqig07crd9sj9wh7i9jpsa0x86a22fqbls7c81lc7ws2
+NarSize: 113256
+References: 7h6icyvqv6lqd0bcx41c8h3615rjcqb2-libiconv-109.100.2
+Deriver: msnhw2b4dcn9kbswsfz63jplf7ncnxik-hello-2.12.2.drv
+Sig: cache.nixos.org-1:oPqkkDFlniUh1BaGWwWd7LY2EfUh3r/GBxriDGE7vCfvJ3fKsnIDg1L4QFkuHKWIfwWxWy4FlpO6/5FHPx00AQ==`
+
+	prefixedEntry := testdata.Entry{
+		NarInfoHash:    testdata.Nar7.NarInfoHash,
+		NarInfoPath:    testdata.Nar7.NarInfoPath,
+		NarInfoText:    prefixedNarInfoText,
+		NarHash:        testdata.Nar7.NarHash,
+		NarCompression: testdata.Nar7.NarCompression,
+		NarPath:        testdata.Nar7.NarPath,
+		NarText:        testdata.Nar7.NarText,
+		NarInfoNarHash: prefixedNarInfoHash,
+	}
+	hts.AddEntry(prefixedEntry)
+
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, hts.URL), &upstream.Options{
+		PublicKeys: testdata.PublicKeys(),
+	})
+	require.NoError(t, err)
+
+	dir, err := os.MkdirTemp("", "cache-nix-serve-prefixed-")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
+	db, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+
+	localStore, err := local.New(newContext(), dir)
+	require.NoError(t, err)
+
+	c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+	require.NoError(t, err)
+
+	c.AddUpstreamCaches(newContext(), uc)
+	c.SetRecordAgeIgnoreTouch(0)
+
+	<-c.GetHealthChecker().Trigger()
+
+	s := server.New(c)
+
+	ts := httptest.NewServer(s)
+	t.Cleanup(ts.Close)
+
+	// Fetch narinfo first to trigger background NAR pull.
+	// This uses the prefixed URL from the upstream.
+	narInfoReq, err := http.NewRequestWithContext(
+		newContext(),
+		http.MethodGet,
+		ts.URL+"/"+prefixedEntry.NarInfoHash+".narinfo",
+		nil,
+	)
+	require.NoError(t, err)
+
+	//nolint:bodyclose // closed below
+	narInfoResp, err := ts.Client().Do(narInfoReq)
+	require.NoError(t, err)
+
+	defer narInfoResp.Body.Close()
+
+	require.Equal(t, http.StatusOK, narInfoResp.StatusCode)
+
+	narInfoBody, err := io.ReadAll(narInfoResp.Body)
+	require.NoError(t, err)
+
+	ni, err := narinfo.Parse(strings.NewReader(string(narInfoBody)))
+	require.NoError(t, err)
+
+	// Parse the URL to get the normalized NAR hash
+	narURL, err := nar.ParseURL(ni.URL)
+	require.NoError(t, err)
+
+	normalizedNarURL, err := narURL.Normalize()
+	require.NoError(t, err)
+
+	// Request the NAR using the normalized URL (as a client would after reading narinfo).
+	// The test server only serves the NAR at the prefixed path (prefixedEntry.NarInfoNarHash),
+	// not at the normalized path.
+	// Without the fix, this would fail because GetNar would try to fetch from upstream
+	// using the normalized URL when the NAR isn't in the store yet.
+	narReqURL := ts.URL + "/nar/" + normalizedNarURL.Hash + ".nar"
+
+	narReq, err := http.NewRequestWithContext(newContext(), http.MethodGet, narReqURL, nil)
+	require.NoError(t, err)
+
+	// Use DisableCompression to prevent Go HTTP client adding Accept-Encoding: gzip.
+	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+
+	//nolint:bodyclose // closed below
+	narResp, err := client.Do(narReq)
+	require.NoError(t, err)
+
+	defer narResp.Body.Close()
+
+	require.Equal(t, http.StatusOK, narResp.StatusCode)
+
+	narBody, err := io.ReadAll(narResp.Body)
+	require.NoError(t, err)
+
+	assert.Equal(t, prefixedEntry.NarText, string(narBody))
+}

--- a/testdata/server.go
+++ b/testdata/server.go
@@ -128,43 +128,61 @@ func (s *Server) handler() http.Handler {
 				bs = []byte(entry.NarInfoText)
 			}
 
-			if r.URL.Path == "/nar/"+entry.NarHash+".nar" {
-				bs = []byte(entry.NarText)
-			}
-
-			// Build path with compression extension, only adding dot if extension is not empty
-			narPath := "/nar/" + entry.NarHash + ".nar"
-			if ext := entry.NarCompression.ToFileExtension(); ext != "" {
-				narPath += "." + ext
-			}
-
-			if r.URL.Path == narPath {
-				bs = []byte(entry.NarText)
-			}
-
-			// Support fetching by normalized hash (with prefix stripped)
-			normalizedURL, err := (&nar.URL{Hash: entry.NarHash}).Normalize()
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-
-				return
-			}
-
-			normalizedHash := normalizedURL.Hash
-
-			if normalizedHash != entry.NarHash {
-				if r.URL.Path == "/nar/"+normalizedHash+".nar" {
+			// If NarInfoNarHash is set (nix-serve style with prefix), only serve at that path
+			if entry.NarInfoNarHash != "" { //nolint:nestif
+				if r.URL.Path == "/nar/"+entry.NarInfoNarHash+".nar" {
 					bs = []byte(entry.NarText)
 				}
 
-				// Build normalized path with compression extension
-				normalizedNarPath := "/nar/" + normalizedHash + ".nar"
+				// Build path with compression extension for prefixed URL
+				narPath := "/nar/" + entry.NarInfoNarHash + ".nar"
 				if ext := entry.NarCompression.ToFileExtension(); ext != "" {
-					normalizedNarPath += "." + ext
+					narPath += "." + ext
 				}
 
-				if r.URL.Path == normalizedNarPath {
+				if r.URL.Path == narPath {
 					bs = []byte(entry.NarText)
+				}
+			} else {
+				// Standard behavior: serve at both the hash and normalized paths
+				if r.URL.Path == "/nar/"+entry.NarHash+".nar" {
+					bs = []byte(entry.NarText)
+				}
+
+				// Build path with compression extension, only adding dot if extension is not empty
+				narPath := "/nar/" + entry.NarHash + ".nar"
+				if ext := entry.NarCompression.ToFileExtension(); ext != "" {
+					narPath += "." + ext
+				}
+
+				if r.URL.Path == narPath {
+					bs = []byte(entry.NarText)
+				}
+
+				// Support fetching by normalized hash (with prefix stripped)
+				normalizedURL, err := (&nar.URL{Hash: entry.NarHash}).Normalize()
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+
+					return
+				}
+
+				normalizedHash := normalizedURL.Hash
+
+				if normalizedHash != entry.NarHash {
+					if r.URL.Path == "/nar/"+normalizedHash+".nar" {
+						bs = []byte(entry.NarText)
+					}
+
+					// Build normalized path with compression extension
+					normalizedNarPath := "/nar/" + normalizedHash + ".nar"
+					if ext := entry.NarCompression.ToFileExtension(); ext != "" {
+						normalizedNarPath += "." + ext
+					}
+
+					if r.URL.Path == normalizedNarPath {
+						bs = []byte(entry.NarText)
+					}
 				}
 			}
 

--- a/testdata/type.go
+++ b/testdata/type.go
@@ -11,4 +11,9 @@ type Entry struct {
 	NarCompression nar.CompressionType
 	NarPath        string
 	NarText        string
+
+	// NarInfoNarHash is the NAR hash as it appears in the upstream narinfo URL.
+	// For nix-serve upstreams, this includes the narinfo hash prefix (e.g., "narinfohash-narhash").
+	// When empty, NarHash is used directly.
+	NarInfoNarHash string
 }


### PR DESCRIPTION
When using upstreams that use prefixed NAR URLs (like nix-serve), a
request for a normalized NAR URL would not be correctly mapped to
existing storage or active download jobs if they were using the prefixed
hash. This resulted in redundant downloads and potential race
conditions.

This change fixes this by:
1. Adding a database query to look up the original upstream URL for a
given NAR file hash by checking associated narinfos.
2. Using this original URL in `Cache.GetNar` to canonicalize the NAR URL
before download coordination.
3. Ensuring that both normalized and prefixed requests for the same
content use the same lock key and `downloadState`.
4. Updating the mock server in tests to support both original and
normalized NAR URL formats.

(cherry picked from commit 6382500aa0ca5cf22b93b995b51b67c676159b0b)