### PR TITLE
fix: remove all shells from the docker image

### DIFF
--- a/nix/packages/docker.nix
+++ b/nix/packages/docker.nix
@@ -29,39 +29,78 @@
               '';
               destination = "/etc/group";
             };
+
+            # Wrap all your contents in a buildEnv to assert disallowedRequisites
+            # securely before they are processed by the Docker tools.
+            imageContents =
+              (pkgs.buildEnv {
+                name = "ncps-contents";
+                paths = [
+                  # required for Open-Telemetry auto-detection of process information
+                  etc-passwd
+                  etc-group
+
+                  # required for TLS certificate validation
+                  pkgs.cacert
+
+                  # required for working with timezones
+                  # Filtered tzdata to drop the bash dependency
+                  (pkgs.runCommand "tzdata-filtered" { } ''
+                    mkdir -p $out/share
+                    cp -a ${pkgs.tzdata}/share/zoneinfo $out/share/
+                  '')
+
+                  # Use real dbmate for the wrapper to call
+                  (pkgs.runCommand "dbmate.real"
+                    {
+                      nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
+                    }
+                    ''
+                      mkdir -p $out/bin
+                      makeWrapper ${pkgs.dbmate}/bin/dbmate $out/bin/dbmate.real
+                    ''
+                  )
+
+                  # dbmate-wrapper provides the dbmate command
+                  (pkgs.runCommand "dbmate"
+                    {
+                      nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
+                    }
+                    ''
+                      mkdir -p $out/bin
+                      makeWrapper ${config.packages.dbmate-wrapper}/bin/dbmate-wrapper $out/bin/dbmate
+                    ''
+                  )
+
+                  # the ncps package
+                  (config.packages.ncps.overrideAttrs (oa: {
+                    # Disable tests for the docker image build. Also remove the
+                    # coverage output that's only generated when tests run.
+                    # This is because the tests takes a while to start databases and
+                    # run and they provide no value in this package since the default
+                    # package (ncps) of the flake already runs the tests.
+                    doCheck = false;
+                    outputs = lib.remove "coverage" (oa.outputs or [ ]);
+                  }))
+                ];
+              }).overrideAttrs
+                (_: {
+                  # Nix will fail the build if any of these sneak into the closure recursively
+                  disallowedRequisites = [
+                    # no tools
+                    pkgs.coreutils
+
+                    # no shell
+                    pkgs.bash
+                    pkgs.bashInteractive
+                    pkgs.busybox
+                    pkgs.dash
+                    pkgs.stdenv.shellPackage
+                    pkgs.zsh
+                  ];
+                });
           in
-          [
-            # required for Open-Telemetry auto-detection of process information
-            etc-passwd
-            etc-group
-
-            # required for TLS certificate validation
-            pkgs.cacert
-
-            # required for working with timezones
-            pkgs.tzdata
-
-            # required for migrating the database
-            # Use real dbmate for the wrapper to call
-            (pkgs.writeShellScriptBin "dbmate.real" ''
-              exec ${pkgs.dbmate}/bin/dbmate "$@"
-            '')
-            # dbmate-wrapper provides the dbmate command
-            (pkgs.writeShellScriptBin "dbmate" ''
-              exec ${config.packages.dbmate-wrapper}/bin/dbmate-wrapper "$@"
-            '')
-
-            # the ncps package
-            (config.packages.ncps.overrideAttrs (oa: {
-              # Disable tests for the docker image build. Also remove the
-              # coverage output that's only generated when tests run.
-              # This is because the tests takes a while to start databases and
-              # run and they provide no value in this package since the default
-              # package (ncps) of the flake already runs the tests.
-              doCheck = false;
-              outputs = lib.remove "coverage" (oa.outputs or [ ]);
-            }))
-          ];
+          [ imageContents ];
 
         config = {
           Cmd = [ "/bin/ncps" ];

--- a/nix/packages/ncps/default.nix
+++ b/nix/packages/ncps/default.nix
@@ -130,6 +130,5 @@
             maintainers = [ lib.maintainers.kalbasit ];
           };
         };
-
     };
 }


### PR DESCRIPTION
The docker image should have had no shells available to it. However,
bash got in anyways as dependency to other packages.

1. Wrap the contents with a derivation, and add a disallowedRequisites
   to detect shell across all packages recursively.
2. Update all contents to remove their reference to bash.