### PR TITLE
perf: Set File Size/Hash to NULL in the same query

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -424,3 +424,14 @@ LIMIT ? OFFSET ?;
 UPDATE narinfos
 SET compression = sqlc.arg(compression), url = sqlc.arg(new_url), updated_at = CURRENT_TIMESTAMP
 WHERE url = sqlc.arg(old_url);
+
+-- name: UpdateNarInfoCompressionFileSizeHashAndURL :execrows
+-- Update narinfo compression, file_size, file_hash and URL after CDC migration.
+UPDATE narinfos
+SET
+    compression = sqlc.arg(compression),
+    url = sqlc.arg(new_url),
+    file_size = sqlc.arg(file_size),
+    file_hash = sqlc.arg(file_hash),
+    updated_at = CURRENT_TIMESTAMP
+WHERE url = sqlc.arg(old_url);

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -456,3 +456,14 @@ LIMIT $2 OFFSET $3;
 UPDATE narinfos
 SET compression = sqlc.arg(compression), url = sqlc.arg(new_url), updated_at = CURRENT_TIMESTAMP
 WHERE url = sqlc.arg(old_url);
+
+-- name: UpdateNarInfoCompressionFileSizeHashAndURL :execrows
+-- Update narinfo compression, file_size, file_hash and URL after CDC migration.
+UPDATE narinfos
+SET
+    compression = sqlc.arg(compression),
+    url = sqlc.arg(new_url),
+    file_size = sqlc.arg(file_size),
+    file_hash = sqlc.arg(file_hash),
+    updated_at = CURRENT_TIMESTAMP
+WHERE url = sqlc.arg(old_url);

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -443,3 +443,14 @@ LIMIT ? OFFSET ?;
 UPDATE narinfos
 SET compression = sqlc.arg(compression), url = sqlc.arg(new_url), updated_at = CURRENT_TIMESTAMP
 WHERE url = sqlc.arg(old_url);
+
+-- name: UpdateNarInfoCompressionFileSizeHashAndURL :execrows
+-- Update narinfo compression, file_size, file_hash and URL after CDC migration.
+UPDATE narinfos
+SET
+    compression = sqlc.arg(compression),
+    url = sqlc.arg(new_url),
+    file_size = sqlc.arg(file_size),
+    file_hash = sqlc.arg(file_hash),
+    updated_at = CURRENT_TIMESTAMP
+WHERE url = sqlc.arg(old_url);

--- a/pkg/database/generated_models.go
+++ b/pkg/database/generated_models.go
@@ -225,6 +225,14 @@ type UpdateNarInfoCompressionAndURLParams struct {
 	OldUrl      sql.NullString
 }
 
+type UpdateNarInfoCompressionFileSizeHashAndURLParams struct {
+	Compression sql.NullString
+	NewUrl      sql.NullString
+	FileSize    sql.NullInt64
+	FileHash    sql.NullString
+	OldUrl      sql.NullString
+}
+
 type UpdateNarInfoFileHashParams struct {
 	Hash     string
 	FileHash sql.NullString

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -502,6 +502,17 @@ type Querier interface {
 	//  SET compression = $1, url = $2, updated_at = CURRENT_TIMESTAMP
 	//  WHERE url = $3
 	UpdateNarInfoCompressionAndURL(ctx context.Context, arg UpdateNarInfoCompressionAndURLParams) (int64, error)
+	// Update narinfo compression, file_size, file_hash and URL after CDC migration.
+	//
+	//  UPDATE narinfos
+	//  SET
+	//      compression = $1,
+	//      url = $2,
+	//      file_size = $3,
+	//      file_hash = $4,
+	//      updated_at = CURRENT_TIMESTAMP
+	//  WHERE url = $5
+	UpdateNarInfoCompressionFileSizeHashAndURL(ctx context.Context, arg UpdateNarInfoCompressionFileSizeHashAndURLParams) (int64, error)
 	//UpdateNarInfoFileHash
 	//
 	//  UPDATE narinfos

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -1348,6 +1348,25 @@ func (w *mysqlWrapper) UpdateNarInfoCompressionAndURL(ctx context.Context, arg U
 	return res, nil
 }
 
+func (w *mysqlWrapper) UpdateNarInfoCompressionFileSizeHashAndURL(ctx context.Context, arg UpdateNarInfoCompressionFileSizeHashAndURLParams) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.UpdateNarInfoCompressionFileSizeHashAndURL(ctx, mysqldb.UpdateNarInfoCompressionFileSizeHashAndURLParams{
+		Compression: arg.Compression,
+		NewUrl:      arg.NewUrl,
+		FileSize:    arg.FileSize,
+		FileHash:    arg.FileHash,
+		OldUrl:      arg.OldUrl,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *mysqlWrapper) UpdateNarInfoFileHash(ctx context.Context, arg UpdateNarInfoFileHashParams) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -1372,6 +1372,25 @@ func (w *postgresWrapper) UpdateNarInfoCompressionAndURL(ctx context.Context, ar
 	return res, nil
 }
 
+func (w *postgresWrapper) UpdateNarInfoCompressionFileSizeHashAndURL(ctx context.Context, arg UpdateNarInfoCompressionFileSizeHashAndURLParams) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.UpdateNarInfoCompressionFileSizeHashAndURL(ctx, postgresdb.UpdateNarInfoCompressionFileSizeHashAndURLParams{
+		Compression: arg.Compression,
+		NewUrl:      arg.NewUrl,
+		FileSize:    arg.FileSize,
+		FileHash:    arg.FileHash,
+		OldUrl:      arg.OldUrl,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *postgresWrapper) UpdateNarInfoFileHash(ctx context.Context, arg UpdateNarInfoFileHashParams) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -1399,6 +1399,25 @@ func (w *sqliteWrapper) UpdateNarInfoCompressionAndURL(ctx context.Context, arg 
 	return res, nil
 }
 
+func (w *sqliteWrapper) UpdateNarInfoCompressionFileSizeHashAndURL(ctx context.Context, arg UpdateNarInfoCompressionFileSizeHashAndURLParams) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.UpdateNarInfoCompressionFileSizeHashAndURL(ctx, sqlitedb.UpdateNarInfoCompressionFileSizeHashAndURLParams{
+		Compression: arg.Compression,
+		NewUrl:      arg.NewUrl,
+		FileSize:    arg.FileSize,
+		FileHash:    arg.FileHash,
+		OldUrl:      arg.OldUrl,
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *sqliteWrapper) UpdateNarInfoFileHash(ctx context.Context, arg UpdateNarInfoFileHashParams) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -473,6 +473,17 @@ type Querier interface {
 	//  SET compression = ?, url = ?, updated_at = CURRENT_TIMESTAMP
 	//  WHERE url = ?
 	UpdateNarInfoCompressionAndURL(ctx context.Context, arg UpdateNarInfoCompressionAndURLParams) (int64, error)
+	// Update narinfo compression, file_size, file_hash and URL after CDC migration.
+	//
+	//  UPDATE narinfos
+	//  SET
+	//      compression = ?,
+	//      url = ?,
+	//      file_size = ?,
+	//      file_hash = ?,
+	//      updated_at = CURRENT_TIMESTAMP
+	//  WHERE url = ?
+	UpdateNarInfoCompressionFileSizeHashAndURL(ctx context.Context, arg UpdateNarInfoCompressionFileSizeHashAndURLParams) (int64, error)
 	//UpdateNarInfoFileHash
 	//
 	//  UPDATE narinfos

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -1988,6 +1988,49 @@ func (q *Queries) UpdateNarInfoCompressionAndURL(ctx context.Context, arg Update
 	return result.RowsAffected()
 }
 
+const updateNarInfoCompressionFileSizeHashAndURL = `-- name: UpdateNarInfoCompressionFileSizeHashAndURL :execrows
+UPDATE narinfos
+SET
+    compression = ?,
+    url = ?,
+    file_size = ?,
+    file_hash = ?,
+    updated_at = CURRENT_TIMESTAMP
+WHERE url = ?
+`
+
+type UpdateNarInfoCompressionFileSizeHashAndURLParams struct {
+	Compression sql.NullString
+	NewUrl      sql.NullString
+	FileSize    sql.NullInt64
+	FileHash    sql.NullString
+	OldUrl      sql.NullString
+}
+
+// Update narinfo compression, file_size, file_hash and URL after CDC migration.
+//
+//	UPDATE narinfos
+//	SET
+//	    compression = ?,
+//	    url = ?,
+//	    file_size = ?,
+//	    file_hash = ?,
+//	    updated_at = CURRENT_TIMESTAMP
+//	WHERE url = ?
+func (q *Queries) UpdateNarInfoCompressionFileSizeHashAndURL(ctx context.Context, arg UpdateNarInfoCompressionFileSizeHashAndURLParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateNarInfoCompressionFileSizeHashAndURL,
+		arg.Compression,
+		arg.NewUrl,
+		arg.FileSize,
+		arg.FileHash,
+		arg.OldUrl,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const updateNarInfoFileHash = `-- name: UpdateNarInfoFileHash :exec
 UPDATE narinfos
 SET file_hash = ?, updated_at = CURRENT_TIMESTAMP

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -505,6 +505,17 @@ type Querier interface {
 	//  SET compression = $1, url = $2, updated_at = CURRENT_TIMESTAMP
 	//  WHERE url = $3
 	UpdateNarInfoCompressionAndURL(ctx context.Context, arg UpdateNarInfoCompressionAndURLParams) (int64, error)
+	// Update narinfo compression, file_size, file_hash and URL after CDC migration.
+	//
+	//  UPDATE narinfos
+	//  SET
+	//      compression = $1,
+	//      url = $2,
+	//      file_size = $3,
+	//      file_hash = $4,
+	//      updated_at = CURRENT_TIMESTAMP
+	//  WHERE url = $5
+	UpdateNarInfoCompressionFileSizeHashAndURL(ctx context.Context, arg UpdateNarInfoCompressionFileSizeHashAndURLParams) (int64, error)
 	//UpdateNarInfoFileHash
 	//
 	//  UPDATE narinfos

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -2065,6 +2065,49 @@ func (q *Queries) UpdateNarInfoCompressionAndURL(ctx context.Context, arg Update
 	return result.RowsAffected()
 }
 
+const updateNarInfoCompressionFileSizeHashAndURL = `-- name: UpdateNarInfoCompressionFileSizeHashAndURL :execrows
+UPDATE narinfos
+SET
+    compression = $1,
+    url = $2,
+    file_size = $3,
+    file_hash = $4,
+    updated_at = CURRENT_TIMESTAMP
+WHERE url = $5
+`
+
+type UpdateNarInfoCompressionFileSizeHashAndURLParams struct {
+	Compression sql.NullString
+	NewUrl      sql.NullString
+	FileSize    sql.NullInt64
+	FileHash    sql.NullString
+	OldUrl      sql.NullString
+}
+
+// Update narinfo compression, file_size, file_hash and URL after CDC migration.
+//
+//	UPDATE narinfos
+//	SET
+//	    compression = $1,
+//	    url = $2,
+//	    file_size = $3,
+//	    file_hash = $4,
+//	    updated_at = CURRENT_TIMESTAMP
+//	WHERE url = $5
+func (q *Queries) UpdateNarInfoCompressionFileSizeHashAndURL(ctx context.Context, arg UpdateNarInfoCompressionFileSizeHashAndURLParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateNarInfoCompressionFileSizeHashAndURL,
+		arg.Compression,
+		arg.NewUrl,
+		arg.FileSize,
+		arg.FileHash,
+		arg.OldUrl,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const updateNarInfoFileHash = `-- name: UpdateNarInfoFileHash :exec
 UPDATE narinfos
 SET file_hash = $2, updated_at = CURRENT_TIMESTAMP

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -492,6 +492,17 @@ type Querier interface {
 	//  SET compression = ?1, url = ?2, updated_at = CURRENT_TIMESTAMP
 	//  WHERE url = ?3
 	UpdateNarInfoCompressionAndURL(ctx context.Context, arg UpdateNarInfoCompressionAndURLParams) (int64, error)
+	// Update narinfo compression, file_size, file_hash and URL after CDC migration.
+	//
+	//  UPDATE narinfos
+	//  SET
+	//      compression = ?1,
+	//      url = ?2,
+	//      file_size = ?3,
+	//      file_hash = ?4,
+	//      updated_at = CURRENT_TIMESTAMP
+	//  WHERE url = ?5
+	UpdateNarInfoCompressionFileSizeHashAndURL(ctx context.Context, arg UpdateNarInfoCompressionFileSizeHashAndURLParams) (int64, error)
 	//UpdateNarInfoFileHash
 	//
 	//  UPDATE narinfos

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -2019,6 +2019,49 @@ func (q *Queries) UpdateNarInfoCompressionAndURL(ctx context.Context, arg Update
 	return result.RowsAffected()
 }
 
+const updateNarInfoCompressionFileSizeHashAndURL = `-- name: UpdateNarInfoCompressionFileSizeHashAndURL :execrows
+UPDATE narinfos
+SET
+    compression = ?1,
+    url = ?2,
+    file_size = ?3,
+    file_hash = ?4,
+    updated_at = CURRENT_TIMESTAMP
+WHERE url = ?5
+`
+
+type UpdateNarInfoCompressionFileSizeHashAndURLParams struct {
+	Compression sql.NullString
+	NewUrl      sql.NullString
+	FileSize    sql.NullInt64
+	FileHash    sql.NullString
+	OldUrl      sql.NullString
+}
+
+// Update narinfo compression, file_size, file_hash and URL after CDC migration.
+//
+//	UPDATE narinfos
+//	SET
+//	    compression = ?1,
+//	    url = ?2,
+//	    file_size = ?3,
+//	    file_hash = ?4,
+//	    updated_at = CURRENT_TIMESTAMP
+//	WHERE url = ?5
+func (q *Queries) UpdateNarInfoCompressionFileSizeHashAndURL(ctx context.Context, arg UpdateNarInfoCompressionFileSizeHashAndURLParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateNarInfoCompressionFileSizeHashAndURL,
+		arg.Compression,
+		arg.NewUrl,
+		arg.FileSize,
+		arg.FileHash,
+		arg.OldUrl,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const updateNarInfoFileHash = `-- name: UpdateNarInfoFileHash :exec
 UPDATE narinfos
 SET file_hash = ?, updated_at = CURRENT_TIMESTAMP


### PR DESCRIPTION
The File Size/Hash needed two additional queries (one read and one
write) in order to set the file_size and file_hash to null. Add a new
query that allows us to set them in the same query setting the
compression and the new url.