### PR TITLE
fix: use a detachedContext when calling checkAndFixNarinfo

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1180,7 +1180,7 @@ func (c *Cache) PutNar(ctx context.Context, narURL nar.URL, r io.ReadCloser) err
 			return err
 		}
 
-		if err := c.checkAndFixNarInfosForNar(ctx, narURL); err != nil {
+		if err := c.checkAndFixNarInfosForNar(c.detachedContext(ctx), narURL); err != nil {
 			zerolog.Ctx(ctx).Warn().Err(err).Msg("failed to fix narinfos after PutNar")
 		}
 
@@ -1213,7 +1213,7 @@ func (c *Cache) putNarWithCDC(ctx context.Context, narURL nar.URL, r io.Reader) 
 		}
 	}
 
-	if err := c.checkAndFixNarInfosForNar(ctx, narURL); err != nil {
+	if err := c.checkAndFixNarInfosForNar(c.detachedContext(ctx), narURL); err != nil {
 		zerolog.Ctx(ctx).Warn().Err(err).Msg("failed to fix narinfos after PutNar")
 	}
 
@@ -1740,7 +1740,7 @@ func (c *Cache) pullNarIntoStore(
 	// This prevents the race condition where other instances check hasAsset() before storage completes
 	ds.storedOnce.Do(func() { close(ds.stored) })
 
-	if err := c.checkAndFixNarInfosForNar(ctx, *narURL); err != nil {
+	if err := c.checkAndFixNarInfosForNar(c.detachedContext(ctx), *narURL); err != nil {
 		zerolog.Ctx(ctx).
 			Warn().
 			Err(err).
@@ -2400,7 +2400,7 @@ func (c *Cache) PutNarInfo(ctx context.Context, hash string, r io.ReadCloser) er
 		return err
 	}
 
-	if err := c.checkAndFixNarInfo(ctx, hash); err != nil {
+	if err := c.checkAndFixNarInfo(c.detachedContext(ctx), hash); err != nil {
 		zerolog.Ctx(ctx).
 			Warn().
 			Err(err).


### PR DESCRIPTION
When uploading to ncps, the PUT returns a 204 as soon as the upload is
finished. This has exposed an issue in the call to checkAndFixNarInfo()
and checkAndFixNarInfosForNar(), since they were called with the
request's context, they end up breaking when the context is canceled. By
using a detached context, we can guarentee that they will run to
completion irrelevant of user's request.