### PR TITLE
perf: speed up xz decompression using xz process

### DIFF
--- a/nix/devshells/flake-module.nix
+++ b/nix/devshells/flake-module.nix
@@ -131,6 +131,7 @@
           pkgs.sqlc
           pkgs.sqlfluff
           pkgs.watchexec
+          pkgs.xz # used by pkgs/xz.Decompress
 
           pkgs.kubernetes-helm
           pkgs.kubernetes-helmPlugins.helm-unittest

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1035,7 +1035,7 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadClose
 
 				fileReader := &fileAvailableReader{f: f, ds: ds}
 
-				decompReader, err := nar.DecompressReader(fileReader, tempFileCompression)
+				decompReader, err := nar.DecompressReader(ctx, fileReader, tempFileCompression)
 				if err != nil {
 					zerolog.Ctx(ctx).Error().Err(err).
 						Str("compression", tempFileCompression.String()).
@@ -1666,7 +1666,7 @@ func (c *Cache) storeNarWithCDC(ctx context.Context, tempPath string, narURL *na
 	var reader io.Reader = f
 
 	if originalCompression != nar.CompressionTypeNone {
-		decompressed, decompErr := nar.DecompressReader(f, originalCompression)
+		decompressed, decompErr := nar.DecompressReader(ctx, f, originalCompression)
 		if decompErr != nil {
 			// If decompression fails, log a warning and proceed with raw data.
 			// This can happen if the stored metadata doesn't match the actual data compression
@@ -2381,7 +2381,7 @@ func (c *Cache) getNarFromStore(
 	storedFileSize := size
 
 	if decompress {
-		decompressed, decompErr := nar.DecompressReader(r, nar.CompressionTypeZstd)
+		decompressed, decompErr := nar.DecompressReader(ctx, r, nar.CompressionTypeZstd)
 		if decompErr != nil {
 			_ = r.Close()
 

--- a/pkg/xz/decompress.go
+++ b/pkg/xz/decompress.go
@@ -1,0 +1,161 @@
+package xz
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/ulikunitz/xz"
+)
+
+// ErrXZBinAbsPath is returned when XZ_BIN is not an absolute path.
+var ErrXZBinAbsPath = errors.New("XZ_BIN must be an absolute path")
+
+//nolint:gochecknoinits // Initialize Decompress variable once.
+func init() {
+	Decompress = computeDecompressFn()
+}
+
+func computeDecompressFn() DecompressorFn {
+	if os.Getenv("FORCE_USE_INTERNAL_XZ") != "" {
+		return decompressInternal
+	}
+
+	p, err := getXZBin()
+	if err == nil {
+		return decompressCommand(p)
+	}
+
+	return decompressInternal
+}
+
+func getXZBin() (string, error) {
+	if p := os.Getenv("XZ_BIN"); p != "" {
+		if !filepath.IsAbs(p) {
+			return "", ErrXZBinAbsPath
+		}
+
+		return p, nil
+	}
+
+	return exec.LookPath("xz")
+}
+
+// Decompress is a function that decompresses data using the system's xz binary,
+// if found, if not it uses the ulikunitz/xz library.
+//
+//nolint:gochecknoglobals // Used by other packages to decompress data.
+var Decompress DecompressorFn
+
+type DecompressorFn func(context.Context, io.Reader) (io.ReadCloser, error)
+
+type xzReadCloser struct {
+	reader io.Reader
+	stdout io.ReadCloser
+	cmd    *exec.Cmd
+	stderr *bytes.Buffer
+
+	waitOnce sync.Once
+	waitErr  error
+}
+
+func (x *xzReadCloser) Read(p []byte) (n int, err error) {
+	n, err = x.reader.Read(p)
+	if err == io.EOF {
+		x.waitOnce.Do(func() {
+			x.waitErr = x.cmd.Wait()
+		})
+
+		if x.waitErr != nil {
+			return n, fmt.Errorf("xz decompression failed: %w, stderr: %s", x.waitErr, x.stderr.String())
+		}
+	}
+
+	return n, err
+}
+
+func (x *xzReadCloser) Close() error {
+	// Close stdout first to signal the reader is done
+	closeErr := x.stdout.Close()
+	if closeErr != nil && (errors.Is(closeErr, os.ErrClosed) ||
+		errors.Is(closeErr, os.ErrInvalid) ||
+		strings.Contains(closeErr.Error(), "file already closed")) {
+		closeErr = nil
+	}
+
+	// Wait for the command to finish and get the exit status
+	x.waitOnce.Do(func() {
+		x.waitErr = x.cmd.Wait()
+	})
+
+	if x.waitErr != nil {
+		// Return the captured stderr to explain WHY it failed
+		return fmt.Errorf("xz decompression failed: %w, stderr: %s", x.waitErr, x.stderr.String())
+	}
+
+	return closeErr
+}
+
+// decompressCommand streams the decompression using the system's xz binary.
+func decompressCommand(path string) DecompressorFn {
+	return func(ctx context.Context, r io.Reader) (io.ReadCloser, error) {
+		cmd := exec.CommandContext(ctx, path, "-d", "-c")
+		cmd.Stdin = r
+
+		var stderr bytes.Buffer
+
+		cmd.Stderr = &stderr
+
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			return nil, fmt.Errorf("failed to start xz process: %w", err)
+		}
+
+		// we peek 1 byte from stdout. If xz fails immediately (e.g. invalid stream),
+		// Peek will return an error or EOF, and we can check Wait() synchronously.
+		br := bufio.NewReader(stdout)
+		_, peekErr := br.Peek(1)
+
+		xrc := &xzReadCloser{
+			reader: br,
+			stdout: stdout,
+			cmd:    cmd,
+			stderr: &stderr,
+		}
+
+		if peekErr != nil {
+			// If we got an error (like EOF), the command might have exited.
+			xrc.waitOnce.Do(func() {
+				xrc.waitErr = cmd.Wait()
+			})
+
+			if xrc.waitErr != nil {
+				return nil, fmt.Errorf("xz decompression failed: %w, stderr: %s", xrc.waitErr, stderr.String())
+			}
+			// If waitErr is nil, it was just a valid empty stream.
+		}
+
+		return xrc, nil
+	}
+}
+
+func decompressInternal(_ context.Context, r io.Reader) (io.ReadCloser, error) {
+	xr, err := xz.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return io.NopCloser(xr), nil
+}

--- a/pkg/xz/decompress_test.go
+++ b/pkg/xz/decompress_test.go
@@ -1,0 +1,75 @@
+package xz_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	xzpkg "github.com/ulikunitz/xz"
+
+	"github.com/kalbasit/ncps/pkg/xz"
+)
+
+// generateValidXZ creates a valid XZ compressed payload for "hello world".
+func generateValidXZ(t *testing.T) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	xw, err := xzpkg.NewWriter(&buf)
+	require.NoError(t, err)
+
+	_, err = io.WriteString(xw, "hello world")
+	require.NoError(t, err)
+
+	require.NoError(t, xw.Close())
+
+	return buf.Bytes()
+}
+
+func testDecompressorBehavior(t *testing.T, name string, fn xz.DecompressorFn) {
+	t.Run(name, func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("Valid stream", func(t *testing.T) {
+			t.Parallel()
+
+			input := generateValidXZ(t)
+			rc, err := fn(context.Background(), bytes.NewReader(input))
+			require.NoError(t, err, "should not error on valid xz stream")
+
+			defer rc.Close()
+
+			output, err := io.ReadAll(rc)
+			require.NoError(t, err, "should read till EOF without error")
+			assert.Equal(t, "hello world", string(output))
+		})
+
+		t.Run("Invalid stream (plaintext)", func(t *testing.T) {
+			t.Parallel()
+
+			input := []byte("this is not an xz stream")
+			_, err := fn(context.Background(), bytes.NewReader(input))
+			require.Error(t, err, "should return an error immediately when parsing the header")
+		})
+
+		t.Run("Empty stream", func(t *testing.T) {
+			t.Parallel()
+
+			input := []byte{}
+			_, err := fn(context.Background(), bytes.NewReader(input))
+			require.Error(t, err, "should return an error immediately for empty stream")
+		})
+	})
+}
+
+func TestDecompressors(t *testing.T) {
+	t.Parallel()
+
+	testDecompressorBehavior(t, "decompressCommand", xz.DecompressCommand)
+	testDecompressorBehavior(t, "decompressInternal", xz.DecompressInternal)
+}

--- a/pkg/xz/export_test.go
+++ b/pkg/xz/export_test.go
@@ -1,0 +1,19 @@
+package xz
+
+import (
+	"context"
+	"io"
+)
+
+func DecompressCommand(ctx context.Context, r io.Reader) (io.ReadCloser, error) {
+	p, err := getXZBin()
+	if err != nil {
+		return nil, err
+	}
+
+	return decompressCommand(p)(ctx, r)
+}
+
+func DecompressInternal(ctx context.Context, r io.Reader) (io.ReadCloser, error) {
+	return decompressInternal(ctx, r)
+}


### PR DESCRIPTION
This change introduces a more efficient way to decompress XZ files by
leveraging the system's xz binary when available.

Key changes:
- Created a new pkg/xz package that wraps the xz command-line tool.
- Implemented a DecompressorFn that uses exec.CommandContext for
  streaming decompression.
- Added logic to catch invalid XZ streams early by peeking at the stdout
  pipe, mirroring the behavior of the ulikunitz/xz library.
- Provided a fallback to the internal ulikunitz/xz library when the xz
  binary is missing.
- Updated nar.DecompressReader and its callers to accept a
  context.Context, allowing for proper process management and
  cancellation.
- Added comprehensive tests in pkg/xz/decompress_test.go to ensure
  consistent behavior between the command-based and library-based
  implementations.
- Included xz in the development shell and the final package build to
  ensure its availability.
- Updated newContext in pkg/cache/cache_test.go to use
  zerolog.ConsoleWriter for better visibility during tests.

Before this change:

```
❯ ./dev-scripts/ttfb.py 9cmq42r6756j8pdw5x3d81maqr8gvx3q
Testing NAR: nar/0sr372mi1crca8chi4dn31m6a6pdbj52ab8wmd9c2amqvqghidhi.nar

URL                   | TTFB       | Total Time   | Status
-------------------------------------------------------------
http://127.0.0.1:8501 | 0.0439s | 20.8003s | 200
http://127.0.0.1:8502 | 1.5692s | 22.7544s | 200
http://127.0.0.1:8503 | 1.4485s | 22.8453s | 200
```

After this change:

```
 ❯ ./dev-scripts/ttfb.py 9cmq42r6756j8pdw5x3d81maqr8gvx3q
Testing NAR: nar/0sr372mi1crca8chi4dn31m6a6pdbj52ab8wmd9c2amqvqghidhi.nar.xz

URL                   | TTFB       | Total Time   | Status
-------------------------------------------------------------
http://127.0.0.1:8501 | 0.0067s    | 1.4244s      | 200
http://127.0.0.1:8502 | 1.5901s    | 1.6414s      | 200
http://127.0.0.1:8503 | 1.6228s    | 1.6569s      | 200
```

fixes #937