### PR TITLE
refactor: improve fsck progress reporting for orphaned chunks

### DIFF
--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -624,10 +624,8 @@ func collectFsckSuspects(
 	// g. Orphaned chunk files in storage
 	logger.Info().Msg("phase 1g: checking orphaned chunk files in storage")
 
-	chunkCount, err := db.GetChunkCount(ctx)
-	if err == nil {
-		total.Add(chunkCount)
-	}
+	// The total number of chunks in storage is not known beforehand, so we cannot
+	// accurately report a percentage for phase 1g. We'll rely on the checked count.
 
 	orphaned, err := collectOrphanedChunksInStorage(ctx, db, chunkStore, &checked)
 	if err != nil {
@@ -1378,7 +1376,7 @@ func logProgress(
 		Int64("checked", checked).
 		Int64("total", total)
 
-	if total > 0 {
+	if total > 0 && checked <= total {
 		pct := float64(checked) / float64(total) * 100
 		evt = evt.Str("percent", fmt.Sprintf("%.1f%%", pct))
 	}


### PR DESCRIPTION
Phase 1g (orphaned chunk files in storage) uses a storage walker to find
chunks that are not in the database. Since the total number of chunks in
storage is not known beforehand, we cannot accurately calculate a
percentage for this phase.

This change:
1. Removes the attempt to pre-calculate chunk count in phase 1g.
2. Updates logProgress to only show percentage when checked <= total,
   preventing misleading percentages when phase 1g is running.

Follow-up on #996 