### PR TITLE
feat: remove CDC flag defaults and add recommended values [backport #973]

### DIFF
--- a/charts/ncps/templates/configmap.yaml
+++ b/charts/ncps/templates/configmap.yaml
@@ -28,9 +28,15 @@ data:
       {{- if .Values.config.cdc.enabled }}
       cdc:
         enabled: true
+        {{- if .Values.config.cdc.min }}
         min: {{ printf "%.0f" .Values.config.cdc.min }}
+        {{- end }}
+        {{- if .Values.config.cdc.avg }}
         avg: {{ printf "%.0f" .Values.config.cdc.avg }}
+        {{- end }}
+        {{- if .Values.config.cdc.max }}
         max: {{ printf "%.0f" .Values.config.cdc.max }}
+        {{- end }}
       {{- end }}
 
       {{- if and (or (eq .Values.config.database.type "postgresql") (eq .Values.config.database.type "mysql")) (or .Values.config.database.pool.maxOpenConns .Values.config.database.pool.maxIdleConns) }}

--- a/charts/ncps/values.yaml
+++ b/charts/ncps/values.yaml
@@ -139,12 +139,11 @@ config:
     # REQUIRED for HA deployments (replicaCount > 1) to prevent timeouts and instability.
     # See https://github.com/kalbasit/ncps/issues/660
     enabled: false
-    # Minimum chunk size in bytes
-    min: 65536
-    # Average chunk size in bytes
-    avg: 262144
-    # Maximum chunk size in bytes
-    max: 1048576
+    # Recommended values: min: 16384, avg: 65536, max: 262144
+    # If set to 0 (not configured) and CDC is enabled, the server will error on startup.
+    min: 0
+    avg: 0
+    max: 0
 
     # Bypass flag for HA validation without CDC
     # Use with EXTREME CAUTION. Doing so may result in timeouts and instability.

--- a/dev-scripts/run.py
+++ b/dev-scripts/run.py
@@ -402,7 +402,9 @@ def perform_clean():
         # Construct MC_HOST_clean env var. Note: we use a specific alias 'clean'
         # The format for MC_HOST_<alias> is http(s)://ACCESS_KEY:SECRET_KEY@HOST:PORT
         parsed_endpoint = urlparse(endpoint)
-        mc_url = parsed_endpoint._replace(netloc=f"{access_key}:{secret_key}@{parsed_endpoint.hostname}:{parsed_endpoint.port}").geturl()
+        mc_url = parsed_endpoint._replace(
+            netloc=f"{access_key}:{secret_key}@{parsed_endpoint.hostname}:{parsed_endpoint.port}"
+        ).geturl()
         mc_env["MC_HOST_clean"] = mc_url
         try:
             subprocess.run(
@@ -679,6 +681,9 @@ def main():
         # Storage Args
         if args.enable_cdc:
             cmd_app.append("--cache-cdc-enabled")
+            cmd_app.append("--cache-cdc-min=16384")
+            cmd_app.append("--cache-cdc-avg=65536")
+            cmd_app.append("--cache-cdc-max=262144")
         if args.storage == "local":
             cmd_app.extend(["--cache-storage-local", local_storage_path])
         else:

--- a/docs/docs/User Guide/Configuration/Reference.md
+++ b/docs/docs/User Guide/Configuration/Reference.md
@@ -168,9 +168,9 @@ Content-Defined Chunking (CDC) enables deduplication of NAR files by splitting t
 | Option | Description | Environment Variable | Default |
 | --- | --- | --- | --- |
 | `--cache-cdc-enabled` | Enable CDC for deduplication | `CACHE_CDC_ENABLED` | `false` |
-| `--cache-cdc-min` | Minimum chunk size in bytes | `CACHE_CDC_MIN` | `65536` (64KB) |
-| `--cache-cdc-avg` | Average chunk size in bytes | `CACHE_CDC_AVG` | `262144` (256KB) |
-| `--cache-cdc-max` | Maximum chunk size in bytes | `CACHE_CDC_MAX` | `1048576` (1MB) |
+| `--cache-cdc-min` | Minimum chunk size in bytes | `CACHE_CDC_MIN` | none (recommended: 16384) |
+| `--cache-cdc-avg` | Average chunk size in bytes | `CACHE_CDC_AVG` | none (recommended: 65536) |
+| `--cache-cdc-max` | Maximum chunk size in bytes | `CACHE_CDC_MAX` | none (recommended: 262144) |
 
 **Example:**
 

--- a/docs/docs/User Guide/Features/CDC.md
+++ b/docs/docs/User Guide/Features/CDC.md
@@ -40,10 +40,10 @@ CDC is disabled by default. You can enable it by setting `cache.cdc.enabled` to 
 cache:
   cdc:
     enabled: true
-    # Optional: Tune chunk sizes (defaults shown)
-    min: 65536    # 64 KB
-    avg: 262144   # 256 KB
-    max: 1048576  # 1 MB
+    # Optional: Tune chunk sizes (recommended values shown)
+    min: 16384    # 16 KB
+    avg: 65536    # 64 KB
+    max: 262144   # 256 KB
 ```
 
 ### Parameters
@@ -51,9 +51,9 @@ cache:
 | Flag | Description | Environment Variable | Default |
 | --- | --- | --- | --- |
 | `--cache-cdc-enabled` | Enable CDC for deduplication | `CACHE_CDC_ENABLED` | `false` |
-| `--cache-cdc-min` | Minimum chunk size in bytes | `CACHE_CDC_MIN` | `65536` (64KB) |
-| `--cache-cdc-avg` | Average (target) chunk size in bytes | `CACHE_CDC_AVG` | `262144` (256KB) |
-| `--cache-cdc-max` | Maximum chunk size in bytes | `CACHE_CDC_MAX` | `1048576` (1MB) |
+| `--cache-cdc-min` | Minimum chunk size in bytes | `CACHE_CDC_MIN` | none (recommended: 16384) |
+| `--cache-cdc-avg` | Average (target) chunk size in bytes | `CACHE_CDC_AVG` | none (recommended: 65536) |
+| `--cache-cdc-max` | Maximum chunk size in bytes | `CACHE_CDC_MAX` | none (recommended: 262144) |
 
 ## Storage Considerations
 

--- a/nix/k8s-tests/config.nix
+++ b/nix/k8s-tests/config.nix
@@ -303,7 +303,14 @@ rec {
   # These get merged into permutation configurations when features are enabled
   features = {
     cdc = {
-      config.cdc.enabled = true;
+      config = {
+        cdc = {
+          enabled = true;
+          min = 16384;
+          avg = 65536;
+          max = 262144;
+        };
+      };
     };
 
     ha = {
@@ -572,7 +579,14 @@ rec {
           # Feature Definitions (re-declared locally for safety)
           featuresDef = {
             cdc = {
-              config.cdc.enabled = true;
+              config = {
+                cdc = {
+                  enabled = true;
+                  min = 16384;
+                  avg = 65536;
+                  max = 262144;
+                };
+              };
             };
             ha = { };
             pod-disruption-budget = {


### PR DESCRIPTION
Bot-based backport to `release-0.9`, triggered by a label in #973.

This removes hardcoded default values from CDC chunk size flags
(--cache-cdc-min, --cache-cdc-avg, --cache-cdc-max) and replaces them
with recommended values shown in help text and documentation.

Changes include:
- Removed Value fields from CLI flags in serve.go and
  migrate_nar_to_chunks.go
- Updated flag help text with recommended values
- Changed Helm chart defaults to 0 with conditional rendering of
  non-zero values
- Updated k8s-tests CDC feature to use recommended values
- Updated documentation to show recommended values instead of old
  defaults

When CDC is enabled with 0-values, fastcdc.NewChunkerPool will error at
startup, preventing silent failures. This encourages users to explicitly
configure chunk sizes based on their use case.

Recommended values: min=16384, avg=65536, max=262144

Additionally, this removes the CDC-related flags from
migrate-nar-to-chunks command and load them from the database instead.