### PR TITLE
perf: reduce database queries in LRU delete and chunk streaming

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -357,6 +357,14 @@ FROM chunks c
 LEFT JOIN nar_file_chunks nfc ON c.id = nfc.chunk_id
 WHERE nfc.chunk_id IS NULL;
 
+-- name: DeleteOrphanedChunks :execrows
+DELETE FROM chunks
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM nar_file_chunks
+    WHERE chunk_id = chunks.id
+);
+
 -- name: DeleteChunkByID :exec
 DELETE FROM chunks
 WHERE id = ?;

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -394,6 +394,14 @@ FROM chunks c
 LEFT JOIN nar_file_chunks nfc ON c.id = nfc.chunk_id
 WHERE nfc.chunk_id IS NULL;
 
+-- name: DeleteOrphanedChunks :execrows
+DELETE FROM chunks
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM nar_file_chunks
+    WHERE chunk_id = chunks.id
+);
+
 -- name: DeleteChunkByID :exec
 DELETE FROM chunks
 WHERE id = $1;

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -381,6 +381,14 @@ FROM chunks c
 LEFT JOIN nar_file_chunks nfc ON c.id = nfc.chunk_id
 WHERE nfc.chunk_id IS NULL;
 
+-- name: DeleteOrphanedChunks :execrows
+DELETE FROM chunks
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM nar_file_chunks
+    WHERE chunk_id = chunks.id
+);
+
 -- name: DeleteChunkByID :exec
 DELETE FROM chunks
 WHERE id = ?;

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -132,6 +132,15 @@ type Querier interface {
 	//  DELETE FROM narinfos
 	//  WHERE id = $1
 	DeleteNarInfoByID(ctx context.Context, id int64) (int64, error)
+	//DeleteOrphanedChunks
+	//
+	//  DELETE FROM chunks
+	//  WHERE NOT EXISTS (
+	//      SELECT 1
+	//      FROM nar_file_chunks
+	//      WHERE chunk_id = chunks.id
+	//  )
+	DeleteOrphanedChunks(ctx context.Context) (int64, error)
 	//DeleteOrphanedNarFiles
 	//
 	//  DELETE FROM nar_files

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -281,6 +281,19 @@ func (w *mysqlWrapper) DeleteNarInfoByID(ctx context.Context, id int64) (int64, 
 	return res, nil
 }
 
+func (w *mysqlWrapper) DeleteOrphanedChunks(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.DeleteOrphanedChunks(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *mysqlWrapper) DeleteOrphanedNarFiles(ctx context.Context) (int64, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -287,6 +287,19 @@ func (w *postgresWrapper) DeleteNarInfoByID(ctx context.Context, id int64) (int6
 	return res, nil
 }
 
+func (w *postgresWrapper) DeleteOrphanedChunks(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.DeleteOrphanedChunks(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *postgresWrapper) DeleteOrphanedNarFiles(ctx context.Context) (int64, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -305,6 +305,19 @@ func (w *sqliteWrapper) DeleteNarInfoByID(ctx context.Context, id int64) (int64,
 	return res, nil
 }
 
+func (w *sqliteWrapper) DeleteOrphanedChunks(ctx context.Context) (int64, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.DeleteOrphanedChunks(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *sqliteWrapper) DeleteOrphanedNarFiles(ctx context.Context) (int64, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -107,6 +107,15 @@ type Querier interface {
 	//  DELETE FROM narinfos
 	//  WHERE id = ?
 	DeleteNarInfoByID(ctx context.Context, id int64) (int64, error)
+	//DeleteOrphanedChunks
+	//
+	//  DELETE FROM chunks
+	//  WHERE NOT EXISTS (
+	//      SELECT 1
+	//      FROM nar_file_chunks
+	//      WHERE chunk_id = chunks.id
+	//  )
+	DeleteOrphanedChunks(ctx context.Context) (int64, error)
 	//DeleteOrphanedNarFiles
 	//
 	//  DELETE FROM nar_files

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -328,6 +328,31 @@ func (q *Queries) DeleteNarInfoByID(ctx context.Context, id int64) (int64, error
 	return result.RowsAffected()
 }
 
+const deleteOrphanedChunks = `-- name: DeleteOrphanedChunks :execrows
+DELETE FROM chunks
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM nar_file_chunks
+    WHERE chunk_id = chunks.id
+)
+`
+
+// DeleteOrphanedChunks
+//
+//	DELETE FROM chunks
+//	WHERE NOT EXISTS (
+//	    SELECT 1
+//	    FROM nar_file_chunks
+//	    WHERE chunk_id = chunks.id
+//	)
+func (q *Queries) DeleteOrphanedChunks(ctx context.Context) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteOrphanedChunks)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const deleteOrphanedNarFiles = `-- name: DeleteOrphanedNarFiles :execrows
 DELETE FROM nar_files
 WHERE id NOT IN (

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -135,6 +135,15 @@ type Querier interface {
 	//  DELETE FROM narinfos
 	//  WHERE id = $1
 	DeleteNarInfoByID(ctx context.Context, id int64) (int64, error)
+	//DeleteOrphanedChunks
+	//
+	//  DELETE FROM chunks
+	//  WHERE NOT EXISTS (
+	//      SELECT 1
+	//      FROM nar_file_chunks
+	//      WHERE chunk_id = chunks.id
+	//  )
+	DeleteOrphanedChunks(ctx context.Context) (int64, error)
 	//DeleteOrphanedNarFiles
 	//
 	//  DELETE FROM nar_files

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -456,6 +456,31 @@ func (q *Queries) DeleteNarInfoByID(ctx context.Context, id int64) (int64, error
 	return result.RowsAffected()
 }
 
+const deleteOrphanedChunks = `-- name: DeleteOrphanedChunks :execrows
+DELETE FROM chunks
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM nar_file_chunks
+    WHERE chunk_id = chunks.id
+)
+`
+
+// DeleteOrphanedChunks
+//
+//	DELETE FROM chunks
+//	WHERE NOT EXISTS (
+//	    SELECT 1
+//	    FROM nar_file_chunks
+//	    WHERE chunk_id = chunks.id
+//	)
+func (q *Queries) DeleteOrphanedChunks(ctx context.Context) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteOrphanedChunks)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const deleteOrphanedNarFiles = `-- name: DeleteOrphanedNarFiles :execrows
 DELETE FROM nar_files
 WHERE id NOT IN (

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -121,6 +121,15 @@ type Querier interface {
 	//  DELETE FROM narinfos
 	//  WHERE id = ?
 	DeleteNarInfoByID(ctx context.Context, id int64) (int64, error)
+	//DeleteOrphanedChunks
+	//
+	//  DELETE FROM chunks
+	//  WHERE NOT EXISTS (
+	//      SELECT 1
+	//      FROM nar_file_chunks
+	//      WHERE chunk_id = chunks.id
+	//  )
+	DeleteOrphanedChunks(ctx context.Context) (int64, error)
 	//DeleteOrphanedNarFiles
 	//
 	//  DELETE FROM nar_files

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -408,6 +408,31 @@ func (q *Queries) DeleteNarInfoByID(ctx context.Context, id int64) (int64, error
 	return result.RowsAffected()
 }
 
+const deleteOrphanedChunks = `-- name: DeleteOrphanedChunks :execrows
+DELETE FROM chunks
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM nar_file_chunks
+    WHERE chunk_id = chunks.id
+)
+`
+
+// DeleteOrphanedChunks
+//
+//	DELETE FROM chunks
+//	WHERE NOT EXISTS (
+//	    SELECT 1
+//	    FROM nar_file_chunks
+//	    WHERE chunk_id = chunks.id
+//	)
+func (q *Queries) DeleteOrphanedChunks(ctx context.Context) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteOrphanedChunks)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const deleteOrphanedNarFiles = `-- name: DeleteOrphanedNarFiles :execrows
 DELETE FROM nar_files
 WHERE id NOT IN (


### PR DESCRIPTION
In deleteLRURecordsFromDB, orphaned nar_files and chunks were deleted
with individual per-row DELETE calls inside a transaction (N queries).
Replace these with batch deletes using the existing
DeleteOrphanedNarFiles and a new DeleteOrphanedChunks query, reducing
N+1 queries to 1 per type.

In streamProgressiveChunks, GetNarFileByID was called on every failed
chunk poll iteration even after totalChunks was already known. Add a
guard so the query only runs when totalChunks == 0, eliminating
redundant DB round-trips for every subsequent chunk poll.

Add DeleteOrphanedChunks SQL query to all three engine query files
(sqlite, postgres, mysql) and regenerate the sqlc and wrapper code.