### PR TITLE
feat: report narinfo storage deprecated and must be migrated

### DIFF
--- a/pkg/s3/config.go
+++ b/pkg/s3/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	// Set to true for MinIO and other S3-compatible services
 	// Set to false for AWS S3 (default)
 	ForcePathStyle bool
+	// Prefix is an optional path prefix for all keys stored in the bucket
+	Prefix string
 	// Transport is the HTTP transport to use (optional, used for testing)
 	Transport http.RoundTripper
 }

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -505,6 +505,18 @@ func (s *Store) DeleteNar(ctx context.Context, narURL nar.URL) error {
 	return nil
 }
 
+func (s *Store) HasNarinfoDir() (bool, error) {
+	if _, err := os.Stat(s.storeNarInfoPath()); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
 // removeEmptyParentDirs removes empty parent directories up to and including categoryDir.
 // It starts from the parent of filePath and walks up the directory tree,
 // removing directories only if they are empty.


### PR DESCRIPTION
The narinfo stored in the storage is deprecated and this is the last
release that will support their migration from storage to the database.
Include this messaging in the next release so I can clean up the code in
the following one.