### PR TITLE
perf: look up original compressed NAR URL for CDC first pulls to improve TTFB

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -18,6 +18,12 @@ SELECT *
 FROM narinfos
 WHERE id = ?;
 
+-- name: GetNarInfoHashByNarURL :one
+SELECT hash
+FROM narinfos
+WHERE url = ?
+LIMIT 1;
+
 
 -- name: GetNarFileByHashAndCompressionAndQuery :one
 SELECT id, hash, compression, file_size, `query`, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -18,6 +18,12 @@ SELECT *
 FROM narinfos
 WHERE id = $1;
 
+-- name: GetNarInfoHashByNarURL :one
+SELECT hash
+FROM narinfos
+WHERE url = $1
+LIMIT 1;
+
 
 -- name: GetNarFileByHashAndCompressionAndQuery :one
 SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -18,6 +18,12 @@ SELECT *
 FROM narinfos
 WHERE id = ?;
 
+-- name: GetNarInfoHashByNarURL :one
+SELECT hash
+FROM narinfos
+WHERE url = ?
+LIMIT 1;
+
 
 -- name: GetNarFileByHashAndCompressionAndQuery :one
 SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -300,6 +300,13 @@ type Querier interface {
 	//  SELECT CAST(COUNT(*) AS BIGINT) AS count
 	//  FROM narinfos
 	GetNarInfoCount(ctx context.Context) (int64, error)
+	//GetNarInfoHashByNarURL
+	//
+	//  SELECT hash
+	//  FROM narinfos
+	//  WHERE url = $1
+	//  LIMIT 1
+	GetNarInfoHashByNarURL(ctx context.Context, url sql.NullString) (string, error)
 	//GetNarInfoHashesByNarFileID
 	//
 	//  SELECT ni.hash

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -932,6 +932,19 @@ func (w *mysqlWrapper) GetNarInfoCount(ctx context.Context) (int64, error) {
 	return res, nil
 }
 
+func (w *mysqlWrapper) GetNarInfoHashByNarURL(ctx context.Context, url sql.NullString) (string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetNarInfoHashByNarURL(ctx, url)
+	if err != nil {
+		return "", err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *mysqlWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -938,6 +938,19 @@ func (w *postgresWrapper) GetNarInfoCount(ctx context.Context) (int64, error) {
 	return res, nil
 }
 
+func (w *postgresWrapper) GetNarInfoHashByNarURL(ctx context.Context, url sql.NullString) (string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetNarInfoHashByNarURL(ctx, url)
+	if err != nil {
+		return "", err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *postgresWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -956,6 +956,19 @@ func (w *sqliteWrapper) GetNarInfoCount(ctx context.Context) (int64, error) {
 	return res, nil
 }
 
+func (w *sqliteWrapper) GetNarInfoHashByNarURL(ctx context.Context, url sql.NullString) (string, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetNarInfoHashByNarURL(ctx, url)
+	if err != nil {
+		return "", err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *sqliteWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -275,6 +275,13 @@ type Querier interface {
 	//  SELECT CAST(COUNT(*) AS SIGNED) AS count
 	//  FROM narinfos
 	GetNarInfoCount(ctx context.Context) (int64, error)
+	//GetNarInfoHashByNarURL
+	//
+	//  SELECT hash
+	//  FROM narinfos
+	//  WHERE url = ?
+	//  LIMIT 1
+	GetNarInfoHashByNarURL(ctx context.Context, url sql.NullString) (string, error)
 	//GetNarInfoHashesByNarFileID
 	//
 	//  SELECT ni.hash

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -1153,6 +1153,26 @@ func (q *Queries) GetNarInfoCount(ctx context.Context) (int64, error) {
 	return count, err
 }
 
+const getNarInfoHashByNarURL = `-- name: GetNarInfoHashByNarURL :one
+SELECT hash
+FROM narinfos
+WHERE url = ?
+LIMIT 1
+`
+
+// GetNarInfoHashByNarURL
+//
+//	SELECT hash
+//	FROM narinfos
+//	WHERE url = ?
+//	LIMIT 1
+func (q *Queries) GetNarInfoHashByNarURL(ctx context.Context, url sql.NullString) (string, error) {
+	row := q.db.QueryRowContext(ctx, getNarInfoHashByNarURL, url)
+	var hash string
+	err := row.Scan(&hash)
+	return hash, err
+}
+
 const getNarInfoHashesByNarFileID = `-- name: GetNarInfoHashesByNarFileID :many
 SELECT ni.hash
 FROM narinfos ni

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -303,6 +303,13 @@ type Querier interface {
 	//  SELECT CAST(COUNT(*) AS BIGINT) AS count
 	//  FROM narinfos
 	GetNarInfoCount(ctx context.Context) (int64, error)
+	//GetNarInfoHashByNarURL
+	//
+	//  SELECT hash
+	//  FROM narinfos
+	//  WHERE url = $1
+	//  LIMIT 1
+	GetNarInfoHashByNarURL(ctx context.Context, url sql.NullString) (string, error)
 	//GetNarInfoHashesByNarFileID
 	//
 	//  SELECT ni.hash

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -1229,6 +1229,26 @@ func (q *Queries) GetNarInfoCount(ctx context.Context) (int64, error) {
 	return count, err
 }
 
+const getNarInfoHashByNarURL = `-- name: GetNarInfoHashByNarURL :one
+SELECT hash
+FROM narinfos
+WHERE url = $1
+LIMIT 1
+`
+
+// GetNarInfoHashByNarURL
+//
+//	SELECT hash
+//	FROM narinfos
+//	WHERE url = $1
+//	LIMIT 1
+func (q *Queries) GetNarInfoHashByNarURL(ctx context.Context, url sql.NullString) (string, error) {
+	row := q.db.QueryRowContext(ctx, getNarInfoHashByNarURL, url)
+	var hash string
+	err := row.Scan(&hash)
+	return hash, err
+}
+
 const getNarInfoHashesByNarFileID = `-- name: GetNarInfoHashesByNarFileID :many
 SELECT ni.hash
 FROM narinfos ni

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -289,6 +289,13 @@ type Querier interface {
 	//  SELECT CAST(COUNT(*) AS INTEGER) AS count
 	//  FROM narinfos
 	GetNarInfoCount(ctx context.Context) (int64, error)
+	//GetNarInfoHashByNarURL
+	//
+	//  SELECT hash
+	//  FROM narinfos
+	//  WHERE url = ?
+	//  LIMIT 1
+	GetNarInfoHashByNarURL(ctx context.Context, url sql.NullString) (string, error)
 	//GetNarInfoHashesByNarFileID
 	//
 	//  SELECT ni.hash

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -1181,6 +1181,26 @@ func (q *Queries) GetNarInfoCount(ctx context.Context) (int64, error) {
 	return count, err
 }
 
+const getNarInfoHashByNarURL = `-- name: GetNarInfoHashByNarURL :one
+SELECT hash
+FROM narinfos
+WHERE url = ?
+LIMIT 1
+`
+
+// GetNarInfoHashByNarURL
+//
+//	SELECT hash
+//	FROM narinfos
+//	WHERE url = ?
+//	LIMIT 1
+func (q *Queries) GetNarInfoHashByNarURL(ctx context.Context, url sql.NullString) (string, error) {
+	row := q.db.QueryRowContext(ctx, getNarInfoHashByNarURL, url)
+	var hash string
+	err := row.Scan(&hash)
+	return hash, err
+}
+
 const getNarInfoHashesByNarFileID = `-- name: GetNarInfoHashesByNarFileID :many
 SELECT ni.hash
 FROM narinfos ni


### PR DESCRIPTION
When a CDC-enabled GetNar request arrives for a compression:none NAR with
no active local download, look up the narinfo hash from the database and
fetch the narinfo from upstream to find the original compressed URL (e.g.
xz). Use this as the preferred download URL while keeping narURL as
compression:none.

This reduces TTFB for CDC first pulls from ~5s to ~2s by downloading the
pre-compressed NAR from upstream (direct read) instead of requesting the
uncompressed version (which causes the upstream to decompress on-the-fly).

The "preferred download URL" is passed separately so narURL stays as
compression:none throughout, ensuring the streaming goroutine's decompressor
path fires correctly (tempFileCompression=xz + narURL.Compression=none →
decompress on-the-fly → serve uncompressed bytes to the HTTP client).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>