### PR TITLE
docs: add note about memory use during migration from nar to chunks

### DIFF
--- a/docs/docs/User Guide/Operations/NAR to Chunks Migration.md
+++ b/docs/docs/User Guide/Operations/NAR to Chunks Migration.md
@@ -23,6 +23,9 @@ NAR to Chunks migration moves NAR files from traditional storage (filesystem or 
 
 ## CLI Migration Guide
 
+> [!WARNING]
+> This migration is memory-intensive, using approximately **5GB of memory** with the default concurrency (see below).
+
 ### Basic Migration
 
 Migrate all NAR files to chunks. Once a NAR is successfully migrated and verified, it is deleted from the original storage:


### PR DESCRIPTION
The migrate from NAR to chunks, with the migrate-nar-to-chunks command,
uses significantly more memory than regular ncps usage. Add a note about
it in the documentation.