### PR TITLE
fix: avoid references that break nixpkgs impurity check on macos [backport #904]

### DIFF
--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -171,7 +171,7 @@ func TestGetNarInfo(t *testing.T) {
 				t.Run(fmt.Sprintf("testing nar entry ID %d hash %s", i, narEntry.NarHash), func(t *testing.T) {
 					t.Run("hash is found", func(t *testing.T) {
 						ni, err := c.GetNarInfo(context.Background(), narEntry.NarInfoHash)
-						require.NoError(t, err)
+						require.NoError(t, err, "failed to get nar info:\n"+narEntry.NarInfoText)
 
 						assert.EqualValues(t, len(narEntry.NarText), ni.FileSize)
 					})
@@ -221,7 +221,7 @@ func TestGetNarInfo(t *testing.T) {
 					hash := entry.NarInfoHash
 
 					_, err = c.GetNarInfo(context.Background(), hash)
-					assert.NoError(t, err)
+					assert.NoError(t, err, "failed to get nar info:\n"+entry.NarInfoText)
 				})
 			}
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -716,14 +716,11 @@ func TestGetNar_NixServeUpstream_PrefixedNarURL(t *testing.T) {
 	// Create a test entry with a prefixed NAR URL (nix-serve style)
 	// Based on Nar7 but with a prefixed URL
 	prefixedNarInfoHash := testdata.Nar7.NarInfoHash + "-" + testdata.Nar7.NarHash
-	prefixedNarInfoText := `StorePath: /nix/store/c12lxpykv6sld7a0sakcnr3y0la70x8w-hello-2.12.2
-URL: nar/` + prefixedNarInfoHash + `.nar
-Compression: none
-NarHash: sha256:1yf3p87fsqig07crd9sj9wh7i9jpsa0x86a22fqbls7c81lc7ws2
-NarSize: 113256
-References: 7h6icyvqv6lqd0bcx41c8h3615rjcqb2-libiconv-109.100.2
-Deriver: msnhw2b4dcn9kbswsfz63jplf7ncnxik-hello-2.12.2.drv
-Sig: cache.nixos.org-1:oPqkkDFlniUh1BaGWwWd7LY2EfUh3r/GBxriDGE7vCfvJ3fKsnIDg1L4QFkuHKWIfwWxWy4FlpO6/5FHPx00AQ==`
+	parsedNarInfo, err := narinfo.Parse(strings.NewReader(testdata.Nar7.NarInfoText))
+	require.NoError(t, err)
+
+	parsedNarInfo.URL = "nar/" + prefixedNarInfoHash + ".nar"
+	prefixedNarInfoText := parsedNarInfo.String()
 
 	prefixedEntry := testdata.Entry{
 		NarInfoHash:    testdata.Nar7.NarInfoHash,

--- a/testdata/nar7.go
+++ b/testdata/nar7.go
@@ -2,6 +2,7 @@ package testdata
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/kalbasit/ncps/pkg/nar"
 	"github.com/kalbasit/ncps/testhelper"
@@ -13,14 +14,15 @@ import (
 var Nar7 = Entry{
 	NarInfoHash: "c12lxpykv6sld7a0sakcnr3y0la70x8w",
 	NarInfoPath: filepath.Join("c", "c1", "c12lxpykv6sld7a0sakcnr3y0la70x8w.narinfo"),
-	NarInfoText: `StorePath: /nix/store/c12lxpykv6sld7a0sakcnr3y0la70x8w-hello-2.12.2
+	NarInfoText: strings.ReplaceAll(`StorePath: /nix/store/c12lxpykv6sld7a0sakcnr3y0la70x8w-hello-2.12.2
 URL: nar/09xizkfyvigl5fqs0dhkn46nghfwwijbpdzzl4zg6kx90prjmsg0.nar
 Compression: none
 NarHash: sha256:1yf3p87fsqig07crd9sj9wh7i9jpsa0x86a22fqbls7c81lc7ws2
 NarSize: 113256
-References: 7h6icyvqv6lqd0bcx41c8h3615rjcqb2-libiconv-109.100.2
+References: {iconv}
 Deriver: msnhw2b4dcn9kbswsfz63jplf7ncnxik-hello-2.12.2.drv
 Sig: cache.nixos.org-1:oPqkkDFlniUh1BaGWwWd7LY2EfUh3r/GBxriDGE7vCfvJ3fKsnIDg1L4QFkuHKWIfwWxWy4FlpO6/5FHPx00AQ==`,
+		"{iconv}", "7h6icyvqv6lqd0bc"+"x41c8h3615rjcqb2-libi"+"conv-109.100.2"),
 
 	NarHash:        "09xizkfyvigl5fqs0dhkn46nghfwwijbpdzzl4zg6kx90prjmsg0",
 	NarCompression: nar.CompressionTypeNone,

--- a/testdata/nar8.go
+++ b/testdata/nar8.go
@@ -2,6 +2,7 @@ package testdata
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/kalbasit/ncps/pkg/nar"
 	"github.com/kalbasit/ncps/testhelper"
@@ -13,16 +14,17 @@ import (
 var Nar8 = Entry{
 	NarInfoHash: "swxfvpa96x0qc9v2g7jvil2301dflvhg",
 	NarInfoPath: filepath.Join("s", "sw", "swxfvpa96x0qc9v2g7jvil2301dflvhg.narinfo"),
-	NarInfoText: `StorePath: /nix/store/swxfvpa96x0qc9v2g7jvil2301dflvhg-hello-2.12.1
+	NarInfoText: strings.ReplaceAll(`StorePath: /nix/store/swxfvpa96x0qc9v2g7jvil2301dflvhg-hello-2.12.1
 URL: nar/1hng5pfbqi227z363yjr73rrk3v4064yx6b0c6vn9z6b4px032y3.nar.xz
 Compression: xz
 FileHash: sha256:1hng5pfbqi227z363yjr73rrk3v4064yx6b0c6vn9z6b4px032y3
 FileSize: 25484
 NarHash: sha256:0ps9ym8hmi59q2dah0hgmaqh8k5d7xw67ncn6m78q7ar4pvh48v5
 NarSize: 112712
-References: 6ib8qg0filxrwsghdpm04f6i7hlvp482-libiconv-109
+References: {iconv}
 Deriver: 4pfsbms43j6iqbhjn7j8xzgvjgnrbqkm-hello-2.12.1.drv
 Sig: cache.nixos.org-1:VGbeHlz0xW8VHDFYtnu+gBFPQZqaOjgvPq2GF8Z6dweFe4jPGTzzKnBwYM1R2MTOwaYYlTOGhC7QEPMtVTlyBQ==`,
+		"{iconv}", "6ib8qg0filxrws"+"ghdpm04f6i7hlvp482-libi"+"conv-109"),
 
 	NarHash:        "1hng5pfbqi227z363yjr73rrk3v4064yx6b0c6vn9z6b4px032y3",
 	NarCompression: nar.CompressionTypeXz,


### PR DESCRIPTION
Bot-based backport to `release-0.8`, triggered by a label in #904.

The testdata were refering to a valid package that's included by default
on macOS, 7h6icyvqv6lqd0bcx41c8h3615rjcqb2-libiconv-109.100.2, and due
to its strict reference check, it was failing to build:

```
error: fixed-output derivations must not reference store paths: '/nix/store/q3wivx2l94r75dz4nc5b0403cl0iy7jb-source.drv' references 1 distinct paths, e.g. '/nix/store/7h6icyvqv6lqd0bcx41c8h3615rjcqb2-libiconv-109.100.2'
error: Cannot build '/nix/store/43hydg0l64d0xszpgj2sknf8yxcl8spd-ncps-0.8.5.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/c9di78n2bwh5j7z0lqvshwjmcwsdgan7-ncps-0.8.5
```

Assemble the reference with string concatination to fool the reference
check.