### PR TITLE
chore: remove unused database queries

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -25,12 +25,6 @@ FROM nar_files nf
 INNER JOIN narinfo_nar_files nnf ON nf.id = nnf.nar_file_id
 WHERE nnf.narinfo_id = ?;
 
--- name: GetNarInfoHashesByNarFileID :many
-SELECT ni.hash
-FROM narinfos ni
-INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-WHERE nnf.nar_file_id = ?;
-
 -- name: GetNarInfoURLByNarFileHash :one
 SELECT ni.url
 FROM narinfos ni
@@ -181,10 +175,6 @@ WHERE hash = ? AND compression = ? AND `query` = ?;
 DELETE FROM narinfos
 WHERE id = ?;
 
--- name: DeleteNarFileByID :execrows
-DELETE FROM nar_files
-WHERE id = ?;
-
 -- name: UpdateNarFileFileSize :exec
 UPDATE nar_files
 SET file_size = ?, updated_at = CURRENT_TIMESTAMP
@@ -194,13 +184,6 @@ WHERE id = ?;
 DELETE FROM nar_files
 WHERE id NOT IN (
     SELECT DISTINCT nar_file_id
-    FROM narinfo_nar_files
-);
-
--- name: DeleteOrphanedNarInfos :execrows
-DELETE FROM narinfos
-WHERE id NOT IN (
-    SELECT DISTINCT narinfo_id
     FROM narinfo_nar_files
 );
 
@@ -235,19 +218,6 @@ WHERE (
     )
 ) <= ?;
 
--- name: GetLeastUsedNarFiles :many
--- NOTE: This query uses a correlated subquery which is not optimal for performance.
--- The ideal implementation would use a window function (SUM OVER), but sqlc v1.30.0
--- does not properly support filtering on window function results in subqueries.
-SELECT n1.id, n1.hash, n1.compression, n1.file_size, n1.`query`, n1.created_at, n1.updated_at, n1.last_accessed_at, n1.total_chunks, n1.chunking_started_at
-FROM nar_files n1
-WHERE (
-    SELECT SUM(n2.file_size)
-    FROM nar_files n2
-    WHERE n2.last_accessed_at < n1.last_accessed_at
-        OR (n2.last_accessed_at = n1.last_accessed_at AND n2.id <= n1.id)
-) <= ?;
-
 -- name: GetOrphanedNarFiles :many
 -- Find files that have no relationship to any narinfo
 SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.`query`, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
@@ -266,22 +236,6 @@ WHERE url IS NULL;
 SELECT hash
 FROM narinfos
 WHERE url IS NOT NULL;
-
--- name: IsNarInfoMigrated :one
--- Check if a narinfo hash has been migrated (has a URL).
-SELECT EXISTS(
-    SELECT 1
-    FROM narinfos
-    WHERE hash = ? AND url IS NOT NULL
-) AS is_migrated;
-
--- name: GetMigratedNarInfoHashesPaginated :many
--- Get migrated narinfo hashes with pagination support.
-SELECT hash
-FROM narinfos
-WHERE url IS NOT NULL
-ORDER BY hash
-LIMIT ? OFFSET ?;
 
 -- name: GetChunkByHash :one
 SELECT *
@@ -319,12 +273,6 @@ INSERT IGNORE INTO nar_file_chunks (
 ) VALUES (
     ?, ?, ?
 );
-
-
-
--- name: GetTotalChunkSize :one
-SELECT CAST(COALESCE(SUM(size), 0) AS SIGNED) AS total_size
-FROM chunks;
 
 -- name: GetChunkCount :one
 SELECT CAST(COUNT(*) AS SIGNED) AS count
@@ -368,16 +316,6 @@ UPDATE nar_files
 SET chunking_started_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
 WHERE id = ?;
 
--- name: GetNarInfoHashesToChunk :many
--- Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
-SELECT ni.hash, ni.url
-FROM narinfos ni
-LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
-WHERE ni.url IS NOT NULL
-  AND (nf.id IS NULL OR nf.total_chunks = 0)
-ORDER BY ni.hash;
-
 -- name: GetNarFilesToChunk :many
 -- Get all NAR files that are not yet chunked.
 SELECT id, hash, compression, `query`, file_size
@@ -390,21 +328,6 @@ ORDER BY id;
 SELECT COUNT(*)
 FROM nar_files
 WHERE total_chunks = 0;
-
--- name: GetCompressedNarInfos :many
-SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, `system`, ca
-FROM narinfos
-WHERE compression NOT IN ('', 'none')
-ORDER BY id
-LIMIT ? OFFSET ?;
-
--- name: GetOldCompressedNarFiles :many
-SELECT id, hash, compression, file_size, `query`, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-FROM nar_files
-WHERE compression NOT IN ('', 'none')
-  AND created_at < ?
-ORDER BY id
-LIMIT ? OFFSET ?;
 
 -- name: UpdateNarInfoCompressionAndURL :execrows
 -- Update narinfo compression and URL after CDC migration.

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -14,7 +14,6 @@ FROM narinfos
 WHERE url = ?
 LIMIT 1;
 
-
 -- name: GetNarFileByHashAndCompressionAndQuery :one
 SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
 FROM nar_files
@@ -25,12 +24,6 @@ SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, 
 FROM nar_files nf
 INNER JOIN narinfo_nar_files nnf ON nf.id = nnf.nar_file_id
 WHERE nnf.narinfo_id = ?;
-
--- name: GetNarInfoHashesByNarFileID :many
-SELECT ni.hash
-FROM narinfos ni
-INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-WHERE nnf.nar_file_id = ?;
 
 -- name: GetNarInfoURLByNarFileHash :one
 SELECT ni.url
@@ -204,10 +197,6 @@ WHERE hash = ? AND compression = ? AND "query" = ?;
 DELETE FROM narinfos
 WHERE id = ?;
 
--- name: DeleteNarFileByID :execrows
-DELETE FROM nar_files
-WHERE id = ?;
-
 -- name: UpdateNarFileFileSize :exec
 UPDATE nar_files
 SET file_size = ?, updated_at = CURRENT_TIMESTAMP
@@ -217,13 +206,6 @@ WHERE id = ?;
 DELETE FROM nar_files
 WHERE id NOT IN (
     SELECT DISTINCT nar_file_id
-    FROM narinfo_nar_files
-);
-
--- name: DeleteOrphanedNarInfos :execrows
-DELETE FROM narinfos
-WHERE id NOT IN (
-    SELECT DISTINCT narinfo_id
     FROM narinfo_nar_files
 );
 
@@ -258,19 +240,6 @@ WHERE (
     )
 ) <= ?;
 
--- name: GetLeastUsedNarFiles :many
--- NOTE: This query uses a correlated subquery which is not optimal for performance.
--- The ideal implementation would use a window function (SUM OVER), but sqlc v1.30.0
--- does not properly support filtering on window function results in subqueries.
-SELECT n1.id, n1.hash, n1.compression, n1.file_size, n1."query", n1.created_at, n1.updated_at, n1.last_accessed_at, n1.total_chunks, n1.chunking_started_at
-FROM nar_files n1
-WHERE (
-    SELECT SUM(n2.file_size)
-    FROM nar_files n2
-    WHERE n2.last_accessed_at < n1.last_accessed_at
-        OR (n2.last_accessed_at = n1.last_accessed_at AND n2.id <= n1.id)
-) <= ?;
-
 -- name: GetOrphanedNarFiles :many
 -- Find files that have no relationship to any narinfo
 SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
@@ -289,22 +258,6 @@ WHERE url IS NULL;
 SELECT hash
 FROM narinfos
 WHERE url IS NOT NULL;
-
--- name: IsNarInfoMigrated :one
--- Check if a narinfo hash has been migrated (has a URL).
-SELECT EXISTS(
-    SELECT 1
-    FROM narinfos
-    WHERE hash = ? AND url IS NOT NULL
-) AS is_migrated;
-
--- name: GetMigratedNarInfoHashesPaginated :many
--- Get migrated narinfo hashes with pagination support.
-SELECT hash
-FROM narinfos
-WHERE url IS NOT NULL
-ORDER BY hash
-LIMIT ? OFFSET ?;
 
 -- name: GetChunkByHash :one
 SELECT *
@@ -345,12 +298,6 @@ INSERT INTO nar_file_chunks (
 )
 ON CONFLICT (nar_file_id, chunk_index) DO NOTHING;
 
-
-
--- name: GetTotalChunkSize :one
-SELECT CAST(COALESCE(SUM(size), 0) AS INTEGER) AS total_size
-FROM chunks;
-
 -- name: GetChunkCount :one
 SELECT CAST(COUNT(*) AS INTEGER) AS count
 FROM chunks;
@@ -388,16 +335,6 @@ UPDATE nar_files
 SET total_chunks = ?, file_size = ?, updated_at = CURRENT_TIMESTAMP, chunking_started_at = NULL
 WHERE id = ?;
 
--- name: GetNarInfoHashesToChunk :many
--- Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
-SELECT ni.hash, ni.url
-FROM narinfos ni
-LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
-WHERE ni.url IS NOT NULL
-  AND (nf.id IS NULL OR nf.total_chunks = 0)
-ORDER BY ni.hash;
-
 -- name: GetNarFilesToChunk :many
 -- Get all NAR files that are not yet chunked.
 SELECT id, hash, compression, "query", file_size
@@ -410,21 +347,6 @@ ORDER BY id;
 SELECT COUNT(*)
 FROM nar_files
 WHERE total_chunks = 0;
-
--- name: GetCompressedNarInfos :many
-SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-FROM narinfos
-WHERE compression NOT IN ('', 'none')
-ORDER BY id
-LIMIT ? OFFSET ?;
-
--- name: GetOldCompressedNarFiles :many
-SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-FROM nar_files
-WHERE compression NOT IN ('', 'none')
-  AND created_at < ?
-ORDER BY id
-LIMIT ? OFFSET ?;
 
 -- name: UpdateNarInfoCompressionAndURL :execrows
 -- Update narinfo compression and URL after CDC migration.

--- a/pkg/database/generated_models.go
+++ b/pkg/database/generated_models.go
@@ -95,16 +95,6 @@ type GetChunkByNarFileIDAndIndexRow struct {
 	UpdatedAt sql.NullTime
 }
 
-type GetCompressedNarInfosParams struct {
-	Limit  int32
-	Offset int32
-}
-
-type GetMigratedNarInfoHashesPaginatedParams struct {
-	Limit  int32
-	Offset int32
-}
-
 type GetNarFileByHashAndCompressionAndQueryParams struct {
 	Hash        string
 	Compression string
@@ -119,21 +109,10 @@ type GetNarFilesToChunkRow struct {
 	FileSize    uint64
 }
 
-type GetNarInfoHashesToChunkRow struct {
-	Hash string
-	URL  sql.NullString
-}
-
 type GetNarInfoURLByNarFileHashParams struct {
 	Hash        string
 	Compression string
 	Query       string
-}
-
-type GetOldCompressedNarFilesParams struct {
-	CreatedAt time.Time
-	Limit     int32
-	Offset    int32
 }
 
 type GetOrphanedChunksRow struct {

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -112,11 +112,6 @@ type Querier interface {
 	//  DELETE FROM nar_files
 	//  WHERE hash = $1 AND compression = $2 AND query = $3
 	DeleteNarFileByHash(ctx context.Context, arg DeleteNarFileByHashParams) (int64, error)
-	//DeleteNarFileByID
-	//
-	//  DELETE FROM nar_files
-	//  WHERE id = $1
-	DeleteNarFileByID(ctx context.Context, id int64) (int64, error)
 	//DeleteNarFileChunksByNarFileID
 	//
 	//  DELETE FROM nar_file_chunks
@@ -149,14 +144,6 @@ type Querier interface {
 	//      FROM narinfo_nar_files
 	//  )
 	DeleteOrphanedNarFiles(ctx context.Context) (int64, error)
-	//DeleteOrphanedNarInfos
-	//
-	//  DELETE FROM narinfos
-	//  WHERE id NOT IN (
-	//      SELECT DISTINCT narinfo_id
-	//      FROM narinfo_nar_files
-	//  )
-	DeleteOrphanedNarInfos(ctx context.Context) (int64, error)
 	//GetChunkByHash
 	//
 	//  SELECT id, hash, size, compressed_size, created_at, updated_at
@@ -185,14 +172,6 @@ type Querier interface {
 	//  WHERE nfc.nar_file_id = $1
 	//  ORDER BY nfc.chunk_index
 	GetChunksByNarFileID(ctx context.Context, narFileID int64) ([]Chunk, error)
-	//GetCompressedNarInfos
-	//
-	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-	//  FROM narinfos
-	//  WHERE compression NOT IN ('', 'none')
-	//  ORDER BY id
-	//  LIMIT $1 OFFSET $2
-	GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error)
 	// GetConfigByID (Synthetic)
 	GetConfigByID(ctx context.Context, id int64) (Config, error)
 	//GetConfigByKey
@@ -201,19 +180,6 @@ type Querier interface {
 	//  FROM config
 	//  WHERE key = $1
 	GetConfigByKey(ctx context.Context, key string) (Config, error)
-	// NOTE: This query uses a correlated subquery which is not optimal for performance.
-	// The ideal implementation would use a window function (SUM OVER), but sqlc v1.30.0
-	// does not properly support filtering on window function results in subqueries.
-	//
-	//  SELECT n1.id, n1.hash, n1.compression, n1.file_size, n1.query, n1.created_at, n1.updated_at, n1.last_accessed_at, n1.total_chunks, n1.chunking_started_at
-	//  FROM nar_files n1
-	//  WHERE (
-	//      SELECT SUM(n2.file_size)
-	//      FROM nar_files n2
-	//      WHERE n2.last_accessed_at < n1.last_accessed_at
-	//         OR (n2.last_accessed_at = n1.last_accessed_at AND n2.id <= n1.id)
-	//  ) <= $1
-	GetLeastUsedNarFiles(ctx context.Context, fileSize uint64) ([]NarFile, error)
 	// NOTE: This query uses a correlated subquery which is not optimal for performance.
 	// The ideal implementation would use a window function (SUM OVER), but sqlc v1.30.0
 	// does not properly support filtering on window function results in subqueries.
@@ -239,14 +205,6 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url IS NOT NULL
 	GetMigratedNarInfoHashes(ctx context.Context) ([]string, error)
-	// Get migrated narinfo hashes with pagination support.
-	//
-	//  SELECT hash
-	//  FROM narinfos
-	//  WHERE url IS NOT NULL
-	//  ORDER BY hash
-	//  LIMIT $1 OFFSET $2
-	GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error)
 	//GetNarFileByHashAndCompressionAndQuery
 	//
 	//  SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
@@ -300,29 +258,12 @@ type Querier interface {
 	//  WHERE url = $1
 	//  LIMIT 1
 	GetNarInfoHashByNarURL(ctx context.Context, url sql.NullString) (string, error)
-	//GetNarInfoHashesByNarFileID
-	//
-	//  SELECT ni.hash
-	//  FROM narinfos ni
-	//  INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-	//  WHERE nnf.nar_file_id = $1
-	GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error)
 	//GetNarInfoHashesByURL
 	//
 	//  SELECT hash
 	//  FROM narinfos
 	//  WHERE url = $1
 	GetNarInfoHashesByURL(ctx context.Context, url sql.NullString) ([]string, error)
-	// Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
-	//
-	//  SELECT ni.hash, ni.url
-	//  FROM narinfos ni
-	//  LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-	//  LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
-	//  WHERE ni.url IS NOT NULL
-	//    AND (nf.id IS NULL OR nf.total_chunks = 0)
-	//  ORDER BY ni.hash
-	GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error)
 	//GetNarInfoReferences
 	//
 	//  SELECT reference
@@ -349,15 +290,6 @@ type Querier interface {
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS BIGINT) AS total_size
 	//  FROM nar_files
 	GetNarTotalSize(ctx context.Context) (int64, error)
-	//GetOldCompressedNarFiles
-	//
-	//  SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-	//  FROM nar_files
-	//  WHERE compression NOT IN ('', 'none')
-	//    AND created_at < $1
-	//  ORDER BY id
-	//  LIMIT $2 OFFSET $3
-	GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]NarFile, error)
 	//GetOrphanedChunks
 	//
 	//  SELECT c.id, c.hash, c.size, c.created_at, c.updated_at
@@ -372,25 +304,12 @@ type Querier interface {
 	//  LEFT JOIN narinfo_nar_files ninf ON nf.id = ninf.nar_file_id
 	//  WHERE ninf.narinfo_id IS NULL
 	GetOrphanedNarFiles(ctx context.Context) ([]NarFile, error)
-	//GetTotalChunkSize
-	//
-	//  SELECT CAST(COALESCE(SUM(size), 0) AS BIGINT) AS total_size
-	//  FROM chunks
-	GetTotalChunkSize(ctx context.Context) (int64, error)
 	// Get all narinfo hashes that have no URL (unmigrated).
 	//
 	//  SELECT hash
 	//  FROM narinfos
 	//  WHERE url IS NULL
 	GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error)
-	// Check if a narinfo hash has been migrated (has a URL).
-	//
-	//  SELECT EXISTS(
-	//      SELECT 1
-	//      FROM narinfos
-	//      WHERE hash = $1 AND url IS NOT NULL
-	//  ) AS is_migrated
-	IsNarInfoMigrated(ctx context.Context, hash string) (bool, error)
 	//LinkNarFileToChunk
 	//
 	//  INSERT INTO nar_file_chunks (

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -236,19 +236,6 @@ func (w *mysqlWrapper) DeleteNarFileByHash(ctx context.Context, arg DeleteNarFil
 	return res, nil
 }
 
-func (w *mysqlWrapper) DeleteNarFileByID(ctx context.Context, id int64) (int64, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.DeleteNarFileByID(ctx, id)
-	if err != nil {
-		return 0, err
-	}
-
-	// Return Primitive / *sql.DB / etc
-
-	return res, nil
-}
-
 func (w *mysqlWrapper) DeleteNarFileChunksByNarFileID(ctx context.Context, narFileID int64) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -298,19 +285,6 @@ func (w *mysqlWrapper) DeleteOrphanedNarFiles(ctx context.Context) (int64, error
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
 	res, err := w.adapter.DeleteOrphanedNarFiles(ctx)
-	if err != nil {
-		return 0, err
-	}
-
-	// Return Primitive / *sql.DB / etc
-
-	return res, nil
-}
-
-func (w *mysqlWrapper) DeleteOrphanedNarInfos(ctx context.Context) (int64, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.DeleteOrphanedNarInfos(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -466,55 +440,6 @@ func (w *mysqlWrapper) GetChunksByNarFileID(ctx context.Context, narFileID int64
 	return items, nil
 }
 
-func (w *mysqlWrapper) GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetCompressedNarInfos(ctx, mysqldb.GetCompressedNarInfosParams{
-		Limit:  arg.Limit,
-		Offset: arg.Offset,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert Slice of Domain Structs
-	items := make([]NarInfo, len(res))
-	for i, v := range res {
-		items[i] = NarInfo{
-			ID: v.ID,
-
-			Hash: v.Hash,
-
-			CreatedAt: v.CreatedAt,
-
-			UpdatedAt: v.UpdatedAt,
-
-			LastAccessedAt: v.LastAccessedAt,
-
-			StorePath: v.StorePath,
-
-			URL: v.URL,
-
-			Compression: v.Compression,
-
-			FileHash: v.FileHash,
-
-			FileSize: v.FileSize,
-
-			NarHash: v.NarHash,
-
-			NarSize: v.NarSize,
-
-			Deriver: v.Deriver,
-
-			System: v.System,
-
-			Ca: v.Ca,
-		}
-	}
-	return items, nil
-}
-
 func (w *mysqlWrapper) GetConfigByID(ctx context.Context, id int64) (Config, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -583,42 +508,6 @@ func (w *mysqlWrapper) GetConfigByKey(ctx context.Context, key string) (Config, 
 	}, nil
 }
 
-func (w *mysqlWrapper) GetLeastUsedNarFiles(ctx context.Context, fileSize uint64) ([]NarFile, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetLeastUsedNarFiles(ctx, fileSize)
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert Slice of Domain Structs
-	items := make([]NarFile, len(res))
-	for i, v := range res {
-		items[i] = NarFile{
-			ID: v.ID,
-
-			Hash: v.Hash,
-
-			Compression: v.Compression,
-
-			FileSize: v.FileSize,
-
-			Query: v.Query,
-
-			CreatedAt: v.CreatedAt,
-
-			UpdatedAt: v.UpdatedAt,
-
-			LastAccessedAt: v.LastAccessedAt,
-
-			TotalChunks: v.TotalChunks,
-
-			ChunkingStartedAt: v.ChunkingStartedAt,
-		}
-	}
-	return items, nil
-}
-
 func (w *mysqlWrapper) GetLeastUsedNarInfos(ctx context.Context, fileSize uint64) ([]NarInfo, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -669,21 +558,6 @@ func (w *mysqlWrapper) GetMigratedNarInfoHashes(ctx context.Context) ([]string, 
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
 	res, err := w.adapter.GetMigratedNarInfoHashes(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Return Slice of Primitives (direct match)
-	return res, nil
-}
-
-func (w *mysqlWrapper) GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetMigratedNarInfoHashesPaginated(ctx, mysqldb.GetMigratedNarInfoHashesPaginatedParams{
-		Limit:  arg.Limit,
-		Offset: arg.Offset,
-	})
 	if err != nil {
 		return nil, err
 	}
@@ -1038,18 +912,6 @@ func (w *mysqlWrapper) GetNarInfoHashByNarURL(ctx context.Context, url sql.NullS
 	return res, nil
 }
 
-func (w *mysqlWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetNarInfoHashesByNarFileID(ctx, narFileID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Return Slice of Primitives (direct match)
-	return res, nil
-}
-
 func (w *mysqlWrapper) GetNarInfoHashesByURL(ctx context.Context, url sql.NullString) ([]string, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -1060,26 +922,6 @@ func (w *mysqlWrapper) GetNarInfoHashesByURL(ctx context.Context, url sql.NullSt
 
 	// Return Slice of Primitives (direct match)
 	return res, nil
-}
-
-func (w *mysqlWrapper) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetNarInfoHashesToChunk(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert Slice of Domain Structs
-	items := make([]GetNarInfoHashesToChunkRow, len(res))
-	for i, v := range res {
-		items[i] = GetNarInfoHashesToChunkRow{
-			Hash: v.Hash,
-
-			URL: v.URL,
-		}
-	}
-	return items, nil
 }
 
 func (w *mysqlWrapper) GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error) {
@@ -1134,46 +976,6 @@ func (w *mysqlWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {
 	// Return Primitive / *sql.DB / etc
 
 	return res, nil
-}
-
-func (w *mysqlWrapper) GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]NarFile, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetOldCompressedNarFiles(ctx, mysqldb.GetOldCompressedNarFilesParams{
-		CreatedAt: arg.CreatedAt,
-		Limit:     arg.Limit,
-		Offset:    arg.Offset,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert Slice of Domain Structs
-	items := make([]NarFile, len(res))
-	for i, v := range res {
-		items[i] = NarFile{
-			ID: v.ID,
-
-			Hash: v.Hash,
-
-			Compression: v.Compression,
-
-			FileSize: v.FileSize,
-
-			Query: v.Query,
-
-			CreatedAt: v.CreatedAt,
-
-			UpdatedAt: v.UpdatedAt,
-
-			LastAccessedAt: v.LastAccessedAt,
-
-			TotalChunks: v.TotalChunks,
-
-			ChunkingStartedAt: v.ChunkingStartedAt,
-		}
-	}
-	return items, nil
 }
 
 func (w *mysqlWrapper) GetOrphanedChunks(ctx context.Context) ([]GetOrphanedChunksRow, error) {
@@ -1238,19 +1040,6 @@ func (w *mysqlWrapper) GetOrphanedNarFiles(ctx context.Context) ([]NarFile, erro
 	return items, nil
 }
 
-func (w *mysqlWrapper) GetTotalChunkSize(ctx context.Context) (int64, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetTotalChunkSize(ctx)
-	if err != nil {
-		return 0, err
-	}
-
-	// Return Primitive / *sql.DB / etc
-
-	return res, nil
-}
-
 func (w *mysqlWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -1260,19 +1049,6 @@ func (w *mysqlWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string
 	}
 
 	// Return Slice of Primitives (direct match)
-	return res, nil
-}
-
-func (w *mysqlWrapper) IsNarInfoMigrated(ctx context.Context, hash string) (bool, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.IsNarInfoMigrated(ctx, hash)
-	if err != nil {
-		return false, err
-	}
-
-	// Return Primitive / *sql.DB / etc
-
 	return res, nil
 }
 

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -242,19 +242,6 @@ func (w *postgresWrapper) DeleteNarFileByHash(ctx context.Context, arg DeleteNar
 	return res, nil
 }
 
-func (w *postgresWrapper) DeleteNarFileByID(ctx context.Context, id int64) (int64, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.DeleteNarFileByID(ctx, id)
-	if err != nil {
-		return 0, err
-	}
-
-	// Return Primitive / *sql.DB / etc
-
-	return res, nil
-}
-
 func (w *postgresWrapper) DeleteNarFileChunksByNarFileID(ctx context.Context, narFileID int64) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -304,19 +291,6 @@ func (w *postgresWrapper) DeleteOrphanedNarFiles(ctx context.Context) (int64, er
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
 	res, err := w.adapter.DeleteOrphanedNarFiles(ctx)
-	if err != nil {
-		return 0, err
-	}
-
-	// Return Primitive / *sql.DB / etc
-
-	return res, nil
-}
-
-func (w *postgresWrapper) DeleteOrphanedNarInfos(ctx context.Context) (int64, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.DeleteOrphanedNarInfos(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -472,55 +446,6 @@ func (w *postgresWrapper) GetChunksByNarFileID(ctx context.Context, narFileID in
 	return items, nil
 }
 
-func (w *postgresWrapper) GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetCompressedNarInfos(ctx, postgresdb.GetCompressedNarInfosParams{
-		Limit:  arg.Limit,
-		Offset: arg.Offset,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert Slice of Domain Structs
-	items := make([]NarInfo, len(res))
-	for i, v := range res {
-		items[i] = NarInfo{
-			ID: v.ID,
-
-			Hash: v.Hash,
-
-			CreatedAt: v.CreatedAt,
-
-			UpdatedAt: v.UpdatedAt,
-
-			LastAccessedAt: v.LastAccessedAt,
-
-			StorePath: v.StorePath,
-
-			URL: v.URL,
-
-			Compression: v.Compression,
-
-			FileHash: v.FileHash,
-
-			FileSize: v.FileSize,
-
-			NarHash: v.NarHash,
-
-			NarSize: v.NarSize,
-
-			Deriver: v.Deriver,
-
-			System: v.System,
-
-			Ca: v.Ca,
-		}
-	}
-	return items, nil
-}
-
 func (w *postgresWrapper) GetConfigByID(ctx context.Context, id int64) (Config, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -589,42 +514,6 @@ func (w *postgresWrapper) GetConfigByKey(ctx context.Context, key string) (Confi
 	}, nil
 }
 
-func (w *postgresWrapper) GetLeastUsedNarFiles(ctx context.Context, fileSize uint64) ([]NarFile, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetLeastUsedNarFiles(ctx, fileSize)
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert Slice of Domain Structs
-	items := make([]NarFile, len(res))
-	for i, v := range res {
-		items[i] = NarFile{
-			ID: v.ID,
-
-			Hash: v.Hash,
-
-			Compression: v.Compression,
-
-			FileSize: v.FileSize,
-
-			Query: v.Query,
-
-			CreatedAt: v.CreatedAt,
-
-			UpdatedAt: v.UpdatedAt,
-
-			LastAccessedAt: v.LastAccessedAt,
-
-			TotalChunks: v.TotalChunks,
-
-			ChunkingStartedAt: v.ChunkingStartedAt,
-		}
-	}
-	return items, nil
-}
-
 func (w *postgresWrapper) GetLeastUsedNarInfos(ctx context.Context, fileSize uint64) ([]NarInfo, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -675,21 +564,6 @@ func (w *postgresWrapper) GetMigratedNarInfoHashes(ctx context.Context) ([]strin
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
 	res, err := w.adapter.GetMigratedNarInfoHashes(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Return Slice of Primitives (direct match)
-	return res, nil
-}
-
-func (w *postgresWrapper) GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetMigratedNarInfoHashesPaginated(ctx, postgresdb.GetMigratedNarInfoHashesPaginatedParams{
-		Limit:  arg.Limit,
-		Offset: arg.Offset,
-	})
 	if err != nil {
 		return nil, err
 	}
@@ -1044,18 +918,6 @@ func (w *postgresWrapper) GetNarInfoHashByNarURL(ctx context.Context, url sql.Nu
 	return res, nil
 }
 
-func (w *postgresWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetNarInfoHashesByNarFileID(ctx, narFileID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Return Slice of Primitives (direct match)
-	return res, nil
-}
-
 func (w *postgresWrapper) GetNarInfoHashesByURL(ctx context.Context, url sql.NullString) ([]string, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -1066,26 +928,6 @@ func (w *postgresWrapper) GetNarInfoHashesByURL(ctx context.Context, url sql.Nul
 
 	// Return Slice of Primitives (direct match)
 	return res, nil
-}
-
-func (w *postgresWrapper) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetNarInfoHashesToChunk(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert Slice of Domain Structs
-	items := make([]GetNarInfoHashesToChunkRow, len(res))
-	for i, v := range res {
-		items[i] = GetNarInfoHashesToChunkRow{
-			Hash: v.Hash,
-
-			URL: v.URL,
-		}
-	}
-	return items, nil
 }
 
 func (w *postgresWrapper) GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error) {
@@ -1140,46 +982,6 @@ func (w *postgresWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {
 	// Return Primitive / *sql.DB / etc
 
 	return res, nil
-}
-
-func (w *postgresWrapper) GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]NarFile, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetOldCompressedNarFiles(ctx, postgresdb.GetOldCompressedNarFilesParams{
-		CreatedAt: arg.CreatedAt,
-		Limit:     arg.Limit,
-		Offset:    arg.Offset,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert Slice of Domain Structs
-	items := make([]NarFile, len(res))
-	for i, v := range res {
-		items[i] = NarFile{
-			ID: v.ID,
-
-			Hash: v.Hash,
-
-			Compression: v.Compression,
-
-			FileSize: v.FileSize,
-
-			Query: v.Query,
-
-			CreatedAt: v.CreatedAt,
-
-			UpdatedAt: v.UpdatedAt,
-
-			LastAccessedAt: v.LastAccessedAt,
-
-			TotalChunks: v.TotalChunks,
-
-			ChunkingStartedAt: v.ChunkingStartedAt,
-		}
-	}
-	return items, nil
 }
 
 func (w *postgresWrapper) GetOrphanedChunks(ctx context.Context) ([]GetOrphanedChunksRow, error) {
@@ -1244,19 +1046,6 @@ func (w *postgresWrapper) GetOrphanedNarFiles(ctx context.Context) ([]NarFile, e
 	return items, nil
 }
 
-func (w *postgresWrapper) GetTotalChunkSize(ctx context.Context) (int64, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetTotalChunkSize(ctx)
-	if err != nil {
-		return 0, err
-	}
-
-	// Return Primitive / *sql.DB / etc
-
-	return res, nil
-}
-
 func (w *postgresWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -1266,19 +1055,6 @@ func (w *postgresWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]str
 	}
 
 	// Return Slice of Primitives (direct match)
-	return res, nil
-}
-
-func (w *postgresWrapper) IsNarInfoMigrated(ctx context.Context, hash string) (bool, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.IsNarInfoMigrated(ctx, hash)
-	if err != nil {
-		return false, err
-	}
-
-	// Return Primitive / *sql.DB / etc
-
 	return res, nil
 }
 

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -260,19 +260,6 @@ func (w *sqliteWrapper) DeleteNarFileByHash(ctx context.Context, arg DeleteNarFi
 	return res, nil
 }
 
-func (w *sqliteWrapper) DeleteNarFileByID(ctx context.Context, id int64) (int64, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.DeleteNarFileByID(ctx, id)
-	if err != nil {
-		return 0, err
-	}
-
-	// Return Primitive / *sql.DB / etc
-
-	return res, nil
-}
-
 func (w *sqliteWrapper) DeleteNarFileChunksByNarFileID(ctx context.Context, narFileID int64) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -322,19 +309,6 @@ func (w *sqliteWrapper) DeleteOrphanedNarFiles(ctx context.Context) (int64, erro
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
 	res, err := w.adapter.DeleteOrphanedNarFiles(ctx)
-	if err != nil {
-		return 0, err
-	}
-
-	// Return Primitive / *sql.DB / etc
-
-	return res, nil
-}
-
-func (w *sqliteWrapper) DeleteOrphanedNarInfos(ctx context.Context) (int64, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.DeleteOrphanedNarInfos(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -490,55 +464,6 @@ func (w *sqliteWrapper) GetChunksByNarFileID(ctx context.Context, narFileID int6
 	return items, nil
 }
 
-func (w *sqliteWrapper) GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetCompressedNarInfos(ctx, sqlitedb.GetCompressedNarInfosParams{
-		Limit:  int64(arg.Limit),
-		Offset: int64(arg.Offset),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert Slice of Domain Structs
-	items := make([]NarInfo, len(res))
-	for i, v := range res {
-		items[i] = NarInfo{
-			ID: v.ID,
-
-			Hash: v.Hash,
-
-			CreatedAt: v.CreatedAt,
-
-			UpdatedAt: v.UpdatedAt,
-
-			LastAccessedAt: v.LastAccessedAt,
-
-			StorePath: v.StorePath,
-
-			URL: v.URL,
-
-			Compression: v.Compression,
-
-			FileHash: v.FileHash,
-
-			FileSize: v.FileSize,
-
-			NarHash: v.NarHash,
-
-			NarSize: v.NarSize,
-
-			Deriver: v.Deriver,
-
-			System: v.System,
-
-			Ca: v.Ca,
-		}
-	}
-	return items, nil
-}
-
 func (w *sqliteWrapper) GetConfigByID(ctx context.Context, id int64) (Config, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -607,42 +532,6 @@ func (w *sqliteWrapper) GetConfigByKey(ctx context.Context, key string) (Config,
 	}, nil
 }
 
-func (w *sqliteWrapper) GetLeastUsedNarFiles(ctx context.Context, fileSize uint64) ([]NarFile, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetLeastUsedNarFiles(ctx, fileSize)
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert Slice of Domain Structs
-	items := make([]NarFile, len(res))
-	for i, v := range res {
-		items[i] = NarFile{
-			ID: v.ID,
-
-			Hash: v.Hash,
-
-			Compression: v.Compression,
-
-			FileSize: v.FileSize,
-
-			Query: v.Query,
-
-			CreatedAt: v.CreatedAt,
-
-			UpdatedAt: v.UpdatedAt,
-
-			LastAccessedAt: v.LastAccessedAt,
-
-			TotalChunks: v.TotalChunks,
-
-			ChunkingStartedAt: v.ChunkingStartedAt,
-		}
-	}
-	return items, nil
-}
-
 func (w *sqliteWrapper) GetLeastUsedNarInfos(ctx context.Context, fileSize uint64) ([]NarInfo, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -693,21 +582,6 @@ func (w *sqliteWrapper) GetMigratedNarInfoHashes(ctx context.Context) ([]string,
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
 	res, err := w.adapter.GetMigratedNarInfoHashes(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Return Slice of Primitives (direct match)
-	return res, nil
-}
-
-func (w *sqliteWrapper) GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetMigratedNarInfoHashesPaginated(ctx, sqlitedb.GetMigratedNarInfoHashesPaginatedParams{
-		Limit:  int64(arg.Limit),
-		Offset: int64(arg.Offset),
-	})
 	if err != nil {
 		return nil, err
 	}
@@ -1062,18 +936,6 @@ func (w *sqliteWrapper) GetNarInfoHashByNarURL(ctx context.Context, url sql.Null
 	return res, nil
 }
 
-func (w *sqliteWrapper) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetNarInfoHashesByNarFileID(ctx, narFileID)
-	if err != nil {
-		return nil, err
-	}
-
-	// Return Slice of Primitives (direct match)
-	return res, nil
-}
-
 func (w *sqliteWrapper) GetNarInfoHashesByURL(ctx context.Context, url sql.NullString) ([]string, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -1084,26 +946,6 @@ func (w *sqliteWrapper) GetNarInfoHashesByURL(ctx context.Context, url sql.NullS
 
 	// Return Slice of Primitives (direct match)
 	return res, nil
-}
-
-func (w *sqliteWrapper) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetNarInfoHashesToChunk(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert Slice of Domain Structs
-	items := make([]GetNarInfoHashesToChunkRow, len(res))
-	for i, v := range res {
-		items[i] = GetNarInfoHashesToChunkRow{
-			Hash: v.Hash,
-
-			URL: v.URL,
-		}
-	}
-	return items, nil
 }
 
 func (w *sqliteWrapper) GetNarInfoReferences(ctx context.Context, narinfoID int64) ([]string, error) {
@@ -1158,46 +1000,6 @@ func (w *sqliteWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {
 	// Return Primitive / *sql.DB / etc
 
 	return res, nil
-}
-
-func (w *sqliteWrapper) GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]NarFile, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetOldCompressedNarFiles(ctx, sqlitedb.GetOldCompressedNarFilesParams{
-		CreatedAt: arg.CreatedAt,
-		Limit:     int64(arg.Limit),
-		Offset:    int64(arg.Offset),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert Slice of Domain Structs
-	items := make([]NarFile, len(res))
-	for i, v := range res {
-		items[i] = NarFile{
-			ID: v.ID,
-
-			Hash: v.Hash,
-
-			Compression: v.Compression,
-
-			FileSize: v.FileSize,
-
-			Query: v.Query,
-
-			CreatedAt: v.CreatedAt,
-
-			UpdatedAt: v.UpdatedAt,
-
-			LastAccessedAt: v.LastAccessedAt,
-
-			TotalChunks: v.TotalChunks,
-
-			ChunkingStartedAt: v.ChunkingStartedAt,
-		}
-	}
-	return items, nil
 }
 
 func (w *sqliteWrapper) GetOrphanedChunks(ctx context.Context) ([]GetOrphanedChunksRow, error) {
@@ -1262,19 +1064,6 @@ func (w *sqliteWrapper) GetOrphanedNarFiles(ctx context.Context) ([]NarFile, err
 	return items, nil
 }
 
-func (w *sqliteWrapper) GetTotalChunkSize(ctx context.Context) (int64, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.GetTotalChunkSize(ctx)
-	if err != nil {
-		return 0, err
-	}
-
-	// Return Primitive / *sql.DB / etc
-
-	return res, nil
-}
-
 func (w *sqliteWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -1285,19 +1074,6 @@ func (w *sqliteWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]strin
 
 	// Return Slice of Primitives (direct match)
 	return res, nil
-}
-
-func (w *sqliteWrapper) IsNarInfoMigrated(ctx context.Context, hash string) (bool, error) {
-	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
-
-	res, err := w.adapter.IsNarInfoMigrated(ctx, hash)
-	if err != nil {
-		return false, err
-	}
-
-	// Return Primitive / *sql.DB / etc
-
-	return res != 0, nil
 }
 
 func (w *sqliteWrapper) LinkNarFileToChunk(ctx context.Context, arg LinkNarFileToChunkParams) error {

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -87,11 +87,6 @@ type Querier interface {
 	//  DELETE FROM nar_files
 	//  WHERE hash = ? AND compression = ? AND `query` = ?
 	DeleteNarFileByHash(ctx context.Context, arg DeleteNarFileByHashParams) (int64, error)
-	//DeleteNarFileByID
-	//
-	//  DELETE FROM nar_files
-	//  WHERE id = ?
-	DeleteNarFileByID(ctx context.Context, id int64) (int64, error)
 	//DeleteNarFileChunksByNarFileID
 	//
 	//  DELETE FROM nar_file_chunks
@@ -124,14 +119,6 @@ type Querier interface {
 	//      FROM narinfo_nar_files
 	//  )
 	DeleteOrphanedNarFiles(ctx context.Context) (int64, error)
-	//DeleteOrphanedNarInfos
-	//
-	//  DELETE FROM narinfos
-	//  WHERE id NOT IN (
-	//      SELECT DISTINCT narinfo_id
-	//      FROM narinfo_nar_files
-	//  )
-	DeleteOrphanedNarInfos(ctx context.Context) (int64, error)
 	//GetChunkByHash
 	//
 	//  SELECT id, hash, size, compressed_size, created_at, updated_at
@@ -158,33 +145,12 @@ type Querier interface {
 	//  WHERE nfc.nar_file_id = ?
 	//  ORDER BY nfc.chunk_index
 	GetChunksByNarFileID(ctx context.Context, narFileID int64) ([]Chunk, error)
-	//GetCompressedNarInfos
-	//
-	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, `system`, ca
-	//  FROM narinfos
-	//  WHERE compression NOT IN ('', 'none')
-	//  ORDER BY id
-	//  LIMIT ? OFFSET ?
-	GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error)
 	//GetConfigByKey
 	//
 	//  SELECT id, `key`, value, created_at, updated_at
 	//  FROM config
 	//  WHERE `key` = ?
 	GetConfigByKey(ctx context.Context, key string) (Config, error)
-	// NOTE: This query uses a correlated subquery which is not optimal for performance.
-	// The ideal implementation would use a window function (SUM OVER), but sqlc v1.30.0
-	// does not properly support filtering on window function results in subqueries.
-	//
-	//  SELECT n1.id, n1.hash, n1.compression, n1.file_size, n1.`query`, n1.created_at, n1.updated_at, n1.last_accessed_at, n1.total_chunks, n1.chunking_started_at
-	//  FROM nar_files n1
-	//  WHERE (
-	//      SELECT SUM(n2.file_size)
-	//      FROM nar_files n2
-	//      WHERE n2.last_accessed_at < n1.last_accessed_at
-	//          OR (n2.last_accessed_at = n1.last_accessed_at AND n2.id <= n1.id)
-	//  ) <= ?
-	GetLeastUsedNarFiles(ctx context.Context, fileSize uint64) ([]GetLeastUsedNarFilesRow, error)
 	// NOTE: This query uses a correlated subquery which is not optimal for performance.
 	// The ideal implementation would use a window function (SUM OVER), but sqlc v1.30.0
 	// does not properly support filtering on window function results in subqueries.
@@ -210,14 +176,6 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url IS NOT NULL
 	GetMigratedNarInfoHashes(ctx context.Context) ([]string, error)
-	// Get migrated narinfo hashes with pagination support.
-	//
-	//  SELECT hash
-	//  FROM narinfos
-	//  WHERE url IS NOT NULL
-	//  ORDER BY hash
-	//  LIMIT ? OFFSET ?
-	GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error)
 	//GetNarFileByHashAndCompressionAndQuery
 	//
 	//  SELECT id, hash, compression, file_size, `query`, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
@@ -267,29 +225,12 @@ type Querier interface {
 	//  WHERE url = ?
 	//  LIMIT 1
 	GetNarInfoHashByNarURL(ctx context.Context, url sql.NullString) (string, error)
-	//GetNarInfoHashesByNarFileID
-	//
-	//  SELECT ni.hash
-	//  FROM narinfos ni
-	//  INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-	//  WHERE nnf.nar_file_id = ?
-	GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error)
 	//GetNarInfoHashesByURL
 	//
 	//  SELECT hash
 	//  FROM narinfos
 	//  WHERE url = ?
 	GetNarInfoHashesByURL(ctx context.Context, url sql.NullString) ([]string, error)
-	// Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
-	//
-	//  SELECT ni.hash, ni.url
-	//  FROM narinfos ni
-	//  LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-	//  LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
-	//  WHERE ni.url IS NOT NULL
-	//    AND (nf.id IS NULL OR nf.total_chunks = 0)
-	//  ORDER BY ni.hash
-	GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error)
 	//GetNarInfoReferences
 	//
 	//  SELECT reference
@@ -316,15 +257,6 @@ type Querier interface {
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS SIGNED) AS total_size
 	//  FROM nar_files
 	GetNarTotalSize(ctx context.Context) (int64, error)
-	//GetOldCompressedNarFiles
-	//
-	//  SELECT id, hash, compression, file_size, `query`, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-	//  FROM nar_files
-	//  WHERE compression NOT IN ('', 'none')
-	//    AND created_at < ?
-	//  ORDER BY id
-	//  LIMIT ? OFFSET ?
-	GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]GetOldCompressedNarFilesRow, error)
 	//GetOrphanedChunks
 	//
 	//  SELECT c.id, c.hash, c.size, c.created_at, c.updated_at
@@ -339,25 +271,12 @@ type Querier interface {
 	//  LEFT JOIN narinfo_nar_files ninf ON nf.id = ninf.nar_file_id
 	//  WHERE ninf.narinfo_id IS NULL
 	GetOrphanedNarFiles(ctx context.Context) ([]GetOrphanedNarFilesRow, error)
-	//GetTotalChunkSize
-	//
-	//  SELECT CAST(COALESCE(SUM(size), 0) AS SIGNED) AS total_size
-	//  FROM chunks
-	GetTotalChunkSize(ctx context.Context) (int64, error)
 	// Get all narinfo hashes that have no URL (unmigrated).
 	//
 	//  SELECT hash
 	//  FROM narinfos
 	//  WHERE url IS NULL
 	GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error)
-	// Check if a narinfo hash has been migrated (has a URL).
-	//
-	//  SELECT EXISTS(
-	//      SELECT 1
-	//      FROM narinfos
-	//      WHERE hash = ? AND url IS NOT NULL
-	//  ) AS is_migrated
-	IsNarInfoMigrated(ctx context.Context, hash string) (bool, error)
 	//LinkNarFileToChunk
 	//
 	//  INSERT IGNORE INTO nar_file_chunks (

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -263,23 +263,6 @@ func (q *Queries) DeleteNarFileByHash(ctx context.Context, arg DeleteNarFileByHa
 	return result.RowsAffected()
 }
 
-const deleteNarFileByID = `-- name: DeleteNarFileByID :execrows
-DELETE FROM nar_files
-WHERE id = ?
-`
-
-// DeleteNarFileByID
-//
-//	DELETE FROM nar_files
-//	WHERE id = ?
-func (q *Queries) DeleteNarFileByID(ctx context.Context, id int64) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteNarFileByID, id)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected()
-}
-
 const deleteNarFileChunksByNarFileID = `-- name: DeleteNarFileChunksByNarFileID :exec
 DELETE FROM nar_file_chunks
 WHERE nar_file_id = ?
@@ -370,29 +353,6 @@ WHERE id NOT IN (
 //	)
 func (q *Queries) DeleteOrphanedNarFiles(ctx context.Context) (int64, error) {
 	result, err := q.db.ExecContext(ctx, deleteOrphanedNarFiles)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected()
-}
-
-const deleteOrphanedNarInfos = `-- name: DeleteOrphanedNarInfos :execrows
-DELETE FROM narinfos
-WHERE id NOT IN (
-    SELECT DISTINCT narinfo_id
-    FROM narinfo_nar_files
-)
-`
-
-// DeleteOrphanedNarInfos
-//
-//	DELETE FROM narinfos
-//	WHERE id NOT IN (
-//	    SELECT DISTINCT narinfo_id
-//	    FROM narinfo_nar_files
-//	)
-func (q *Queries) DeleteOrphanedNarInfos(ctx context.Context) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteOrphanedNarInfos)
 	if err != nil {
 		return 0, err
 	}
@@ -524,65 +484,6 @@ func (q *Queries) GetChunksByNarFileID(ctx context.Context, narFileID int64) ([]
 	return items, nil
 }
 
-const getCompressedNarInfos = `-- name: GetCompressedNarInfos :many
-SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, ` + "`" + `system` + "`" + `, ca
-FROM narinfos
-WHERE compression NOT IN ('', 'none')
-ORDER BY id
-LIMIT ? OFFSET ?
-`
-
-type GetCompressedNarInfosParams struct {
-	Limit  int32
-	Offset int32
-}
-
-// GetCompressedNarInfos
-//
-//	SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, `system`, ca
-//	FROM narinfos
-//	WHERE compression NOT IN ('', 'none')
-//	ORDER BY id
-//	LIMIT ? OFFSET ?
-func (q *Queries) GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error) {
-	rows, err := q.db.QueryContext(ctx, getCompressedNarInfos, arg.Limit, arg.Offset)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []NarInfo
-	for rows.Next() {
-		var i NarInfo
-		if err := rows.Scan(
-			&i.ID,
-			&i.Hash,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.LastAccessedAt,
-			&i.StorePath,
-			&i.URL,
-			&i.Compression,
-			&i.FileHash,
-			&i.FileSize,
-			&i.NarHash,
-			&i.NarSize,
-			&i.Deriver,
-			&i.System,
-			&i.Ca,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getConfigByKey = `-- name: GetConfigByKey :one
 SELECT id, ` + "`" + `key` + "`" + `, value, created_at, updated_at
 FROM config
@@ -605,76 +506,6 @@ func (q *Queries) GetConfigByKey(ctx context.Context, key string) (Config, error
 		&i.UpdatedAt,
 	)
 	return i, err
-}
-
-const getLeastUsedNarFiles = `-- name: GetLeastUsedNarFiles :many
-SELECT n1.id, n1.hash, n1.compression, n1.file_size, n1.` + "`" + `query` + "`" + `, n1.created_at, n1.updated_at, n1.last_accessed_at, n1.total_chunks, n1.chunking_started_at
-FROM nar_files n1
-WHERE (
-    SELECT SUM(n2.file_size)
-    FROM nar_files n2
-    WHERE n2.last_accessed_at < n1.last_accessed_at
-        OR (n2.last_accessed_at = n1.last_accessed_at AND n2.id <= n1.id)
-) <= ?
-`
-
-type GetLeastUsedNarFilesRow struct {
-	ID                int64
-	Hash              string
-	Compression       string
-	FileSize          uint64
-	Query             string
-	CreatedAt         time.Time
-	UpdatedAt         sql.NullTime
-	LastAccessedAt    sql.NullTime
-	TotalChunks       int64
-	ChunkingStartedAt sql.NullTime
-}
-
-// NOTE: This query uses a correlated subquery which is not optimal for performance.
-// The ideal implementation would use a window function (SUM OVER), but sqlc v1.30.0
-// does not properly support filtering on window function results in subqueries.
-//
-//	SELECT n1.id, n1.hash, n1.compression, n1.file_size, n1.`query`, n1.created_at, n1.updated_at, n1.last_accessed_at, n1.total_chunks, n1.chunking_started_at
-//	FROM nar_files n1
-//	WHERE (
-//	    SELECT SUM(n2.file_size)
-//	    FROM nar_files n2
-//	    WHERE n2.last_accessed_at < n1.last_accessed_at
-//	        OR (n2.last_accessed_at = n1.last_accessed_at AND n2.id <= n1.id)
-//	) <= ?
-func (q *Queries) GetLeastUsedNarFiles(ctx context.Context, fileSize uint64) ([]GetLeastUsedNarFilesRow, error) {
-	rows, err := q.db.QueryContext(ctx, getLeastUsedNarFiles, fileSize)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []GetLeastUsedNarFilesRow
-	for rows.Next() {
-		var i GetLeastUsedNarFilesRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.Hash,
-			&i.Compression,
-			&i.FileSize,
-			&i.Query,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.LastAccessedAt,
-			&i.TotalChunks,
-			&i.ChunkingStartedAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }
 
 const getLeastUsedNarInfos = `-- name: GetLeastUsedNarInfos :many
@@ -763,49 +594,6 @@ WHERE url IS NOT NULL
 //	WHERE url IS NOT NULL
 func (q *Queries) GetMigratedNarInfoHashes(ctx context.Context) ([]string, error) {
 	rows, err := q.db.QueryContext(ctx, getMigratedNarInfoHashes)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []string
-	for rows.Next() {
-		var hash string
-		if err := rows.Scan(&hash); err != nil {
-			return nil, err
-		}
-		items = append(items, hash)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const getMigratedNarInfoHashesPaginated = `-- name: GetMigratedNarInfoHashesPaginated :many
-SELECT hash
-FROM narinfos
-WHERE url IS NOT NULL
-ORDER BY hash
-LIMIT ? OFFSET ?
-`
-
-type GetMigratedNarInfoHashesPaginatedParams struct {
-	Limit  int32
-	Offset int32
-}
-
-// Get migrated narinfo hashes with pagination support.
-//
-//	SELECT hash
-//	FROM narinfos
-//	WHERE url IS NOT NULL
-//	ORDER BY hash
-//	LIMIT ? OFFSET ?
-func (q *Queries) GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, getMigratedNarInfoHashesPaginated, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
@@ -1073,42 +861,6 @@ func (q *Queries) GetNarInfoHashByNarURL(ctx context.Context, url sql.NullString
 	return hash, err
 }
 
-const getNarInfoHashesByNarFileID = `-- name: GetNarInfoHashesByNarFileID :many
-SELECT ni.hash
-FROM narinfos ni
-INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-WHERE nnf.nar_file_id = ?
-`
-
-// GetNarInfoHashesByNarFileID
-//
-//	SELECT ni.hash
-//	FROM narinfos ni
-//	INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-//	WHERE nnf.nar_file_id = ?
-func (q *Queries) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, getNarInfoHashesByNarFileID, narFileID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []string
-	for rows.Next() {
-		var hash string
-		if err := rows.Scan(&hash); err != nil {
-			return nil, err
-		}
-		items = append(items, hash)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getNarInfoHashesByURL = `-- name: GetNarInfoHashesByURL :many
 SELECT hash
 FROM narinfos
@@ -1133,53 +885,6 @@ func (q *Queries) GetNarInfoHashesByURL(ctx context.Context, url sql.NullString)
 			return nil, err
 		}
 		items = append(items, hash)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const getNarInfoHashesToChunk = `-- name: GetNarInfoHashesToChunk :many
-SELECT ni.hash, ni.url
-FROM narinfos ni
-LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
-WHERE ni.url IS NOT NULL
-  AND (nf.id IS NULL OR nf.total_chunks = 0)
-ORDER BY ni.hash
-`
-
-type GetNarInfoHashesToChunkRow struct {
-	Hash string
-	URL  sql.NullString
-}
-
-// Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
-//
-//	SELECT ni.hash, ni.url
-//	FROM narinfos ni
-//	LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-//	LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
-//	WHERE ni.url IS NOT NULL
-//	  AND (nf.id IS NULL OR nf.total_chunks = 0)
-//	ORDER BY ni.hash
-func (q *Queries) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error) {
-	rows, err := q.db.QueryContext(ctx, getNarInfoHashesToChunk)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []GetNarInfoHashesToChunkRow
-	for rows.Next() {
-		var i GetNarInfoHashesToChunkRow
-		if err := rows.Scan(&i.Hash, &i.URL); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -1304,76 +1009,6 @@ func (q *Queries) GetNarTotalSize(ctx context.Context) (int64, error) {
 	return total_size, err
 }
 
-const getOldCompressedNarFiles = `-- name: GetOldCompressedNarFiles :many
-SELECT id, hash, compression, file_size, ` + "`" + `query` + "`" + `, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-FROM nar_files
-WHERE compression NOT IN ('', 'none')
-  AND created_at < ?
-ORDER BY id
-LIMIT ? OFFSET ?
-`
-
-type GetOldCompressedNarFilesParams struct {
-	CreatedAt time.Time
-	Limit     int32
-	Offset    int32
-}
-
-type GetOldCompressedNarFilesRow struct {
-	ID                int64
-	Hash              string
-	Compression       string
-	FileSize          uint64
-	Query             string
-	CreatedAt         time.Time
-	UpdatedAt         sql.NullTime
-	LastAccessedAt    sql.NullTime
-	TotalChunks       int64
-	ChunkingStartedAt sql.NullTime
-}
-
-// GetOldCompressedNarFiles
-//
-//	SELECT id, hash, compression, file_size, `query`, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-//	FROM nar_files
-//	WHERE compression NOT IN ('', 'none')
-//	  AND created_at < ?
-//	ORDER BY id
-//	LIMIT ? OFFSET ?
-func (q *Queries) GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]GetOldCompressedNarFilesRow, error) {
-	rows, err := q.db.QueryContext(ctx, getOldCompressedNarFiles, arg.CreatedAt, arg.Limit, arg.Offset)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []GetOldCompressedNarFilesRow
-	for rows.Next() {
-		var i GetOldCompressedNarFilesRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.Hash,
-			&i.Compression,
-			&i.FileSize,
-			&i.Query,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.LastAccessedAt,
-			&i.TotalChunks,
-			&i.ChunkingStartedAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getOrphanedChunks = `-- name: GetOrphanedChunks :many
 SELECT c.id, c.hash, c.size, c.created_at, c.updated_at
 FROM chunks c
@@ -1484,22 +1119,6 @@ func (q *Queries) GetOrphanedNarFiles(ctx context.Context) ([]GetOrphanedNarFile
 	return items, nil
 }
 
-const getTotalChunkSize = `-- name: GetTotalChunkSize :one
-SELECT CAST(COALESCE(SUM(size), 0) AS SIGNED) AS total_size
-FROM chunks
-`
-
-// GetTotalChunkSize
-//
-//	SELECT CAST(COALESCE(SUM(size), 0) AS SIGNED) AS total_size
-//	FROM chunks
-func (q *Queries) GetTotalChunkSize(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getTotalChunkSize)
-	var total_size int64
-	err := row.Scan(&total_size)
-	return total_size, err
-}
-
 const getUnmigratedNarInfoHashes = `-- name: GetUnmigratedNarInfoHashes :many
 SELECT hash
 FROM narinfos
@@ -1532,28 +1151,6 @@ func (q *Queries) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, err
 		return nil, err
 	}
 	return items, nil
-}
-
-const isNarInfoMigrated = `-- name: IsNarInfoMigrated :one
-SELECT EXISTS(
-    SELECT 1
-    FROM narinfos
-    WHERE hash = ? AND url IS NOT NULL
-) AS is_migrated
-`
-
-// Check if a narinfo hash has been migrated (has a URL).
-//
-//	SELECT EXISTS(
-//	    SELECT 1
-//	    FROM narinfos
-//	    WHERE hash = ? AND url IS NOT NULL
-//	) AS is_migrated
-func (q *Queries) IsNarInfoMigrated(ctx context.Context, hash string) (bool, error) {
-	row := q.db.QueryRowContext(ctx, isNarInfoMigrated, hash)
-	var is_migrated bool
-	err := row.Scan(&is_migrated)
-	return is_migrated, err
 }
 
 const linkNarFileToChunk = `-- name: LinkNarFileToChunk :exec

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -115,11 +115,6 @@ type Querier interface {
 	//  DELETE FROM nar_files
 	//  WHERE hash = $1 AND compression = $2 AND query = $3
 	DeleteNarFileByHash(ctx context.Context, arg DeleteNarFileByHashParams) (int64, error)
-	//DeleteNarFileByID
-	//
-	//  DELETE FROM nar_files
-	//  WHERE id = $1
-	DeleteNarFileByID(ctx context.Context, id int64) (int64, error)
 	//DeleteNarFileChunksByNarFileID
 	//
 	//  DELETE FROM nar_file_chunks
@@ -152,14 +147,6 @@ type Querier interface {
 	//      FROM narinfo_nar_files
 	//  )
 	DeleteOrphanedNarFiles(ctx context.Context) (int64, error)
-	//DeleteOrphanedNarInfos
-	//
-	//  DELETE FROM narinfos
-	//  WHERE id NOT IN (
-	//      SELECT DISTINCT narinfo_id
-	//      FROM narinfo_nar_files
-	//  )
-	DeleteOrphanedNarInfos(ctx context.Context) (int64, error)
 	//GetChunkByHash
 	//
 	//  SELECT id, hash, size, compressed_size, created_at, updated_at
@@ -186,33 +173,12 @@ type Querier interface {
 	//  WHERE nfc.nar_file_id = $1
 	//  ORDER BY nfc.chunk_index
 	GetChunksByNarFileID(ctx context.Context, narFileID int64) ([]Chunk, error)
-	//GetCompressedNarInfos
-	//
-	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-	//  FROM narinfos
-	//  WHERE compression NOT IN ('', 'none')
-	//  ORDER BY id
-	//  LIMIT $1 OFFSET $2
-	GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error)
 	//GetConfigByKey
 	//
 	//  SELECT id, key, value, created_at, updated_at
 	//  FROM config
 	//  WHERE key = $1
 	GetConfigByKey(ctx context.Context, key string) (Config, error)
-	// NOTE: This query uses a correlated subquery which is not optimal for performance.
-	// The ideal implementation would use a window function (SUM OVER), but sqlc v1.30.0
-	// does not properly support filtering on window function results in subqueries.
-	//
-	//  SELECT n1.id, n1.hash, n1.compression, n1.file_size, n1.query, n1.created_at, n1.updated_at, n1.last_accessed_at, n1.total_chunks, n1.chunking_started_at
-	//  FROM nar_files n1
-	//  WHERE (
-	//      SELECT SUM(n2.file_size)
-	//      FROM nar_files n2
-	//      WHERE n2.last_accessed_at < n1.last_accessed_at
-	//         OR (n2.last_accessed_at = n1.last_accessed_at AND n2.id <= n1.id)
-	//  ) <= $1
-	GetLeastUsedNarFiles(ctx context.Context, fileSize uint64) ([]NarFile, error)
 	// NOTE: This query uses a correlated subquery which is not optimal for performance.
 	// The ideal implementation would use a window function (SUM OVER), but sqlc v1.30.0
 	// does not properly support filtering on window function results in subqueries.
@@ -238,14 +204,6 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url IS NOT NULL
 	GetMigratedNarInfoHashes(ctx context.Context) ([]string, error)
-	// Get migrated narinfo hashes with pagination support.
-	//
-	//  SELECT hash
-	//  FROM narinfos
-	//  WHERE url IS NOT NULL
-	//  ORDER BY hash
-	//  LIMIT $1 OFFSET $2
-	GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error)
 	//GetNarFileByHashAndCompressionAndQuery
 	//
 	//  SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
@@ -295,29 +253,12 @@ type Querier interface {
 	//  WHERE url = $1
 	//  LIMIT 1
 	GetNarInfoHashByNarURL(ctx context.Context, url sql.NullString) (string, error)
-	//GetNarInfoHashesByNarFileID
-	//
-	//  SELECT ni.hash
-	//  FROM narinfos ni
-	//  INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-	//  WHERE nnf.nar_file_id = $1
-	GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error)
 	//GetNarInfoHashesByURL
 	//
 	//  SELECT hash
 	//  FROM narinfos
 	//  WHERE url = $1
 	GetNarInfoHashesByURL(ctx context.Context, url sql.NullString) ([]string, error)
-	// Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
-	//
-	//  SELECT ni.hash, ni.url
-	//  FROM narinfos ni
-	//  LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-	//  LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
-	//  WHERE ni.url IS NOT NULL
-	//    AND (nf.id IS NULL OR nf.total_chunks = 0)
-	//  ORDER BY ni.hash
-	GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error)
 	//GetNarInfoReferences
 	//
 	//  SELECT reference
@@ -344,15 +285,6 @@ type Querier interface {
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS BIGINT) AS total_size
 	//  FROM nar_files
 	GetNarTotalSize(ctx context.Context) (int64, error)
-	//GetOldCompressedNarFiles
-	//
-	//  SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-	//  FROM nar_files
-	//  WHERE compression NOT IN ('', 'none')
-	//    AND created_at < $1
-	//  ORDER BY id
-	//  LIMIT $2 OFFSET $3
-	GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]NarFile, error)
 	//GetOrphanedChunks
 	//
 	//  SELECT c.id, c.hash, c.size, c.created_at, c.updated_at
@@ -367,25 +299,12 @@ type Querier interface {
 	//  LEFT JOIN narinfo_nar_files ninf ON nf.id = ninf.nar_file_id
 	//  WHERE ninf.narinfo_id IS NULL
 	GetOrphanedNarFiles(ctx context.Context) ([]NarFile, error)
-	//GetTotalChunkSize
-	//
-	//  SELECT CAST(COALESCE(SUM(size), 0) AS BIGINT) AS total_size
-	//  FROM chunks
-	GetTotalChunkSize(ctx context.Context) (int64, error)
 	// Get all narinfo hashes that have no URL (unmigrated).
 	//
 	//  SELECT hash
 	//  FROM narinfos
 	//  WHERE url IS NULL
 	GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error)
-	// Check if a narinfo hash has been migrated (has a URL).
-	//
-	//  SELECT EXISTS(
-	//      SELECT 1
-	//      FROM narinfos
-	//      WHERE hash = $1 AND url IS NOT NULL
-	//  ) AS is_migrated
-	IsNarInfoMigrated(ctx context.Context, hash string) (bool, error)
 	//LinkNarFileToChunk
 	//
 	//  INSERT INTO nar_file_chunks (

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -343,23 +343,6 @@ func (q *Queries) DeleteNarFileByHash(ctx context.Context, arg DeleteNarFileByHa
 	return result.RowsAffected()
 }
 
-const deleteNarFileByID = `-- name: DeleteNarFileByID :execrows
-DELETE FROM nar_files
-WHERE id = ?
-`
-
-// DeleteNarFileByID
-//
-//	DELETE FROM nar_files
-//	WHERE id = ?
-func (q *Queries) DeleteNarFileByID(ctx context.Context, id int64) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteNarFileByID, id)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected()
-}
-
 const deleteNarFileChunksByNarFileID = `-- name: DeleteNarFileChunksByNarFileID :exec
 DELETE FROM nar_file_chunks
 WHERE nar_file_id = ?
@@ -450,29 +433,6 @@ WHERE id NOT IN (
 //	)
 func (q *Queries) DeleteOrphanedNarFiles(ctx context.Context) (int64, error) {
 	result, err := q.db.ExecContext(ctx, deleteOrphanedNarFiles)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected()
-}
-
-const deleteOrphanedNarInfos = `-- name: DeleteOrphanedNarInfos :execrows
-DELETE FROM narinfos
-WHERE id NOT IN (
-    SELECT DISTINCT narinfo_id
-    FROM narinfo_nar_files
-)
-`
-
-// DeleteOrphanedNarInfos
-//
-//	DELETE FROM narinfos
-//	WHERE id NOT IN (
-//	    SELECT DISTINCT narinfo_id
-//	    FROM narinfo_nar_files
-//	)
-func (q *Queries) DeleteOrphanedNarInfos(ctx context.Context) (int64, error) {
-	result, err := q.db.ExecContext(ctx, deleteOrphanedNarInfos)
 	if err != nil {
 		return 0, err
 	}
@@ -604,65 +564,6 @@ func (q *Queries) GetChunksByNarFileID(ctx context.Context, narFileID int64) ([]
 	return items, nil
 }
 
-const getCompressedNarInfos = `-- name: GetCompressedNarInfos :many
-SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-FROM narinfos
-WHERE compression NOT IN ('', 'none')
-ORDER BY id
-LIMIT ? OFFSET ?
-`
-
-type GetCompressedNarInfosParams struct {
-	Limit  int64
-	Offset int64
-}
-
-// GetCompressedNarInfos
-//
-//	SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-//	FROM narinfos
-//	WHERE compression NOT IN ('', 'none')
-//	ORDER BY id
-//	LIMIT ? OFFSET ?
-func (q *Queries) GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error) {
-	rows, err := q.db.QueryContext(ctx, getCompressedNarInfos, arg.Limit, arg.Offset)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []NarInfo
-	for rows.Next() {
-		var i NarInfo
-		if err := rows.Scan(
-			&i.ID,
-			&i.Hash,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.LastAccessedAt,
-			&i.StorePath,
-			&i.URL,
-			&i.Compression,
-			&i.FileHash,
-			&i.FileSize,
-			&i.NarHash,
-			&i.NarSize,
-			&i.Deriver,
-			&i.System,
-			&i.Ca,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getConfigByKey = `-- name: GetConfigByKey :one
 SELECT id, "key", value, created_at, updated_at
 FROM config
@@ -685,63 +586,6 @@ func (q *Queries) GetConfigByKey(ctx context.Context, key string) (Config, error
 		&i.UpdatedAt,
 	)
 	return i, err
-}
-
-const getLeastUsedNarFiles = `-- name: GetLeastUsedNarFiles :many
-SELECT n1.id, n1.hash, n1.compression, n1.file_size, n1."query", n1.created_at, n1.updated_at, n1.last_accessed_at, n1.total_chunks, n1.chunking_started_at
-FROM nar_files n1
-WHERE (
-    SELECT SUM(n2.file_size)
-    FROM nar_files n2
-    WHERE n2.last_accessed_at < n1.last_accessed_at
-        OR (n2.last_accessed_at = n1.last_accessed_at AND n2.id <= n1.id)
-) <= ?
-`
-
-// NOTE: This query uses a correlated subquery which is not optimal for performance.
-// The ideal implementation would use a window function (SUM OVER), but sqlc v1.30.0
-// does not properly support filtering on window function results in subqueries.
-//
-//	SELECT n1.id, n1.hash, n1.compression, n1.file_size, n1."query", n1.created_at, n1.updated_at, n1.last_accessed_at, n1.total_chunks, n1.chunking_started_at
-//	FROM nar_files n1
-//	WHERE (
-//	    SELECT SUM(n2.file_size)
-//	    FROM nar_files n2
-//	    WHERE n2.last_accessed_at < n1.last_accessed_at
-//	        OR (n2.last_accessed_at = n1.last_accessed_at AND n2.id <= n1.id)
-//	) <= ?
-func (q *Queries) GetLeastUsedNarFiles(ctx context.Context, fileSize uint64) ([]NarFile, error) {
-	rows, err := q.db.QueryContext(ctx, getLeastUsedNarFiles, fileSize)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []NarFile
-	for rows.Next() {
-		var i NarFile
-		if err := rows.Scan(
-			&i.ID,
-			&i.Hash,
-			&i.Compression,
-			&i.FileSize,
-			&i.Query,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.LastAccessedAt,
-			&i.TotalChunks,
-			&i.ChunkingStartedAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }
 
 const getLeastUsedNarInfos = `-- name: GetLeastUsedNarInfos :many
@@ -830,49 +674,6 @@ WHERE url IS NOT NULL
 //	WHERE url IS NOT NULL
 func (q *Queries) GetMigratedNarInfoHashes(ctx context.Context) ([]string, error) {
 	rows, err := q.db.QueryContext(ctx, getMigratedNarInfoHashes)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []string
-	for rows.Next() {
-		var hash string
-		if err := rows.Scan(&hash); err != nil {
-			return nil, err
-		}
-		items = append(items, hash)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const getMigratedNarInfoHashesPaginated = `-- name: GetMigratedNarInfoHashesPaginated :many
-SELECT hash
-FROM narinfos
-WHERE url IS NOT NULL
-ORDER BY hash
-LIMIT ? OFFSET ?
-`
-
-type GetMigratedNarInfoHashesPaginatedParams struct {
-	Limit  int64
-	Offset int64
-}
-
-// Get migrated narinfo hashes with pagination support.
-//
-//	SELECT hash
-//	FROM narinfos
-//	WHERE url IS NOT NULL
-//	ORDER BY hash
-//	LIMIT ? OFFSET ?
-func (q *Queries) GetMigratedNarInfoHashesPaginated(ctx context.Context, arg GetMigratedNarInfoHashesPaginatedParams) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, getMigratedNarInfoHashesPaginated, arg.Limit, arg.Offset)
 	if err != nil {
 		return nil, err
 	}
@@ -1114,42 +915,6 @@ func (q *Queries) GetNarInfoHashByNarURL(ctx context.Context, url sql.NullString
 	return hash, err
 }
 
-const getNarInfoHashesByNarFileID = `-- name: GetNarInfoHashesByNarFileID :many
-SELECT ni.hash
-FROM narinfos ni
-INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-WHERE nnf.nar_file_id = ?
-`
-
-// GetNarInfoHashesByNarFileID
-//
-//	SELECT ni.hash
-//	FROM narinfos ni
-//	INNER JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-//	WHERE nnf.nar_file_id = ?
-func (q *Queries) GetNarInfoHashesByNarFileID(ctx context.Context, narFileID int64) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, getNarInfoHashesByNarFileID, narFileID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []string
-	for rows.Next() {
-		var hash string
-		if err := rows.Scan(&hash); err != nil {
-			return nil, err
-		}
-		items = append(items, hash)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getNarInfoHashesByURL = `-- name: GetNarInfoHashesByURL :many
 SELECT hash
 FROM narinfos
@@ -1174,53 +939,6 @@ func (q *Queries) GetNarInfoHashesByURL(ctx context.Context, url sql.NullString)
 			return nil, err
 		}
 		items = append(items, hash)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const getNarInfoHashesToChunk = `-- name: GetNarInfoHashesToChunk :many
-SELECT ni.hash, ni.url
-FROM narinfos ni
-LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
-WHERE ni.url IS NOT NULL
-  AND (nf.id IS NULL OR nf.total_chunks = 0)
-ORDER BY ni.hash
-`
-
-type GetNarInfoHashesToChunkRow struct {
-	Hash string
-	URL  sql.NullString
-}
-
-// Get all narinfo hashes that have a URL (migrated) but whose NAR is not yet chunked.
-//
-//	SELECT ni.hash, ni.url
-//	FROM narinfos ni
-//	LEFT JOIN narinfo_nar_files nnf ON ni.id = nnf.narinfo_id
-//	LEFT JOIN nar_files nf ON nnf.nar_file_id = nf.id
-//	WHERE ni.url IS NOT NULL
-//	  AND (nf.id IS NULL OR nf.total_chunks = 0)
-//	ORDER BY ni.hash
-func (q *Queries) GetNarInfoHashesToChunk(ctx context.Context) ([]GetNarInfoHashesToChunkRow, error) {
-	rows, err := q.db.QueryContext(ctx, getNarInfoHashesToChunk)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []GetNarInfoHashesToChunkRow
-	for rows.Next() {
-		var i GetNarInfoHashesToChunkRow
-		if err := rows.Scan(&i.Hash, &i.URL); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err
@@ -1345,63 +1063,6 @@ func (q *Queries) GetNarTotalSize(ctx context.Context) (int64, error) {
 	return total_size, err
 }
 
-const getOldCompressedNarFiles = `-- name: GetOldCompressedNarFiles :many
-SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-FROM nar_files
-WHERE compression NOT IN ('', 'none')
-  AND created_at < ?
-ORDER BY id
-LIMIT ? OFFSET ?
-`
-
-type GetOldCompressedNarFilesParams struct {
-	CreatedAt time.Time
-	Limit     int64
-	Offset    int64
-}
-
-// GetOldCompressedNarFiles
-//
-//	SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-//	FROM nar_files
-//	WHERE compression NOT IN ('', 'none')
-//	  AND created_at < ?
-//	ORDER BY id
-//	LIMIT ? OFFSET ?
-func (q *Queries) GetOldCompressedNarFiles(ctx context.Context, arg GetOldCompressedNarFilesParams) ([]NarFile, error) {
-	rows, err := q.db.QueryContext(ctx, getOldCompressedNarFiles, arg.CreatedAt, arg.Limit, arg.Offset)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []NarFile
-	for rows.Next() {
-		var i NarFile
-		if err := rows.Scan(
-			&i.ID,
-			&i.Hash,
-			&i.Compression,
-			&i.FileSize,
-			&i.Query,
-			&i.CreatedAt,
-			&i.UpdatedAt,
-			&i.LastAccessedAt,
-			&i.TotalChunks,
-			&i.ChunkingStartedAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getOrphanedChunks = `-- name: GetOrphanedChunks :many
 SELECT c.id, c.hash, c.size, c.created_at, c.updated_at
 FROM chunks c
@@ -1499,22 +1160,6 @@ func (q *Queries) GetOrphanedNarFiles(ctx context.Context) ([]NarFile, error) {
 	return items, nil
 }
 
-const getTotalChunkSize = `-- name: GetTotalChunkSize :one
-SELECT CAST(COALESCE(SUM(size), 0) AS INTEGER) AS total_size
-FROM chunks
-`
-
-// GetTotalChunkSize
-//
-//	SELECT CAST(COALESCE(SUM(size), 0) AS INTEGER) AS total_size
-//	FROM chunks
-func (q *Queries) GetTotalChunkSize(ctx context.Context) (int64, error) {
-	row := q.db.QueryRowContext(ctx, getTotalChunkSize)
-	var total_size int64
-	err := row.Scan(&total_size)
-	return total_size, err
-}
-
 const getUnmigratedNarInfoHashes = `-- name: GetUnmigratedNarInfoHashes :many
 SELECT hash
 FROM narinfos
@@ -1547,28 +1192,6 @@ func (q *Queries) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, err
 		return nil, err
 	}
 	return items, nil
-}
-
-const isNarInfoMigrated = `-- name: IsNarInfoMigrated :one
-SELECT EXISTS(
-    SELECT 1
-    FROM narinfos
-    WHERE hash = ? AND url IS NOT NULL
-) AS is_migrated
-`
-
-// Check if a narinfo hash has been migrated (has a URL).
-//
-//	SELECT EXISTS(
-//	    SELECT 1
-//	    FROM narinfos
-//	    WHERE hash = ? AND url IS NOT NULL
-//	) AS is_migrated
-func (q *Queries) IsNarInfoMigrated(ctx context.Context, hash string) (int64, error) {
-	row := q.db.QueryRowContext(ctx, isNarInfoMigrated, hash)
-	var is_migrated int64
-	err := row.Scan(&is_migrated)
-	return is_migrated, err
 }
 
 const linkNarFileToChunk = `-- name: LinkNarFileToChunk :exec


### PR DESCRIPTION
Removed unused SQL queries that were not called by any business logic:
GetNarInfoHashesByNarFileID, DeleteNarFileByID, DeleteOrphanedNarInfos,
GetLeastUsedNarFiles, IsNarInfoMigrated, GetMigratedNarInfoHashesPaginated,
GetTotalChunkSize, GetNarInfoHashesToChunk, GetCompressedNarInfos,
GetOldCompressedNarFiles.

This cleanup reduces dead code, simplifies the database interface, and
reduces maintenance burden. Removed corresponding test blocks from
contract_test.go and regenerated database binding code using sqlc and go
generate.