### PR TITLE
chore: restore default values for CDC parameters

### DIFF
--- a/charts/ncps/values.yaml
+++ b/charts/ncps/values.yaml
@@ -139,11 +139,9 @@ config:
     # REQUIRED for HA deployments (replicaCount > 1) to prevent timeouts and instability.
     # See https://github.com/kalbasit/ncps/issues/660
     enabled: false
-    # Recommended values: min: 16384, avg: 65536, max: 262144
-    # If set to 0 (not configured) and CDC is enabled, the server will error on startup.
-    min: 0
-    avg: 0
-    max: 0
+    min: 16384
+    avg: 65536
+    max: 262144
 
     # Bypass flag for HA validation without CDC
     # Use with EXTREME CAUTION. Doing so may result in timeouts and instability.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -68,12 +68,12 @@ cache:
   cdc:
     # Enable CDC chunking
     enabled: false
-    # Minimum chunk size for CDC in bytes (default: 65536)
-    min: 65536
-    # Average chunk size for CDC in bytes (default: 262144)
-    avg: 262144
-    # Maximum chunk size for CDC in bytes (default: 1048576)
-    max: 1048576
+    # Minimum chunk size for CDC in bytes (default: 16384)
+    min: 16384
+    # Average chunk size for CDC in bytes (default: 65536)
+    avg: 65536
+    # Maximum chunk size for CDC in bytes (default: 262144)
+    max: 262144
   # The maximum size of the store. It can be given with units such as 5K, 10G
   # etc. Supported units: B, K, M, G, T
   max-size: 100G

--- a/docs/docs/User Guide/Configuration/Reference.md
+++ b/docs/docs/User Guide/Configuration/Reference.md
@@ -168,9 +168,9 @@ Content-Defined Chunking (CDC) enables deduplication of NAR files by splitting t
 | Option | Description | Environment Variable | Default |
 | --- | --- | --- | --- |
 | `--cache-cdc-enabled` | Enable CDC for deduplication | `CACHE_CDC_ENABLED` | `false` |
-| `--cache-cdc-min` | Minimum chunk size in bytes | `CACHE_CDC_MIN` | none (recommended: 16384) |
-| `--cache-cdc-avg` | Average chunk size in bytes | `CACHE_CDC_AVG` | none (recommended: 65536) |
-| `--cache-cdc-max` | Maximum chunk size in bytes | `CACHE_CDC_MAX` | none (recommended: 262144) |
+| `--cache-cdc-min` | Minimum chunk size in bytes | `CACHE_CDC_MIN` | 16384 |
+| `--cache-cdc-avg` | Average chunk size in bytes | `CACHE_CDC_AVG` | 65536 |
+| `--cache-cdc-max` | Maximum chunk size in bytes | `CACHE_CDC_MAX` | 262144 |
 
 **Example:**
 
@@ -429,9 +429,9 @@ cache:
 
   cdc:
     enabled: true
-    min: 65536
-    avg: 262144
-    max: 1048576
+    min: 16384
+    avg: 65536
+    max: 262144
 
   lru:
     schedule: "0 2 * * *"

--- a/docs/docs/User Guide/Features/CDC.md
+++ b/docs/docs/User Guide/Features/CDC.md
@@ -40,7 +40,7 @@ CDC is disabled by default. You can enable it by setting `cache.cdc.enabled` to 
 cache:
   cdc:
     enabled: true
-    # Optional: Tune chunk sizes (recommended values shown)
+    # Optional: Tune chunk sizes (default values shown)
     min: 16384    # 16 KB
     avg: 65536    # 64 KB
     max: 262144   # 256 KB
@@ -51,9 +51,9 @@ cache:
 | Flag | Description | Environment Variable | Default |
 | --- | --- | --- | --- |
 | `--cache-cdc-enabled` | Enable CDC for deduplication | `CACHE_CDC_ENABLED` | `false` |
-| `--cache-cdc-min` | Minimum chunk size in bytes | `CACHE_CDC_MIN` | none (recommended: 16384) |
-| `--cache-cdc-avg` | Average (target) chunk size in bytes | `CACHE_CDC_AVG` | none (recommended: 65536) |
-| `--cache-cdc-max` | Maximum chunk size in bytes | `CACHE_CDC_MAX` | none (recommended: 262144) |
+| `--cache-cdc-min` | Minimum chunk size in bytes | `CACHE_CDC_MIN` | 16384 |
+| `--cache-cdc-avg` | Average (target) chunk size in bytes | `CACHE_CDC_AVG` | 65536 |
+| `--cache-cdc-max` | Maximum chunk size in bytes | `CACHE_CDC_MAX` | 262144 |
 
 ## Storage Considerations
 

--- a/docs/docs/User Guide/Installation/Helm Chart.md
+++ b/docs/docs/User Guide/Installation/Helm Chart.md
@@ -446,10 +446,10 @@ Content-Defined Chunking (CDC) for deduplication:
 config:
   cdc:
     enabled: true
-    # Optional: Tune chunk sizes
-    min: 65536
-    avg: 262144
-    max: 1048576
+    # Optional: Tune chunk sizes (default values)
+    min: 16384
+    avg: 65536
+    max: 262144
 ```
 
 ## Upstream Cache Configuration

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -168,18 +168,21 @@ func serveCommand(
 			},
 			&cli.Uint32Flag{
 				Name:    "cache-cdc-min",
-				Usage:   "Minimum chunk size for CDC in bytes (recommended: 16384)",
+				Usage:   "Minimum chunk size for CDC in bytes",
 				Sources: flagSources("cache.cdc.min", "CACHE_CDC_MIN"),
+				Value:   16384,
 			},
 			&cli.Uint32Flag{
 				Name:    "cache-cdc-avg",
-				Usage:   "Average chunk size for CDC in bytes (recommended: 65536)",
+				Usage:   "Average chunk size for CDC in bytes",
 				Sources: flagSources("cache.cdc.avg", "CACHE_CDC_AVG"),
+				Value:   65536,
 			},
 			&cli.Uint32Flag{
 				Name:    "cache-cdc-max",
-				Usage:   "Maximum chunk size for CDC in bytes (recommended: 262144)",
+				Usage:   "Maximum chunk size for CDC in bytes",
 				Sources: flagSources("cache.cdc.max", "CACHE_CDC_MAX"),
+				Value:   262144,
 			},
 			&cli.StringFlag{
 				Name:     "cache-database-url",


### PR DESCRIPTION
Now that ncps v0.9.2 was released with the change of the values to have
no default, it's safe to put defaults that are more aligned with Attic.