### PR TITLE
fix: prevent nil pointer panic when CDC is disabled but DB has chunked NARs [backport #963]

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -2986,8 +2986,14 @@ func testHasNarFileRecord(factory cacheFactory) func(*testing.T) {
 
 		ctx := context.Background()
 
-		c, db, _, _, _, cleanup := factory(t)
+		c, db, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
+
+		// Setup chunk store and enable CDC
+		cs, err := chunk.NewLocalStore(dir)
+		require.NoError(t, err)
+		c.SetChunkStore(cs)
+		require.NoError(t, c.SetCDCConfiguration(true, 1024, 2048, 4096))
 
 		// Create a test NAR URL
 		narURL := nar.URL{


### PR DESCRIPTION
Bot-based backport to `release-0.9`, triggered by a label in #963.

Guard `HasNarInChunks` and `getNarFromChunks` against a nil `chunkStore`
so that disabling CDC after NARs have been stored as chunks does not
cause a nil pointer dereference in `streamChunksWithPrefetch`.

fixes #962

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>