### PR TITLE
refactor: automatically generate all Get*ByID functions

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -1,8 +1,3 @@
--- name: GetConfigByID :one
-SELECT *
-FROM config
-WHERE id = ?;
-
 -- name: GetConfigByKey :one
 SELECT *
 FROM config
@@ -13,27 +8,16 @@ SELECT *
 FROM narinfos
 WHERE hash = ?;
 
--- name: GetNarInfoByID :one
-SELECT *
-FROM narinfos
-WHERE id = ?;
-
 -- name: GetNarInfoHashByNarURL :one
 SELECT hash
 FROM narinfos
 WHERE url = ?
 LIMIT 1;
 
-
 -- name: GetNarFileByHashAndCompressionAndQuery :one
 SELECT id, hash, compression, file_size, `query`, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
 FROM nar_files
 WHERE hash = ? AND compression = ? AND `query` = ?;
-
--- name: GetNarFileByID :one
-SELECT id, hash, compression, file_size, `query`, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-FROM nar_files
-WHERE id = ?;
 
 -- name: GetNarFileByNarInfoID :one
 SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.`query`, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
@@ -303,11 +287,6 @@ LIMIT ? OFFSET ?;
 SELECT *
 FROM chunks
 WHERE hash = ?;
-
--- name: GetChunkByID :one
-SELECT *
-FROM chunks
-WHERE id = ?;
 
 -- name: GetChunksByNarFileID :many
 SELECT c.id, c.hash, c.size, c.compressed_size, c.created_at, c.updated_at

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -1,8 +1,3 @@
--- name: GetConfigByID :one
-SELECT *
-FROM config
-WHERE id = $1;
-
 -- name: GetConfigByKey :one
 SELECT *
 FROM config
@@ -12,11 +7,6 @@ WHERE key = $1;
 SELECT *
 FROM narinfos
 WHERE hash = $1;
-
--- name: GetNarInfoByID :one
-SELECT *
-FROM narinfos
-WHERE id = $1;
 
 -- name: GetNarInfoHashByNarURL :one
 SELECT hash
@@ -29,11 +19,6 @@ LIMIT 1;
 SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
 FROM nar_files
 WHERE hash = $1 AND compression = $2 AND query = $3;
-
--- name: GetNarFileByID :one
-SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-FROM nar_files
-WHERE id = $1;
 
 -- name: GetNarFileByNarInfoID :one
 SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.query, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
@@ -339,11 +324,6 @@ LIMIT $1 OFFSET $2;
 SELECT *
 FROM chunks
 WHERE hash = $1;
-
--- name: GetChunkByID :one
-SELECT *
-FROM chunks
-WHERE id = $1;
 
 -- name: GetChunksByNarFileID :many
 SELECT c.id, c.hash, c.size, c.compressed_size, c.created_at, c.updated_at

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -1,8 +1,3 @@
--- name: GetConfigByID :one
-SELECT *
-FROM config
-WHERE id = ?;
-
 -- name: GetConfigByKey :one
 SELECT *
 FROM config
@@ -12,11 +7,6 @@ WHERE key = ?;
 SELECT *
 FROM narinfos
 WHERE hash = ?;
-
--- name: GetNarInfoByID :one
-SELECT *
-FROM narinfos
-WHERE id = ?;
 
 -- name: GetNarInfoHashByNarURL :one
 SELECT hash
@@ -29,11 +19,6 @@ LIMIT 1;
 SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
 FROM nar_files
 WHERE hash = ? AND compression = ? AND "query" = ?;
-
--- name: GetNarFileByID :one
-SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-FROM nar_files
-WHERE id = ?;
 
 -- name: GetNarFileByNarInfoID :one
 SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
@@ -325,11 +310,6 @@ LIMIT ? OFFSET ?;
 SELECT *
 FROM chunks
 WHERE hash = ?;
-
--- name: GetChunkByID :one
-SELECT *
-FROM chunks
-WHERE id = ?;
 
 -- name: GetChunksByNarFileID :many
 SELECT c.id, c.hash, c.size, c.compressed_size, c.created_at, c.updated_at

--- a/nix/gen-db-wrappers/src/main_test.go
+++ b/nix/gen-db-wrappers/src/main_test.go
@@ -284,6 +284,8 @@ func TestWrapperTemplate(t *testing.T) {
 			return joinParamsCall(params, engPkg, targetMethod, structs, structs)
 		},
 		"hasSuffix":               strings.HasSuffix,
+		"toSnakeCase":             toSnakeCase,
+		"quote":                   quote,
 		"generateFieldConversion": generateFieldConversion,
 		"zeroReturn": func(m MethodInfo) string {
 			// simplified for test
@@ -292,6 +294,7 @@ func TestWrapperTemplate(t *testing.T) {
 			}
 			return "0"
 		},
+		"getTableName": func(structName string) string { return "users" },
 	}
 
 	tmpl, err := template.New("wrapper").Funcs(funcMap).Parse(wrapperTemplate)
@@ -450,6 +453,7 @@ func TestWrapperTemplate(t *testing.T) {
 		}
 		return joinParamsCall(params, engPkg, targetMethod, structs, structs)
 	}
+	funcMap["getTableName"] = func(structName string) string { return "users" }
 
 	tmpl, err = template.New("wrapper").Funcs(funcMap).Parse(wrapperTemplate)
 	if err != nil {

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -163,11 +163,7 @@ type Querier interface {
 	//  FROM chunks
 	//  WHERE hash = $1
 	GetChunkByHash(ctx context.Context, hash string) (Chunk, error)
-	//GetChunkByID
-	//
-	//  SELECT id, hash, size, compressed_size, created_at, updated_at
-	//  FROM chunks
-	//  WHERE id = $1
+	// GetChunkByID (Synthetic)
 	GetChunkByID(ctx context.Context, id int64) (Chunk, error)
 	//GetChunkByNarFileIDAndIndex
 	//
@@ -197,11 +193,7 @@ type Querier interface {
 	//  ORDER BY id
 	//  LIMIT $1 OFFSET $2
 	GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error)
-	//GetConfigByID
-	//
-	//  SELECT id, key, value, created_at, updated_at
-	//  FROM config
-	//  WHERE id = $1
+	// GetConfigByID (Synthetic)
 	GetConfigByID(ctx context.Context, id int64) (Config, error)
 	//GetConfigByKey
 	//
@@ -261,11 +253,7 @@ type Querier interface {
 	//  FROM nar_files
 	//  WHERE hash = $1 AND compression = $2 AND query = $3
 	GetNarFileByHashAndCompressionAndQuery(ctx context.Context, arg GetNarFileByHashAndCompressionAndQueryParams) (NarFile, error)
-	//GetNarFileByID
-	//
-	//  SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-	//  FROM nar_files
-	//  WHERE id = $1
+	// GetNarFileByID (Synthetic)
 	GetNarFileByID(ctx context.Context, id int64) (NarFile, error)
 	//GetNarFileByNarInfoID
 	//
@@ -298,11 +286,7 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE hash = $1
 	GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error)
-	//GetNarInfoByID
-	//
-	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-	//  FROM narinfos
-	//  WHERE id = $1
+	// GetNarInfoByID (Synthetic)
 	GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
 	//GetNarInfoCount
 	//

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -353,17 +353,31 @@ func (w *mysqlWrapper) GetChunkByHash(ctx context.Context, hash string) (Chunk, 
 func (w *mysqlWrapper) GetChunkByID(ctx context.Context, id int64) (Chunk, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	res, err := w.adapter.GetChunkByID(ctx, id)
-	if err != nil {
+	query := "SELECT `id`, `hash`, `size`, `compressed_size`, `created_at`, `updated_at` FROM chunks WHERE id = ?"
+	row := w.adapter.DBTX().QueryRowContext(ctx, query, id)
+	var res mysqldb.Chunk
+	err := row.Scan(
 
+		&res.ID,
+
+		&res.Hash,
+
+		&res.Size,
+
+		&res.CompressedSize,
+
+		&res.CreatedAt,
+
+		&res.UpdatedAt,
+	)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return Chunk{}, ErrNotFound
 		}
-
 		return Chunk{}, err
 	}
 
-	// Convert Single Domain Struct
+	// Convert to Domain Struct
 
 	return Chunk{
 		ID: res.ID,
@@ -504,17 +518,29 @@ func (w *mysqlWrapper) GetCompressedNarInfos(ctx context.Context, arg GetCompres
 func (w *mysqlWrapper) GetConfigByID(ctx context.Context, id int64) (Config, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	res, err := w.adapter.GetConfigByID(ctx, id)
-	if err != nil {
+	query := "SELECT `id`, `key`, `value`, `created_at`, `updated_at` FROM config WHERE id = ?"
+	row := w.adapter.DBTX().QueryRowContext(ctx, query, id)
+	var res mysqldb.Config
+	err := row.Scan(
 
+		&res.ID,
+
+		&res.Key,
+
+		&res.Value,
+
+		&res.CreatedAt,
+
+		&res.UpdatedAt,
+	)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return Config{}, ErrNotFound
 		}
-
 		return Config{}, err
 	}
 
-	// Convert Single Domain Struct
+	// Convert to Domain Struct
 
 	return Config{
 		ID: res.ID,
@@ -711,17 +737,39 @@ func (w *mysqlWrapper) GetNarFileByHashAndCompressionAndQuery(ctx context.Contex
 func (w *mysqlWrapper) GetNarFileByID(ctx context.Context, id int64) (NarFile, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	res, err := w.adapter.GetNarFileByID(ctx, id)
-	if err != nil {
+	query := "SELECT `id`, `hash`, `compression`, `file_size`, `created_at`, `updated_at`, `last_accessed_at`, `query`, `total_chunks`, `chunking_started_at` FROM nar_files WHERE id = ?"
+	row := w.adapter.DBTX().QueryRowContext(ctx, query, id)
+	var res mysqldb.NarFile
+	err := row.Scan(
 
+		&res.ID,
+
+		&res.Hash,
+
+		&res.Compression,
+
+		&res.FileSize,
+
+		&res.CreatedAt,
+
+		&res.UpdatedAt,
+
+		&res.LastAccessedAt,
+
+		&res.Query,
+
+		&res.TotalChunks,
+
+		&res.ChunkingStartedAt,
+	)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarFile{}, ErrNotFound
 		}
-
 		return NarFile{}, err
 	}
 
-	// Convert Single Domain Struct
+	// Convert to Domain Struct
 
 	return NarFile{
 		ID: res.ID,
@@ -887,17 +935,49 @@ func (w *mysqlWrapper) GetNarInfoByHash(ctx context.Context, hash string) (NarIn
 func (w *mysqlWrapper) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	res, err := w.adapter.GetNarInfoByID(ctx, id)
-	if err != nil {
+	query := "SELECT `id`, `hash`, `created_at`, `updated_at`, `last_accessed_at`, `store_path`, `url`, `compression`, `file_hash`, `file_size`, `nar_hash`, `nar_size`, `deriver`, `system`, `ca` FROM narinfos WHERE id = ?"
+	row := w.adapter.DBTX().QueryRowContext(ctx, query, id)
+	var res mysqldb.NarInfo
+	err := row.Scan(
 
+		&res.ID,
+
+		&res.Hash,
+
+		&res.CreatedAt,
+
+		&res.UpdatedAt,
+
+		&res.LastAccessedAt,
+
+		&res.StorePath,
+
+		&res.URL,
+
+		&res.Compression,
+
+		&res.FileHash,
+
+		&res.FileSize,
+
+		&res.NarHash,
+
+		&res.NarSize,
+
+		&res.Deriver,
+
+		&res.System,
+
+		&res.Ca,
+	)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarInfo{}, ErrNotFound
 		}
-
 		return NarInfo{}, err
 	}
 
-	// Convert Single Domain Struct
+	// Convert to Domain Struct
 
 	return NarInfo{
 		ID: res.ID,

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -359,17 +359,31 @@ func (w *postgresWrapper) GetChunkByHash(ctx context.Context, hash string) (Chun
 func (w *postgresWrapper) GetChunkByID(ctx context.Context, id int64) (Chunk, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	res, err := w.adapter.GetChunkByID(ctx, id)
-	if err != nil {
+	query := "SELECT \"id\", \"hash\", \"size\", \"compressed_size\", \"created_at\", \"updated_at\" FROM chunks WHERE id = $1"
+	row := w.adapter.DBTX().QueryRowContext(ctx, query, id)
+	var res postgresdb.Chunk
+	err := row.Scan(
 
+		&res.ID,
+
+		&res.Hash,
+
+		&res.Size,
+
+		&res.CompressedSize,
+
+		&res.CreatedAt,
+
+		&res.UpdatedAt,
+	)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return Chunk{}, ErrNotFound
 		}
-
 		return Chunk{}, err
 	}
 
-	// Convert Single Domain Struct
+	// Convert to Domain Struct
 
 	return Chunk{
 		ID: res.ID,
@@ -510,17 +524,29 @@ func (w *postgresWrapper) GetCompressedNarInfos(ctx context.Context, arg GetComp
 func (w *postgresWrapper) GetConfigByID(ctx context.Context, id int64) (Config, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	res, err := w.adapter.GetConfigByID(ctx, id)
-	if err != nil {
+	query := "SELECT \"id\", \"key\", \"value\", \"created_at\", \"updated_at\" FROM config WHERE id = $1"
+	row := w.adapter.DBTX().QueryRowContext(ctx, query, id)
+	var res postgresdb.Config
+	err := row.Scan(
 
+		&res.ID,
+
+		&res.Key,
+
+		&res.Value,
+
+		&res.CreatedAt,
+
+		&res.UpdatedAt,
+	)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return Config{}, ErrNotFound
 		}
-
 		return Config{}, err
 	}
 
-	// Convert Single Domain Struct
+	// Convert to Domain Struct
 
 	return Config{
 		ID: res.ID,
@@ -717,17 +743,39 @@ func (w *postgresWrapper) GetNarFileByHashAndCompressionAndQuery(ctx context.Con
 func (w *postgresWrapper) GetNarFileByID(ctx context.Context, id int64) (NarFile, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	res, err := w.adapter.GetNarFileByID(ctx, id)
-	if err != nil {
+	query := "SELECT \"id\", \"hash\", \"compression\", \"file_size\", \"query\", \"created_at\", \"updated_at\", \"last_accessed_at\", \"total_chunks\", \"chunking_started_at\" FROM nar_files WHERE id = $1"
+	row := w.adapter.DBTX().QueryRowContext(ctx, query, id)
+	var res postgresdb.NarFile
+	err := row.Scan(
 
+		&res.ID,
+
+		&res.Hash,
+
+		&res.Compression,
+
+		&res.FileSize,
+
+		&res.Query,
+
+		&res.CreatedAt,
+
+		&res.UpdatedAt,
+
+		&res.LastAccessedAt,
+
+		&res.TotalChunks,
+
+		&res.ChunkingStartedAt,
+	)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarFile{}, ErrNotFound
 		}
-
 		return NarFile{}, err
 	}
 
-	// Convert Single Domain Struct
+	// Convert to Domain Struct
 
 	return NarFile{
 		ID: res.ID,
@@ -893,17 +941,49 @@ func (w *postgresWrapper) GetNarInfoByHash(ctx context.Context, hash string) (Na
 func (w *postgresWrapper) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	res, err := w.adapter.GetNarInfoByID(ctx, id)
-	if err != nil {
+	query := "SELECT \"id\", \"hash\", \"created_at\", \"updated_at\", \"last_accessed_at\", \"store_path\", \"url\", \"compression\", \"file_hash\", \"file_size\", \"nar_hash\", \"nar_size\", \"deriver\", \"system\", \"ca\" FROM narinfos WHERE id = $1"
+	row := w.adapter.DBTX().QueryRowContext(ctx, query, id)
+	var res postgresdb.NarInfo
+	err := row.Scan(
 
+		&res.ID,
+
+		&res.Hash,
+
+		&res.CreatedAt,
+
+		&res.UpdatedAt,
+
+		&res.LastAccessedAt,
+
+		&res.StorePath,
+
+		&res.URL,
+
+		&res.Compression,
+
+		&res.FileHash,
+
+		&res.FileSize,
+
+		&res.NarHash,
+
+		&res.NarSize,
+
+		&res.Deriver,
+
+		&res.System,
+
+		&res.Ca,
+	)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarInfo{}, ErrNotFound
 		}
-
 		return NarInfo{}, err
 	}
 
-	// Convert Single Domain Struct
+	// Convert to Domain Struct
 
 	return NarInfo{
 		ID: res.ID,

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -377,17 +377,31 @@ func (w *sqliteWrapper) GetChunkByHash(ctx context.Context, hash string) (Chunk,
 func (w *sqliteWrapper) GetChunkByID(ctx context.Context, id int64) (Chunk, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	res, err := w.adapter.GetChunkByID(ctx, id)
-	if err != nil {
+	query := "SELECT \"id\", \"hash\", \"size\", \"compressed_size\", \"created_at\", \"updated_at\" FROM chunks WHERE id = ?"
+	row := w.adapter.DBTX().QueryRowContext(ctx, query, id)
+	var res sqlitedb.Chunk
+	err := row.Scan(
 
+		&res.ID,
+
+		&res.Hash,
+
+		&res.Size,
+
+		&res.CompressedSize,
+
+		&res.CreatedAt,
+
+		&res.UpdatedAt,
+	)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return Chunk{}, ErrNotFound
 		}
-
 		return Chunk{}, err
 	}
 
-	// Convert Single Domain Struct
+	// Convert to Domain Struct
 
 	return Chunk{
 		ID: res.ID,
@@ -528,17 +542,29 @@ func (w *sqliteWrapper) GetCompressedNarInfos(ctx context.Context, arg GetCompre
 func (w *sqliteWrapper) GetConfigByID(ctx context.Context, id int64) (Config, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	res, err := w.adapter.GetConfigByID(ctx, id)
-	if err != nil {
+	query := "SELECT \"id\", \"key\", \"value\", \"created_at\", \"updated_at\" FROM config WHERE id = ?"
+	row := w.adapter.DBTX().QueryRowContext(ctx, query, id)
+	var res sqlitedb.Config
+	err := row.Scan(
 
+		&res.ID,
+
+		&res.Key,
+
+		&res.Value,
+
+		&res.CreatedAt,
+
+		&res.UpdatedAt,
+	)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return Config{}, ErrNotFound
 		}
-
 		return Config{}, err
 	}
 
-	// Convert Single Domain Struct
+	// Convert to Domain Struct
 
 	return Config{
 		ID: res.ID,
@@ -735,17 +761,39 @@ func (w *sqliteWrapper) GetNarFileByHashAndCompressionAndQuery(ctx context.Conte
 func (w *sqliteWrapper) GetNarFileByID(ctx context.Context, id int64) (NarFile, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	res, err := w.adapter.GetNarFileByID(ctx, id)
-	if err != nil {
+	query := "SELECT \"id\", \"hash\", \"compression\", \"file_size\", \"query\", \"created_at\", \"updated_at\", \"last_accessed_at\", \"total_chunks\", \"chunking_started_at\" FROM nar_files WHERE id = ?"
+	row := w.adapter.DBTX().QueryRowContext(ctx, query, id)
+	var res sqlitedb.NarFile
+	err := row.Scan(
 
+		&res.ID,
+
+		&res.Hash,
+
+		&res.Compression,
+
+		&res.FileSize,
+
+		&res.Query,
+
+		&res.CreatedAt,
+
+		&res.UpdatedAt,
+
+		&res.LastAccessedAt,
+
+		&res.TotalChunks,
+
+		&res.ChunkingStartedAt,
+	)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarFile{}, ErrNotFound
 		}
-
 		return NarFile{}, err
 	}
 
-	// Convert Single Domain Struct
+	// Convert to Domain Struct
 
 	return NarFile{
 		ID: res.ID,
@@ -911,17 +959,49 @@ func (w *sqliteWrapper) GetNarInfoByHash(ctx context.Context, hash string) (NarI
 func (w *sqliteWrapper) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	res, err := w.adapter.GetNarInfoByID(ctx, id)
-	if err != nil {
+	query := "SELECT \"id\", \"hash\", \"created_at\", \"updated_at\", \"last_accessed_at\", \"store_path\", \"url\", \"compression\", \"file_hash\", \"file_size\", \"nar_hash\", \"nar_size\", \"deriver\", \"system\", \"ca\" FROM narinfos WHERE id = ?"
+	row := w.adapter.DBTX().QueryRowContext(ctx, query, id)
+	var res sqlitedb.NarInfo
+	err := row.Scan(
 
+		&res.ID,
+
+		&res.Hash,
+
+		&res.CreatedAt,
+
+		&res.UpdatedAt,
+
+		&res.LastAccessedAt,
+
+		&res.StorePath,
+
+		&res.URL,
+
+		&res.Compression,
+
+		&res.FileHash,
+
+		&res.FileSize,
+
+		&res.NarHash,
+
+		&res.NarSize,
+
+		&res.Deriver,
+
+		&res.System,
+
+		&res.Ca,
+	)
+	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return NarInfo{}, ErrNotFound
 		}
-
 		return NarInfo{}, err
 	}
 
-	// Convert Single Domain Struct
+	// Convert to Domain Struct
 
 	return NarInfo{
 		ID: res.ID,

--- a/pkg/database/mysqldb/adapter.go
+++ b/pkg/database/mysqldb/adapter.go
@@ -30,3 +30,8 @@ func (a *Adapter) WithTx(tx *sql.Tx) *Adapter {
 		db:      a.db,
 	}
 }
+
+// DBTX returns the current database executor (can be a transaction or the pool).
+func (a *Adapter) DBTX() DBTX {
+	return a.Queries.db
+}

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -138,12 +138,6 @@ type Querier interface {
 	//  FROM chunks
 	//  WHERE hash = ?
 	GetChunkByHash(ctx context.Context, hash string) (Chunk, error)
-	//GetChunkByID
-	//
-	//  SELECT id, hash, size, compressed_size, created_at, updated_at
-	//  FROM chunks
-	//  WHERE id = ?
-	GetChunkByID(ctx context.Context, id int64) (Chunk, error)
 	//GetChunkByNarFileIDAndIndex
 	//
 	//  SELECT c.id, c.hash, c.size, c.created_at, c.updated_at
@@ -172,12 +166,6 @@ type Querier interface {
 	//  ORDER BY id
 	//  LIMIT ? OFFSET ?
 	GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error)
-	//GetConfigByID
-	//
-	//  SELECT id, `key`, value, created_at, updated_at
-	//  FROM config
-	//  WHERE id = ?
-	GetConfigByID(ctx context.Context, id int64) (Config, error)
 	//GetConfigByKey
 	//
 	//  SELECT id, `key`, value, created_at, updated_at
@@ -236,12 +224,6 @@ type Querier interface {
 	//  FROM nar_files
 	//  WHERE hash = ? AND compression = ? AND `query` = ?
 	GetNarFileByHashAndCompressionAndQuery(ctx context.Context, arg GetNarFileByHashAndCompressionAndQueryParams) (GetNarFileByHashAndCompressionAndQueryRow, error)
-	//GetNarFileByID
-	//
-	//  SELECT id, hash, compression, file_size, `query`, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-	//  FROM nar_files
-	//  WHERE id = ?
-	GetNarFileByID(ctx context.Context, id int64) (GetNarFileByIDRow, error)
 	//GetNarFileByNarInfoID
 	//
 	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.`query`, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
@@ -273,12 +255,6 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE hash = ?
 	GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error)
-	//GetNarInfoByID
-	//
-	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, `system`, ca
-	//  FROM narinfos
-	//  WHERE id = ?
-	GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
 	//GetNarInfoCount
 	//
 	//  SELECT CAST(COUNT(*) AS SIGNED) AS count

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -424,31 +424,6 @@ func (q *Queries) GetChunkByHash(ctx context.Context, hash string) (Chunk, error
 	return i, err
 }
 
-const getChunkByID = `-- name: GetChunkByID :one
-SELECT id, hash, size, compressed_size, created_at, updated_at
-FROM chunks
-WHERE id = ?
-`
-
-// GetChunkByID
-//
-//	SELECT id, hash, size, compressed_size, created_at, updated_at
-//	FROM chunks
-//	WHERE id = ?
-func (q *Queries) GetChunkByID(ctx context.Context, id int64) (Chunk, error) {
-	row := q.db.QueryRowContext(ctx, getChunkByID, id)
-	var i Chunk
-	err := row.Scan(
-		&i.ID,
-		&i.Hash,
-		&i.Size,
-		&i.CompressedSize,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
-}
-
 const getChunkByNarFileIDAndIndex = `-- name: GetChunkByNarFileIDAndIndex :one
 SELECT c.id, c.hash, c.size, c.created_at, c.updated_at
 FROM chunks c
@@ -606,30 +581,6 @@ func (q *Queries) GetCompressedNarInfos(ctx context.Context, arg GetCompressedNa
 		return nil, err
 	}
 	return items, nil
-}
-
-const getConfigByID = `-- name: GetConfigByID :one
-SELECT id, ` + "`" + `key` + "`" + `, value, created_at, updated_at
-FROM config
-WHERE id = ?
-`
-
-// GetConfigByID
-//
-//	SELECT id, `key`, value, created_at, updated_at
-//	FROM config
-//	WHERE id = ?
-func (q *Queries) GetConfigByID(ctx context.Context, id int64) (Config, error) {
-	row := q.db.QueryRowContext(ctx, getConfigByID, id)
-	var i Config
-	err := row.Scan(
-		&i.ID,
-		&i.Key,
-		&i.Value,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
 }
 
 const getConfigByKey = `-- name: GetConfigByKey :one
@@ -924,48 +875,6 @@ func (q *Queries) GetNarFileByHashAndCompressionAndQuery(ctx context.Context, ar
 	return i, err
 }
 
-const getNarFileByID = `-- name: GetNarFileByID :one
-SELECT id, hash, compression, file_size, ` + "`" + `query` + "`" + `, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-FROM nar_files
-WHERE id = ?
-`
-
-type GetNarFileByIDRow struct {
-	ID                int64
-	Hash              string
-	Compression       string
-	FileSize          uint64
-	Query             string
-	CreatedAt         time.Time
-	UpdatedAt         sql.NullTime
-	LastAccessedAt    sql.NullTime
-	TotalChunks       int64
-	ChunkingStartedAt sql.NullTime
-}
-
-// GetNarFileByID
-//
-//	SELECT id, hash, compression, file_size, `query`, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-//	FROM nar_files
-//	WHERE id = ?
-func (q *Queries) GetNarFileByID(ctx context.Context, id int64) (GetNarFileByIDRow, error) {
-	row := q.db.QueryRowContext(ctx, getNarFileByID, id)
-	var i GetNarFileByIDRow
-	err := row.Scan(
-		&i.ID,
-		&i.Hash,
-		&i.Compression,
-		&i.FileSize,
-		&i.Query,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.LastAccessedAt,
-		&i.TotalChunks,
-		&i.ChunkingStartedAt,
-	)
-	return i, err
-}
-
 const getNarFileByNarInfoID = `-- name: GetNarFileByNarInfoID :one
 SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.` + "`" + `query` + "`" + `, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
 FROM nar_files nf
@@ -1107,40 +1016,6 @@ WHERE hash = ?
 //	WHERE hash = ?
 func (q *Queries) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error) {
 	row := q.db.QueryRowContext(ctx, getNarInfoByHash, hash)
-	var i NarInfo
-	err := row.Scan(
-		&i.ID,
-		&i.Hash,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.LastAccessedAt,
-		&i.StorePath,
-		&i.URL,
-		&i.Compression,
-		&i.FileHash,
-		&i.FileSize,
-		&i.NarHash,
-		&i.NarSize,
-		&i.Deriver,
-		&i.System,
-		&i.Ca,
-	)
-	return i, err
-}
-
-const getNarInfoByID = `-- name: GetNarInfoByID :one
-SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, ` + "`" + `system` + "`" + `, ca
-FROM narinfos
-WHERE id = ?
-`
-
-// GetNarInfoByID
-//
-//	SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, `system`, ca
-//	FROM narinfos
-//	WHERE id = ?
-func (q *Queries) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error) {
-	row := q.db.QueryRowContext(ctx, getNarInfoByID, id)
 	var i NarInfo
 	err := row.Scan(
 		&i.ID,

--- a/pkg/database/postgresdb/adapter.go
+++ b/pkg/database/postgresdb/adapter.go
@@ -30,3 +30,8 @@ func (a *Adapter) WithTx(tx *sql.Tx) *Adapter {
 		db:      a.db,
 	}
 }
+
+// DBTX returns the current database executor (can be a transaction or the pool).
+func (a *Adapter) DBTX() DBTX {
+	return a.Queries.db
+}

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -166,12 +166,6 @@ type Querier interface {
 	//  FROM chunks
 	//  WHERE hash = $1
 	GetChunkByHash(ctx context.Context, hash string) (Chunk, error)
-	//GetChunkByID
-	//
-	//  SELECT id, hash, size, compressed_size, created_at, updated_at
-	//  FROM chunks
-	//  WHERE id = $1
-	GetChunkByID(ctx context.Context, id int64) (Chunk, error)
 	//GetChunkByNarFileIDAndIndex
 	//
 	//  SELECT c.id, c.hash, c.size, c.created_at, c.updated_at
@@ -200,12 +194,6 @@ type Querier interface {
 	//  ORDER BY id
 	//  LIMIT $1 OFFSET $2
 	GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error)
-	//GetConfigByID
-	//
-	//  SELECT id, key, value, created_at, updated_at
-	//  FROM config
-	//  WHERE id = $1
-	GetConfigByID(ctx context.Context, id int64) (Config, error)
 	//GetConfigByKey
 	//
 	//  SELECT id, key, value, created_at, updated_at
@@ -264,12 +252,6 @@ type Querier interface {
 	//  FROM nar_files
 	//  WHERE hash = $1 AND compression = $2 AND query = $3
 	GetNarFileByHashAndCompressionAndQuery(ctx context.Context, arg GetNarFileByHashAndCompressionAndQueryParams) (NarFile, error)
-	//GetNarFileByID
-	//
-	//  SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-	//  FROM nar_files
-	//  WHERE id = $1
-	GetNarFileByID(ctx context.Context, id int64) (NarFile, error)
 	//GetNarFileByNarInfoID
 	//
 	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.query, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
@@ -301,12 +283,6 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE hash = $1
 	GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error)
-	//GetNarInfoByID
-	//
-	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-	//  FROM narinfos
-	//  WHERE id = $1
-	GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
 	//GetNarInfoCount
 	//
 	//  SELECT CAST(COUNT(*) AS BIGINT) AS count

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -552,31 +552,6 @@ func (q *Queries) GetChunkByHash(ctx context.Context, hash string) (Chunk, error
 	return i, err
 }
 
-const getChunkByID = `-- name: GetChunkByID :one
-SELECT id, hash, size, compressed_size, created_at, updated_at
-FROM chunks
-WHERE id = $1
-`
-
-// GetChunkByID
-//
-//	SELECT id, hash, size, compressed_size, created_at, updated_at
-//	FROM chunks
-//	WHERE id = $1
-func (q *Queries) GetChunkByID(ctx context.Context, id int64) (Chunk, error) {
-	row := q.db.QueryRowContext(ctx, getChunkByID, id)
-	var i Chunk
-	err := row.Scan(
-		&i.ID,
-		&i.Hash,
-		&i.Size,
-		&i.CompressedSize,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
-}
-
 const getChunkByNarFileIDAndIndex = `-- name: GetChunkByNarFileIDAndIndex :one
 SELECT c.id, c.hash, c.size, c.created_at, c.updated_at
 FROM chunks c
@@ -734,30 +709,6 @@ func (q *Queries) GetCompressedNarInfos(ctx context.Context, arg GetCompressedNa
 		return nil, err
 	}
 	return items, nil
-}
-
-const getConfigByID = `-- name: GetConfigByID :one
-SELECT id, key, value, created_at, updated_at
-FROM config
-WHERE id = $1
-`
-
-// GetConfigByID
-//
-//	SELECT id, key, value, created_at, updated_at
-//	FROM config
-//	WHERE id = $1
-func (q *Queries) GetConfigByID(ctx context.Context, id int64) (Config, error) {
-	row := q.db.QueryRowContext(ctx, getConfigByID, id)
-	var i Config
-	err := row.Scan(
-		&i.ID,
-		&i.Key,
-		&i.Value,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
 }
 
 const getConfigByKey = `-- name: GetConfigByKey :one
@@ -1026,35 +977,6 @@ func (q *Queries) GetNarFileByHashAndCompressionAndQuery(ctx context.Context, ar
 	return i, err
 }
 
-const getNarFileByID = `-- name: GetNarFileByID :one
-SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-FROM nar_files
-WHERE id = $1
-`
-
-// GetNarFileByID
-//
-//	SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-//	FROM nar_files
-//	WHERE id = $1
-func (q *Queries) GetNarFileByID(ctx context.Context, id int64) (NarFile, error) {
-	row := q.db.QueryRowContext(ctx, getNarFileByID, id)
-	var i NarFile
-	err := row.Scan(
-		&i.ID,
-		&i.Hash,
-		&i.Compression,
-		&i.FileSize,
-		&i.Query,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.LastAccessedAt,
-		&i.TotalChunks,
-		&i.ChunkingStartedAt,
-	)
-	return i, err
-}
-
 const getNarFileByNarInfoID = `-- name: GetNarFileByNarInfoID :one
 SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.query, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
 FROM nar_files nf
@@ -1183,40 +1105,6 @@ WHERE hash = $1
 //	WHERE hash = $1
 func (q *Queries) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error) {
 	row := q.db.QueryRowContext(ctx, getNarInfoByHash, hash)
-	var i NarInfo
-	err := row.Scan(
-		&i.ID,
-		&i.Hash,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.LastAccessedAt,
-		&i.StorePath,
-		&i.URL,
-		&i.Compression,
-		&i.FileHash,
-		&i.FileSize,
-		&i.NarHash,
-		&i.NarSize,
-		&i.Deriver,
-		&i.System,
-		&i.Ca,
-	)
-	return i, err
-}
-
-const getNarInfoByID = `-- name: GetNarInfoByID :one
-SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-FROM narinfos
-WHERE id = $1
-`
-
-// GetNarInfoByID
-//
-//	SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-//	FROM narinfos
-//	WHERE id = $1
-func (q *Queries) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error) {
-	row := q.db.QueryRowContext(ctx, getNarInfoByID, id)
 	var i NarInfo
 	err := row.Scan(
 		&i.ID,

--- a/pkg/database/sqlitedb/adapter.go
+++ b/pkg/database/sqlitedb/adapter.go
@@ -30,3 +30,8 @@ func (a *Adapter) WithTx(tx *sql.Tx) *Adapter {
 		db:      a.db,
 	}
 }
+
+// DBTX returns the current database executor (can be a transaction or the pool).
+func (a *Adapter) DBTX() DBTX {
+	return a.Queries.db
+}

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -152,12 +152,6 @@ type Querier interface {
 	//  FROM chunks
 	//  WHERE hash = ?
 	GetChunkByHash(ctx context.Context, hash string) (Chunk, error)
-	//GetChunkByID
-	//
-	//  SELECT id, hash, size, compressed_size, created_at, updated_at
-	//  FROM chunks
-	//  WHERE id = ?
-	GetChunkByID(ctx context.Context, id int64) (Chunk, error)
 	//GetChunkByNarFileIDAndIndex
 	//
 	//  SELECT c.id, c.hash, c.size, c.created_at, c.updated_at
@@ -186,12 +180,6 @@ type Querier interface {
 	//  ORDER BY id
 	//  LIMIT ? OFFSET ?
 	GetCompressedNarInfos(ctx context.Context, arg GetCompressedNarInfosParams) ([]NarInfo, error)
-	//GetConfigByID
-	//
-	//  SELECT id, "key", value, created_at, updated_at
-	//  FROM config
-	//  WHERE id = ?
-	GetConfigByID(ctx context.Context, id int64) (Config, error)
 	//GetConfigByKey
 	//
 	//  SELECT id, "key", value, created_at, updated_at
@@ -250,12 +238,6 @@ type Querier interface {
 	//  FROM nar_files
 	//  WHERE hash = ? AND compression = ? AND "query" = ?
 	GetNarFileByHashAndCompressionAndQuery(ctx context.Context, arg GetNarFileByHashAndCompressionAndQueryParams) (NarFile, error)
-	//GetNarFileByID
-	//
-	//  SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-	//  FROM nar_files
-	//  WHERE id = ?
-	GetNarFileByID(ctx context.Context, id int64) (NarFile, error)
 	//GetNarFileByNarInfoID
 	//
 	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
@@ -287,12 +269,6 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE hash = ?
 	GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error)
-	//GetNarInfoByID
-	//
-	//  SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-	//  FROM narinfos
-	//  WHERE id = ?
-	GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error)
 	//GetNarInfoCount
 	//
 	//  SELECT CAST(COUNT(*) AS INTEGER) AS count

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -504,31 +504,6 @@ func (q *Queries) GetChunkByHash(ctx context.Context, hash string) (Chunk, error
 	return i, err
 }
 
-const getChunkByID = `-- name: GetChunkByID :one
-SELECT id, hash, size, compressed_size, created_at, updated_at
-FROM chunks
-WHERE id = ?
-`
-
-// GetChunkByID
-//
-//	SELECT id, hash, size, compressed_size, created_at, updated_at
-//	FROM chunks
-//	WHERE id = ?
-func (q *Queries) GetChunkByID(ctx context.Context, id int64) (Chunk, error) {
-	row := q.db.QueryRowContext(ctx, getChunkByID, id)
-	var i Chunk
-	err := row.Scan(
-		&i.ID,
-		&i.Hash,
-		&i.Size,
-		&i.CompressedSize,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
-}
-
 const getChunkByNarFileIDAndIndex = `-- name: GetChunkByNarFileIDAndIndex :one
 SELECT c.id, c.hash, c.size, c.created_at, c.updated_at
 FROM chunks c
@@ -686,30 +661,6 @@ func (q *Queries) GetCompressedNarInfos(ctx context.Context, arg GetCompressedNa
 		return nil, err
 	}
 	return items, nil
-}
-
-const getConfigByID = `-- name: GetConfigByID :one
-SELECT id, "key", value, created_at, updated_at
-FROM config
-WHERE id = ?
-`
-
-// GetConfigByID
-//
-//	SELECT id, "key", value, created_at, updated_at
-//	FROM config
-//	WHERE id = ?
-func (q *Queries) GetConfigByID(ctx context.Context, id int64) (Config, error) {
-	row := q.db.QueryRowContext(ctx, getConfigByID, id)
-	var i Config
-	err := row.Scan(
-		&i.ID,
-		&i.Key,
-		&i.Value,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-	)
-	return i, err
 }
 
 const getConfigByKey = `-- name: GetConfigByKey :one
@@ -978,35 +929,6 @@ func (q *Queries) GetNarFileByHashAndCompressionAndQuery(ctx context.Context, ar
 	return i, err
 }
 
-const getNarFileByID = `-- name: GetNarFileByID :one
-SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-FROM nar_files
-WHERE id = ?
-`
-
-// GetNarFileByID
-//
-//	SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
-//	FROM nar_files
-//	WHERE id = ?
-func (q *Queries) GetNarFileByID(ctx context.Context, id int64) (NarFile, error) {
-	row := q.db.QueryRowContext(ctx, getNarFileByID, id)
-	var i NarFile
-	err := row.Scan(
-		&i.ID,
-		&i.Hash,
-		&i.Compression,
-		&i.FileSize,
-		&i.Query,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.LastAccessedAt,
-		&i.TotalChunks,
-		&i.ChunkingStartedAt,
-	)
-	return i, err
-}
-
 const getNarFileByNarInfoID = `-- name: GetNarFileByNarInfoID :one
 SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
 FROM nar_files nf
@@ -1135,40 +1057,6 @@ WHERE hash = ?
 //	WHERE hash = ?
 func (q *Queries) GetNarInfoByHash(ctx context.Context, hash string) (NarInfo, error) {
 	row := q.db.QueryRowContext(ctx, getNarInfoByHash, hash)
-	var i NarInfo
-	err := row.Scan(
-		&i.ID,
-		&i.Hash,
-		&i.CreatedAt,
-		&i.UpdatedAt,
-		&i.LastAccessedAt,
-		&i.StorePath,
-		&i.URL,
-		&i.Compression,
-		&i.FileHash,
-		&i.FileSize,
-		&i.NarHash,
-		&i.NarSize,
-		&i.Deriver,
-		&i.System,
-		&i.Ca,
-	)
-	return i, err
-}
-
-const getNarInfoByID = `-- name: GetNarInfoByID :one
-SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-FROM narinfos
-WHERE id = ?
-`
-
-// GetNarInfoByID
-//
-//	SELECT id, hash, created_at, updated_at, last_accessed_at, store_path, url, compression, file_hash, file_size, nar_hash, nar_size, deriver, system, ca
-//	FROM narinfos
-//	WHERE id = ?
-func (q *Queries) GetNarInfoByID(ctx context.Context, id int64) (NarInfo, error) {
-	row := q.db.QueryRowContext(ctx, getNarInfoByID, id)
 	var i NarInfo
 	err := row.Scan(
 		&i.ID,


### PR DESCRIPTION
It's common to pull a database entry by its ID, generate them for all
tables instead of creating them in the query files.