### PR TITLE
refactor: remove redundant error check

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1057,7 +1057,7 @@ func (c *Cache) lookupOriginalNarURL(ctx context.Context, normalizedNarURL nar.U
 	})
 	if err != nil {
 		// Not found is an expected case. We should log any other database errors.
-		if !database.IsNotFoundError(err) && !errors.Is(err, sql.ErrNoRows) {
+		if !database.IsNotFoundError(err) {
 			zerolog.Ctx(ctx).Warn().Err(err).Msg("Failed to lookup original nar URL")
 		}
 


### PR DESCRIPTION
The `errors.Is(err, sql.ErrNoRows)` check is redundant because
`database.IsNotFoundError(err)` already makes that check.