### PR TITLE
fix: delete original whole-file NAR from narStore after CDC migration

### DIFF
--- a/pkg/cache/export_test.go
+++ b/pkg/cache/export_test.go
@@ -12,12 +12,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kalbasit/ncps/pkg/nar"
 	"github.com/kalbasit/ncps/pkg/zstd"
 )
 
 // CheckAndFixNarInfo is a test-only export of the unexported checkAndFixNarInfo method.
 func (c *Cache) CheckAndFixNarInfo(ctx context.Context, hash string) error {
 	return c.checkAndFixNarInfo(ctx, hash)
+}
+
+// HasNarInStore is a test-only export of the unexported hasNarInStore method.
+// It returns true if the NAR exists as a whole file in narStore (not chunks).
+func (c *Cache) HasNarInStore(ctx context.Context, narURL nar.URL) bool {
+	return c.hasNarInStore(ctx, narURL)
 }
 
 // SetupNarInfo is a test-only export.


### PR DESCRIPTION
After MigrateNarToChunks (both background and explicit) successfully chunks
a NAR, the original whole-file NAR was never deleted from narStore. This
caused storage space to accumulate indefinitely after CDC migration — files
in var/ncps/storage/store/nar/ remained even though all data was stored as
CDC chunks and narinfos pointed to the chunked URLs.

The fix attempts deletion of both the original compression URL and the
.nar.zst variant (Compression:none NARs are stored on disk as zstd). If
neither exists, a debug log is emitted and the migration still succeeds.

A failing test (testCDCMigrateNarToChunksDeletesOriginalFile) was added
first to confirm the bug, then the fix was applied.