### PR TITLE
fix: allow the dev-db user to create databases

### DIFF
--- a/nix/devshells/flake-module.nix
+++ b/nix/devshells/flake-module.nix
@@ -176,6 +176,8 @@
           # Set the environment variables to help users login to MySQL and PostgreSQL
           export NCPS_DEV_POSTGRES_URL="postgresql://dev-user:dev-password@127.0.0.1:5432/dev-db?sslmode=disable"
           export NCPS_DEV_MYSQL_URL="mysql://dev-user:dev-password@127.0.0.1:3306/dev-db"
+          export NCPS_ADMIN_POSTGRES_URL="postgresql://postgres:@127.0.0.1:5432/postgres?sslmode=disable"
+          export NCPS_ADMIN_MYSQL_URL="mysql://root:@127.0.0.1:3306"
 
           if [[ "$(${pkgs.gnugrep}/bin/grep '^\(go \)[0-9.]*$' go.mod)" != "go ''${_GO_VERSION}" ]]; then
             ${pkgs.gnused}/bin/sed -e "s:^\(go \)[0-9.]*$:\1''${_GO_VERSION}:" -i go.mod

--- a/nix/process-compose/init-postgres.sh
+++ b/nix/process-compose/init-postgres.sh
@@ -25,7 +25,7 @@ fi
 # SETUP: Dev User (Standard)
 # ---------------------------------------------------
 echo "Creating dev user and database..."
-psql -c "CREATE USER \"$PG_DEV_USER\" WITH PASSWORD '$PG_DEV_PASSWORD';"
+psql -c "CREATE USER \"$PG_DEV_USER\" WITH PASSWORD '$PG_DEV_PASSWORD' CREATEDB;"
 psql -c "CREATE DATABASE \"$PG_DEV_DB\" OWNER \"$PG_DEV_USER\";"
 
 # ---------------------------------------------------


### PR DESCRIPTION
The run.py needs to be able to drop and create the database, but
currently, it can drop its database but cannot re-create it. Give it
permission to do so.