### PR TITLE
fix: correct fsck CDC mode to check chunks instead of whole NAR files [backport #986]

### DIFF
--- a/pkg/ncps/fsck_test.go
+++ b/pkg/ncps/fsck_test.go
@@ -12,9 +12,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	locklocal "github.com/kalbasit/ncps/pkg/lock/local"
+	chunkstore "github.com/kalbasit/ncps/pkg/storage/chunk"
 	localstorage "github.com/kalbasit/ncps/pkg/storage/local"
 	narinfopkg "github.com/nix-community/go-nix/pkg/narinfo"
 
+	"github.com/kalbasit/ncps/pkg/config"
 	"github.com/kalbasit/ncps/pkg/database"
 	"github.com/kalbasit/ncps/pkg/nar"
 	"github.com/kalbasit/ncps/pkg/ncps"
@@ -73,6 +76,7 @@ func runFsckSuite(t *testing.T, setup fsckSetupFn) {
 	t.Run("OrphanedNarInStorage", testFsckOrphanedNarInStorage(setup))
 	t.Run("Repair", testFsckRepair(setup))
 	t.Run("DryRun", testFsckDryRun(setup))
+	t.Run("CDC", testFsckCDCSuite(setup))
 }
 
 // testFsckClean verifies that a clean (consistent) state results in 0 issues.
@@ -474,4 +478,432 @@ func parseFsckNarInfoText(t *testing.T, text string) *narinfopkg.NarInfo {
 	require.NoError(t, err)
 
 	return ni
+}
+
+// configureFsckCDCInDatabase sets up CDC configuration in the database for fsck tests.
+func configureFsckCDCInDatabase(ctx context.Context, t *testing.T, db database.Querier) {
+	t.Helper()
+
+	rwLocker := locklocal.NewRWLocker()
+	cfg := config.New(db, rwLocker)
+
+	require.NoError(t, cfg.SetCDCEnabled(ctx, "true"), "failed to set CDC enabled")
+	require.NoError(t, cfg.SetCDCMin(ctx, "16384"), "failed to set CDC min")
+	require.NoError(t, cfg.SetCDCAvg(ctx, "65536"), "failed to set CDC avg")
+	require.NoError(t, cfg.SetCDCMax(ctx, "262144"), "failed to set CDC max")
+}
+
+// setupFsckCDCNarFile creates a narinfo + nar_file + numChunks chunks in DB and chunk storage.
+// Returns the created NarFile.
+func setupFsckCDCNarFile(
+	ctx context.Context,
+	t *testing.T,
+	db database.Querier,
+	cs chunkstore.Store,
+	narInfoHash string,
+	narInfoText string,
+	narHash string,
+	narCompression nar.CompressionType,
+	numChunks int,
+) database.NarFile {
+	t.Helper()
+
+	ni := parseFsckNarInfoText(t, narInfoText)
+
+	// Create narinfo in DB.
+	narInfo, err := db.CreateNarInfo(ctx, database.CreateNarInfoParams{
+		Hash:        narInfoHash,
+		StorePath:   sql.NullString{String: ni.StorePath, Valid: ni.StorePath != ""},
+		URL:         sql.NullString{String: ni.URL, Valid: ni.URL != ""},
+		Compression: sql.NullString{String: ni.Compression, Valid: ni.Compression != ""},
+		NarHash:     sql.NullString{String: ni.NarHash.String(), Valid: ni.NarHash != nil},
+		NarSize:     sql.NullInt64{Int64: int64(ni.NarSize), Valid: true}, //nolint:gosec
+		FileHash:    sql.NullString{String: ni.FileHash.String(), Valid: ni.FileHash != nil},
+		FileSize:    sql.NullInt64{Int64: int64(ni.FileSize), Valid: true}, //nolint:gosec
+		Deriver:     sql.NullString{String: ni.Deriver, Valid: ni.Deriver != ""},
+		System:      sql.NullString{String: ni.System, Valid: ni.System != ""},
+		Ca:          sql.NullString{String: ni.CA, Valid: ni.CA != ""},
+	})
+	require.NoError(t, err)
+
+	// Create nar_file in DB.
+	narFile, err := db.CreateNarFile(ctx, database.CreateNarFileParams{
+		Hash:        narHash,
+		Compression: narCompression.String(),
+		Query:       "",
+		FileSize:    uint64(len(narInfoText)),
+		TotalChunks: int64(numChunks),
+	})
+	require.NoError(t, err)
+
+	// Link narinfo to nar_file.
+	require.NoError(t, db.LinkNarInfoToNarFile(ctx, database.LinkNarInfoToNarFileParams{
+		NarInfoID: narInfo.ID,
+		NarFileID: narFile.ID,
+	}))
+
+	// Create chunks in DB and storage.
+	chunkIDs := make([]int64, numChunks)
+	chunkIndexes := make([]int64, numChunks)
+
+	for i := range numChunks {
+		// Use a simple deterministic hash: replace last char with a letter based on index.
+		chunkHash := narHash[:len(narHash)-2] + string(rune('a'+(i/26))) + string(rune('a'+(i%26)))
+
+		data := []byte(strings.Repeat("x", 64) + string(rune(i)))
+		_, _, err := cs.PutChunk(ctx, chunkHash, data)
+		require.NoError(t, err, "failed to put chunk %d", i)
+
+		chunk, err := db.CreateChunk(ctx, database.CreateChunkParams{
+			Hash:           chunkHash,
+			Size:           uint32(len(data)),     //nolint:gosec
+			CompressedSize: uint32(len(data) / 2), //nolint:gosec
+		})
+		require.NoError(t, err)
+
+		chunkIDs[i] = chunk.ID
+		chunkIndexes[i] = int64(i)
+	}
+
+	require.NoError(t, db.LinkNarFileToChunks(ctx, database.LinkNarFileToChunksParams{
+		NarFileID:  narFile.ID,
+		ChunkID:    chunkIDs,
+		ChunkIndex: chunkIndexes,
+	}))
+
+	return narFile
+}
+
+// testFsckCDCSuite returns a test function that runs all CDC fsck tests.
+func testFsckCDCSuite(setup fsckSetupFn) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("Clean", testFsckCDCClean(setup))
+		t.Run("NarFileChunkCountMismatch", testFsckCDCNarFileChunkCountMismatch(setup))
+		t.Run("ChunkMissingFromStorage", testFsckCDCChunkMissingFromStorage(setup))
+		t.Run("OrphanedChunkInStorage", testFsckCDCOrphanedChunkInStorage(setup))
+		t.Run("RepairIncompleteNar", testFsckCDCRepairIncompleteNar(setup))
+		t.Run("RepairOrphanedChunkInStorage", testFsckCDCRepairOrphanedChunkInStorage(setup))
+	}
+}
+
+// testFsckCDCClean verifies a fully-consistent CDC state produces 0 issues.
+func testFsckCDCClean(setup fsckSetupFn) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+		db, _, dir, dbURL, cleanup := setup(t)
+		t.Cleanup(cleanup)
+
+		configureFsckCDCInDatabase(ctx, t, db)
+
+		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
+		require.NoError(t, err)
+
+		setupFsckCDCNarFile(ctx, t, db, cs,
+			testdata.Nar1.NarInfoHash, testdata.Nar1.NarInfoText,
+			testdata.Nar1.NarHash, testdata.Nar1.NarCompression, 2)
+
+		app, err := ncps.New()
+		require.NoError(t, err)
+
+		args := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+		}
+
+		require.NoError(t, app.Run(ctx, args))
+	}
+}
+
+// testFsckCDCNarFileChunkCountMismatch verifies that a nar_file with fewer chunks than total_chunks is detected.
+func testFsckCDCNarFileChunkCountMismatch(setup fsckSetupFn) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+		db, _, dir, dbURL, cleanup := setup(t)
+		t.Cleanup(cleanup)
+
+		configureFsckCDCInDatabase(ctx, t, db)
+
+		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
+		require.NoError(t, err)
+
+		// Create nar_file with total_chunks=2 but only link 1 chunk.
+		narFile := setupFsckCDCNarFile(ctx, t, db, cs,
+			testdata.Nar1.NarInfoHash, testdata.Nar1.NarInfoText,
+			testdata.Nar1.NarHash, testdata.Nar1.NarCompression, 1)
+
+		// Force total_chunks to 2 while only 1 chunk is linked.
+		require.NoError(t, db.UpdateNarFileTotalChunks(ctx, database.UpdateNarFileTotalChunksParams{
+			TotalChunks: 2,
+			FileSize:    narFile.FileSize,
+			ID:          narFile.ID,
+		}))
+
+		app, err := ncps.New()
+		require.NoError(t, err)
+
+		args := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+			"--dry-run",
+		}
+
+		err = app.Run(ctx, args)
+		assert.ErrorIs(t, err, ncps.ErrFsckIssuesFound)
+	}
+}
+
+// testFsckCDCChunkMissingFromStorage verifies that a nar_file with a chunk missing from storage is detected.
+func testFsckCDCChunkMissingFromStorage(setup fsckSetupFn) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+		db, _, dir, dbURL, cleanup := setup(t)
+		t.Cleanup(cleanup)
+
+		configureFsckCDCInDatabase(ctx, t, db)
+
+		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
+		require.NoError(t, err)
+
+		// Create nar_file with 2 chunks.
+		setupFsckCDCNarFile(ctx, t, db, cs,
+			testdata.Nar1.NarInfoHash, testdata.Nar1.NarInfoText,
+			testdata.Nar1.NarHash, testdata.Nar1.NarCompression, 2)
+
+		// Delete one chunk file from storage.
+		allChunks, err := db.GetAllChunks(ctx)
+		require.NoError(t, err)
+		require.Len(t, allChunks, 2)
+
+		require.NoError(t, cs.DeleteChunk(ctx, allChunks[0].Hash))
+
+		app, err := ncps.New()
+		require.NoError(t, err)
+
+		args := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+			"--dry-run",
+		}
+
+		err = app.Run(ctx, args)
+		assert.ErrorIs(t, err, ncps.ErrFsckIssuesFound)
+	}
+}
+
+// testFsckCDCOrphanedChunkInStorage verifies that a chunk file in storage with no DB record is detected.
+func testFsckCDCOrphanedChunkInStorage(setup fsckSetupFn) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+		db, _, dir, dbURL, cleanup := setup(t)
+		t.Cleanup(cleanup)
+
+		configureFsckCDCInDatabase(ctx, t, db)
+
+		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
+		require.NoError(t, err)
+
+		// Write a chunk file directly to storage without any DB record.
+		orphanHash := testdata.Nar1.NarHash[:len(testdata.Nar1.NarHash)-1] + "z"
+		_, _, err = cs.PutChunk(ctx, orphanHash, []byte("orphan chunk data"))
+		require.NoError(t, err)
+
+		app, err := ncps.New()
+		require.NoError(t, err)
+
+		args := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+			"--dry-run",
+		}
+
+		err = app.Run(ctx, args)
+		assert.ErrorIs(t, err, ncps.ErrFsckIssuesFound)
+	}
+}
+
+// testFsckCDCRepairIncompleteNar verifies that repair removes a broken nar_file, its narinfo,
+// and orphaned chunks; and that a second run is clean. Also verifies ref-counting: a chunk
+// shared with another nar_file is NOT deleted.
+func testFsckCDCRepairIncompleteNar(setup fsckSetupFn) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+		db, _, dir, dbURL, cleanup := setup(t)
+		t.Cleanup(cleanup)
+
+		configureFsckCDCInDatabase(ctx, t, db)
+
+		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
+		require.NoError(t, err)
+
+		// Create Nar1 with 2 chunks.
+		setupFsckCDCNarFile(ctx, t, db, cs,
+			testdata.Nar1.NarInfoHash, testdata.Nar1.NarInfoText,
+			testdata.Nar1.NarHash, testdata.Nar1.NarCompression, 2)
+
+		// Get the chunks for Nar1.
+		nar1Chunks, err := db.GetAllChunks(ctx)
+		require.NoError(t, err)
+		require.Len(t, nar1Chunks, 2)
+
+		// Create Nar2 sharing one chunk with Nar1.
+		nar2File, err := db.CreateNarFile(ctx, database.CreateNarFileParams{
+			Hash:        testdata.Nar2.NarHash,
+			Compression: testdata.Nar2.NarCompression.String(),
+			Query:       "",
+			FileSize:    uint64(len(testdata.Nar2.NarText)),
+			TotalChunks: 1,
+		})
+		require.NoError(t, err)
+
+		ni2 := parseFsckNarInfoText(t, testdata.Nar2.NarInfoText)
+		narInfo2, err := db.CreateNarInfo(ctx, database.CreateNarInfoParams{
+			Hash:        testdata.Nar2.NarInfoHash,
+			StorePath:   sql.NullString{String: ni2.StorePath, Valid: ni2.StorePath != ""},
+			URL:         sql.NullString{String: ni2.URL, Valid: ni2.URL != ""},
+			Compression: sql.NullString{String: ni2.Compression, Valid: ni2.Compression != ""},
+			NarHash:     sql.NullString{String: ni2.NarHash.String(), Valid: ni2.NarHash != nil},
+			NarSize:     sql.NullInt64{Int64: int64(ni2.NarSize), Valid: true}, //nolint:gosec
+			FileHash:    sql.NullString{String: ni2.FileHash.String(), Valid: ni2.FileHash != nil},
+			FileSize:    sql.NullInt64{Int64: int64(ni2.FileSize), Valid: true}, //nolint:gosec
+			Deriver:     sql.NullString{String: ni2.Deriver, Valid: ni2.Deriver != ""},
+			System:      sql.NullString{String: ni2.System, Valid: ni2.System != ""},
+			Ca:          sql.NullString{String: ni2.CA, Valid: ni2.CA != ""},
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, db.LinkNarInfoToNarFile(ctx, database.LinkNarInfoToNarFileParams{
+			NarInfoID: narInfo2.ID,
+			NarFileID: nar2File.ID,
+		}))
+
+		// Link Nar2 to the first chunk of Nar1 (shared chunk).
+		sharedChunk := nar1Chunks[0]
+
+		require.NoError(t, db.LinkNarFileToChunks(ctx, database.LinkNarFileToChunksParams{
+			NarFileID:  nar2File.ID,
+			ChunkID:    []int64{sharedChunk.ID},
+			ChunkIndex: []int64{0},
+		}))
+
+		// Delete chunk[1] of Nar1 from storage → Nar1 becomes broken.
+		brokenChunk := nar1Chunks[1]
+		require.NoError(t, cs.DeleteChunk(ctx, brokenChunk.Hash))
+
+		app, err := ncps.New()
+		require.NoError(t, err)
+
+		repairArgs := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+			"--repair",
+		}
+
+		require.NoError(t, app.Run(ctx, repairArgs))
+
+		// Verify Nar1 narinfo and nar_file are deleted.
+		_, err = db.GetNarInfoByHash(ctx, testdata.Nar1.NarInfoHash)
+		assert.True(t, database.IsNotFoundError(err), "Nar1 narinfo should be deleted")
+
+		_, err = db.GetNarFileByHashAndCompressionAndQuery(ctx, database.GetNarFileByHashAndCompressionAndQueryParams{
+			Hash:        testdata.Nar1.NarHash,
+			Compression: testdata.Nar1.NarCompression.String(),
+			Query:       "",
+		})
+		assert.True(t, database.IsNotFoundError(err), "Nar1 nar_file should be deleted")
+
+		// Verify the broken chunk (chunk[1]) is removed from DB and storage.
+		_, err = db.GetChunkByHash(ctx, brokenChunk.Hash)
+		assert.True(t, database.IsNotFoundError(err), "broken chunk should be deleted from DB")
+
+		exists, err := cs.HasChunk(ctx, brokenChunk.Hash)
+		require.NoError(t, err)
+		assert.False(t, exists, "broken chunk file should not exist in storage")
+
+		// Verify Nar2 and its shared chunk still exist.
+		_, err = db.GetNarInfoByHash(ctx, testdata.Nar2.NarInfoHash)
+		require.NoError(t, err, "Nar2 narinfo should still exist")
+
+		exists, err = cs.HasChunk(ctx, sharedChunk.Hash)
+		require.NoError(t, err)
+		assert.True(t, exists, "shared chunk should still exist in storage")
+
+		// Second run: should be clean.
+		cleanArgs := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+		}
+
+		require.NoError(t, app.Run(ctx, cleanArgs))
+	}
+}
+
+// testFsckCDCRepairOrphanedChunkInStorage verifies that an orphaned chunk file in storage is removed.
+func testFsckCDCRepairOrphanedChunkInStorage(setup fsckSetupFn) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+		db, _, dir, dbURL, cleanup := setup(t)
+		t.Cleanup(cleanup)
+
+		configureFsckCDCInDatabase(ctx, t, db)
+
+		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
+		require.NoError(t, err)
+
+		// Write an orphaned chunk to storage (no DB record).
+		orphanHash := testdata.Nar1.NarHash[:len(testdata.Nar1.NarHash)-1] + "z"
+		_, _, err = cs.PutChunk(ctx, orphanHash, []byte("orphan chunk data"))
+		require.NoError(t, err)
+
+		app, err := ncps.New()
+		require.NoError(t, err)
+
+		repairArgs := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+			"--repair",
+		}
+
+		require.NoError(t, app.Run(ctx, repairArgs))
+
+		// Chunk file should be gone from storage.
+		exists, err := cs.HasChunk(ctx, orphanHash)
+		require.NoError(t, err)
+		assert.False(t, exists, "orphaned chunk should be removed from storage")
+
+		// Second run: should be clean.
+		cleanArgs := []string{
+			"ncps", "fsck",
+			"--cache-database-url", dbURL,
+			"--cache-storage-local", dir,
+		}
+
+		require.NoError(t, app.Run(ctx, cleanArgs))
+	}
 }


### PR DESCRIPTION
Bot-based backport to `release-0.9`, triggered by a label in #986.

In CDC mode, NAR files are stored as chunks rather than whole .nar
files, so the existing fsck logic incorrectly flagged all chunked
nar_files as missing from storage. Additionally, the CDC-mode
consistency check only looked for orphaned chunk DB records, but did not
verify that every chunk linked to a nar_file actually existed in chunk
storage.

This commit fixes fsck CDC mode by:

- Fixing a pre-existing key mismatch bug: fsck was looking up
  'cdc.enabled' (dot) but the config key is 'cdc_enabled' (underscore),
  so CDC mode was never activated during fsck runs.
- Skipping whole-NAR storage checks for nar_files with TotalChunks > 0
  in CDC mode, since those files live in chunk storage instead.
- Replacing the 'chunks missing from storage' check (which only found
  orphaned chunk records) with a per-nar_file completeness check:
  verifies that the actual chunk count in nar_file_chunks matches
  total_chunks, and that every linked chunk exists in chunk storage.
- Repairing broken CDC nar_files by deleting the nar_file record
  (cascading to nar_file_chunks), sweeping for newly orphaned narinfos,
  and cleaning up orphaned chunks from both DB and storage.
- Upgrading the chunkStore variable from ChunkWalker to chunk.Store
  throughout fsck to eliminate redundant interface casts.
- Adding a full CDC test suite covering: clean state, chunk count
  mismatch, chunk missing from storage, orphaned chunk in storage,
  repair of incomplete NAR (with ref-count verification), and repair of
  orphaned chunks.