### PR TITLE
feat: report storage type and storage mode [backport #959]

### DIFF
--- a/docs/docs/User Guide/Configuration/Analytics.md
+++ b/docs/docs/User Guide/Configuration/Analytics.md
@@ -25,9 +25,11 @@ These attributes are attached to all metrics and logs:
 
 | Attribute | Description | Example Values |
 | --- | --- | --- |
+| `ncps.cluster_uuid` | Unique cluster identifier | `550e8400-e29b-41d4-a716-446655440000` |
 | `ncps.db_type` | Database backend type | `sqlite`, `postgres`, `mysql` |
 | `ncps.lock_type` | Lock mechanism type | `local`, `redis` |
-| `ncps.cluster_uuid` | Unique cluster identifier | `550e8400-e29b-41d4-a716-446655440000` |
+| `ncps.storage_mode` | Storage mode | `cdc`, `whole` |
+| `ncps.storage_type` | Storage type | `local`, `s3` |
 | `service.name` | Service name | `ncps` |
 | `service.version` | ncps version | `v1.2.3` |
 

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -1038,6 +1038,25 @@ func detectExtraResourceAttrs(
 
 	attrs = append(attrs, attribute.String("ncps.cluster_uuid", clusterUUID))
 
+	// 4. Add storage type
+	localDataPath, s3Cfg, err := getStorageConfig(ctx, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	if localDataPath != "" {
+		attrs = append(attrs, attribute.String("ncps.storage_type", "local"))
+	} else if s3Cfg != nil {
+		attrs = append(attrs, attribute.String("ncps.storage_type", "s3"))
+	}
+
+	// 5. Add storage mode
+	if cmd.Bool("cache-cdc-enabled") {
+		attrs = append(attrs, attribute.String("ncps.storage_mode", "cdc"))
+	} else {
+		attrs = append(attrs, attribute.String("ncps.storage_mode", "whole"))
+	}
+
 	return attrs, nil
 }
 


### PR DESCRIPTION
Bot-based backport to `release-0.9`, triggered by a label in #959.

Report the storage type (local or s3) and storage mode (cdc or whole) in
public analytics and internal metrics.