### PR TITLE
fix: prevent fsck false positives for chunked nar_files when CDC config is absent [backport #992]

### DIFF
--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -363,3 +363,7 @@ WHERE NOT EXISTS (
 -- Returns all chunks for storage existence verification (CDC mode).
 SELECT id, hash, size, compressed_size, created_at, updated_at
 FROM chunks;
+
+-- name: HasAnyChunkedNarFiles :one
+-- Returns true if any nar_file has total_chunks > 0 (used for CDC auto-detection).
+SELECT EXISTS(SELECT 1 FROM nar_files WHERE total_chunks > 0) AS "exists";

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -395,3 +395,7 @@ WHERE NOT EXISTS (
 -- Returns all chunks for storage existence verification (CDC mode).
 SELECT id, hash, size, compressed_size, created_at, updated_at
 FROM chunks;
+
+-- name: HasAnyChunkedNarFiles :one
+-- Returns true if any nar_file has total_chunks > 0 (used for CDC auto-detection).
+SELECT EXISTS(SELECT 1 FROM nar_files WHERE total_chunks > 0) AS "exists";

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -382,3 +382,7 @@ WHERE NOT EXISTS (
 -- Returns all chunks for storage existence verification (CDC mode).
 SELECT id, hash, size, compressed_size, created_at, updated_at
 FROM chunks;
+
+-- name: HasAnyChunkedNarFiles :one
+-- Returns true if any nar_file has total_chunks > 0 (used for CDC auto-detection).
+SELECT EXISTS(SELECT 1 FROM nar_files WHERE total_chunks > 0) AS "exists";

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -328,6 +328,10 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url IS NULL
 	GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error)
+	// Returns true if any nar_file has total_chunks > 0 (used for CDC auto-detection).
+	//
+	//  SELECT EXISTS(SELECT 1 FROM nar_files WHERE total_chunks > 0) AS "exists"
+	HasAnyChunkedNarFiles(ctx context.Context) (bool, error)
 	//LinkNarFileToChunk
 	//
 	//  INSERT INTO nar_file_chunks (

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -1162,6 +1162,19 @@ func (w *mysqlWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string
 	return res, nil
 }
 
+func (w *mysqlWrapper) HasAnyChunkedNarFiles(ctx context.Context) (bool, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.HasAnyChunkedNarFiles(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *mysqlWrapper) LinkNarFileToChunk(ctx context.Context, arg LinkNarFileToChunkParams) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -1168,6 +1168,19 @@ func (w *postgresWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]str
 	return res, nil
 }
 
+func (w *postgresWrapper) HasAnyChunkedNarFiles(ctx context.Context) (bool, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.HasAnyChunkedNarFiles(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res, nil
+}
+
 func (w *postgresWrapper) LinkNarFileToChunk(ctx context.Context, arg LinkNarFileToChunkParams) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -1186,6 +1186,19 @@ func (w *sqliteWrapper) GetUnmigratedNarInfoHashes(ctx context.Context) ([]strin
 	return res, nil
 }
 
+func (w *sqliteWrapper) HasAnyChunkedNarFiles(ctx context.Context) (bool, error) {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	res, err := w.adapter.HasAnyChunkedNarFiles(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	// Return Primitive / *sql.DB / etc
+
+	return res != 0, nil
+}
+
 func (w *sqliteWrapper) LinkNarFileToChunk(ctx context.Context, arg LinkNarFileToChunkParams) error {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -295,6 +295,10 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url IS NULL
 	GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error)
+	// Returns true if any nar_file has total_chunks > 0 (used for CDC auto-detection).
+	//
+	//  SELECT EXISTS(SELECT 1 FROM nar_files WHERE total_chunks > 0) AS "exists"
+	HasAnyChunkedNarFiles(ctx context.Context) (bool, error)
 	//LinkNarFileToChunk
 	//
 	//  INSERT IGNORE INTO nar_file_chunks (

--- a/pkg/database/mysqldb/query.mysql.sql.go
+++ b/pkg/database/mysqldb/query.mysql.sql.go
@@ -1302,6 +1302,20 @@ func (q *Queries) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, err
 	return items, nil
 }
 
+const hasAnyChunkedNarFiles = `-- name: HasAnyChunkedNarFiles :one
+SELECT EXISTS(SELECT 1 FROM nar_files WHERE total_chunks > 0) AS "exists"
+`
+
+// Returns true if any nar_file has total_chunks > 0 (used for CDC auto-detection).
+//
+//	SELECT EXISTS(SELECT 1 FROM nar_files WHERE total_chunks > 0) AS "exists"
+func (q *Queries) HasAnyChunkedNarFiles(ctx context.Context) (bool, error) {
+	row := q.db.QueryRowContext(ctx, hasAnyChunkedNarFiles)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const linkNarFileToChunk = `-- name: LinkNarFileToChunk :exec
 INSERT IGNORE INTO nar_file_chunks (
     nar_file_id, chunk_id, chunk_index

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -323,6 +323,10 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url IS NULL
 	GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error)
+	// Returns true if any nar_file has total_chunks > 0 (used for CDC auto-detection).
+	//
+	//  SELECT EXISTS(SELECT 1 FROM nar_files WHERE total_chunks > 0) AS "exists"
+	HasAnyChunkedNarFiles(ctx context.Context) (bool, error)
 	//LinkNarFileToChunk
 	//
 	//  INSERT INTO nar_file_chunks (

--- a/pkg/database/postgresdb/query.postgres.sql.go
+++ b/pkg/database/postgresdb/query.postgres.sql.go
@@ -1391,6 +1391,20 @@ func (q *Queries) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, err
 	return items, nil
 }
 
+const hasAnyChunkedNarFiles = `-- name: HasAnyChunkedNarFiles :one
+SELECT EXISTS(SELECT 1 FROM nar_files WHERE total_chunks > 0) AS "exists"
+`
+
+// Returns true if any nar_file has total_chunks > 0 (used for CDC auto-detection).
+//
+//	SELECT EXISTS(SELECT 1 FROM nar_files WHERE total_chunks > 0) AS "exists"
+func (q *Queries) HasAnyChunkedNarFiles(ctx context.Context) (bool, error) {
+	row := q.db.QueryRowContext(ctx, hasAnyChunkedNarFiles)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const linkNarFileToChunk = `-- name: LinkNarFileToChunk :exec
 INSERT INTO nar_file_chunks (
     nar_file_id, chunk_id, chunk_index

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -309,6 +309,10 @@ type Querier interface {
 	//  FROM narinfos
 	//  WHERE url IS NULL
 	GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, error)
+	// Returns true if any nar_file has total_chunks > 0 (used for CDC auto-detection).
+	//
+	//  SELECT EXISTS(SELECT 1 FROM nar_files WHERE total_chunks > 0) AS "exists"
+	HasAnyChunkedNarFiles(ctx context.Context) (int64, error)
 	//LinkNarFileToChunk
 	//
 	//  INSERT INTO nar_file_chunks (

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -1343,6 +1343,20 @@ func (q *Queries) GetUnmigratedNarInfoHashes(ctx context.Context) ([]string, err
 	return items, nil
 }
 
+const hasAnyChunkedNarFiles = `-- name: HasAnyChunkedNarFiles :one
+SELECT EXISTS(SELECT 1 FROM nar_files WHERE total_chunks > 0) AS "exists"
+`
+
+// Returns true if any nar_file has total_chunks > 0 (used for CDC auto-detection).
+//
+//	SELECT EXISTS(SELECT 1 FROM nar_files WHERE total_chunks > 0) AS "exists"
+func (q *Queries) HasAnyChunkedNarFiles(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, hasAnyChunkedNarFiles)
+	var exists int64
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const linkNarFileToChunk = `-- name: LinkNarFileToChunk :exec
 INSERT INTO nar_file_chunks (
     nar_file_id, chunk_id, chunk_index


### PR DESCRIPTION
Bot-based backport to `release-0.9`, triggered by a label in #992.

Two bugs compounded to cause all chunked nar_files to be falsely
reported as 'missing from storage' when the cdc_enabled DB config key
could not be read.

Bug 1 — Silent failure of CDC detection: if GetConfigByKey returned an
error, cdcMode stayed false with no log output. The error is now logged
as a warning, and a data-based fallback is added: if
HasAnyChunkedNarFiles returns true, cdcMode is enabled automatically
with a warning prompting the operator to verify --cache-database-url.

Bug 2 — Unnecessary cdcMode gate on the TotalChunks check: the condition
'if cdcMode && nf.TotalChunks > 0' meant that when Bug 1 fired
(cdcMode=false), all 60,953 chunked nar_files fell through to the HasNar
check and were all flagged as missing. Chunked nar_files (total_chunks >
0) are always stored in chunk storage, never as whole NAR files, so the
cdcMode guard is incorrect. The fix removes it: 'if nf.TotalChunks > 0'
skips the whole-NAR check unconditionally.

A new HasAnyChunkedNarFiles DB query is added to all three engine query
files (SQLite, PostgreSQL, MySQL) and regenerated via sqlc + go
generate.

A regression test
(CDC/ChunkedNarFilesNotFlaggedAsMissingWithoutCDCConfig) verifies that
chunked nar_files with no cdc_enabled config key produce zero fsck
issues.