### PR TITLE
fix: avoid spurious pipe-closed error in checkAndFixNarInfo

### DIFF
--- a/pkg/cache/upload_only_test.go
+++ b/pkg/cache/upload_only_test.go
@@ -1,9 +1,13 @@
 package cache_test
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"strings"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -112,4 +116,61 @@ func TestGetNarInfo_UploadOnly(t *testing.T) {
 		assert.ErrorIs(t, err, storage.ErrNotFound,
 			"should return ErrNotFound when item is only upstream and UploadOnly is set")
 	})
+}
+
+// TestPutNarInfo_DoesNotTriggerNARStreaming verifies that calling PutNarInfo when the
+// corresponding NAR is already in the local store does not trigger a NAR streaming
+// pipeline (pipe + background goroutine), which would log a spurious "pipe closed"
+// error when the reader is immediately closed after getting the file size.
+//
+// Regression test for: PUT /upload/<hash>.narinfo logging "pipe closed during NAR
+// copy (client likely disconnected)" for the same trace_id as the upload operation.
+//
+// The bug manifests as a data race: the background goroutine spawned by GetNar()
+// writes "pipe closed" to the log buffer concurrently with the test reading it.
+// With -race, this causes the test to fail. After the fix, no goroutine is spawned,
+// no race occurs, and the "pipe closed" message is never logged.
+func TestPutNarInfo_DoesNotTriggerNARStreaming(t *testing.T) {
+	t.Parallel()
+
+	db, localStore, _, _, cleanup := setupTestComponents(t)
+	t.Cleanup(cleanup)
+
+	c, err := newTestCache(newContext(), cacheName, db, localStore, localStore, localStore, "")
+	require.NoError(t, err)
+
+	// Step 1: Store the NAR locally so checkAndFixNarInfo finds it in the store.
+	narURL := nar.URL{
+		Hash:        testdata.Nar1.NarHash,
+		Compression: testdata.Nar1.NarCompression,
+	}
+	require.NoError(t, c.PutNar(context.Background(), narURL, io.NopCloser(strings.NewReader(testdata.Nar1.NarText))))
+
+	// Step 2: Call PutNarInfo with a context whose logger writes to an unprotected
+	// buffer. If the buggy code path runs (GetNar → serveNarFromStorageViaPipe →
+	// background goroutine), that goroutine will write to this buffer concurrently,
+	// causing a data race detected by -race.
+	//
+	// After the fix, no goroutine is spawned, no concurrent write occurs, and the
+	// buffer read below is safe.
+	var logBuf bytes.Buffer
+
+	logger := zerolog.New(&logBuf)
+	ctx := logger.WithContext(context.Background())
+
+	err = c.PutNarInfo(ctx, testdata.Nar1.NarInfoHash, io.NopCloser(strings.NewReader(testdata.Nar1.NarInfoText)))
+	require.NoError(t, err)
+
+	// Wait for all background work spawned by PutNarInfo to complete.
+	// Note: this waits for backgroundWG goroutines (e.g. checkAndFixNarInfo's
+	// detached context), but not for SafeGo goroutines spawned by the buggy
+	// GetNar → serveNarFromStorageViaPipe path.
+	c.Close()
+
+	// Step 3: Read the buffer. If the bug is present, the background goroutine
+	// from serveNarFromStorageViaPipe is still running and writing to logBuf
+	// concurrently — the race detector will flag this read as a data race,
+	// failing the test. After the fix, this read is safe.
+	assert.NotContains(t, logBuf.String(), "pipe closed during NAR copy",
+		"PutNarInfo should not trigger NAR streaming when checking file size")
 }


### PR DESCRIPTION
checkAndFixNarInfo was calling c.GetNar() solely to retrieve the NAR
file size for a database consistency check. GetNar() internally creates
a streaming pipeline (io.Pipe + background goroutine via SafeGo). When
the returned reader was immediately closed, the background goroutine
would fail writing to the closed pipe and log:

  "pipe closed during NAR copy (client likely disconnected)"

This error appeared for the same trace_id as a PUT
/upload/<hash>.narinfo request, making it look like an upload was
triggering a NAR download — confusing and misleading.

Fix by using getNarActualSize(), which reads the size directly from
storage (no pipe, no goroutine) for whole-file NARs, or from the
nar_files.file_size column in the database for CDC-chunked NARs.

A regression test (TestPutNarInfo_DoesNotTriggerNARStreaming) is added
that exposes the bug as a data race under -race: the buggy code spawns a
background goroutine that writes to an unprotected log buffer while the
test reads it. After the fix, no goroutine is spawned and the read is
safe.