### PR TITLE
refactor: expose xz binary path via flags

### DIFF
--- a/docs/docs/User Guide/Configuration/Reference.md
+++ b/docs/docs/User Guide/Configuration/Reference.md
@@ -15,6 +15,8 @@ Options that apply to the entire ncps process.
 | `--otel-enabled` | Enable OpenTelemetry (logs, metrics, tracing) | `OTEL_ENABLED` | `false` |
 | `--otel-grpc-url` | OpenTelemetry gRPC collector URL (omit for stdout) | `OTEL_GRPC_URL` | - |
 | `--prometheus-enabled` | Enable Prometheus metrics endpoint at /metrics | `PROMETHEUS_ENABLED` | `false` |
+| `--use-xz-binary` | Use the xz binary instead of the Go implementation | `USE_XZ_BINARY` | `true` |
+| `--xz-binary-path` | Absolute Path to the xz binary | `XZ_BINARY_PATH` | System `xz` command |
 
 **Example:**
 

--- a/nix/packages/ncps/default.nix
+++ b/nix/packages/ncps/default.nix
@@ -114,12 +114,13 @@
             mkdir -p $out/share/ncps
             cp -r db $out/share/ncps/db
 
-            # ncps makes use of xz for decompression as it's 15-20x faster than
+            # ncps makes use of xz for decompression as it's 3-5x faster than
             # using the native Go implementation of xz. By wrapping ncps, and
-            # setting the XZ_BIN environment variable, we ensure that ncps can
-            # always find the xz binary. This environment variable is read by
-            # pkg/xz.
-            wrapProgram $out/bin/ncps --set XZ_BIN ${lib.getExe' pkgs.xz "xz"}
+            # setting the XZ_BINARY_PATH environment variable, we ensure that
+            # ncps can always find the xz binary. This environment variable is
+            # read by a flag in pkg/ncps and can be overriden by using calling
+            # ncps with the --xz-binary-path flag.
+            wrapProgram $out/bin/ncps --set XZ_BINARY_PATH ${lib.getExe' pkgs.xz "xz"}
           '';
 
           meta = {

--- a/pkg/nar/reader_test.go
+++ b/pkg/nar/reader_test.go
@@ -161,7 +161,7 @@ func TestDecompressReader(t *testing.T) {
 				return bytes.NewReader([]byte("invalid xz data"))
 			},
 			expectError: true,
-			errorMsg:    "File format not recognized",
+			errorMsg:    "invalid header magic bytes",
 		},
 	}
 

--- a/pkg/xz/decompress.go
+++ b/pkg/xz/decompress.go
@@ -1,161 +1,43 @@
 package xz
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
-	"sync"
-
-	"github.com/ulikunitz/xz"
+	"sync/atomic"
 )
 
-// ErrXZBinAbsPath is returned when XZ_BIN is not an absolute path.
-var ErrXZBinAbsPath = errors.New("XZ_BIN must be an absolute path")
+var (
+	// ErrDecompressorNotInitialized is returned when the decompressor is not initialized.
+	ErrDecompressorNotInitialized = errors.New("decompressor not initialized")
 
-//nolint:gochecknoinits // Initialize Decompress variable once.
-func init() {
-	Decompress = computeDecompressFn()
-}
+	//nolint:gochecknoglobals // Used by other packages to decompress data.
+	decompress atomic.Pointer[DecompressorFn]
+)
 
-func computeDecompressFn() DecompressorFn {
-	if os.Getenv("FORCE_USE_INTERNAL_XZ") != "" {
-		return decompressInternal
-	}
-
-	p, err := getXZBin()
-	if err == nil {
-		return decompressCommand(p)
-	}
-
-	return decompressInternal
-}
-
-func getXZBin() (string, error) {
-	if p := os.Getenv("XZ_BIN"); p != "" {
-		if !filepath.IsAbs(p) {
-			return "", ErrXZBinAbsPath
-		}
-
-		return p, nil
-	}
-
-	return exec.LookPath("xz")
-}
-
-// Decompress is a function that decompresses data using the system's xz binary,
-// if found, if not it uses the ulikunitz/xz library.
-//
-//nolint:gochecknoglobals // Used by other packages to decompress data.
-var Decompress DecompressorFn
+//nolint:gochecknoinits // Initialize the decompressor with the internal decompressor.
+func init() { store(decompressInternal) }
 
 type DecompressorFn func(context.Context, io.Reader) (io.ReadCloser, error)
 
-type xzReadCloser struct {
-	reader io.Reader
-	stdout io.ReadCloser
-	cmd    *exec.Cmd
-	stderr *bytes.Buffer
-
-	waitOnce sync.Once
-	waitErr  error
-}
-
-func (x *xzReadCloser) Read(p []byte) (n int, err error) {
-	n, err = x.reader.Read(p)
-	if err == io.EOF {
-		x.waitOnce.Do(func() {
-			x.waitErr = x.cmd.Wait()
-		})
-
-		if x.waitErr != nil {
-			return n, fmt.Errorf("xz decompression failed: %w, stderr: %s", x.waitErr, x.stderr.String())
-		}
-	}
-
-	return n, err
-}
-
-func (x *xzReadCloser) Close() error {
-	// Close stdout first to signal the reader is done
-	closeErr := x.stdout.Close()
-	if closeErr != nil && (errors.Is(closeErr, os.ErrClosed) ||
-		errors.Is(closeErr, os.ErrInvalid) ||
-		strings.Contains(closeErr.Error(), "file already closed")) {
-		closeErr = nil
-	}
-
-	// Wait for the command to finish and get the exit status
-	x.waitOnce.Do(func() {
-		x.waitErr = x.cmd.Wait()
-	})
-
-	if x.waitErr != nil {
-		// Return the captured stderr to explain WHY it failed
-		return fmt.Errorf("xz decompression failed: %w, stderr: %s", x.waitErr, x.stderr.String())
-	}
-
-	return closeErr
-}
-
-// decompressCommand streams the decompression using the system's xz binary.
-func decompressCommand(path string) DecompressorFn {
-	return func(ctx context.Context, r io.Reader) (io.ReadCloser, error) {
-		cmd := exec.CommandContext(ctx, path, "-d", "-c")
-		cmd.Stdin = r
-
-		var stderr bytes.Buffer
-
-		cmd.Stderr = &stderr
-
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
-		}
-
-		if err := cmd.Start(); err != nil {
-			return nil, fmt.Errorf("failed to start xz process: %w", err)
-		}
-
-		// we peek 1 byte from stdout. If xz fails immediately (e.g. invalid stream),
-		// Peek will return an error or EOF, and we can check Wait() synchronously.
-		br := bufio.NewReader(stdout)
-		_, peekErr := br.Peek(1)
-
-		xrc := &xzReadCloser{
-			reader: br,
-			stdout: stdout,
-			cmd:    cmd,
-			stderr: &stderr,
-		}
-
-		if peekErr != nil {
-			// If we got an error (like EOF), the command might have exited.
-			xrc.waitOnce.Do(func() {
-				xrc.waitErr = cmd.Wait()
-			})
-
-			if xrc.waitErr != nil {
-				return nil, fmt.Errorf("xz decompression failed: %w, stderr: %s", xrc.waitErr, stderr.String())
-			}
-			// If waitErr is nil, it was just a valid empty stream.
-		}
-
-		return xrc, nil
-	}
-}
-
-func decompressInternal(_ context.Context, r io.Reader) (io.ReadCloser, error) {
-	xr, err := xz.NewReader(r)
+func Decompress(ctx context.Context, r io.Reader) (io.ReadCloser, error) {
+	fn, err := load()
 	if err != nil {
 		return nil, err
 	}
 
-	return io.NopCloser(xr), nil
+	return fn(ctx, r)
+}
+
+func load() (DecompressorFn, error) {
+	fnPtr := decompress.Load()
+	if fnPtr == nil || *fnPtr == nil {
+		return nil, ErrDecompressorNotInitialized
+	}
+
+	return *fnPtr, nil
+}
+
+func store(fn DecompressorFn) {
+	decompress.Store(&fn)
 }

--- a/pkg/xz/decompress_internal.go
+++ b/pkg/xz/decompress_internal.go
@@ -1,0 +1,21 @@
+package xz
+
+import (
+	"context"
+	"io"
+
+	"github.com/ulikunitz/xz"
+)
+
+func UseInternal() {
+	store(decompressInternal)
+}
+
+func decompressInternal(_ context.Context, r io.Reader) (io.ReadCloser, error) {
+	xr, err := xz.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return io.NopCloser(xr), nil
+}

--- a/pkg/xz/decompress_xz.go
+++ b/pkg/xz/decompress_xz.go
@@ -1,0 +1,112 @@
+package xz
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+func UseXZBinary(path string) {
+	store(decompressCommand(path))
+}
+
+type xzReadCloser struct {
+	reader io.Reader
+	stdout io.ReadCloser
+	cmd    *exec.Cmd
+	stderr *bytes.Buffer
+
+	waitOnce sync.Once
+	waitErr  error
+}
+
+func (x *xzReadCloser) Read(p []byte) (n int, err error) {
+	n, err = x.reader.Read(p)
+	if err == io.EOF {
+		x.waitOnce.Do(func() {
+			x.waitErr = x.cmd.Wait()
+		})
+
+		if x.waitErr != nil {
+			return n, fmt.Errorf("xz decompression failed: %w, stderr: %s", x.waitErr, x.stderr.String())
+		}
+	}
+
+	return n, err
+}
+
+func (x *xzReadCloser) Close() error {
+	// Close stdout first to signal the reader is done
+	closeErr := x.stdout.Close()
+	if closeErr != nil && (errors.Is(closeErr, os.ErrClosed) ||
+		errors.Is(closeErr, os.ErrInvalid) ||
+		strings.Contains(closeErr.Error(), "file already closed")) {
+		closeErr = nil
+	}
+
+	// Wait for the command to finish and get the exit status
+	x.waitOnce.Do(func() {
+		x.waitErr = x.cmd.Wait()
+	})
+
+	if x.waitErr != nil {
+		// Return the captured stderr to explain WHY it failed
+		return fmt.Errorf("xz decompression failed: %w, stderr: %s", x.waitErr, x.stderr.String())
+	}
+
+	return closeErr
+}
+
+// decompressCommand streams the decompression using the system's xz binary.
+func decompressCommand(path string) DecompressorFn {
+	return func(ctx context.Context, r io.Reader) (io.ReadCloser, error) {
+		cmd := exec.CommandContext(ctx, path, "-d", "-c")
+		cmd.Stdin = r
+
+		var stderr bytes.Buffer
+
+		cmd.Stderr = &stderr
+
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			return nil, fmt.Errorf("failed to start xz process: %w", err)
+		}
+
+		// we peek 1 byte from stdout. If xz fails immediately (e.g. invalid stream),
+		// Peek will return an error or EOF, and we can check Wait() synchronously.
+		br := bufio.NewReader(stdout)
+		_, peekErr := br.Peek(1)
+
+		xrc := &xzReadCloser{
+			reader: br,
+			stdout: stdout,
+			cmd:    cmd,
+			stderr: &stderr,
+		}
+
+		if peekErr != nil {
+			// If we got an error (like EOF), the command might have exited.
+			xrc.waitOnce.Do(func() {
+				xrc.waitErr = cmd.Wait()
+			})
+
+			if xrc.waitErr != nil {
+				return nil, fmt.Errorf("xz decompression failed: %w, stderr: %s", xrc.waitErr, stderr.String())
+			}
+			// If waitErr is nil, it was just a valid empty stream.
+		}
+
+		return xrc, nil
+	}
+}

--- a/pkg/xz/export_test.go
+++ b/pkg/xz/export_test.go
@@ -2,8 +2,15 @@ package xz
 
 import (
 	"context"
+	"errors"
 	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 )
+
+// ErrXZBinAbsPath is returned when XZ_BINARY_PATH is not an absolute path.
+var ErrXZBinAbsPath = errors.New("XZ_BINARY_PATH must be an absolute path")
 
 func DecompressCommand(ctx context.Context, r io.Reader) (io.ReadCloser, error) {
 	p, err := getXZBin()
@@ -16,4 +23,16 @@ func DecompressCommand(ctx context.Context, r io.Reader) (io.ReadCloser, error) 
 
 func DecompressInternal(ctx context.Context, r io.Reader) (io.ReadCloser, error) {
 	return decompressInternal(ctx, r)
+}
+
+func getXZBin() (string, error) {
+	if p := os.Getenv("XZ_BINARY_PATH"); p != "" {
+		if !filepath.IsAbs(p) {
+			return "", ErrXZBinAbsPath
+		}
+
+		return p, nil
+	}
+
+	return exec.LookPath("xz")
 }


### PR DESCRIPTION
The binary path of xz, and its use, is currently magic computed within
the xz package; This is not a very nice UX. Move it to flags set on the
main command so the user can enable it, disable it or set a custom xz
binary path.