### PR TITLE
fix: k8s-tests on macOS

### DIFF
--- a/nix/k8s-tests/flake-module.nix
+++ b/nix/k8s-tests/flake-module.nix
@@ -15,12 +15,14 @@ _: {
           docker
           (pkgs.python3.withPackages (
             ps: with ps; [
-              requests
-              pyyaml
+              boto3
+              brotli
+              kubernetes
               psycopg2
               pymysql
-              kubernetes
-              boto3
+              pyyaml
+              requests
+              zstandard
             ]
           ))
         ];

--- a/nix/k8s-tests/src/k8s_tests.py
+++ b/nix/k8s-tests/src/k8s_tests.py
@@ -793,16 +793,17 @@ spec:
         system = os.uname().sysname.lower()
         machine = os.uname().machine.lower()
 
-        if system == "darwin":
-            if machine == "arm64":
-                return "aarch64-darwin"
-            elif machine == "x86_64":
-                return "x86_64-darwin"
-        elif system == "linux":
-            if machine in ("arm64", "aarch64"):
-                return "aarch64-linux"
-            elif machine in ("x86_64", "amd64"):
-                return "x86_64-linux"
+        platform_map = {
+            ("darwin", "arm64"): "aarch64-linux",
+            ("darwin", "x86_64"): "x86_64-linux",
+            ("linux", "arm64"): "aarch64-linux",
+            ("linux", "aarch64"): "aarch64-linux",
+            ("linux", "x86_64"): "x86_64-linux",
+            ("linux", "amd64"): "x86_64-linux",
+        }
+
+        if (system, machine) in platform_map:
+            return platform_map[(system, machine)]
 
         self.error(f"Unsupported OS/architecture combination: {system}/{machine}")
 

--- a/nix/k8s-tests/src/k8s_tests_tester.py
+++ b/nix/k8s-tests/src/k8s_tests_tester.py
@@ -35,6 +35,8 @@ try:
 except ImportError:
     boto3 = None
 
+HTTP_TIMEOUT = 60
+
 
 @dataclass
 class TestResult:
@@ -547,13 +549,17 @@ class NCPSTester:
                 try:
                     # Fetch narinfo
                     resp = requests.get(
-                        f"{base_url}/{narinfo_hash}.narinfo", timeout=30
+                        f"{base_url}/{narinfo_hash}.narinfo", timeout=HTTP_TIMEOUT
                     )
                     if resp.status_code != 200:
                         return TestResult(
                             "HTTP Endpoints",
                             False,
                             f"Failed to fetch narinfo {narinfo_hash}: HTTP {resp.status_code}",
+                        )
+                    if self.verbose:
+                        print(
+                            f"      ✓ Fetched {narinfo_hash}.narinfo ({len(resp.text)} bytes)"
                         )
 
                     # Parse URL from narinfo
@@ -569,13 +575,17 @@ class NCPSTester:
                     nar_url = url_match.group(1).strip()
 
                     # Fetch the NAR file
-                    resp = requests.get(f"{base_url}/{nar_url}", timeout=30)
+                    if self.verbose:
+                        print(f"      ✓ Fetching {nar_url}")
+                    resp = requests.get(f"{base_url}/{nar_url}", timeout=HTTP_TIMEOUT)
                     if resp.status_code != 200:
                         return TestResult(
                             "HTTP Endpoints",
                             False,
                             f"Failed to fetch NAR {nar_url}: HTTP {resp.status_code}",
                         )
+                    if self.verbose:
+                        print(f"      ✓ Fetched {nar_url} ({len(resp.content)} bytes)")
 
                     if len(resp.content) == 0:
                         return TestResult(


### PR DESCRIPTION
It was using the wrong platform to build the image. Additionally,
increase the HTTP timeout when pulling narinfo and nars.