### PR TITLE
perf: optimize storage existence checks and improve local walking performance in fsck

### DIFF
--- a/pkg/storage/chunk/local.go
+++ b/pkg/storage/chunk/local.go
@@ -53,18 +53,16 @@ func (s *localStore) WalkChunks(_ context.Context, fn func(hash string) error) e
 		return nil
 	}
 
-	return filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
+	return filepath.WalkDir(root, func(_ string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 
-		hash := filepath.Base(path)
-
-		return fn(hash)
+		return fn(d.Name())
 	})
 }
 

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -523,16 +523,16 @@ func (s *Store) WalkNars(ctx context.Context, fn func(narURL nar.URL) error) err
 		return nil
 	}
 
-	return filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
+	return filepath.WalkDir(root, func(_ string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 
-		fileName := filepath.Base(path)
+		fileName := d.Name()
 
 		narURL, err := nar.ParseURL(fileName)
 		if err != nil {


### PR DESCRIPTION
Improve the efficiency and safety of the fsck command:
- Use storage walkers (WalkNars and WalkChunks) to build a local set of
  present items, reducing storage metadata calls from O(N) to O(1)
  lookups during consistency checks.
- Switch from filepath.Walk to filepath.WalkDir in local storage
  backends for more efficient directory traversal.
- Add a terminal awareness check before the repair prompt to prevent the
  command from hanging in non-interactive environments.
- Refactor interactivity logic to reduce nesting complexity and improve
  maintainability.