### PR TITLE
docs: rename claude settings to allow for local configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,9 +9,9 @@
       "Bash(export NCPS_TEST_S3_REGION=\"us-east-1\")",
       "Bash(export NCPS_TEST_S3_SECRET_ACCESS_KEY=\"test-secret-key\")",
       "Bash(find:*)",
-      "Bash(git add:*)",
-      "Bash(git checkout:*)",
-      "Bash(git revert:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
       "Bash(go build:*)",
       "Bash(go doc:*)",
       "Bash(go generate:*)",
@@ -21,20 +21,16 @@
       "Bash(go test:*)",
       "Bash(golangci-lint run:*)",
       "Bash(grep:*)",
-      "Bash(gt ls:*)",
       "Bash(helm lint:*)",
       "Bash(helm template:*)",
       "Bash(helm version:*)",
-      "Bash(ln:*)",
       "Bash(ls:*)",
       "Bash(nix build:*)",
       "Bash(nix flake check:*)",
       "Bash(nix fmt:*)",
       "Bash(sqlc generate:*)",
       "Bash(sqlfluff:*)",
-      "Bash(sqlite3 :memory::*)",
-      "WebFetch(domain:github.com)",
-      "WebSearch"
+      "Bash(sqlite3 :memory::*)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ charts/ncps/test-values/
 __pycache__/
 *.pyc
 *.pyo
+
+# Agents
+/.claude/settings.local.json


### PR DESCRIPTION
The current model of storing .claude/settings.local.json leaves no room
for user-specific configurations. Move it to .claude/settings.json and
make it less permissive in order to allow users to add their own
settings without checking them into Git.