### PR TITLE
feat: add /upload route for upload-only cache operations

### DIFF
--- a/docs/docs/Developer Guide/Architecture/Components.md
+++ b/docs/docs/Developer Guide/Architecture/Components.md
@@ -18,8 +18,15 @@ Detailed breakdown of ncps system components.
 - `GET /pubkey` - Public key
 - `GET /nix-cache-info` - Cache metadata
 - `GET /<hash>.narinfo` - Package metadata
-- `GET /nar/<path>` - Package archive
+- `GET /nar/<hash>.nar(.compression)?` - Package archive
 - `GET /metrics` - Prometheus metrics (if enabled)
+
+**Upload Endpoints:**
+
+- `GET /upload/<hash>.narinfo` - Retrieve narinfo metadata without pulling from upstream cache
+- `PUT /upload/<hash>.narinfo` - Store narinfo metadata in the cache
+- `GET /upload/nar/<hash>.nar(.compression)?` - Retrieve NAR archive without pulling from upstream cache
+- `PUT /upload/nar/<hash>.nar(.compression)?` - Store NAR archive in the cache
 
 ## Cache Layer (pkg/cache/)
 

--- a/docs/docs/User Guide/Configuration/Reference.md
+++ b/docs/docs/User Guide/Configuration/Reference.md
@@ -188,7 +188,7 @@ See <a class="reference-link" href="../Features/CDC.md">CDC</a> for details.
 | --- | --- | --- | --- |
 | `--cache-sign-narinfo` | Sign NarInfo files with private key | `CACHE_SIGN_NARINFO` | `true` |
 | `--cache-secret-key-path` | Path to signing private key | `CACHE_SECRET_KEY_PATH` | auto-generated |
-| `--cache-allow-put-verb` | Allow PUT uploads to cache | `CACHE_ALLOW_PUT_VERB` | `false` |
+| `--cache-allow-put-verb` | Allow PUT uploads to cache (requires `/upload` prefix) | `CACHE_ALLOW_PUT_VERB` | `false` |
 | `--cache-allow-delete-verb` | Allow DELETE operations on cache | `CACHE_ALLOW_DELETE_VERB` | `false` |
 | `--netrc-file` | Path to netrc file for upstream auth | `NETRC_FILE` | `~/.netrc` |
 

--- a/docs/docs/User Guide/Usage/Cache Management.md
+++ b/docs/docs/User Guide/Usage/Cache Management.md
@@ -214,6 +214,21 @@ INFO migration completed found=10000 processed=10000 succeeded=9987 failed=13 du
 
 See [NarInfo Migration Guide](../Operations/NarInfo%20Migration.md) for comprehensive documentation.
 
+## Uploading Packages
+
+You can upload packages to your ncps cache using `nix copy`. This requires that the `--cache-allow-put-verb` flag is set to `true`.
+
+### Using nix copy
+
+To upload a package to your ncps cache, use the following command:
+
+```sh
+nix copy --to http://your-ncps-hostname:8501/upload ./your-package
+```
+
+> [!NOTE]
+> The `/upload` prefix is required for all PUT operations. This ensures that the upload is handled correctly and skips any upstream checks.
+
 ## Best Practices
 
 1. **Set reasonable max-size** - Based on available disk space

--- a/pkg/cache/upload_only_test.go
+++ b/pkg/cache/upload_only_test.go
@@ -1,0 +1,115 @@
+package cache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/cache"
+	"github.com/kalbasit/ncps/pkg/cache/upstream"
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
+	"github.com/kalbasit/ncps/testdata"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+func TestGetNar_UploadOnly(t *testing.T) {
+	t.Parallel()
+
+	// Setup necessary components
+	ts := testdata.NewTestServer(t, 40)
+	t.Cleanup(ts.Close)
+
+	db, localStore, _, _, cleanup := setupTestComponents(t)
+	t.Cleanup(cleanup)
+
+	c, err := newTestCache(newContext(), cacheName, db, localStore, localStore, localStore, "")
+	require.NoError(t, err)
+
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
+		PublicKeys: testdata.PublicKeys(),
+	})
+	require.NoError(t, err)
+
+	c.AddUpstreamCaches(newContext(), uc)
+	// Wait for upstream caches to become available
+	<-c.GetHealthChecker().Trigger()
+
+	// Use Nar1 which exists in the upstream
+	nu := nar.URL{
+		Hash:        testdata.Nar1.NarHash,
+		Compression: nar.CompressionTypeXz,
+	}
+
+	// First verify we can fetch it normally (sanity check)
+	// We use a separate context for this to avoid any interference
+	t.Run("sanity check - normal fetch works", func(t *testing.T) {
+		t.Parallel()
+
+		size, reader, err := c.GetNar(context.Background(), nu)
+		require.NoError(t, err)
+		require.NotNil(t, reader)
+		reader.Close()
+		// size can be -1 if streaming from upstream, or > 0 if known
+		if size != -1 {
+			assert.Positive(t, size)
+		}
+	})
+
+	// Now try with UploadOnly
+	t.Run("upload only - should fail if not in local store", func(t *testing.T) {
+		t.Parallel()
+
+		// Ensure it's not in the local store first (might have been pulled by sanity check)
+		// Since we share the cache instance and store in the test setup, we need to be careful.
+		// Actually, the sanity check pulled it into the store.
+		// So let's pick another NAR, say Nar2, for this specific test case.
+		nu2 := nar.URL{
+			Hash:        testdata.Nar2.NarHash,
+			Compression: nar.CompressionTypeXz,
+		}
+
+		ctx := cache.WithUploadOnly(context.Background())
+		_, _, err := c.GetNar(ctx, nu2)
+		assert.ErrorIs(t, err, storage.ErrNotFound,
+			"should return ErrNotFound when item is only upstream and UploadOnly is set")
+	})
+}
+
+func TestGetNarInfo_UploadOnly(t *testing.T) {
+	t.Parallel()
+
+	// Setup necessary components
+	ts := testdata.NewTestServer(t, 40)
+	t.Cleanup(ts.Close)
+
+	db, localStore, _, _, cleanup := setupTestComponents(t)
+	t.Cleanup(cleanup)
+
+	c, err := newTestCache(newContext(), cacheName, db, localStore, localStore, localStore, "")
+	require.NoError(t, err)
+
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
+		PublicKeys: testdata.PublicKeys(),
+	})
+	require.NoError(t, err)
+
+	c.AddUpstreamCaches(newContext(), uc)
+	// Wait for upstream caches to become available
+	<-c.GetHealthChecker().Trigger()
+
+	// Use Nar2 which exists upstream but not locally yet
+	hash := testdata.Nar2.NarInfoHash
+
+	// Try with UploadOnly
+	t.Run("upload only - should fail if not in local store", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := cache.WithUploadOnly(context.Background())
+		_, err := c.GetNarInfo(ctx, hash)
+		assert.ErrorIs(t, err, storage.ErrNotFound,
+			"should return ErrNotFound when item is only upstream and UploadOnly is set")
+	})
+}


### PR DESCRIPTION
This change introduces the /upload route which allows clients to upload
NARs and NARInfos that are served exclusively from the local cache
without ever attempting to fetch from upstream caches.

Key changes:
- Introduced 'upload-only' mode in the cache package to bypass upstream
  NARInfo lookups.
- Added a new /upload/ route handler in the server that enables this
  mode for all requests under that prefix.
- Remove PUT routes from the root.
- Implemented comprehensive unit tests for the upload-only cache logic.
- Added integration tests verifying that /upload correctly handles PUT
  requests and subsequent GET requests without querying upstreams.

fixes #907