### PR TITLE
perf: serve CDC first pull from temp file without waiting for chunking

### DIFF
--- a/pkg/cache/export_test.go
+++ b/pkg/cache/export_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kalbasit/ncps/pkg/chunker"
 	"github.com/kalbasit/ncps/pkg/nar"
 	"github.com/kalbasit/ncps/pkg/zstd"
 )
@@ -19,6 +20,14 @@ import (
 // CheckAndFixNarInfo is a test-only export of the unexported checkAndFixNarInfo method.
 func (c *Cache) CheckAndFixNarInfo(ctx context.Context, hash string) error {
 	return c.checkAndFixNarInfo(ctx, hash)
+}
+
+// SetChunker is a test-only export to inject a custom chunker implementation.
+func (c *Cache) SetChunker(ch chunker.Chunker) {
+	c.cdcMu.Lock()
+	defer c.cdcMu.Unlock()
+
+	c.chunker = ch
 }
 
 // HasNarInStore is a test-only export of the unexported hasNarInStore method.


### PR DESCRIPTION
On the first pull of a large NAR with CDC enabled, the HTTP response was
waiting ~18–22 seconds because the streaming goroutine in GetNar waited for
ds.stored, which was only signaled after storeNarWithCDC (including the full
CDC chunking loop) completed.

This commit restructures the CDC path in pullNarIntoStore to:

1. Add an onNarFileReady callback to storeNarWithCDC that fires right after
   findOrCreateNarFileForCDC creates the nar_files DB record. That callback
   closes ds.stored early, releasing the distributed download lock as soon
   as another server can safely see the record (and enter progressive chunk
   streaming rather than starting a duplicate download).

2. Keep the job in upstreamJobs while the CDC goroutine runs (keepJobAlive=true).
   This allows concurrent GetNar calls on the same server to find the original
   downloadState and stream bytes from the still-present temp file instead of
   waiting for chunks to become available.

3. Add cdcWg (a sync.WaitGroup) to downloadState. The temp-file cleanup
   goroutine now waits on cdcWg before setting ds.closed=true. This prevents
   the race where ds.closed=true is set immediately after pullNarIntoStore
   returns (before chunking finishes), which previously caused concurrent
   GetNar calls to fall through to streamProgressiveChunks and wait ~18s.

4. Have the CDC goroutine own job-removal and ds.done closure (instead of
   pullNarIntoStore's defer). This ensures ds.done is not closed until after
   the nar_files DB record is committed, which is required so the distributed
   lock is not released before the record exists.

The result: a client calling GetNar immediately after GetNarInfo on a fresh
CDC NAR now receives bytes directly from the in-progress temp file and
completes in download time (~few ms for small NARs, proportional to file
size for large NARs), not in download + chunking time.

A new TDD test testCDCFirstPullCompletesBeforeChunking verifies this with a
slow-mock chunker (2-second delay) and asserts that io.ReadAll completes in
less than 2 seconds.