### PR TITLE
feat: add fsck command to detect and repair DB/storage inconsistencies [backport #975]

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -345,3 +345,21 @@ SET
     file_hash = sqlc.arg(file_hash),
     updated_at = CURRENT_TIMESTAMP
 WHERE url = sqlc.arg(old_url);
+
+-- name: GetAllNarFiles :many
+-- Returns all nar_files for storage existence verification.
+SELECT id, hash, compression, `query`, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+FROM nar_files;
+
+-- name: GetNarInfosWithoutNarFiles :many
+-- Returns narinfos that have no linked nar_file entries.
+SELECT ni.*
+FROM narinfos ni
+WHERE NOT EXISTS (
+    SELECT 1 FROM narinfo_nar_files nnf WHERE nnf.narinfo_id = ni.id
+);
+
+-- name: GetAllChunks :many
+-- Returns all chunks for storage existence verification (CDC mode).
+SELECT id, hash, size, compressed_size, created_at, updated_at
+FROM chunks;

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -377,3 +377,21 @@ SET
     file_hash = sqlc.arg(file_hash),
     updated_at = CURRENT_TIMESTAMP
 WHERE url = sqlc.arg(old_url);
+
+-- name: GetAllNarFiles :many
+-- Returns all nar_files for storage existence verification.
+SELECT id, hash, compression, query, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+FROM nar_files;
+
+-- name: GetNarInfosWithoutNarFiles :many
+-- Returns narinfos that have no linked nar_file entries.
+SELECT ni.*
+FROM narinfos ni
+WHERE NOT EXISTS (
+    SELECT 1 FROM narinfo_nar_files nnf WHERE nnf.narinfo_id = ni.id
+);
+
+-- name: GetAllChunks :many
+-- Returns all chunks for storage existence verification (CDC mode).
+SELECT id, hash, size, compressed_size, created_at, updated_at
+FROM chunks;

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -364,3 +364,21 @@ SET
     file_hash = sqlc.arg(file_hash),
     updated_at = CURRENT_TIMESTAMP
 WHERE url = sqlc.arg(old_url);
+
+-- name: GetAllNarFiles :many
+-- Returns all nar_files for storage existence verification.
+SELECT id, hash, compression, "query", file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+FROM nar_files;
+
+-- name: GetNarInfosWithoutNarFiles :many
+-- Returns narinfos that have no linked nar_file entries.
+SELECT ni.*
+FROM narinfos ni
+WHERE NOT EXISTS (
+    SELECT 1 FROM narinfo_nar_files nnf WHERE nnf.narinfo_id = ni.id
+);
+
+-- name: GetAllChunks :many
+-- Returns all chunks for storage existence verification (CDC mode).
+SELECT id, hash, size, compressed_size, created_at, updated_at
+FROM chunks;

--- a/pkg/database/generated_models.go
+++ b/pkg/database/generated_models.go
@@ -82,6 +82,19 @@ type DeleteNarFileByHashParams struct {
 	Query       string
 }
 
+type GetAllNarFilesRow struct {
+	ID                int64
+	Hash              string
+	Compression       string
+	Query             string
+	FileSize          uint64
+	TotalChunks       int64
+	ChunkingStartedAt sql.NullTime
+	CreatedAt         time.Time
+	UpdatedAt         sql.NullTime
+	LastAccessedAt    sql.NullTime
+}
+
 type GetChunkByNarFileIDAndIndexParams struct {
 	NarFileID  int64
 	ChunkIndex int64

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -294,6 +294,70 @@ func (w *mysqlWrapper) DeleteOrphanedNarFiles(ctx context.Context) (int64, error
 	return res, nil
 }
 
+func (w *mysqlWrapper) GetAllChunks(ctx context.Context) ([]Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetAllChunks(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]Chunk, len(res))
+	for i, v := range res {
+		items[i] = Chunk{
+			ID: v.ID,
+
+			Hash: v.Hash,
+
+			Size: v.Size,
+
+			CompressedSize: v.CompressedSize,
+
+			CreatedAt: v.CreatedAt,
+
+			UpdatedAt: v.UpdatedAt,
+		}
+	}
+	return items, nil
+}
+
+func (w *mysqlWrapper) GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetAllNarFiles(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]GetAllNarFilesRow, len(res))
+	for i, v := range res {
+		items[i] = GetAllNarFilesRow{
+			ID: v.ID,
+
+			Hash: v.Hash,
+
+			Compression: v.Compression,
+
+			Query: v.Query,
+
+			FileSize: v.FileSize,
+
+			TotalChunks: v.TotalChunks,
+
+			ChunkingStartedAt: v.ChunkingStartedAt,
+
+			CreatedAt: v.CreatedAt,
+
+			UpdatedAt: v.UpdatedAt,
+
+			LastAccessedAt: v.LastAccessedAt,
+		}
+	}
+	return items, nil
+}
+
 func (w *mysqlWrapper) GetChunkByHash(ctx context.Context, hash string) (Chunk, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -963,6 +1027,52 @@ func (w *mysqlWrapper) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNa
 	// Return Primitive / *sql.DB / etc
 
 	return res, nil
+}
+
+func (w *mysqlWrapper) GetNarInfosWithoutNarFiles(ctx context.Context) ([]NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetNarInfosWithoutNarFiles(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]NarInfo, len(res))
+	for i, v := range res {
+		items[i] = NarInfo{
+			ID: v.ID,
+
+			Hash: v.Hash,
+
+			CreatedAt: v.CreatedAt,
+
+			UpdatedAt: v.UpdatedAt,
+
+			LastAccessedAt: v.LastAccessedAt,
+
+			StorePath: v.StorePath,
+
+			URL: v.URL,
+
+			Compression: v.Compression,
+
+			FileHash: v.FileHash,
+
+			FileSize: v.FileSize,
+
+			NarHash: v.NarHash,
+
+			NarSize: v.NarSize,
+
+			Deriver: v.Deriver,
+
+			System: v.System,
+
+			Ca: v.Ca,
+		}
+	}
+	return items, nil
 }
 
 func (w *mysqlWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -300,6 +300,70 @@ func (w *postgresWrapper) DeleteOrphanedNarFiles(ctx context.Context) (int64, er
 	return res, nil
 }
 
+func (w *postgresWrapper) GetAllChunks(ctx context.Context) ([]Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetAllChunks(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]Chunk, len(res))
+	for i, v := range res {
+		items[i] = Chunk{
+			ID: v.ID,
+
+			Hash: v.Hash,
+
+			Size: v.Size,
+
+			CompressedSize: v.CompressedSize,
+
+			CreatedAt: v.CreatedAt,
+
+			UpdatedAt: v.UpdatedAt,
+		}
+	}
+	return items, nil
+}
+
+func (w *postgresWrapper) GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetAllNarFiles(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]GetAllNarFilesRow, len(res))
+	for i, v := range res {
+		items[i] = GetAllNarFilesRow{
+			ID: v.ID,
+
+			Hash: v.Hash,
+
+			Compression: v.Compression,
+
+			Query: v.Query,
+
+			FileSize: v.FileSize,
+
+			TotalChunks: v.TotalChunks,
+
+			ChunkingStartedAt: v.ChunkingStartedAt,
+
+			CreatedAt: v.CreatedAt,
+
+			UpdatedAt: v.UpdatedAt,
+
+			LastAccessedAt: v.LastAccessedAt,
+		}
+	}
+	return items, nil
+}
+
 func (w *postgresWrapper) GetChunkByHash(ctx context.Context, hash string) (Chunk, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -969,6 +1033,52 @@ func (w *postgresWrapper) GetNarInfoURLByNarFileHash(ctx context.Context, arg Ge
 	// Return Primitive / *sql.DB / etc
 
 	return res, nil
+}
+
+func (w *postgresWrapper) GetNarInfosWithoutNarFiles(ctx context.Context) ([]NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetNarInfosWithoutNarFiles(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]NarInfo, len(res))
+	for i, v := range res {
+		items[i] = NarInfo{
+			ID: v.ID,
+
+			Hash: v.Hash,
+
+			CreatedAt: v.CreatedAt,
+
+			UpdatedAt: v.UpdatedAt,
+
+			LastAccessedAt: v.LastAccessedAt,
+
+			StorePath: v.StorePath,
+
+			URL: v.URL,
+
+			Compression: v.Compression,
+
+			FileHash: v.FileHash,
+
+			FileSize: v.FileSize,
+
+			NarHash: v.NarHash,
+
+			NarSize: v.NarSize,
+
+			Deriver: v.Deriver,
+
+			System: v.System,
+
+			Ca: v.Ca,
+		}
+	}
+	return items, nil
 }
 
 func (w *postgresWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -318,6 +318,70 @@ func (w *sqliteWrapper) DeleteOrphanedNarFiles(ctx context.Context) (int64, erro
 	return res, nil
 }
 
+func (w *sqliteWrapper) GetAllChunks(ctx context.Context) ([]Chunk, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetAllChunks(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]Chunk, len(res))
+	for i, v := range res {
+		items[i] = Chunk{
+			ID: v.ID,
+
+			Hash: v.Hash,
+
+			Size: v.Size,
+
+			CompressedSize: v.CompressedSize,
+
+			CreatedAt: v.CreatedAt,
+
+			UpdatedAt: v.UpdatedAt,
+		}
+	}
+	return items, nil
+}
+
+func (w *sqliteWrapper) GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetAllNarFiles(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]GetAllNarFilesRow, len(res))
+	for i, v := range res {
+		items[i] = GetAllNarFilesRow{
+			ID: v.ID,
+
+			Hash: v.Hash,
+
+			Compression: v.Compression,
+
+			Query: v.Query,
+
+			FileSize: v.FileSize,
+
+			TotalChunks: v.TotalChunks,
+
+			ChunkingStartedAt: v.ChunkingStartedAt,
+
+			CreatedAt: v.CreatedAt,
+
+			UpdatedAt: v.UpdatedAt,
+
+			LastAccessedAt: v.LastAccessedAt,
+		}
+	}
+	return items, nil
+}
+
 func (w *sqliteWrapper) GetChunkByHash(ctx context.Context, hash string) (Chunk, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
@@ -987,6 +1051,52 @@ func (w *sqliteWrapper) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetN
 	// Return Primitive / *sql.DB / etc
 
 	return res, nil
+}
+
+func (w *sqliteWrapper) GetNarInfosWithoutNarFiles(ctx context.Context) ([]NarInfo, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.GetNarInfosWithoutNarFiles(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert Slice of Domain Structs
+	items := make([]NarInfo, len(res))
+	for i, v := range res {
+		items[i] = NarInfo{
+			ID: v.ID,
+
+			Hash: v.Hash,
+
+			CreatedAt: v.CreatedAt,
+
+			UpdatedAt: v.UpdatedAt,
+
+			LastAccessedAt: v.LastAccessedAt,
+
+			StorePath: v.StorePath,
+
+			URL: v.URL,
+
+			Compression: v.Compression,
+
+			FileHash: v.FileHash,
+
+			FileSize: v.FileSize,
+
+			NarHash: v.NarHash,
+
+			NarSize: v.NarSize,
+
+			Deriver: v.Deriver,
+
+			System: v.System,
+
+			Ca: v.Ca,
+		}
+	}
+	return items, nil
 }
 
 func (w *sqliteWrapper) GetNarTotalSize(ctx context.Context) (int64, error) {

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -119,6 +119,16 @@ type Querier interface {
 	//      FROM narinfo_nar_files
 	//  )
 	DeleteOrphanedNarFiles(ctx context.Context) (int64, error)
+	// Returns all chunks for storage existence verification (CDC mode).
+	//
+	//  SELECT id, hash, size, compressed_size, created_at, updated_at
+	//  FROM chunks
+	GetAllChunks(ctx context.Context) ([]Chunk, error)
+	// Returns all nar_files for storage existence verification.
+	//
+	//  SELECT id, hash, compression, `query`, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+	//  FROM nar_files
+	GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow, error)
 	//GetChunkByHash
 	//
 	//  SELECT id, hash, size, compressed_size, created_at, updated_at
@@ -252,6 +262,14 @@ type Querier interface {
 	//  WHERE nf.hash = ? AND nf.compression = ? AND nf.query = ?
 	//  LIMIT 1
 	GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error)
+	// Returns narinfos that have no linked nar_file entries.
+	//
+	//  SELECT ni.id, ni.hash, ni.created_at, ni.updated_at, ni.last_accessed_at, ni.store_path, ni.url, ni.compression, ni.file_hash, ni.file_size, ni.nar_hash, ni.nar_size, ni.deriver, ni.`system`, ni.ca
+	//  FROM narinfos ni
+	//  WHERE NOT EXISTS (
+	//      SELECT 1 FROM narinfo_nar_files nnf WHERE nnf.narinfo_id = ni.id
+	//  )
+	GetNarInfosWithoutNarFiles(ctx context.Context) ([]NarInfo, error)
 	//GetNarTotalSize
 	//
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS SIGNED) AS total_size

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -147,6 +147,16 @@ type Querier interface {
 	//      FROM narinfo_nar_files
 	//  )
 	DeleteOrphanedNarFiles(ctx context.Context) (int64, error)
+	// Returns all chunks for storage existence verification (CDC mode).
+	//
+	//  SELECT id, hash, size, compressed_size, created_at, updated_at
+	//  FROM chunks
+	GetAllChunks(ctx context.Context) ([]Chunk, error)
+	// Returns all nar_files for storage existence verification.
+	//
+	//  SELECT id, hash, compression, query, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+	//  FROM nar_files
+	GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow, error)
 	//GetChunkByHash
 	//
 	//  SELECT id, hash, size, compressed_size, created_at, updated_at
@@ -280,6 +290,14 @@ type Querier interface {
 	//  WHERE nf.hash = $1 AND nf.compression = $2 AND nf.query = $3
 	//  LIMIT 1
 	GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error)
+	// Returns narinfos that have no linked nar_file entries.
+	//
+	//  SELECT ni.id, ni.hash, ni.created_at, ni.updated_at, ni.last_accessed_at, ni.store_path, ni.url, ni.compression, ni.file_hash, ni.file_size, ni.nar_hash, ni.nar_size, ni.deriver, ni.system, ni.ca
+	//  FROM narinfos ni
+	//  WHERE NOT EXISTS (
+	//      SELECT 1 FROM narinfo_nar_files nnf WHERE nnf.narinfo_id = ni.id
+	//  )
+	GetNarInfosWithoutNarFiles(ctx context.Context) ([]NarInfo, error)
 	//GetNarTotalSize
 	//
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS BIGINT) AS total_size

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -487,6 +487,101 @@ func (q *Queries) DeleteOrphanedNarFiles(ctx context.Context) (int64, error) {
 	return result.RowsAffected()
 }
 
+const getAllChunks = `-- name: GetAllChunks :many
+SELECT id, hash, size, compressed_size, created_at, updated_at
+FROM chunks
+`
+
+// Returns all chunks for storage existence verification (CDC mode).
+//
+//	SELECT id, hash, size, compressed_size, created_at, updated_at
+//	FROM chunks
+func (q *Queries) GetAllChunks(ctx context.Context) ([]Chunk, error) {
+	rows, err := q.db.QueryContext(ctx, getAllChunks)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Chunk
+	for rows.Next() {
+		var i Chunk
+		if err := rows.Scan(
+			&i.ID,
+			&i.Hash,
+			&i.Size,
+			&i.CompressedSize,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getAllNarFiles = `-- name: GetAllNarFiles :many
+SELECT id, hash, compression, query, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+FROM nar_files
+`
+
+type GetAllNarFilesRow struct {
+	ID                int64
+	Hash              string
+	Compression       string
+	Query             string
+	FileSize          uint64
+	TotalChunks       int64
+	ChunkingStartedAt sql.NullTime
+	CreatedAt         time.Time
+	UpdatedAt         sql.NullTime
+	LastAccessedAt    sql.NullTime
+}
+
+// Returns all nar_files for storage existence verification.
+//
+//	SELECT id, hash, compression, query, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+//	FROM nar_files
+func (q *Queries) GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllNarFiles)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetAllNarFilesRow
+	for rows.Next() {
+		var i GetAllNarFilesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Hash,
+			&i.Compression,
+			&i.Query,
+			&i.FileSize,
+			&i.TotalChunks,
+			&i.ChunkingStartedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.LastAccessedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getChunkByHash = `-- name: GetChunkByHash :one
 SELECT id, hash, size, compressed_size, created_at, updated_at
 FROM chunks
@@ -1093,6 +1188,60 @@ func (q *Queries) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfo
 	var url sql.NullString
 	err := row.Scan(&url)
 	return url, err
+}
+
+const getNarInfosWithoutNarFiles = `-- name: GetNarInfosWithoutNarFiles :many
+SELECT ni.id, ni.hash, ni.created_at, ni.updated_at, ni.last_accessed_at, ni.store_path, ni.url, ni.compression, ni.file_hash, ni.file_size, ni.nar_hash, ni.nar_size, ni.deriver, ni.system, ni.ca
+FROM narinfos ni
+WHERE NOT EXISTS (
+    SELECT 1 FROM narinfo_nar_files nnf WHERE nnf.narinfo_id = ni.id
+)
+`
+
+// Returns narinfos that have no linked nar_file entries.
+//
+//	SELECT ni.id, ni.hash, ni.created_at, ni.updated_at, ni.last_accessed_at, ni.store_path, ni.url, ni.compression, ni.file_hash, ni.file_size, ni.nar_hash, ni.nar_size, ni.deriver, ni.system, ni.ca
+//	FROM narinfos ni
+//	WHERE NOT EXISTS (
+//	    SELECT 1 FROM narinfo_nar_files nnf WHERE nnf.narinfo_id = ni.id
+//	)
+func (q *Queries) GetNarInfosWithoutNarFiles(ctx context.Context) ([]NarInfo, error) {
+	rows, err := q.db.QueryContext(ctx, getNarInfosWithoutNarFiles)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []NarInfo
+	for rows.Next() {
+		var i NarInfo
+		if err := rows.Scan(
+			&i.ID,
+			&i.Hash,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.LastAccessedAt,
+			&i.StorePath,
+			&i.URL,
+			&i.Compression,
+			&i.FileHash,
+			&i.FileSize,
+			&i.NarHash,
+			&i.NarSize,
+			&i.Deriver,
+			&i.System,
+			&i.Ca,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getNarTotalSize = `-- name: GetNarTotalSize :one

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -133,6 +133,16 @@ type Querier interface {
 	//      FROM narinfo_nar_files
 	//  )
 	DeleteOrphanedNarFiles(ctx context.Context) (int64, error)
+	// Returns all chunks for storage existence verification (CDC mode).
+	//
+	//  SELECT id, hash, size, compressed_size, created_at, updated_at
+	//  FROM chunks
+	GetAllChunks(ctx context.Context) ([]Chunk, error)
+	// Returns all nar_files for storage existence verification.
+	//
+	//  SELECT id, hash, compression, "query", file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+	//  FROM nar_files
+	GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow, error)
 	//GetChunkByHash
 	//
 	//  SELECT id, hash, size, compressed_size, created_at, updated_at
@@ -266,6 +276,14 @@ type Querier interface {
 	//  WHERE nf.hash = ? AND nf.compression = ? AND nf."query" = ?
 	//  LIMIT 1
 	GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfoURLByNarFileHashParams) (sql.NullString, error)
+	// Returns narinfos that have no linked nar_file entries.
+	//
+	//  SELECT ni.id, ni.hash, ni.created_at, ni.updated_at, ni.last_accessed_at, ni.store_path, ni.url, ni.compression, ni.file_hash, ni.file_size, ni.nar_hash, ni.nar_size, ni.deriver, ni.system, ni.ca
+	//  FROM narinfos ni
+	//  WHERE NOT EXISTS (
+	//      SELECT 1 FROM narinfo_nar_files nnf WHERE nnf.narinfo_id = ni.id
+	//  )
+	GetNarInfosWithoutNarFiles(ctx context.Context) ([]NarInfo, error)
 	//GetNarTotalSize
 	//
 	//  SELECT CAST(COALESCE(SUM(file_size), 0) AS INTEGER) AS total_size

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -439,6 +439,101 @@ func (q *Queries) DeleteOrphanedNarFiles(ctx context.Context) (int64, error) {
 	return result.RowsAffected()
 }
 
+const getAllChunks = `-- name: GetAllChunks :many
+SELECT id, hash, size, compressed_size, created_at, updated_at
+FROM chunks
+`
+
+// Returns all chunks for storage existence verification (CDC mode).
+//
+//	SELECT id, hash, size, compressed_size, created_at, updated_at
+//	FROM chunks
+func (q *Queries) GetAllChunks(ctx context.Context) ([]Chunk, error) {
+	rows, err := q.db.QueryContext(ctx, getAllChunks)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Chunk
+	for rows.Next() {
+		var i Chunk
+		if err := rows.Scan(
+			&i.ID,
+			&i.Hash,
+			&i.Size,
+			&i.CompressedSize,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getAllNarFiles = `-- name: GetAllNarFiles :many
+SELECT id, hash, compression, "query", file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+FROM nar_files
+`
+
+type GetAllNarFilesRow struct {
+	ID                int64
+	Hash              string
+	Compression       string
+	Query             string
+	FileSize          uint64
+	TotalChunks       int64
+	ChunkingStartedAt sql.NullTime
+	CreatedAt         time.Time
+	UpdatedAt         sql.NullTime
+	LastAccessedAt    sql.NullTime
+}
+
+// Returns all nar_files for storage existence verification.
+//
+//	SELECT id, hash, compression, "query", file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+//	FROM nar_files
+func (q *Queries) GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow, error) {
+	rows, err := q.db.QueryContext(ctx, getAllNarFiles)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetAllNarFilesRow
+	for rows.Next() {
+		var i GetAllNarFilesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Hash,
+			&i.Compression,
+			&i.Query,
+			&i.FileSize,
+			&i.TotalChunks,
+			&i.ChunkingStartedAt,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.LastAccessedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getChunkByHash = `-- name: GetChunkByHash :one
 SELECT id, hash, size, compressed_size, created_at, updated_at
 FROM chunks
@@ -1045,6 +1140,60 @@ func (q *Queries) GetNarInfoURLByNarFileHash(ctx context.Context, arg GetNarInfo
 	var url sql.NullString
 	err := row.Scan(&url)
 	return url, err
+}
+
+const getNarInfosWithoutNarFiles = `-- name: GetNarInfosWithoutNarFiles :many
+SELECT ni.id, ni.hash, ni.created_at, ni.updated_at, ni.last_accessed_at, ni.store_path, ni.url, ni.compression, ni.file_hash, ni.file_size, ni.nar_hash, ni.nar_size, ni.deriver, ni.system, ni.ca
+FROM narinfos ni
+WHERE NOT EXISTS (
+    SELECT 1 FROM narinfo_nar_files nnf WHERE nnf.narinfo_id = ni.id
+)
+`
+
+// Returns narinfos that have no linked nar_file entries.
+//
+//	SELECT ni.id, ni.hash, ni.created_at, ni.updated_at, ni.last_accessed_at, ni.store_path, ni.url, ni.compression, ni.file_hash, ni.file_size, ni.nar_hash, ni.nar_size, ni.deriver, ni.system, ni.ca
+//	FROM narinfos ni
+//	WHERE NOT EXISTS (
+//	    SELECT 1 FROM narinfo_nar_files nnf WHERE nnf.narinfo_id = ni.id
+//	)
+func (q *Queries) GetNarInfosWithoutNarFiles(ctx context.Context) ([]NarInfo, error) {
+	rows, err := q.db.QueryContext(ctx, getNarInfosWithoutNarFiles)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []NarInfo
+	for rows.Next() {
+		var i NarInfo
+		if err := rows.Scan(
+			&i.ID,
+			&i.Hash,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+			&i.LastAccessedAt,
+			&i.StorePath,
+			&i.URL,
+			&i.Compression,
+			&i.FileHash,
+			&i.FileSize,
+			&i.NarHash,
+			&i.NarSize,
+			&i.Deriver,
+			&i.System,
+			&i.Ca,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getNarTotalSize = `-- name: GetNarTotalSize :one

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -1,0 +1,964 @@
+package ncps
+
+import (
+	"bufio"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/urfave/cli/v3"
+
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+
+	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/otel"
+	"github.com/kalbasit/ncps/pkg/storage"
+)
+
+// ErrFsckIssuesFound is returned when fsck finds consistency issues.
+var ErrFsckIssuesFound = errors.New("consistency issues found")
+
+// fsckResults holds the results of a fsck run.
+type fsckResults struct {
+	// narinfosWithoutNarFiles: narinfos in DB with no linked nar_file.
+	narinfosWithoutNarFiles []database.NarInfo
+
+	// orphanedNarFilesInDB: nar_files in DB not linked to any narinfo.
+	orphanedNarFilesInDB []database.NarFile
+
+	// narFilesMissingInStorage: nar_files in DB whose physical file is absent.
+	narFilesMissingInStorage []database.NarFile
+
+	// orphanedNarFilesInStorage: NAR files in storage with no DB record.
+	orphanedNarFilesInStorage []nar.URL
+
+	// cdcMode indicates whether CDC-related checks were performed.
+	cdcMode bool
+
+	// orphanedChunksInDB: chunks in DB not linked to any nar_file.
+	orphanedChunksInDB []database.GetOrphanedChunksRow
+
+	// chunksMissingInStorage: chunks in DB whose physical file is absent.
+	chunksMissingInStorage []database.Chunk
+
+	// orphanedChunksInStorage: chunk files in storage with no DB record.
+	orphanedChunksInStorage []string
+}
+
+func (r *fsckResults) totalIssues() int {
+	return len(r.narinfosWithoutNarFiles) +
+		len(r.orphanedNarFilesInDB) +
+		len(r.narFilesMissingInStorage) +
+		len(r.orphanedNarFilesInStorage) +
+		len(r.orphanedChunksInDB) +
+		len(r.chunksMissingInStorage) +
+		len(r.orphanedChunksInStorage)
+}
+
+// NarWalker is implemented by storage backends that support walking NAR files.
+type NarWalker interface {
+	WalkNars(ctx context.Context, fn func(narURL nar.URL) error) error
+}
+
+// ChunkWalker is implemented by chunk stores that support walking chunk files.
+type ChunkWalker interface {
+	WalkChunks(ctx context.Context, fn func(hash string) error) error
+}
+
+// hasChunker is implemented by chunk stores that support HasChunk.
+type hasChunker interface {
+	HasChunk(ctx context.Context, hash string) (bool, error)
+}
+
+// chunkDeleter is implemented by chunk stores that support DeleteChunk.
+type chunkDeleter interface {
+	DeleteChunk(ctx context.Context, hash string) error
+}
+
+func fsckCommand(
+	flagSources flagSourcesFn,
+	registerShutdown registerShutdownFn,
+) *cli.Command {
+	return &cli.Command{
+		Name:  "fsck",
+		Usage: "Check consistency between database and storage",
+		Description: `Checks for consistency issues between the database and storage backend.
+
+Detects:
+  - Narinfos in the database with no linked nar_file records
+  - Orphaned nar_file records in the database (not linked to any narinfo)
+  - Nar_file records in the database whose physical file is missing from storage
+  - NAR files in storage that have no corresponding database record
+  - [CDC] Orphaned chunk records in the database (not linked to any nar_file)
+  - [CDC] Chunk records in the database whose physical file is missing from storage
+  - [CDC] Chunk files in storage that have no corresponding database record
+
+Use --repair to automatically fix detected issues, or --dry-run to preview what would be fixed.`,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "repair",
+				Usage: "Automatically fix detected issues (delete orphaned records and files)",
+			},
+			&cli.BoolFlag{
+				Name:  "dry-run",
+				Usage: "Show what would be fixed without making any changes",
+			},
+
+			// Storage Flags
+			&cli.StringFlag{
+				Name:    "cache-storage-local",
+				Usage:   "The local data path used for configuration and cache storage (use this OR S3 storage)",
+				Sources: flagSources("cache.storage.local", "CACHE_STORAGE_LOCAL"),
+			},
+			&cli.StringFlag{
+				Name:    "cache-storage-s3-bucket",
+				Usage:   "S3 bucket name for storage (use this OR --cache-storage-local for local storage)",
+				Sources: flagSources("cache.storage.s3.bucket", "CACHE_STORAGE_S3_BUCKET"),
+			},
+			&cli.StringFlag{
+				Name:    "cache-storage-s3-endpoint",
+				Usage:   "S3-compatible endpoint URL with scheme",
+				Sources: flagSources("cache.storage.s3.endpoint", "CACHE_STORAGE_S3_ENDPOINT"),
+			},
+			&cli.StringFlag{
+				Name:    "cache-storage-s3-region",
+				Usage:   "S3 region (optional)",
+				Sources: flagSources("cache.storage.s3.region", "CACHE_STORAGE_S3_REGION"),
+			},
+			&cli.StringFlag{
+				Name:    "cache-storage-s3-access-key-id",
+				Usage:   "S3 access key ID",
+				Sources: flagSources("cache.storage.s3.access-key-id", "CACHE_STORAGE_S3_ACCESS_KEY_ID"),
+			},
+			&cli.StringFlag{
+				Name:    "cache-storage-s3-secret-access-key",
+				Usage:   "S3 secret access key",
+				Sources: flagSources("cache.storage.s3.secret-access-key", "CACHE_STORAGE_S3_SECRET_ACCESS_KEY"),
+			},
+			&cli.BoolFlag{
+				Name:    "cache-storage-s3-force-path-style",
+				Usage:   "Force path-style S3 addressing",
+				Sources: flagSources("cache.storage.s3.force-path-style", "CACHE_STORAGE_S3_FORCE_PATH_STYLE"),
+			},
+
+			// Database Flags
+			&cli.StringFlag{
+				Name:     "cache-database-url",
+				Usage:    "The URL of the database",
+				Sources:  flagSources("cache.database-url", "CACHE_DATABASE_URL"),
+				Required: true,
+			},
+			&cli.IntFlag{
+				Name:    "cache-database-pool-max-open-conns",
+				Usage:   "Maximum number of open connections to the database",
+				Sources: flagSources("cache.database.pool.max-open-conns", "CACHE_DATABASE_POOL_MAX_OPEN_CONNS"),
+			},
+			&cli.IntFlag{
+				Name:    "cache-database-pool-max-idle-conns",
+				Usage:   "Maximum number of idle connections in the pool",
+				Sources: flagSources("cache.database.pool.max-idle-conns", "CACHE_DATABASE_POOL_MAX_IDLE_CONNS"),
+			},
+
+			// Lock Backend Flags (optional)
+			&cli.StringSliceFlag{
+				Name:    "cache-redis-addrs",
+				Usage:   "Redis server addresses for distributed locking",
+				Sources: flagSources("cache.redis.addrs", "CACHE_REDIS_ADDRS"),
+			},
+			&cli.StringFlag{
+				Name:    "cache-redis-username",
+				Usage:   "Redis username",
+				Sources: flagSources("cache.redis.username", "CACHE_REDIS_USERNAME"),
+			},
+			&cli.StringFlag{
+				Name:    "cache-redis-password",
+				Usage:   "Redis password",
+				Sources: flagSources("cache.redis.password", "CACHE_REDIS_PASSWORD"),
+			},
+			&cli.IntFlag{
+				Name:    "cache-redis-db",
+				Usage:   "Redis database number",
+				Sources: flagSources("cache.redis.db", "CACHE_REDIS_DB"),
+			},
+			&cli.BoolFlag{
+				Name:    "cache-redis-use-tls",
+				Usage:   "Use TLS for Redis connections",
+				Sources: flagSources("cache.redis.use-tls", "CACHE_REDIS_USE_TLS"),
+			},
+			&cli.StringFlag{
+				Name:    "cache-lock-backend",
+				Usage:   "Lock backend to use: 'local' (single instance) or 'redis' (distributed)",
+				Sources: flagSources("cache.lock.backend", "CACHE_LOCK_BACKEND"),
+				Value:   "local",
+			},
+			&cli.StringFlag{
+				Name:    "cache-lock-redis-key-prefix",
+				Usage:   "Prefix for all Redis lock keys",
+				Sources: flagSources("cache.lock.redis.key-prefix", "CACHE_LOCK_REDIS_KEY_PREFIX"),
+				Value:   "ncps:lock:",
+			},
+			&cli.DurationFlag{
+				Name:    "cache-lock-download-ttl",
+				Usage:   "TTL for download locks",
+				Sources: flagSources("cache.lock.download-lock-ttl", "CACHE_LOCK_DOWNLOAD_TTL"),
+				Value:   5 * time.Minute,
+			},
+			&cli.DurationFlag{
+				Name:    "cache-lock-lru-ttl",
+				Usage:   "TTL for LRU lock",
+				Sources: flagSources("cache.lock.lru-lock-ttl", "CACHE_LOCK_LRU_TTL"),
+				Value:   30 * time.Minute,
+			},
+			&cli.IntFlag{
+				Name:    "cache-lock-retry-max-attempts",
+				Usage:   "Maximum number of retry attempts for distributed locks",
+				Sources: flagSources("cache.lock.retry.max-attempts", "CACHE_LOCK_RETRY_MAX_ATTEMPTS"),
+				Value:   3,
+			},
+			&cli.DurationFlag{
+				Name:    "cache-lock-retry-initial-delay",
+				Usage:   "Initial retry delay for distributed locks",
+				Sources: flagSources("cache.lock.retry.initial-delay", "CACHE_LOCK_RETRY_INITIAL_DELAY"),
+				Value:   100 * time.Millisecond,
+			},
+			&cli.DurationFlag{
+				Name:    "cache-lock-retry-max-delay",
+				Usage:   "Maximum retry delay for distributed locks",
+				Sources: flagSources("cache.lock.retry.max-delay", "CACHE_LOCK_RETRY_MAX_DELAY"),
+				Value:   2 * time.Second,
+			},
+			&cli.BoolFlag{
+				Name:    "cache-lock-retry-jitter",
+				Usage:   "Enable jitter in retry delays",
+				Sources: flagSources("cache.lock.retry.jitter", "CACHE_LOCK_RETRY_JITTER"),
+				Value:   true,
+			},
+			&cli.BoolFlag{
+				Name:    "cache-lock-allow-degraded-mode",
+				Usage:   "Allow falling back to local locks if Redis is unavailable",
+				Sources: flagSources("cache.lock.allow-degraded-mode", "CACHE_LOCK_ALLOW_DEGRADED_MODE"),
+			},
+			&cli.IntFlag{
+				Name:    "cache-redis-pool-size",
+				Usage:   "Redis connection pool size",
+				Sources: flagSources("cache.redis.pool-size", "CACHE_REDIS_POOL_SIZE"),
+				Value:   10,
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			logger := zerolog.Ctx(ctx).With().Str("cmd", "fsck").Logger()
+			ctx = logger.WithContext(ctx)
+
+			dryRun := cmd.Bool("dry-run")
+			repair := cmd.Bool("repair")
+
+			// 1. Setup Database
+			db, err := createDatabaseQuerier(cmd)
+			if err != nil {
+				logger.Error().Err(err).Msg("error creating database querier")
+
+				return err
+			}
+
+			// 2. Setup Lockers
+			locker, rwLocker, err := getLockers(ctx, cmd)
+			if err != nil {
+				logger.Error().Err(err).Msg("error creating the lockers")
+
+				return err
+			}
+
+			// 3. Setup OTel
+			extraResourceAttrs, err := detectExtraResourceAttrs(ctx, cmd, db, rwLocker)
+			if err != nil {
+				logger.Error().Err(err).Msg("error detecting extra resource attributes")
+
+				return err
+			}
+
+			otelResource, err := otel.NewResource(
+				ctx,
+				cmd.Root().Name,
+				Version,
+				semconv.SchemaURL,
+				extraResourceAttrs...,
+			)
+			if err != nil {
+				logger.Error().Err(err).Msg("error creating a new otel resource")
+
+				return err
+			}
+
+			otelShutdown, err := otel.SetupOTelSDK(
+				ctx,
+				cmd.Root().Bool("otel-enabled"),
+				cmd.Root().String("otel-grpc-url"),
+				otelResource,
+			)
+			if err != nil {
+				return err
+			}
+
+			registerShutdown("open telemetry", otelShutdown)
+
+			// 4. Setup Storage
+			_, _, narStore, err := getStorageBackend(ctx, cmd)
+			if err != nil {
+				logger.Error().Err(err).Msg("error creating storage backend")
+
+				return err
+			}
+
+			// 5. Detect CDC mode
+			cdcMode := false
+
+			cdcConfig, dbErr := db.GetConfigByKey(ctx, "cdc.enabled")
+			if dbErr == nil && cdcConfig.Value == configValueTrue {
+				cdcMode = true
+			}
+
+			var chunkStore ChunkWalker
+
+			if cdcMode {
+				cs, csErr := getChunkStorageBackend(ctx, cmd, locker)
+				if csErr != nil {
+					logger.Error().Err(csErr).Msg("error creating chunk storage backend")
+
+					return csErr
+				}
+
+				chunkStore, _ = cs.(ChunkWalker)
+			}
+
+			// 6. Phase 1: Collect suspects
+			logger.Info().Msg("phase 1: collecting suspects")
+
+			suspects, err := collectFsckSuspects(ctx, db, narStore, chunkStore, cdcMode)
+			if err != nil {
+				return fmt.Errorf("error collecting suspects: %w", err)
+			}
+
+			// 7. Phase 2: Re-verify (double-check to handle in-flight operations)
+			logger.Info().Msg("phase 2: re-verifying suspects")
+
+			results, err := reVerifyFsckSuspects(ctx, db, narStore, chunkStore, suspects)
+			if err != nil {
+				return fmt.Errorf("error re-verifying suspects: %w", err)
+			}
+
+			// 8. Print summary
+			printFsckSummary(results)
+
+			if results.totalIssues() == 0 {
+				fmt.Println("All checks passed.")
+
+				return nil
+			}
+
+			// 9. Decide what to do
+			if dryRun {
+				fmt.Println("\nRun with --repair to fix, or omit --dry-run to be prompted.")
+
+				return ErrFsckIssuesFound
+			}
+
+			if !repair {
+				fmt.Print("\nRepair all issues? [y/N]: ")
+
+				scanner := bufio.NewScanner(os.Stdin)
+				if scanner.Scan() {
+					answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
+					if answer != "y" && answer != "yes" {
+						fmt.Println("Aborted.")
+
+						return ErrFsckIssuesFound
+					}
+				} else {
+					fmt.Println("Aborted (no input).")
+
+					return ErrFsckIssuesFound
+				}
+			}
+
+			// 10. Phase 3: Repair
+			logger.Info().Msg("phase 3: repairing issues")
+
+			if err := repairFsckIssues(ctx, db, narStore, chunkStore, results); err != nil {
+				return fmt.Errorf("error repairing issues: %w", err)
+			}
+
+			fmt.Println("Repair complete.")
+
+			return nil
+		},
+	}
+}
+
+// collectFsckSuspects runs all DB queries and storage walks to collect potential issues.
+func collectFsckSuspects(
+	ctx context.Context,
+	db database.Querier,
+	narStore storage.NarStore,
+	chunkStore ChunkWalker,
+	cdcMode bool,
+) (*fsckResults, error) {
+	results := &fsckResults{cdcMode: cdcMode}
+
+	// a. Narinfos without nar_files
+	narinfosWithoutNarFiles, err := db.GetNarInfosWithoutNarFiles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("GetNarInfosWithoutNarFiles: %w", err)
+	}
+
+	results.narinfosWithoutNarFiles = narinfosWithoutNarFiles
+
+	// b. Orphaned nar_files in DB
+	orphanedNarFiles, err := db.GetOrphanedNarFiles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("GetOrphanedNarFiles: %w", err)
+	}
+
+	results.orphanedNarFilesInDB = orphanedNarFiles
+
+	// c. Nar_files missing from storage
+	allNarFiles, err := db.GetAllNarFiles(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("GetAllNarFiles: %w", err)
+	}
+
+	for _, nf := range allNarFiles {
+		narURL, err := narFileRowToURL(nf.Hash, nf.Compression, nf.Query)
+		if err != nil {
+			return nil, fmt.Errorf("narFileRowToURL for nar_file %d: %w", nf.ID, err)
+		}
+
+		if !narStore.HasNar(ctx, narURL) {
+			// Convert GetAllNarFilesRow to NarFile
+			results.narFilesMissingInStorage = append(results.narFilesMissingInStorage, database.NarFile{
+				ID:                nf.ID,
+				Hash:              nf.Hash,
+				Compression:       nf.Compression,
+				Query:             nf.Query,
+				FileSize:          nf.FileSize,
+				TotalChunks:       nf.TotalChunks,
+				ChunkingStartedAt: nf.ChunkingStartedAt,
+				CreatedAt:         nf.CreatedAt,
+				UpdatedAt:         nf.UpdatedAt,
+				LastAccessedAt:    nf.LastAccessedAt,
+			})
+		}
+	}
+
+	// d. Orphaned NAR files in storage
+	narWalker, ok := narStore.(NarWalker)
+	if ok {
+		if err := narWalker.WalkNars(ctx, func(narURL nar.URL) error {
+			_, dbErr := db.GetNarFileByHashAndCompressionAndQuery(ctx, database.GetNarFileByHashAndCompressionAndQueryParams{
+				Hash:        narURL.Hash,
+				Compression: narURL.Compression.String(),
+				Query:       narURL.Query.Encode(),
+			})
+			if dbErr != nil {
+				if database.IsNotFoundError(dbErr) {
+					results.orphanedNarFilesInStorage = append(results.orphanedNarFilesInStorage, narURL)
+				} else {
+					return fmt.Errorf("DB lookup for NAR %s: %w", narURL, dbErr)
+				}
+			}
+
+			return nil
+		}); err != nil {
+			return nil, fmt.Errorf("WalkNars: %w", err)
+		}
+	}
+
+	if !cdcMode {
+		return results, nil
+	}
+
+	// e. Orphaned chunks in DB
+	orphanedChunks, err := db.GetOrphanedChunks(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("GetOrphanedChunks: %w", err)
+	}
+
+	results.orphanedChunksInDB = orphanedChunks
+
+	// f. Chunks missing from storage
+	missing, err := collectChunksMissingFromStorage(ctx, db, chunkStore)
+	if err != nil {
+		return nil, err
+	}
+
+	results.chunksMissingInStorage = missing
+
+	// g. Orphaned chunk files in storage
+	orphaned, err := collectOrphanedChunksInStorage(ctx, db, chunkStore)
+	if err != nil {
+		return nil, err
+	}
+
+	results.orphanedChunksInStorage = orphaned
+
+	return results, nil
+}
+
+// reVerifyFsckSuspects re-checks each suspected issue to handle in-flight operations.
+// Items that are no longer issues are silently removed from the results.
+func reVerifyFsckSuspects(
+	ctx context.Context,
+	db database.Querier,
+	narStore storage.NarStore,
+	chunkStore ChunkWalker,
+	suspects *fsckResults,
+) (*fsckResults, error) {
+	results := &fsckResults{cdcMode: suspects.cdcMode}
+
+	// Re-verify: narinfos without nar_files
+	for _, ni := range suspects.narinfosWithoutNarFiles {
+		_, err := db.GetNarFileByNarInfoID(ctx, ni.ID)
+		if err != nil {
+			if database.IsNotFoundError(err) {
+				results.narinfosWithoutNarFiles = append(results.narinfosWithoutNarFiles, ni)
+			} else {
+				return nil, fmt.Errorf("re-verify GetNarFileByNarInfoID(%d): %w", ni.ID, err)
+			}
+		}
+	}
+
+	// Re-verify: orphaned nar_files in DB
+	for _, nf := range suspects.orphanedNarFilesInDB {
+		// Check if it's still orphaned by checking for narinfo link
+		_, err := db.GetNarInfoURLByNarFileHash(ctx, database.GetNarInfoURLByNarFileHashParams{
+			Hash:        nf.Hash,
+			Compression: nf.Compression,
+			Query:       nf.Query,
+		})
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) || database.IsNotFoundError(err) {
+				results.orphanedNarFilesInDB = append(results.orphanedNarFilesInDB, nf)
+			} else {
+				return nil, fmt.Errorf("re-verify orphaned nar_file(%d): %w", nf.ID, err)
+			}
+		}
+	}
+
+	// Re-verify: nar_files missing from storage
+	for _, nf := range suspects.narFilesMissingInStorage {
+		narURL, err := narFileRowToURL(nf.Hash, nf.Compression, nf.Query)
+		if err != nil {
+			return nil, fmt.Errorf("narFileRowToURL for nar_file %d: %w", nf.ID, err)
+		}
+
+		if !narStore.HasNar(ctx, narURL) {
+			results.narFilesMissingInStorage = append(results.narFilesMissingInStorage, nf)
+		}
+	}
+
+	// Re-verify: orphaned NAR files in storage
+	for _, narURL := range suspects.orphanedNarFilesInStorage {
+		_, err := db.GetNarFileByHashAndCompressionAndQuery(ctx, database.GetNarFileByHashAndCompressionAndQueryParams{
+			Hash:        narURL.Hash,
+			Compression: narURL.Compression.String(),
+			Query:       narURL.Query.Encode(),
+		})
+		if err != nil {
+			if database.IsNotFoundError(err) {
+				results.orphanedNarFilesInStorage = append(results.orphanedNarFilesInStorage, narURL)
+			} else {
+				return nil, fmt.Errorf("re-verify orphaned NAR in storage (%s): %w", narURL, err)
+			}
+		}
+	}
+
+	if !suspects.cdcMode {
+		return results, nil
+	}
+
+	// Re-verify: orphaned chunks in DB
+	recheckedOrphanedChunks, err := db.GetOrphanedChunks(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("re-verify GetOrphanedChunks: %w", err)
+	}
+
+	recheckedMap := make(map[int64]struct{}, len(recheckedOrphanedChunks))
+	for _, rc := range recheckedOrphanedChunks {
+		recheckedMap[rc.ID] = struct{}{}
+	}
+
+	for _, c := range suspects.orphanedChunksInDB {
+		if _, ok := recheckedMap[c.ID]; ok {
+			results.orphanedChunksInDB = append(results.orphanedChunksInDB, c)
+		}
+	}
+
+	// Re-verify: chunks missing from storage
+	hc, _ := chunkStore.(hasChunker)
+
+	for _, c := range suspects.chunksMissingInStorage {
+		if hc == nil {
+			break
+		}
+
+		exists, err := hc.HasChunk(ctx, c.Hash)
+		if err != nil {
+			return nil, fmt.Errorf("re-verify HasChunk(%s): %w", c.Hash, err)
+		}
+
+		if !exists {
+			results.chunksMissingInStorage = append(results.chunksMissingInStorage, c)
+		}
+	}
+
+	// Re-verify: orphaned chunk files in storage
+	for _, hash := range suspects.orphanedChunksInStorage {
+		_, err := db.GetChunkByHash(ctx, hash)
+		if err != nil {
+			if database.IsNotFoundError(err) {
+				results.orphanedChunksInStorage = append(results.orphanedChunksInStorage, hash)
+			} else {
+				return nil, fmt.Errorf("re-verify orphaned chunk in storage (%s): %w", hash, err)
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// printFsckSummary prints the fsck summary report.
+func printFsckSummary(r *fsckResults) {
+	fmt.Println()
+	fmt.Println("ncps fsck summary")
+	fmt.Println("=================")
+	fmt.Printf("Narinfos without nar_files:         %d\n", len(r.narinfosWithoutNarFiles))
+	fmt.Printf("Orphaned nar_files (DB only):       %d\n", len(r.orphanedNarFilesInDB))
+	fmt.Printf("Nar_files missing from storage:     %d\n", len(r.narFilesMissingInStorage))
+	fmt.Printf("Orphaned NAR files in storage:      %d\n", len(r.orphanedNarFilesInStorage))
+
+	if r.cdcMode {
+		fmt.Printf("[CDC] Orphaned chunks (DB only):    %d\n", len(r.orphanedChunksInDB))
+		fmt.Printf("[CDC] Chunks missing from storage:  %d\n", len(r.chunksMissingInStorage))
+		fmt.Printf("[CDC] Orphaned chunk files:         %d\n", len(r.orphanedChunksInStorage))
+	}
+
+	fmt.Println("-----------------")
+	fmt.Printf("Total issues:                       %d\n", r.totalIssues())
+}
+
+// repairFsckIssues applies fixes for each category of issue, re-verifying each item before acting.
+func repairFsckIssues(
+	ctx context.Context,
+	db database.Querier,
+	narStore storage.NarStore,
+	chunkStore ChunkWalker,
+	results *fsckResults,
+) error {
+	logger := zerolog.Ctx(ctx)
+
+	// a. Delete narinfos without nar_files
+	for _, ni := range results.narinfosWithoutNarFiles {
+		// Re-verify before deleting
+		_, err := db.GetNarFileByNarInfoID(ctx, ni.ID)
+		if err == nil {
+			// Now has a nar_file, skip
+			continue
+		}
+
+		if !database.IsNotFoundError(err) {
+			return fmt.Errorf("repair re-verify narinfo(%d): %w", ni.ID, err)
+		}
+
+		if _, err := db.DeleteNarInfoByID(ctx, ni.ID); err != nil {
+			logger.Error().Err(err).Int64("narinfo_id", ni.ID).Msg("failed to delete narinfo without nar_file")
+		} else {
+			logger.Info().Int64("narinfo_id", ni.ID).Str("hash", ni.Hash).Msg("deleted narinfo without nar_file")
+		}
+	}
+
+	// b. Delete orphaned nar_files in DB
+	for _, nf := range results.orphanedNarFilesInDB {
+		// Re-verify before deleting
+		_, err := db.GetNarInfoURLByNarFileHash(ctx, database.GetNarInfoURLByNarFileHashParams{
+			Hash:        nf.Hash,
+			Compression: nf.Compression,
+			Query:       nf.Query,
+		})
+		if err == nil {
+			// Now has a narinfo link, skip
+			continue
+		}
+
+		if !errors.Is(err, sql.ErrNoRows) && !database.IsNotFoundError(err) {
+			return fmt.Errorf("repair re-verify nar_file(%d): %w", nf.ID, err)
+		}
+
+		if _, err := db.DeleteNarFileByHash(ctx, database.DeleteNarFileByHashParams{
+			Hash:        nf.Hash,
+			Compression: nf.Compression,
+			Query:       nf.Query,
+		}); err != nil {
+			logger.Error().Err(err).Int64("nar_file_id", nf.ID).Msg("failed to delete orphaned nar_file")
+		} else {
+			logger.Info().Int64("nar_file_id", nf.ID).Str("hash", nf.Hash).Msg("deleted orphaned nar_file from DB")
+		}
+	}
+
+	// c. Delete nar_file DB records missing from storage.
+	// Snapshot which narinfos are already orphaned before our deletions so we can
+	// distinguish pre-existing orphans (handled in section a) from narinfos that
+	// become orphaned as a cascade of removing the missing nar_file record.
+	existingOrphans, err := db.GetNarInfosWithoutNarFiles(ctx)
+	if err != nil {
+		return fmt.Errorf("repair pre-check GetNarInfosWithoutNarFiles: %w", err)
+	}
+
+	existingOrphanIDs := make(map[int64]struct{}, len(existingOrphans))
+	for _, ni := range existingOrphans {
+		existingOrphanIDs[ni.ID] = struct{}{}
+	}
+
+	for _, nf := range results.narFilesMissingInStorage {
+		// Re-verify before deleting
+		narURL, err := narFileRowToURL(nf.Hash, nf.Compression, nf.Query)
+		if err != nil {
+			return fmt.Errorf("narFileRowToURL for nar_file %d: %w", nf.ID, err)
+		}
+
+		if narStore.HasNar(ctx, narURL) {
+			// File appeared, skip
+			continue
+		}
+
+		if _, err := db.DeleteNarFileByHash(ctx, database.DeleteNarFileByHashParams{
+			Hash:        nf.Hash,
+			Compression: nf.Compression,
+			Query:       nf.Query,
+		}); err != nil {
+			logger.Error().Err(err).Int64("nar_file_id", nf.ID).Msg("failed to delete nar_file missing from storage")
+		} else {
+			logger.Info().
+				Int64("nar_file_id", nf.ID).
+				Str("hash", nf.Hash).
+				Msg("deleted nar_file DB record (missing from storage)")
+		}
+	}
+
+	// Delete narinfos that became orphaned as a result of the nar_file deletions above.
+	// These would otherwise only be caught on a second fsck run.
+	newOrphans, err := db.GetNarInfosWithoutNarFiles(ctx)
+	if err != nil {
+		return fmt.Errorf("repair post-check GetNarInfosWithoutNarFiles: %w", err)
+	}
+
+	for _, ni := range newOrphans {
+		if _, alreadyOrphaned := existingOrphanIDs[ni.ID]; alreadyOrphaned {
+			// Pre-existing orphan; handled in section a.
+			continue
+		}
+
+		if _, err := db.DeleteNarInfoByID(ctx, ni.ID); err != nil {
+			logger.Error().Err(err).
+				Int64("narinfo_id", ni.ID).
+				Msg("failed to delete narinfo orphaned by missing nar_file")
+		} else {
+			logger.Info().
+				Int64("narinfo_id", ni.ID).
+				Str("hash", ni.Hash).
+				Msg("deleted narinfo orphaned by nar_file missing from storage")
+		}
+	}
+
+	// d. Delete orphaned NAR files from storage
+	type narDeleter interface {
+		DeleteNar(ctx context.Context, narURL nar.URL) error
+	}
+
+	nd, hasDeleter := narStore.(narDeleter)
+
+	for _, narURL := range results.orphanedNarFilesInStorage {
+		// Re-verify before deleting
+		_, err := db.GetNarFileByHashAndCompressionAndQuery(ctx, database.GetNarFileByHashAndCompressionAndQueryParams{
+			Hash:        narURL.Hash,
+			Compression: narURL.Compression.String(),
+			Query:       narURL.Query.Encode(),
+		})
+		if err == nil {
+			// Now in DB, skip
+			continue
+		}
+
+		if !database.IsNotFoundError(err) {
+			return fmt.Errorf("repair re-verify orphaned NAR (%s): %w", narURL, err)
+		}
+
+		if hasDeleter {
+			if err := nd.DeleteNar(ctx, narURL); err != nil {
+				logger.Error().Err(err).Str("nar_url", narURL.String()).Msg("failed to delete orphaned NAR from storage")
+			} else {
+				logger.Info().Str("nar_url", narURL.String()).Msg("deleted orphaned NAR from storage")
+			}
+		}
+	}
+
+	if !results.cdcMode || chunkStore == nil {
+		return nil
+	}
+
+	// e. Delete orphaned chunks in DB
+	recheckChunks, err := db.GetOrphanedChunks(ctx)
+	if err != nil {
+		return fmt.Errorf("repair re-verify GetOrphanedChunks: %w", err)
+	}
+
+	recheckMap := make(map[int64]struct{}, len(recheckChunks))
+	for _, rc := range recheckChunks {
+		recheckMap[rc.ID] = struct{}{}
+	}
+
+	for _, c := range results.orphanedChunksInDB {
+		if _, ok := recheckMap[c.ID]; !ok {
+			continue
+		}
+
+		if err := db.DeleteChunkByID(ctx, c.ID); err != nil {
+			logger.Error().Err(err).Int64("chunk_id", c.ID).Msg("failed to delete orphaned chunk from DB")
+		} else {
+			logger.Info().Int64("chunk_id", c.ID).Str("hash", c.Hash).Msg("deleted orphaned chunk from DB")
+		}
+	}
+
+	// f. Delete chunk DB records missing from storage
+	if hc, ok := chunkStore.(hasChunker); ok {
+		for _, c := range results.chunksMissingInStorage {
+			exists, err := hc.HasChunk(ctx, c.Hash)
+			if err != nil {
+				return fmt.Errorf("repair re-verify HasChunk(%s): %w", c.Hash, err)
+			}
+
+			if exists {
+				// File appeared, skip
+				continue
+			}
+
+			if err := db.DeleteChunkByID(ctx, c.ID); err != nil {
+				logger.Error().Err(err).Int64("chunk_id", c.ID).Msg("failed to delete chunk DB record missing from storage")
+			} else {
+				logger.Info().
+					Int64("chunk_id", c.ID).
+					Str("hash", c.Hash).
+					Msg("deleted chunk DB record (missing from storage)")
+			}
+		}
+	}
+
+	// g. Delete orphaned chunk files from storage
+	if cd, ok := chunkStore.(chunkDeleter); ok {
+		for _, hash := range results.orphanedChunksInStorage {
+			// Re-verify before deleting
+			_, err := db.GetChunkByHash(ctx, hash)
+			if err == nil {
+				// Now in DB, skip
+				continue
+			}
+
+			if !database.IsNotFoundError(err) {
+				return fmt.Errorf("repair re-verify orphaned chunk (%s): %w", hash, err)
+			}
+
+			if err := cd.DeleteChunk(ctx, hash); err != nil {
+				logger.Error().Err(err).Str("hash", hash).Msg("failed to delete orphaned chunk from storage")
+			} else {
+				logger.Info().Str("hash", hash).Msg("deleted orphaned chunk from storage")
+			}
+		}
+	}
+
+	return nil
+}
+
+// collectChunksMissingFromStorage returns all DB chunks that are absent from storage.
+func collectChunksMissingFromStorage(
+	ctx context.Context,
+	db database.Querier,
+	chunkStore ChunkWalker,
+) ([]database.Chunk, error) {
+	if chunkStore == nil {
+		return nil, nil
+	}
+
+	hc, ok := chunkStore.(hasChunker)
+	if !ok {
+		return nil, nil
+	}
+
+	allChunks, err := db.GetAllChunks(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("GetAllChunks: %w", err)
+	}
+
+	var missing []database.Chunk
+
+	for _, c := range allChunks {
+		exists, checkErr := hc.HasChunk(ctx, c.Hash)
+		if checkErr != nil {
+			return nil, fmt.Errorf("HasChunk(%s): %w", c.Hash, checkErr)
+		}
+
+		if !exists {
+			missing = append(missing, c)
+		}
+	}
+
+	return missing, nil
+}
+
+// collectOrphanedChunksInStorage returns all chunk files in storage that have no DB record.
+func collectOrphanedChunksInStorage(
+	ctx context.Context,
+	db database.Querier,
+	chunkStore ChunkWalker,
+) ([]string, error) {
+	if chunkStore == nil {
+		return nil, nil
+	}
+
+	var orphaned []string
+
+	if err := chunkStore.WalkChunks(ctx, func(hash string) error {
+		_, dbErr := db.GetChunkByHash(ctx, hash)
+		if dbErr != nil {
+			if database.IsNotFoundError(dbErr) {
+				orphaned = append(orphaned, hash)
+			} else {
+				return fmt.Errorf("DB lookup for chunk %s: %w", hash, dbErr)
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("WalkChunks: %w", err)
+	}
+
+	return orphaned, nil
+}
+
+// narFileRowToURL converts nar_file fields into a nar.URL.
+func narFileRowToURL(hash, compression, query string) (nar.URL, error) {
+	parsedQuery, err := url.ParseQuery(query)
+	if err != nil {
+		return nar.URL{}, fmt.Errorf("parsing query %q: %w", query, err)
+	}
+
+	return nar.URL{
+		Hash:        hash,
+		Compression: nar.CompressionTypeFromString(compression),
+		Query:       parsedQuery,
+	}, nil
+}

--- a/pkg/ncps/fsck_test.go
+++ b/pkg/ncps/fsck_test.go
@@ -1,0 +1,477 @@
+package ncps_test
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	localstorage "github.com/kalbasit/ncps/pkg/storage/local"
+	narinfopkg "github.com/nix-community/go-nix/pkg/narinfo"
+
+	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/ncps"
+	"github.com/kalbasit/ncps/testdata"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// fsckSetupFn returns (db, localStore, storageDir, dbURL, cleanup).
+type fsckSetupFn func(t *testing.T) (database.Querier, *localstorage.Store, string, string, func())
+
+func TestFsckBackends(t *testing.T) {
+	t.Parallel()
+
+	backends := []struct {
+		name   string
+		envVar string
+		setup  fsckSetupFn
+	}{
+		{
+			name:  "SQLite",
+			setup: setupFsckSQLite,
+		},
+		{
+			name:   "PostgreSQL",
+			envVar: "NCPS_TEST_ADMIN_POSTGRES_URL",
+			setup:  setupFsckPostgres,
+		},
+		{
+			name:   "MySQL",
+			envVar: "NCPS_TEST_ADMIN_MYSQL_URL",
+			setup:  setupFsckMySQL,
+		},
+	}
+
+	for _, b := range backends {
+		t.Run(b.name, func(t *testing.T) {
+			t.Parallel()
+
+			if b.envVar != "" && os.Getenv(b.envVar) == "" {
+				t.Skipf("Skipping %s: %s not set", b.name, b.envVar)
+			}
+
+			runFsckSuite(t, b.setup)
+		})
+	}
+}
+
+func runFsckSuite(t *testing.T, setup fsckSetupFn) {
+	t.Helper()
+
+	t.Run("Clean", testFsckClean(setup))
+	t.Run("NarInfosWithoutNarFiles", testFsckNarInfosWithoutNarFiles(setup))
+	t.Run("OrphanedNarFilesInDB", testFsckOrphanedNarFilesInDB(setup))
+	t.Run("NarFileMissingInStorage", testFsckNarFileMissingInStorage(setup))
+	t.Run("NarFileMissingInStorageCascadeRepair", testFsckNarFileMissingCascadeRepair(setup))
+	t.Run("OrphanedNarInStorage", testFsckOrphanedNarInStorage(setup))
+	t.Run("Repair", testFsckRepair(setup))
+	t.Run("DryRun", testFsckDryRun(setup))
+}
+
+// testFsckClean verifies that a clean (consistent) state results in 0 issues.
+func testFsckClean(setup fsckSetupFn) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+		db, store, dir, dbURL, cleanup := setup(t)
+		t.Cleanup(cleanup)
+
+		// Seed a fully consistent narinfo+narfile in DB and storage.
+		writeFsckNar1ToStorage(t, dir)
+
+		ni := getFsckNarInfo(ctx, t, store, testdata.Nar1.NarInfoHash)
+
+		require.NoError(t, testhelper.MigrateNarInfoToDatabase(ctx, db, testdata.Nar1.NarInfoHash, ni))
+
+		app, err := ncps.New()
+		require.NoError(t, err)
+
+		args := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+		}
+
+		require.NoError(t, app.Run(ctx, args))
+	}
+}
+
+// testFsckNarInfosWithoutNarFiles verifies narinfos with no nar_file link are detected.
+func testFsckNarInfosWithoutNarFiles(setup fsckSetupFn) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+		db, _, dir, dbURL, cleanup := setup(t)
+		t.Cleanup(cleanup)
+
+		// Insert a narinfo in DB with a URL but with no linked nar_file.
+		// UpdateNarInfo requires the narinfo to already exist; we use CreateNarInfo directly.
+		ni := parseFsckNarInfoText(t, testdata.Nar1.NarInfoText)
+
+		// Create narinfo in DB with a URL (migrated) but not yet linked to nar_file.
+		_, err := db.CreateNarInfo(ctx, database.CreateNarInfoParams{
+			Hash:        testdata.Nar1.NarInfoHash,
+			StorePath:   sql.NullString{String: ni.StorePath, Valid: ni.StorePath != ""},
+			URL:         sql.NullString{String: ni.URL, Valid: ni.URL != ""},
+			Compression: sql.NullString{String: ni.Compression, Valid: ni.Compression != ""},
+			NarHash:     sql.NullString{String: ni.NarHash.String(), Valid: ni.NarHash != nil},
+			NarSize:     sql.NullInt64{Int64: int64(ni.NarSize), Valid: true}, //nolint:gosec
+			FileHash:    sql.NullString{String: ni.FileHash.String(), Valid: ni.FileHash != nil},
+			FileSize:    sql.NullInt64{Int64: int64(ni.FileSize), Valid: true}, //nolint:gosec
+			Deriver:     sql.NullString{String: ni.Deriver, Valid: ni.Deriver != ""},
+			System:      sql.NullString{String: ni.System, Valid: ni.System != ""},
+			Ca:          sql.NullString{String: ni.CA, Valid: ni.CA != ""},
+		})
+		require.NoError(t, err)
+
+		app, err := ncps.New()
+		require.NoError(t, err)
+
+		args := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+			"--dry-run",
+		}
+
+		err = app.Run(ctx, args)
+		assert.ErrorIs(t, err, ncps.ErrFsckIssuesFound)
+	}
+}
+
+// testFsckOrphanedNarFilesInDB verifies nar_files with no narinfo link are detected.
+func testFsckOrphanedNarFilesInDB(setup fsckSetupFn) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+		db, _, dir, dbURL, cleanup := setup(t)
+		t.Cleanup(cleanup)
+
+		// Create a nar_file in DB with no linked narinfo.
+		narURL := nar.URL{
+			Hash:        testdata.Nar1.NarHash,
+			Compression: testdata.Nar1.NarCompression,
+		}
+
+		_, err := db.CreateNarFile(ctx, database.CreateNarFileParams{
+			Hash:        narURL.Hash,
+			Compression: narURL.Compression.String(),
+			Query:       narURL.Query.Encode(),
+			FileSize:    uint64(len(testdata.Nar1.NarText)),
+		})
+		require.NoError(t, err)
+
+		// Also write the physical file so it doesn't show up as missing-in-storage.
+		narPath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(narPath), 0o755))
+		require.NoError(t, os.WriteFile(narPath, []byte(testdata.Nar1.NarText), 0o600))
+
+		app, err := ncps.New()
+		require.NoError(t, err)
+
+		args := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+			"--dry-run",
+		}
+
+		err = app.Run(ctx, args)
+		assert.ErrorIs(t, err, ncps.ErrFsckIssuesFound)
+	}
+}
+
+// testFsckNarFileMissingInStorage verifies nar_file DB records without a physical file are detected.
+func testFsckNarFileMissingInStorage(setup fsckSetupFn) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+		db, store, dir, dbURL, cleanup := setup(t)
+		t.Cleanup(cleanup)
+
+		// Write narinfo+nar to storage and fully migrate to DB.
+		writeFsckNar1ToStorage(t, dir)
+
+		ni := getFsckNarInfo(ctx, t, store, testdata.Nar1.NarInfoHash)
+
+		require.NoError(t, testhelper.MigrateNarInfoToDatabase(ctx, db, testdata.Nar1.NarInfoHash, ni))
+
+		// Delete the physical NAR file to simulate missing storage.
+		narPath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath)
+		require.NoError(t, os.Remove(narPath))
+
+		app, err := ncps.New()
+		require.NoError(t, err)
+
+		args := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+			"--dry-run",
+		}
+
+		err = app.Run(ctx, args)
+		assert.ErrorIs(t, err, ncps.ErrFsckIssuesFound)
+	}
+}
+
+// testFsckNarFileMissingCascadeRepair verifies that repairing a nar_file missing from storage
+// also cleans up the parent narinfo in a single pass (no second run required).
+func testFsckNarFileMissingCascadeRepair(setup fsckSetupFn) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+		db, store, dir, dbURL, cleanup := setup(t)
+		t.Cleanup(cleanup)
+
+		// Seed a fully consistent narinfo+narfile in DB and storage.
+		writeFsckNar1ToStorage(t, dir)
+
+		ni := getFsckNarInfo(ctx, t, store, testdata.Nar1.NarInfoHash)
+
+		require.NoError(t, testhelper.MigrateNarInfoToDatabase(ctx, db, testdata.Nar1.NarInfoHash, ni))
+
+		// Delete the physical NAR file to simulate missing storage.
+		narPath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath)
+		require.NoError(t, os.Remove(narPath))
+
+		app, err := ncps.New()
+		require.NoError(t, err)
+
+		// First run: repair the missing nar_file (and its now-orphaned narinfo).
+		repairArgs := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+			"--repair",
+		}
+
+		require.NoError(t, app.Run(ctx, repairArgs))
+
+		// Second run without --repair: must find 0 issues (repair was complete in one pass).
+		cleanArgs := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+		}
+
+		require.NoError(t, app.Run(ctx, cleanArgs))
+	}
+}
+
+// testFsckOrphanedNarInStorage verifies NAR files in storage with no DB record are detected.
+func testFsckOrphanedNarInStorage(setup fsckSetupFn) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+		_, _, dir, dbURL, cleanup := setup(t)
+		t.Cleanup(cleanup)
+
+		// Write a NAR file to storage without any DB record.
+		narPath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(narPath), 0o755))
+		require.NoError(t, os.WriteFile(narPath, []byte(testdata.Nar1.NarText), 0o600))
+
+		app, err := ncps.New()
+		require.NoError(t, err)
+
+		args := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+			"--dry-run",
+		}
+
+		err = app.Run(ctx, args)
+		assert.ErrorIs(t, err, ncps.ErrFsckIssuesFound)
+	}
+}
+
+// testFsckRepair verifies that --repair fixes detected issues and a second run is clean.
+func testFsckRepair(setup fsckSetupFn) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+		db, store, dir, dbURL, cleanup := setup(t)
+		t.Cleanup(cleanup)
+
+		// Seed a consistent entry.
+		writeFsckNar1ToStorage(t, dir)
+
+		ni := getFsckNarInfo(ctx, t, store, testdata.Nar1.NarInfoHash)
+
+		require.NoError(t, testhelper.MigrateNarInfoToDatabase(ctx, db, testdata.Nar1.NarInfoHash, ni))
+
+		// Break it: delete the physical NAR file.
+		narPath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath)
+		require.NoError(t, os.Remove(narPath))
+
+		// Also seed an orphaned NAR in storage (Nar2 has no DB record).
+		orphanPath := filepath.Join(dir, "store", "nar", testdata.Nar2.NarPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(orphanPath), 0o755))
+		require.NoError(t, os.WriteFile(orphanPath, []byte(testdata.Nar2.NarText), 0o600))
+
+		app, err := ncps.New()
+		require.NoError(t, err)
+
+		// First run: repair.
+		args := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+			"--repair",
+		}
+
+		require.NoError(t, app.Run(ctx, args))
+
+		// Second run: should be clean.
+		require.NoError(t, app.Run(ctx, args))
+	}
+}
+
+// testFsckDryRun verifies that --dry-run reports issues but does not change anything.
+func testFsckDryRun(setup fsckSetupFn) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+		db, store, dir, dbURL, cleanup := setup(t)
+		t.Cleanup(cleanup)
+
+		// Seed a consistent entry.
+		writeFsckNar1ToStorage(t, dir)
+
+		ni := getFsckNarInfo(ctx, t, store, testdata.Nar1.NarInfoHash)
+
+		require.NoError(t, testhelper.MigrateNarInfoToDatabase(ctx, db, testdata.Nar1.NarInfoHash, ni))
+
+		// Break: delete physical NAR file.
+		narPath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath)
+		require.NoError(t, os.Remove(narPath))
+
+		app, err := ncps.New()
+		require.NoError(t, err)
+
+		// Dry-run: should report issues.
+		args := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+			"--dry-run",
+		}
+
+		err = app.Run(ctx, args)
+		require.ErrorIs(t, err, ncps.ErrFsckIssuesFound)
+
+		// Verify DB record is still there (dry-run should not delete it).
+		_, dbErr := db.GetNarInfoByHash(ctx, testdata.Nar1.NarInfoHash)
+		assert.NoError(t, dbErr, "dry-run should not delete DB records")
+	}
+}
+
+// setupFsckSQLite creates a SQLite-backed test environment.
+func setupFsckSQLite(t *testing.T) (database.Querier, *localstorage.Store, string, string, func()) {
+	t.Helper()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbFile := filepath.Join(dir, "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
+	db, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+
+	store, err := localstorage.New(ctx, dir)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		db.DB().Close()
+	}
+
+	return db, store, dir, "sqlite:" + dbFile, cleanup
+}
+
+// setupFsckPostgres creates a PostgreSQL-backed test environment.
+func setupFsckPostgres(t *testing.T) (database.Querier, *localstorage.Store, string, string, func()) {
+	t.Helper()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	db, dbURL, dbCleanup := testhelper.SetupPostgres(t)
+
+	store, err := localstorage.New(ctx, dir)
+	require.NoError(t, err)
+
+	return db, store, dir, dbURL, dbCleanup
+}
+
+// setupFsckMySQL creates a MySQL-backed test environment.
+func setupFsckMySQL(t *testing.T) (database.Querier, *localstorage.Store, string, string, func()) {
+	t.Helper()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	db, dbURL, dbCleanup := testhelper.SetupMySQL(t)
+
+	store, err := localstorage.New(ctx, dir)
+	require.NoError(t, err)
+
+	return db, store, dir, dbURL, dbCleanup
+}
+
+// writeFsckNar1ToStorage writes Nar1's narinfo and NAR file to the storage directory.
+func writeFsckNar1ToStorage(t *testing.T, dir string) {
+	t.Helper()
+
+	narInfoPath := filepath.Join(dir, "store", "narinfo", testdata.Nar1.NarInfoPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(narInfoPath), 0o755))
+	require.NoError(t, os.WriteFile(narInfoPath, []byte(testdata.Nar1.NarInfoText), 0o600))
+
+	narPath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(narPath), 0o755))
+	require.NoError(t, os.WriteFile(narPath, []byte(testdata.Nar1.NarText), 0o600))
+}
+
+// getFsckNarInfo reads a narinfo from local storage.
+func getFsckNarInfo(ctx context.Context, t *testing.T, store *localstorage.Store, hash string) *narinfopkg.NarInfo {
+	t.Helper()
+
+	ni, err := store.GetNarInfo(ctx, hash)
+	require.NoError(t, err)
+
+	return ni
+}
+
+// parseFsckNarInfoText parses a narinfo text string into a NarInfo struct.
+func parseFsckNarInfoText(t *testing.T, text string) *narinfopkg.NarInfo {
+	t.Helper()
+
+	ni, err := narinfopkg.Parse(strings.NewReader(text))
+	require.NoError(t, err)
+
+	return ni
+}

--- a/pkg/ncps/migrate_nar_to_chunks.go
+++ b/pkg/ncps/migrate_nar_to_chunks.go
@@ -231,7 +231,7 @@ Once a NAR is successfully migrated to chunks and verified, it is deleted from t
 				return fmt.Errorf("error loading CDC enabled flag from database: %w", err)
 			}
 
-			if cdcEnabledStr != "true" {
+			if cdcEnabledStr != configValueTrue {
 				//nolint:err113 // no need to define package level error for this.
 				return errors.New("migrate-nar-to-chunks command requires CDC to be enabled in the database")
 			}

--- a/pkg/ncps/root.go
+++ b/pkg/ncps/root.go
@@ -223,6 +223,7 @@ func New() (*cli.Command, error) {
 			serveCommand(userDirs, flagSources, registerShutdown),
 			migrateNarInfoCommand(flagSources, registerShutdown),
 			migrateNarToChunksCommand(flagSources, registerShutdown),
+			fsckCommand(flagSources, registerShutdown),
 		},
 	}
 

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -77,6 +77,8 @@ const (
 
 	storageModeCDC   = "cdc"
 	storageModeWhole = "whole"
+
+	configValueTrue = "true"
 )
 
 // parseNetrcFile parses the netrc file and returns the parsed netrc object.
@@ -1073,7 +1075,7 @@ func loadCDCConfigFromDB(
 		return false, 0, 0, 0, err
 	}
 
-	if cdcEnabledStr != "true" {
+	if cdcEnabledStr != configValueTrue {
 		return enabled, 0, 0, 0, nil
 	}
 

--- a/pkg/storage/chunk/store.go
+++ b/pkg/storage/chunk/store.go
@@ -24,4 +24,7 @@ type Store interface {
 
 	// DeleteChunk removes a chunk.
 	DeleteChunk(ctx context.Context, hash string) error
+
+	// WalkChunks walks all chunks in the store and calls fn for each hash.
+	WalkChunks(ctx context.Context, fn func(hash string) error) error
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -74,4 +74,7 @@ type NarStore interface {
 
 	// DeleteNar deletes the nar from the store.
 	DeleteNar(ctx context.Context, narURL nar.URL) error
+
+	// WalkNars walks all NAR files in the store and calls fn for each one.
+	WalkNars(ctx context.Context, fn func(narURL nar.URL) error) error
 }


### PR DESCRIPTION
Bot-based backport to `release-0.9`, triggered by a label in #975.

## Summary

- Adds a new `ncps fsck` command that performs integrity checks between the database and storage backends
- Uses a double-check pattern (collect suspects → re-verify → report → optionally repair) to safely handle in-flight operations without exclusive locks
- Supports `--dry-run` (preview issues without changes) and `--repair` (fix without prompting)

## Checks performed

- Narinfos in DB with no linked `nar_file` entries
- `nar_files` in DB not linked to any narinfo (orphaned)
- `nar_files` in DB whose physical files are missing from storage
- NAR files in storage with no corresponding DB record
- (CDC mode) Orphaned chunks in DB, chunks missing from storage, orphaned chunk files in storage

## Changes

- New SQL queries (`GetAllNarFiles`, `GetNarInfosWithoutNarFiles`, `GetAllChunks`) added to all 3 DB backends and regenerated
- `WalkNars` added to `storage.NarStore` interface with local + S3 implementations
- `WalkChunks` added to `chunk.Store` interface with local + S3 implementations
- New `pkg/ncps/fsck.go` command implementation
- New `pkg/ncps/fsck_test.go` with 7 test cases (clean, narinfos-without-narfiles, orphaned-narfiles, missing-from-storage, orphaned-in-storage, repair, dry-run)

## Test plan

- [ ] `go test -race ./pkg/ncps/... -run TestFsck -v` — all subtests pass
- [ ] `ncps fsck --help` shows correct flags
- [ ] `ncps fsck --dry-run ...` reports issues without modifying anything
- [ ] `ncps fsck --repair ...` fixes issues; second run shows 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)