### PR TITLE
feat: persist CDC configuration in database config table [backport #971]

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -17,6 +18,14 @@ const (
 	KeyClusterUUID = "cluster_uuid"
 	// KeySecretKey is the key for the secret key in the configuration database.
 	KeySecretKey = "secret_key"
+	// KeyCDCEnabled is the key for CDC enabled flag in the configuration database.
+	KeyCDCEnabled = "cdc_enabled"
+	// KeyCDCMin is the key for CDC minimum chunk size in the configuration database.
+	KeyCDCMin = "cdc_min"
+	// KeyCDCAvg is the key for CDC average chunk size in the configuration database.
+	KeyCDCAvg = "cdc_avg"
+	// KeyCDCMax is the key for CDC maximum chunk size in the configuration database.
+	KeyCDCMax = "cdc_max"
 
 	// lockKeyPrefix is the prefix used for locking configuration keys.
 	lockKeyPrefix = "config_"
@@ -25,8 +34,18 @@ const (
 	lockTTL = 5 * time.Minute
 )
 
-// ErrConfigNotFound is returned if no config with this key was found.
-var ErrConfigNotFound = errors.New("no config was found for this key")
+var (
+	// ErrConfigNotFound is returned if no config with this key was found.
+	ErrConfigNotFound = errors.New("no config was found for this key")
+	// ErrCDCDisabledAfterEnabled is returned when attempting to disable CDC after being enabled.
+	ErrCDCDisabledAfterEnabled = errors.New(
+		"CDC cannot be disabled after being enabled; existing chunked NARs would not be reconstructed",
+	)
+	// ErrCDCConfigMismatch is returned when CDC configuration values differ from stored values.
+	ErrCDCConfigMismatch = errors.New(
+		"CDC config changed; different chunk sizes create new chunks without reusing old ones, causing storage duplication",
+	)
+)
 
 // Config provides access to the persistent configuration stored in the database.
 // It uses an RWLocker to ensure thread-safe access to configuration keys.
@@ -61,6 +80,46 @@ func (c *Config) GetSecretKey(ctx context.Context) (string, error) {
 // SetSecretKey stores the secret key in the configuration.
 func (c *Config) SetSecretKey(ctx context.Context, value string) error {
 	return c.setConfig(ctx, KeySecretKey, value)
+}
+
+// GetCDCEnabled returns the CDC enabled flag from the configuration.
+func (c *Config) GetCDCEnabled(ctx context.Context) (string, error) {
+	return c.getConfig(ctx, KeyCDCEnabled)
+}
+
+// SetCDCEnabled stores the CDC enabled flag in the configuration.
+func (c *Config) SetCDCEnabled(ctx context.Context, value string) error {
+	return c.setConfig(ctx, KeyCDCEnabled, value)
+}
+
+// GetCDCMin returns the CDC minimum chunk size from the configuration.
+func (c *Config) GetCDCMin(ctx context.Context) (string, error) {
+	return c.getConfig(ctx, KeyCDCMin)
+}
+
+// SetCDCMin stores the CDC minimum chunk size in the configuration.
+func (c *Config) SetCDCMin(ctx context.Context, value string) error {
+	return c.setConfig(ctx, KeyCDCMin, value)
+}
+
+// GetCDCAvg returns the CDC average chunk size from the configuration.
+func (c *Config) GetCDCAvg(ctx context.Context) (string, error) {
+	return c.getConfig(ctx, KeyCDCAvg)
+}
+
+// SetCDCAvg stores the CDC average chunk size in the configuration.
+func (c *Config) SetCDCAvg(ctx context.Context, value string) error {
+	return c.setConfig(ctx, KeyCDCAvg, value)
+}
+
+// GetCDCMax returns the CDC maximum chunk size from the configuration.
+func (c *Config) GetCDCMax(ctx context.Context) (string, error) {
+	return c.getConfig(ctx, KeyCDCMax)
+}
+
+// SetCDCMax stores the CDC maximum chunk size in the configuration.
+func (c *Config) SetCDCMax(ctx context.Context, value string) error {
+	return c.setConfig(ctx, KeyCDCMax, value)
 }
 
 // getConfig retrieves a configuration value by key, acquiring a read lock.
@@ -123,6 +182,137 @@ func (c *Config) setConfig(ctx context.Context, key, value string) error {
 		Key:   key,
 		Value: value,
 	})
+}
+
+// ValidateOrStoreCDCConfig validates CDC configuration against stored values or stores them if not yet configured.
+// If CDC is disabled and no config exists, returns nil (no-op).
+// If CDC is enabled and no config exists, stores all 4 values.
+// If config exists, validates that enabled flag matches and all values are identical.
+// If CDC was previously enabled (config exists) but now disabled, returns an error.
+func (c *Config) ValidateOrStoreCDCConfig(
+	ctx context.Context,
+	enabled bool,
+	minSize, avgSize, maxSize uint32,
+) error {
+	// Try to get the stored CDC enabled flag
+	storedEnabledStr, err := c.GetCDCEnabled(ctx)
+	if err != nil {
+		if errors.Is(err, ErrConfigNotFound) {
+			// First boot - no CDC config in DB yet
+			if !enabled {
+				// CDC is disabled and never used before - nothing to store
+				return nil
+			}
+
+			return c.storeCDCConfig(ctx, minSize, avgSize, maxSize)
+		}
+
+		return fmt.Errorf("failed to get CDC enabled config: %w", err)
+	}
+
+	// CDC config exists in DB
+	return c.validateCDCConfig(ctx, enabled, minSize, avgSize, maxSize, storedEnabledStr)
+}
+
+// storeCDCConfig stores all 4 CDC configuration values in the database.
+func (c *Config) storeCDCConfig(
+	ctx context.Context,
+	minSize, avgSize, maxSize uint32,
+) error {
+	minStr := fmt.Sprintf("%d", minSize)
+	avgStr := fmt.Sprintf("%d", avgSize)
+	maxStr := fmt.Sprintf("%d", maxSize)
+
+	if err := c.SetCDCEnabled(ctx, "true"); err != nil {
+		return fmt.Errorf("failed to store CDC enabled flag: %w", err)
+	}
+
+	if err := c.SetCDCMin(ctx, minStr); err != nil {
+		return fmt.Errorf("failed to store CDC min: %w", err)
+	}
+
+	if err := c.SetCDCAvg(ctx, avgStr); err != nil {
+		return fmt.Errorf("failed to store CDC avg: %w", err)
+	}
+
+	if err := c.SetCDCMax(ctx, maxStr); err != nil {
+		return fmt.Errorf("failed to store CDC max: %w", err)
+	}
+
+	return nil
+}
+
+// validateCDCConfig validates that the current CDC configuration matches stored values.
+func (c *Config) validateCDCConfig(
+	ctx context.Context,
+	enabled bool,
+	minSize, avgSize, maxSize uint32,
+	storedEnabledStr string,
+) error {
+	storedEnabled := storedEnabledStr == "true"
+
+	// Check if user is trying to disable CDC after it was previously enabled
+	if storedEnabled && !enabled {
+		return fmt.Errorf(
+			"%w; stored cdc_enabled=%s, current cdc_enabled=%v",
+			ErrCDCDisabledAfterEnabled,
+			storedEnabledStr, enabled,
+		)
+	}
+
+	// Get stored values for comparison
+	storedMinStr, err := c.GetCDCMin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get stored CDC min: %w", err)
+	}
+
+	storedAvgStr, err := c.GetCDCAvg(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get stored CDC avg: %w", err)
+	}
+
+	storedMaxStr, err := c.GetCDCMax(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get stored CDC max: %w", err)
+	}
+
+	// Compare current values with stored values
+	minStr := fmt.Sprintf("%d", minSize)
+	avgStr := fmt.Sprintf("%d", avgSize)
+	maxStr := fmt.Sprintf("%d", maxSize)
+
+	var mismatches []string
+
+	if minStr != storedMinStr {
+		mismatches = append(mismatches, fmt.Sprintf(
+			"cdc_min: stored=%s, current=%s",
+			storedMinStr, minStr,
+		))
+	}
+
+	if avgStr != storedAvgStr {
+		mismatches = append(mismatches, fmt.Sprintf(
+			"cdc_avg: stored=%s, current=%s",
+			storedAvgStr, avgStr,
+		))
+	}
+
+	if maxStr != storedMaxStr {
+		mismatches = append(mismatches, fmt.Sprintf(
+			"cdc_max: stored=%s, current=%s",
+			storedMaxStr, maxStr,
+		))
+	}
+
+	if len(mismatches) > 0 {
+		return fmt.Errorf(
+			"%w: %s",
+			ErrCDCConfigMismatch,
+			strings.Join(mismatches, "; "),
+		)
+	}
+
+	return nil
 }
 
 // getLockKey returns the lock key for the specified configuration key.

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -962,12 +962,17 @@ func createCache(
 
 	// Configure CDC
 	cdcEnabled := cmd.Bool("cache-cdc-enabled")
-	if err := c.SetCDCConfiguration(
-		cdcEnabled,
-		cmd.Uint32("cache-cdc-min"),
-		cmd.Uint32("cache-cdc-avg"),
-		cmd.Uint32("cache-cdc-max"),
-	); err != nil {
+	cdcMin := cmd.Uint32("cache-cdc-min")
+	cdcAvg := cmd.Uint32("cache-cdc-avg")
+	cdcMax := cmd.Uint32("cache-cdc-max")
+
+	// Validate CDC configuration against stored values
+	cfg := config.New(db, rwLocker)
+	if err := cfg.ValidateOrStoreCDCConfig(ctx, cdcEnabled, cdcMin, cdcAvg, cdcMax); err != nil {
+		return nil, fmt.Errorf("CDC configuration validation failed: %w", err)
+	}
+
+	if err := c.SetCDCConfiguration(cdcEnabled, cdcMin, cdcAvg, cdcMax); err != nil {
 		return nil, fmt.Errorf("error configuring CDC: %w", err)
 	}
 


### PR DESCRIPTION
Bot-based backport to `release-0.9`, triggered by a label in #971.

Implement boot-time CDC configuration validation and persistence:
- Add CDC config keys (cdc_enabled, cdc_min, cdc_avg, cdc_max) to database
- Enforce immutable CDC configuration: once enabled, cannot be disabled or changed
- Store CDC settings on first boot with CDC enabled
- Validate on subsequent boots to prevent accidental configuration changes
- Provide detailed error messages when configuration mismatches occur

Boot behavior:
1. CDC disabled, no config → no-op (nothing stored)
2. CDC enabled, no config → store all 4 values
3. CDC enabled, config exists, same values → proceed normally
4. CDC enabled, config exists, different values → fail boot with error
5. CDC disabled, config exists (was enabled) → fail boot with error

Implementation:
- Add sentinel errors: ErrCDCDisabledAfterEnabled, ErrCDCConfigMismatch
- Implement ValidateOrStoreCDCConfig() with helper methods for clarity
- Call validation in createCache() before SetCDCConfiguration()
- Add 7 comprehensive test scenarios covering all boot rules
- Support all database backends (SQLite, PostgreSQL, MySQL)

All tests pass, code passes linting, no migrations needed (uses existing config table).