### PR TITLE
chore: fixup the Go code with Go 1.26's go fix

### DIFF
--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -157,8 +157,6 @@ func (r *reporter) Shutdown(ctx context.Context) error {
 	var g errgroup.Group
 
 	for name, sfn := range r.shutdownFns {
-		name, sfn := name, sfn
-
 		g.Go(func() error {
 			if err := sfn(ctx); err != nil {
 				zerolog.Ctx(ctx).

--- a/pkg/cache/cache_distributed_test.go
+++ b/pkg/cache/cache_distributed_test.go
@@ -215,7 +215,7 @@ func testDistributedDownloadDeduplication(factory distributedDBFactory) func(*te
 		// Create multiple cache instances
 		var caches []*cache.Cache
 
-		for i := 0; i < numInstances; i++ {
+		for range numInstances {
 			downloadLocker, err := redis.NewLocker(ctx, redisCfg, retryCfg, false)
 			require.NoError(t, err)
 
@@ -375,7 +375,7 @@ func testDistributedConcurrentReads(factory distributedDBFactory) func(*testing.
 		// Now create multiple instances that will read concurrently
 		var caches []*cache.Cache
 
-		for i := 0; i < numInstances; i++ {
+		for range numInstances {
 			downloadLocker := locklocal.NewLocker()
 			cacheLocker := locklocal.NewRWLocker()
 
@@ -505,7 +505,7 @@ func testPutNarInfoConcurrentSharedNar(factory distributedDBFactory) func(*testi
 		t.Parallel()
 
 		// We run this loop to increase chance of hitting the race condition.
-		for run := 0; run < 50; run++ {
+		for run := range 50 {
 			func() {
 				ctx := newContext()
 
@@ -730,12 +730,12 @@ func testLargeNARConcurrentDownloadScenario(t *testing.T, factory distributedDBF
 
 	// Create multiple cache instances
 	var (
-		caches         []*cache.Cache
+		caches         = make([]*cache.Cache, 0, numInstances)
 		downloadErrors []error
 		mu             sync.Mutex
 	)
 
-	for i := 0; i < numInstances; i++ {
+	for i := range numInstances {
 		downloadLocker, err := redis.NewLocker(ctx, redisCfg, retryCfg, false)
 		require.NoError(t, err)
 
@@ -974,7 +974,7 @@ func testCDCProgressiveStreamingDuringChunking(factory distributedDBFactory) fun
 		// Create multiple cache instances with CDC enabled
 		var caches []*cache.Cache
 
-		for i := 0; i < numInstances; i++ {
+		for range numInstances {
 			downloadLocker, err := redis.NewLocker(ctx, redisCfg, retryCfg, false)
 			require.NoError(t, err)
 

--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -938,7 +938,7 @@ func testPutNarInfoConcurrentSameHash(factory cacheFactory) func(*testing.T) {
 
 		results := make(chan result, numGoroutines)
 
-		for i := 0; i < numGoroutines; i++ {
+		for range numGoroutines {
 			go func() {
 				// Each goroutine gets its own reader
 				r := io.NopCloser(strings.NewReader(testdata.Nar1.NarInfoText))
@@ -951,7 +951,7 @@ func testPutNarInfoConcurrentSameHash(factory cacheFactory) func(*testing.T) {
 		// Collect results
 		var successCount int
 
-		for i := 0; i < numGoroutines; i++ {
+		for range numGoroutines {
 			res := <-results
 			if res.err == nil {
 				successCount++
@@ -1115,12 +1115,8 @@ func testWithWriteLock(factory cacheFactory) func(*testing.T) {
 
 			var wg sync.WaitGroup
 
-			for i := 0; i < numGoroutines; i++ {
-				wg.Add(1)
-
-				go func() {
-					defer wg.Done()
-
+			for range numGoroutines {
+				wg.Go(func() {
 					err := c.withWriteLock(ctx, "test", "shared-key", func() error {
 						// This critical section is now correctly protected only by withWriteLock.
 						// A temporary variable is used to simulate a read-modify-write data race.
@@ -1133,7 +1129,7 @@ func testWithWriteLock(factory cacheFactory) func(*testing.T) {
 						return nil
 					})
 					assert.NoError(t, err)
-				}()
+				})
 			}
 
 			wg.Wait()

--- a/pkg/cache/cache_prefetch_test.go
+++ b/pkg/cache/cache_prefetch_test.go
@@ -121,7 +121,7 @@ func TestPrefetchPipelineOrdering(t *testing.T) {
 	// Create content that will be split into multiple chunks
 	// Use a pattern that makes it easy to verify ordering
 	var contentBuilder strings.Builder
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		contentBuilder.WriteString(fmt.Sprintf("CHUNK_%02d_", i))
 		contentBuilder.WriteString(strings.Repeat("X", 500))
 	}
@@ -435,7 +435,7 @@ func TestProgressiveStreamingNoGoroutineLeak(t *testing.T) {
 	goroutinesBefore := runtime.NumGoroutine()
 
 	// Start progressive streaming and cancel mid-stream
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		_, rc, err := c.GetNar(ctx, nu)

--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -265,7 +265,7 @@ func (c *Cache) doRequest(
 		err  error
 	)
 
-	for i := 0; i < defaultHTTPRetries; i++ {
+	for i := range defaultHTTPRetries {
 		var r *http.Request
 
 		r, err = http.NewRequestWithContext(ctx, method, url, nil)

--- a/pkg/chunker/error_test.go
+++ b/pkg/chunker/error_test.go
@@ -39,7 +39,7 @@ func TestCDCChunker_Chunk_ErrorRace(t *testing.T) {
 	require.NoError(t, err)
 
 	// Run many times to increase chance of hitting the race if it exists
-	for i := 0; i < 10000; i++ {
+	for i := range 10000 {
 		reader := &errorReader{
 			data: make([]byte, 1024), // At least one chunk
 			err:  errRead,

--- a/pkg/circuitbreaker/circuit_breaker_test.go
+++ b/pkg/circuitbreaker/circuit_breaker_test.go
@@ -30,7 +30,6 @@ func TestNew(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/circuitbreaker/state_test.go
+++ b/pkg/circuitbreaker/state_test.go
@@ -64,7 +64,6 @@ func TestState_String(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.expected, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tc.expected, tc.state.String())

--- a/pkg/database/contract_test.go
+++ b/pkg/database/contract_test.go
@@ -152,18 +152,14 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 
 			errC := make(chan error, numWrites)
 
-			for i := 0; i < numWrites; i++ {
-				wg.Add(1)
-
-				go func() {
-					defer wg.Done()
-
+			for range numWrites {
+				wg.Go(func() {
 					hash := testhelper.MustRandString(128)
 
 					if _, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash}); err != nil {
 						errC <- fmt.Errorf("error creating the narinfo record: %w", err)
 					}
-				}()
+				})
 			}
 
 			wg.Wait()
@@ -1939,7 +1935,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 		initialCount, err := db.GetNarInfoCount(context.Background())
 		require.NoError(t, err)
 
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			hash := testhelper.MustRandString(32)
 
 			_, err = db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
@@ -1960,7 +1956,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 		initialCount, err := db.GetNarFileCount(context.Background())
 		require.NoError(t, err)
 
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			hash := testhelper.MustRandString(32)
 
 			//nolint:gosec // G115: Safe conversion, i is small and controlled
@@ -2235,7 +2231,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 		db := factory(t)
 
 		// Create 5 migrated narinfos
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			hash := testhelper.MustRandString(32)
 
 			_, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{
@@ -2246,7 +2242,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 		}
 
 		// Create 2 unmigrated narinfos (should not appear in results)
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			hash := testhelper.MustRandString(32)
 
 			_, err := db.CreateNarInfo(context.Background(), database.CreateNarInfoParams{Hash: hash})
@@ -2492,7 +2488,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			chunkIDs := make([]int64, 3)
 			chunkIndices := make([]int64, 3)
 
-			for i := 0; i < 3; i++ {
+			for i := range 3 {
 				chunkHash, err := testhelper.RandString(32)
 				require.NoError(t, err)
 
@@ -2520,7 +2516,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 
 			if assert.Len(t, chunks, 3) {
 				// Verify order is maintained
-				for i := 0; i < 3; i++ {
+				for i := range 3 {
 					assert.Equal(t, chunkIDs[i], chunks[i].ID)
 				}
 			}
@@ -2609,7 +2605,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			chunkIDs := make([]int64, 2)
 			chunkIndices := make([]int64, 2)
 
-			for i := 0; i < 2; i++ {
+			for i := range 2 {
 				chunkHash, err := testhelper.RandString(32)
 				require.NoError(t, err)
 
@@ -2664,7 +2660,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			chunkIDs := make([]int64, numChunks)
 			chunkIndices := make([]int64, numChunks)
 
-			for i := 0; i < numChunks; i++ {
+			for i := range numChunks {
 				chunkHash, err := testhelper.RandString(32)
 				require.NoError(t, err)
 
@@ -2691,7 +2687,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			require.NoError(t, err)
 
 			if assert.Len(t, chunks, numChunks) {
-				for i := 0; i < numChunks; i++ {
+				for i := range numChunks {
 					assert.Equal(t, chunkIDs[i], chunks[i].ID, "chunk at index %d should match", i)
 				}
 			}
@@ -2715,7 +2711,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			chunkIDs := make([]int64, 3)
 			chunkIndices := []int64{10, 20, 30}
 
-			for i := 0; i < 3; i++ {
+			for i := range 3 {
 				chunkHash, err := testhelper.RandString(32)
 				require.NoError(t, err)
 
@@ -2742,7 +2738,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 
 			if assert.Len(t, chunks, 3) {
 				// Chunks should be returned in order by index
-				for i := 0; i < 3; i++ {
+				for i := range 3 {
 					assert.Equal(t, chunkIDs[i], chunks[i].ID)
 				}
 			}
@@ -2765,7 +2761,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			// Create 4 chunks
 			var allChunkIDs []int64
 
-			for i := 0; i < 4; i++ {
+			for range 4 {
 				chunkHash, err := testhelper.RandString(32)
 				require.NoError(t, err)
 
@@ -2779,7 +2775,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			}
 
 			// Link first 2 chunks individually
-			for i := 0; i < 2; i++ {
+			for i := range 2 {
 				err = db.LinkNarFileToChunk(context.Background(), database.LinkNarFileToChunkParams{
 					NarFileID:  nf.ID,
 					ChunkID:    allChunkIDs[i],
@@ -2801,7 +2797,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			require.NoError(t, err)
 
 			if assert.Len(t, chunks, 4) {
-				for i := 0; i < 4; i++ {
+				for i := range 4 {
 					assert.Equal(t, allChunkIDs[i], chunks[i].ID)
 				}
 			}
@@ -2875,7 +2871,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 			// Create 3 chunks
 			var chunkIDs []int64
 
-			for i := 0; i < 3; i++ {
+			for i := range 3 {
 				chunkHash, err := testhelper.RandString(32)
 				require.NoError(t, err)
 
@@ -2982,7 +2978,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 
 		var totalAdded int64
 
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			chunkHash := testhelper.MustRandString(32)
 
 			//nolint:gosec // G115: Safe conversion, i is small and controlled
@@ -3010,7 +3006,7 @@ func runComplianceSuite(t *testing.T, factory querierFactory) {
 		initialCount, err := db.GetChunkCount(context.Background())
 		require.NoError(t, err)
 
-		for i := 0; i < 4; i++ {
+		for range 4 {
 			chunkHash := testhelper.MustRandString(32)
 
 			_, err := db.CreateChunk(context.Background(), database.CreateChunkParams{

--- a/pkg/lock/postgres/circuit_breaker_integration_test.go
+++ b/pkg/lock/postgres/circuit_breaker_integration_test.go
@@ -49,7 +49,7 @@ func TestLocker_CircuitBreakerOpensAfterFailures(t *testing.T) {
 	// In a real scenario, this would happen due to database connection failures
 	threshold := 5 // Default circuit breaker threshold
 
-	for i := 0; i < threshold; i++ {
+	for range threshold {
 		cb.RecordFailure()
 	}
 
@@ -90,7 +90,7 @@ func TestLocker_DegradedModeFallback(t *testing.T) {
 
 	// Open the circuit breaker by recording failures
 	threshold := 5
-	for i := 0; i < threshold; i++ {
+	for range threshold {
 		cb.RecordFailure()
 	}
 
@@ -116,7 +116,7 @@ func TestLocker_CircuitBreakerRecovery(t *testing.T) {
 	defer restore()
 
 	// Open the circuit breaker
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		cbShort.RecordFailure()
 	}
 
@@ -175,7 +175,7 @@ func TestRWLocker_DegradedMode(t *testing.T) {
 
 	// Open the circuit breaker
 	threshold := 5
-	for i := 0; i < threshold; i++ {
+	for range threshold {
 		cb.RecordFailure()
 	}
 
@@ -209,7 +209,7 @@ func TestLocker_CircuitBreakerReopensOnFailure(t *testing.T) {
 	defer restore()
 
 	// Open the circuit
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		cbShort.RecordFailure()
 	}
 
@@ -257,7 +257,7 @@ func TestLocker_CircuitBreaker_HealthClassification(t *testing.T) {
 	t.Run("ContextCanceledDoesNotTripCircuitBreaker", func(t *testing.T) {
 		assert.False(t, cb.IsOpen())
 
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			canceledCtx, cancel := context.WithCancel(ctx)
 			cancel()
 
@@ -271,7 +271,7 @@ func TestLocker_CircuitBreaker_HealthClassification(t *testing.T) {
 	t.Run("ContextTimeoutDoesNotTripCircuitBreaker", func(t *testing.T) {
 		assert.False(t, cb.IsOpen())
 
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Millisecond)
 			time.Sleep(5 * time.Millisecond)
 			cancel()
@@ -296,7 +296,7 @@ func TestLocker_CircuitBreaker_HealthClassification(t *testing.T) {
 
 		db2.DB().Close()
 
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			err = locker2.Lock(ctx, key, 1*time.Second)
 			require.Error(t, err)
 		}

--- a/pkg/lock/postgres/postgres_test.go
+++ b/pkg/lock/postgres/postgres_test.go
@@ -348,9 +348,9 @@ func TestRWLocker_MultipleReaders(t *testing.T) {
 	retryCfg := getTestRetryConfig()
 
 	// Create multiple locker instances
-	var lockers []lock.RWLocker
+	lockers := make([]lock.RWLocker, 0, 5)
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		locker, err := postgres.NewRWLocker(ctx, db, cfg, retryCfg, false)
 		require.NoError(t, err)
 

--- a/pkg/lock/redis/redis_test.go
+++ b/pkg/lock/redis/redis_test.go
@@ -337,12 +337,12 @@ func TestRWLocker_MultipleReaders(t *testing.T) {
 	retryCfg := getTestRetryConfig()
 
 	// Create multiple locker instances
-	var lockers []interface {
+	lockers := make([]interface {
 		RLock(context.Context, string, time.Duration) error
 		RUnlock(context.Context, string) error
-	}
+	}, 0, 5)
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		locker, err := redis.NewRWLocker(ctx, cfg, retryCfg, false)
 		require.NoError(t, err)
 

--- a/pkg/maxprocs/maxprocs.go
+++ b/pkg/maxprocs/maxprocs.go
@@ -39,10 +39,10 @@ func AutoMaxProcs(ctx context.Context, d time.Duration, logger zerolog.Logger) e
 	}
 }
 
-func diffInfof(logger zerolog.Logger) func(string, ...interface{}) {
+func diffInfof(logger zerolog.Logger) func(string, ...any) {
 	var last string
 
-	return func(format string, args ...interface{}) {
+	return func(format string, args ...any) {
 		msg := fmt.Sprintf(format, args...)
 		if msg != last {
 			logger.Info().Msg(msg)

--- a/pkg/ncps/migrate_nar_to_chunks.go
+++ b/pkg/ncps/migrate_nar_to_chunks.go
@@ -389,8 +389,6 @@ Once a NAR is successfully migrated to chunks and verified, it is deleted from t
 			}
 
 			for _, row := range narFiles {
-				row := row // captured for closure
-
 				g.Go(func() error {
 					log := logger.With().Str("nar_hash", row.Hash).Logger()
 

--- a/pkg/ncps/migrate_narinfo.go
+++ b/pkg/ncps/migrate_narinfo.go
@@ -345,8 +345,6 @@ to enable safe concurrent migration.`,
 
 			// Process unmigrated hashes
 			for _, hash := range unmigratedHashes {
-				hash := hash // captured for closure
-
 				g.Go(func() error {
 					atomic.AddInt32(&totalProcessed, 1)
 
@@ -403,8 +401,6 @@ to enable safe concurrent migration.`,
 
 			// Process migrated hashes (only cleanup from storage)
 			for _, hash := range migratedHashes {
-				hash := hash // captured for closure
-
 				g.Go(func() error {
 					atomic.AddInt32(&totalProcessed, 1)
 

--- a/pkg/ncps/migrate_narinfo_test.go
+++ b/pkg/ncps/migrate_narinfo_test.go
@@ -847,7 +847,7 @@ func testMigrateNarInfoLargeNarInfo(factory migrationFactory) func(*testing.T) {
 
 		referencesBuilder.WriteString("References:")
 
-		for i := 0; i < numReferences; i++ {
+		for i := range numReferences {
 			referencesBuilder.WriteString(fmt.Sprintf(" ref%d-abcdefgh1234567890abcdefgh1234567890", i))
 		}
 
@@ -875,7 +875,7 @@ func testMigrateNarInfoLargeNarInfo(factory migrationFactory) func(*testing.T) {
 		narInfoBuilder.WriteString("\n")
 
 		// Add many signatures
-		for i := 0; i < numSignatures; i++ {
+		for i := range numSignatures {
 			narInfoBuilder.WriteString(fmt.Sprintf(
 				"Sig: cache.test.org-%d:MadTCU1OSFCGUw4aqCKpLCZJpqBc7AbLvO7wgdlls0eq1DwaSnF/82SZE+wJGEiwlHbnZR+14daSaec0W3XoBQ==\n",
 				i,

--- a/pkg/ncps/root.go
+++ b/pkg/ncps/root.go
@@ -183,7 +183,7 @@ func getZeroLogger(ctx context.Context, cmd *cli.Command) (context.Context, erro
 	if cmd.Bool("log-console-writer-enabled") {
 		writer := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
 		if prefix := cmd.String("log-console-writer-prefix"); prefix != "" {
-			writer.FormatTimestamp = func(i interface{}) string {
+			writer.FormatTimestamp = func(i any) string {
 				return fmt.Sprintf("[%s] %s", prefix, i)
 			}
 		}

--- a/pkg/otelzerolog/logging.go
+++ b/pkg/otelzerolog/logging.go
@@ -30,7 +30,7 @@ func NewOtelWriter(loggerProvider log.LoggerProvider) (*OtelWriter, error) {
 
 // Write implements io.Writer.
 func (w *OtelWriter) Write(p []byte) (n int, err error) {
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	if err := json.Unmarshal(p, &logEntry); err != nil {
 		return 0, err
 	}
@@ -94,7 +94,7 @@ func convertLevel(level zerolog.Level) log.Severity {
 	}
 }
 
-func getKeyValueForMap(m map[string]interface{}) []log.KeyValue {
+func getKeyValueForMap(m map[string]any) []log.KeyValue {
 	kvs := make([]log.KeyValue, 0, len(m))
 
 	for k, v := range m {
@@ -109,9 +109,9 @@ func getKeyValueForMap(m map[string]interface{}) []log.KeyValue {
 			}
 		case string:
 			kvs = append(kvs, log.String(k, val))
-		case []interface{}:
+		case []any:
 			kvs = append(kvs, log.Slice(k, getValuesForSlice(val)...))
-		case map[string]interface{}:
+		case map[string]any:
 			kvs = append(kvs, log.Map(k, getKeyValueForMap(val)...))
 		default:
 			panic(fmt.Sprintf("Typeof(%q) => %T: not known", k, v))
@@ -121,7 +121,7 @@ func getKeyValueForMap(m map[string]interface{}) []log.KeyValue {
 	return kvs
 }
 
-func getValuesForSlice(vals []interface{}) []log.Value {
+func getValuesForSlice(vals []any) []log.Value {
 	var vs []log.Value
 
 	for _, v := range vals {
@@ -136,9 +136,9 @@ func getValuesForSlice(vals []interface{}) []log.Value {
 			}
 		case string:
 			vs = append(vs, log.StringValue(val))
-		case map[string]interface{}:
+		case map[string]any:
 			vs = append(vs, log.MapValue(getKeyValueForMap(val)...))
-		case []interface{}:
+		case []any:
 			vs = append(vs, log.SliceValue(getValuesForSlice(val)...))
 		default:
 			panic(fmt.Sprintf("Typeof(%#v) => %T: not known", v, v))

--- a/pkg/otelzerolog/logging_internal_test.go
+++ b/pkg/otelzerolog/logging_internal_test.go
@@ -16,7 +16,7 @@ func TestGetKeyValueForMap(t *testing.T) {
 		assert.Equal(
 			t,
 			[]log.KeyValue{log.Bool("a", true)},
-			getKeyValueForMap(map[string]interface{}{"a": true}),
+			getKeyValueForMap(map[string]any{"a": true}),
 		)
 	})
 
@@ -28,7 +28,7 @@ func TestGetKeyValueForMap(t *testing.T) {
 			[]log.KeyValue{
 				log.String("a", "test"),
 			},
-			getKeyValueForMap(map[string]interface{}{
+			getKeyValueForMap(map[string]any{
 				"a": "test",
 			}),
 		)
@@ -42,7 +42,7 @@ func TestGetKeyValueForMap(t *testing.T) {
 			[]log.KeyValue{
 				log.Float64("a", 10.5),
 			},
-			getKeyValueForMap(map[string]interface{}{
+			getKeyValueForMap(map[string]any{
 				"a": 10.5,
 			}),
 		)
@@ -51,8 +51,8 @@ func TestGetKeyValueForMap(t *testing.T) {
 	t.Run("map includes a slice", func(t *testing.T) {
 		t.Parallel()
 
-		kvs := getKeyValueForMap(map[string]interface{}{
-			"a": []interface{}{"b"},
+		kvs := getKeyValueForMap(map[string]any{
+			"a": []any{"b"},
 		})
 
 		if assert.Len(t, kvs, 1) {
@@ -68,8 +68,8 @@ func TestGetKeyValueForMap(t *testing.T) {
 	t.Run("map includes a map", func(t *testing.T) {
 		t.Parallel()
 
-		kvs := getKeyValueForMap(map[string]interface{}{
-			"a": map[string]interface{}{
+		kvs := getKeyValueForMap(map[string]any{
+			"a": map[string]any{
 				"b": "c",
 			},
 		})
@@ -97,7 +97,7 @@ func TestGetValuesForSlice(t *testing.T) {
 				log.BoolValue(true),
 				log.BoolValue(false),
 			},
-			getValuesForSlice([]interface{}{true, false}),
+			getValuesForSlice([]any{true, false}),
 		)
 	})
 
@@ -110,7 +110,7 @@ func TestGetValuesForSlice(t *testing.T) {
 				log.Float64Value(10.5),
 				log.Float64Value(20.5),
 			},
-			getValuesForSlice([]interface{}{10.5, 20.5}),
+			getValuesForSlice([]any{10.5, 20.5}),
 		)
 	})
 
@@ -123,7 +123,7 @@ func TestGetValuesForSlice(t *testing.T) {
 				log.StringValue("a"),
 				log.StringValue("b"),
 			},
-			getValuesForSlice([]interface{}{"a", "b"}),
+			getValuesForSlice([]any{"a", "b"}),
 		)
 	})
 
@@ -140,9 +140,9 @@ func TestGetValuesForSlice(t *testing.T) {
 					log.Bool("b", true),
 				),
 			},
-			getValuesForSlice([]interface{}{
-				map[string]interface{}{"a": "c"},
-				map[string]interface{}{"b": true},
+			getValuesForSlice([]any{
+				map[string]any{"a": "c"},
+				map[string]any{"b": true},
 			}),
 		)
 	})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -560,7 +560,7 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 
 			clientAccepts := make(map[string]struct{})
 
-			for _, v := range strings.Split(ae, ",") {
+			for v := range strings.SplitSeq(ae, ",") {
 				// Trim whitespace and remove q-factor if present
 				enc := strings.TrimSpace(strings.Split(v, ";")[0])
 				if enc != "" {

--- a/pkg/storage/chunk/local_test.go
+++ b/pkg/storage/chunk/local_test.go
@@ -124,7 +124,7 @@ func TestLocalStore(t *testing.T) {
 
 		wg.Add(numGoroutines)
 
-		for i := 0; i < numGoroutines; i++ {
+		for range numGoroutines {
 			go func() {
 				defer wg.Done()
 

--- a/pkg/zstd/zstd_test.go
+++ b/pkg/zstd/zstd_test.go
@@ -258,7 +258,6 @@ func TestPooledWriterAndReaderRoundTrip(t *testing.T) {
 	}
 
 	for _, testData := range testCases {
-		testData := testData
 		t.Run(testData, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
Using Go 1.26, I ran go fix ./... to fix up the code with all the recent
changes to the language.