### PR TITLE
fix: align the chunk storage with nar storage

### DIFF
--- a/docs/docs/User Guide/Features/CDC.md
+++ b/docs/docs/User Guide/Features/CDC.md
@@ -57,7 +57,7 @@ cache:
 
 When CDC is enabled:
 
-- Chunks are stored in the configured storage backend (local or S3) under a `chunks/` prefix or directory.
+- Chunks are stored in the configured storage backend (local or S3) under a `chunk/` prefix or directory.
 - `ncps` maintains a mapping between NAR files and their chunks in the database.
 - The `max-size` and LRU cleanup mechanisms still apply to the total size of the cache, including chunks.
 

--- a/docs/docs/User Guide/Operations/NAR to Chunks Migration.md
+++ b/docs/docs/User Guide/Operations/NAR to Chunks Migration.md
@@ -130,7 +130,7 @@ histogram_quantile(0.99, ncps_migration_duration_seconds{migration_type="nar-to-
 
 ### Check Storage Usage
 
-You should see a decrease in total storage usage (sum of `nar/` and `chunks/` directories) after migration, as original NAR files are deleted.
+You should see a decrease in total storage usage (sum of `nar/` and `chunk/` directories) after migration, as original NAR files are deleted.
 
 ### Database Inspection
 
@@ -150,7 +150,7 @@ SELECT count(DISTINCT nar_id) FROM nar_chunks;
 
 ### "Already in Chunks" Skipping
 
-If the logs show many skipped NARs, it means they were already processed. If you believe this is in error, check if the chunks actually exist in the storage backend under the `chunks/` prefix.
+If the logs show many skipped NARs, it means they were already processed. If you believe this is in error, check if the chunks actually exist in the storage backend under the `chunk/` prefix.
 
 ### Failed Deletions
 

--- a/pkg/cache/cache_distributed_test.go
+++ b/pkg/cache/cache_distributed_test.go
@@ -701,7 +701,7 @@ func testLargeNARConcurrentDownloadScenario(t *testing.T, factory distributedDBF
 	var chunkStore chunk.Store
 
 	if cdcEnabled {
-		chunksDir := filepath.Join(sharedDir, "chunks")
+		chunksDir := filepath.Join(sharedDir, "chunk")
 		require.NoError(t, os.MkdirAll(chunksDir, 0o755))
 
 		chunkStore, err = chunk.NewLocalStore(chunksDir)
@@ -947,7 +947,7 @@ func testCDCProgressiveStreamingDuringChunking(factory distributedDBFactory) fun
 		require.NoError(t, err)
 
 		// Setup CDC chunk store
-		chunksDir := filepath.Join(sharedDir, "chunks")
+		chunksDir := filepath.Join(sharedDir, "chunk")
 		require.NoError(t, os.MkdirAll(chunksDir, 0o755))
 
 		chunkStore, err := chunk.NewLocalStore(chunksDir)

--- a/pkg/storage/chunk/local_test.go
+++ b/pkg/storage/chunk/local_test.go
@@ -87,7 +87,7 @@ func TestLocalStore(t *testing.T) {
 		_, _, err := store.PutChunk(ctx, hash, []byte(content))
 		require.NoError(t, err)
 
-		path := filepath.Join(dir, "chunks", hash[:2], hash)
+		path := filepath.Join(dir, "chunk", hash[:1], hash[:2], hash)
 		parentDir := filepath.Dir(path)
 
 		// Verify chunk and parent directory exist
@@ -106,6 +106,10 @@ func TestLocalStore(t *testing.T) {
 
 		// Verify parent directory is gone (since it should be empty)
 		_, err = os.Stat(parentDir)
+		assert.True(t, os.IsNotExist(err))
+
+		// Verify parent directory is gone (since it should be empty)
+		_, err = os.Stat(filepath.Dir(parentDir))
 		assert.True(t, os.IsNotExist(err))
 	})
 

--- a/pkg/storage/chunk/s3_test.go
+++ b/pkg/storage/chunk/s3_test.go
@@ -283,13 +283,6 @@ func TestNewS3Store_Validation(t *testing.T) {
 func TestS3Store_ChunkPath(t *testing.T) {
 	t.Parallel()
 
-	// Since we can't easily access the unexported method without export_test.go
-	// and we are in chunk_test package, we use a trick or just test through PutChunk/GetChunk
-	// but those already use integration.
-	// However, we added export_test.go which is in package chunk.
-	// Wait, TestS3Store_ChunkPath should be in package chunk to test it directly.
-	// Or we can just call PutChunk with a short hash.
-
 	ctx := context.Background()
 
 	cfg := testhelper.S3TestConfig(t)
@@ -301,7 +294,7 @@ func TestS3Store_ChunkPath(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("short hash", func(t *testing.T) {
-		hash := "a"
+		hash := "aaa"
 		content := strings.Repeat("short hash content", 1024)
 
 		created, size, err := store.PutChunk(ctx, hash, []byte(content))


### PR DESCRIPTION
The chunks were stored under store/chunks/{2-char}/{hash} but
nars were stored as store store/nar/{1-char}/{2-char}/{hash}. Have the
chunks also be stored under the same sharding as nars.