### PR TITLE
perf: optimize fsck with verified_at timestamp [backport #998]

### DIFF
--- a/db/migrations/mysql/20260301000000_add_verified_at_to_nar_files.sql
+++ b/db/migrations/mysql/20260301000000_add_verified_at_to_nar_files.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+ALTER TABLE nar_files ADD COLUMN verified_at TIMESTAMP NULL;
+
+-- migrate:down
+ALTER TABLE nar_files DROP COLUMN verified_at;

--- a/db/migrations/postgres/20260301000000_add_verified_at_to_nar_files.sql
+++ b/db/migrations/postgres/20260301000000_add_verified_at_to_nar_files.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+ALTER TABLE nar_files ADD COLUMN verified_at TIMESTAMP WITH TIME ZONE;
+
+-- migrate:down
+ALTER TABLE nar_files DROP COLUMN verified_at;

--- a/db/migrations/sqlite/20260301000000_add_verified_at_to_nar_files.sql
+++ b/db/migrations/sqlite/20260301000000_add_verified_at_to_nar_files.sql
@@ -1,0 +1,40 @@
+-- migrate:up
+ALTER TABLE nar_files ADD COLUMN verified_at TIMESTAMP;
+
+-- migrate:down
+CREATE TABLE nar_files_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    hash TEXT NOT NULL,
+    compression TEXT NOT NULL DEFAULT '',
+    file_size INTEGER NOT NULL,
+    "query" TEXT NOT NULL DEFAULT '',
+    total_chunks BIGINT NOT NULL DEFAULT 0,
+    chunking_started_at TIMESTAMP NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP,
+    last_accessed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (hash, compression, "query")
+);
+
+INSERT INTO nar_files_new (
+    id, hash, compression, file_size, "query", total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+)
+SELECT
+    id,
+    hash,
+    compression,
+    file_size,
+    "query",
+    total_chunks,
+    chunking_started_at,
+    created_at,
+    updated_at,
+    last_accessed_at
+FROM nar_files;
+
+PRAGMA foreign_keys = OFF;
+DROP TABLE nar_files;
+ALTER TABLE nar_files_new RENAME TO nar_files;
+PRAGMA foreign_keys = ON;
+
+CREATE INDEX idx_nar_files_last_accessed_at ON nar_files (last_accessed_at);

--- a/db/query.mysql.sql
+++ b/db/query.mysql.sql
@@ -15,12 +15,12 @@ WHERE url = ?
 LIMIT 1;
 
 -- name: GetNarFileByHashAndCompressionAndQuery :one
-SELECT id, hash, compression, file_size, `query`, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
+SELECT id, hash, compression, file_size, `query`, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at, verified_at
 FROM nar_files
 WHERE hash = ? AND compression = ? AND `query` = ?;
 
 -- name: GetNarFileByNarInfoID :one
-SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.`query`, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.`query`, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 FROM nar_files nf
 INNER JOIN narinfo_nar_files nnf ON nf.id = nnf.nar_file_id
 WHERE nnf.narinfo_id = ?;
@@ -220,7 +220,7 @@ WHERE (
 
 -- name: GetOrphanedNarFiles :many
 -- Find files that have no relationship to any narinfo
-SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.`query`, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.`query`, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 FROM nar_files nf
 LEFT JOIN narinfo_nar_files ninf ON nf.id = ninf.nar_file_id
 WHERE ninf.narinfo_id IS NULL;
@@ -311,6 +311,11 @@ UPDATE nar_files
 SET total_chunks = ?, file_size = ?, updated_at = CURRENT_TIMESTAMP, chunking_started_at = NULL
 WHERE id = ?;
 
+-- name: UpdateNarFileVerifiedAt :exec
+UPDATE nar_files
+SET verified_at = CURRENT_TIMESTAMP
+WHERE id = ?;
+
 -- name: SetNarFileChunkingStarted :exec
 UPDATE nar_files
 SET chunking_started_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
@@ -348,7 +353,7 @@ WHERE url = sqlc.arg(old_url);
 
 -- name: GetAllNarFiles :many
 -- Returns all nar_files for storage existence verification.
-SELECT id, hash, compression, `query`, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+SELECT id, hash, compression, `query`, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at, verified_at
 FROM nar_files;
 
 -- name: GetNarInfosWithoutNarFiles :many

--- a/db/query.postgres.sql
+++ b/db/query.postgres.sql
@@ -15,12 +15,12 @@ WHERE url = $1
 LIMIT 1;
 
 -- name: GetNarFileByHashAndCompressionAndQuery :one
-SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
+SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at, verified_at
 FROM nar_files
 WHERE hash = $1 AND compression = $2 AND query = $3;
 
 -- name: GetNarFileByNarInfoID :one
-SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.query, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.query, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 FROM nar_files nf
 INNER JOIN narinfo_nar_files nnf ON nf.id = nnf.nar_file_id
 WHERE nnf.narinfo_id = $1;
@@ -163,7 +163,8 @@ RETURNING
     updated_at,
     last_accessed_at,
     total_chunks,
-    chunking_started_at;
+    chunking_started_at,
+    verified_at;
 
 -- name: SetNarFileChunkingStarted :exec
 UPDATE nar_files
@@ -256,7 +257,7 @@ WHERE (
 
 -- name: GetOrphanedNarFiles :many
 -- Find files that have no relationship to any narinfo
-SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.query, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.query, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 FROM nar_files nf
 LEFT JOIN narinfo_nar_files ninf ON nf.id = ninf.nar_file_id
 WHERE ninf.narinfo_id IS NULL;
@@ -348,6 +349,11 @@ UPDATE nar_files
 SET total_chunks = $1, file_size = $2, updated_at = CURRENT_TIMESTAMP, chunking_started_at = NULL
 WHERE id = $3;
 
+-- name: UpdateNarFileVerifiedAt :exec
+UPDATE nar_files
+SET verified_at = CURRENT_TIMESTAMP
+WHERE id = $1;
+
 -- name: GetNarFilesToChunk :many
 -- Get all NAR files that are not yet chunked.
 SELECT id, hash, compression, query, file_size
@@ -380,7 +386,7 @@ WHERE url = sqlc.arg(old_url);
 
 -- name: GetAllNarFiles :many
 -- Returns all nar_files for storage existence verification.
-SELECT id, hash, compression, query, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+SELECT id, hash, compression, query, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at, verified_at
 FROM nar_files;
 
 -- name: GetNarInfosWithoutNarFiles :many

--- a/db/query.sqlite.sql
+++ b/db/query.sqlite.sql
@@ -15,12 +15,12 @@ WHERE url = ?
 LIMIT 1;
 
 -- name: GetNarFileByHashAndCompressionAndQuery :one
-SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
+SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at, verified_at
 FROM nar_files
 WHERE hash = ? AND compression = ? AND "query" = ?;
 
 -- name: GetNarFileByNarInfoID :one
-SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 FROM nar_files nf
 INNER JOIN narinfo_nar_files nnf ON nf.id = nnf.nar_file_id
 WHERE nnf.narinfo_id = ?;
@@ -149,7 +149,8 @@ RETURNING
     updated_at,
     last_accessed_at,
     total_chunks,
-    chunking_started_at;
+    chunking_started_at,
+    verified_at;
 
 -- name: SetNarFileChunkingStarted :exec
 UPDATE nar_files
@@ -242,7 +243,7 @@ WHERE (
 
 -- name: GetOrphanedNarFiles :many
 -- Find files that have no relationship to any narinfo
-SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 FROM nar_files nf
 LEFT JOIN narinfo_nar_files ninf ON nf.id = ninf.nar_file_id
 WHERE ninf.narinfo_id IS NULL;
@@ -335,6 +336,11 @@ UPDATE nar_files
 SET total_chunks = ?, file_size = ?, updated_at = CURRENT_TIMESTAMP, chunking_started_at = NULL
 WHERE id = ?;
 
+-- name: UpdateNarFileVerifiedAt :exec
+UPDATE nar_files
+SET verified_at = CURRENT_TIMESTAMP
+WHERE id = ?;
+
 -- name: GetNarFilesToChunk :many
 -- Get all NAR files that are not yet chunked.
 SELECT id, hash, compression, "query", file_size
@@ -367,7 +373,7 @@ WHERE url = sqlc.arg(old_url);
 
 -- name: GetAllNarFiles :many
 -- Returns all nar_files for storage existence verification.
-SELECT id, hash, compression, "query", file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+SELECT id, hash, compression, "query", file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at, verified_at
 FROM nar_files;
 
 -- name: GetNarInfosWithoutNarFiles :many

--- a/db/schema/mysql.sql
+++ b/db/schema/mysql.sql
@@ -85,6 +85,7 @@ CREATE TABLE `nar_files` (
   `last_accessed_at` timestamp NULL DEFAULT current_timestamp(),
   `total_chunks` bigint(20) NOT NULL DEFAULT 0,
   `chunking_started_at` timestamp NULL DEFAULT NULL,
+  `verified_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_nar_files_hash_compression_query` (`hash`,`compression`,`query`) USING HASH,
   KEY `idx_nar_files_last_accessed_at` (`last_accessed_at`)
@@ -203,5 +204,6 @@ INSERT INTO `schema_migrations` (version) VALUES
   ('20260127223000'),
   ('20260131021850'),
   ('20260205063659'),
-  ('20260217071237');
+  ('20260217071237'),
+  ('20260301000000');
 UNLOCK TABLES;

--- a/db/schema/postgres.sql
+++ b/db/schema/postgres.sql
@@ -107,6 +107,7 @@ CREATE TABLE public.nar_files (
     last_accessed_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
     total_chunks bigint DEFAULT 0 NOT NULL,
     chunking_started_at timestamp with time zone,
+    verified_at timestamp with time zone,
     CONSTRAINT nar_files_file_size_check CHECK ((file_size >= 0))
 );
 
@@ -451,4 +452,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260127223000'),
     ('20260131021850'),
     ('20260205063658'),
-    ('20260217071237');
+    ('20260217071237'),
+    ('20260301000000');

--- a/db/schema/sqlite.sql
+++ b/db/schema/sqlite.sql
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS "nar_files" (
     "query" TEXT NOT NULL DEFAULT '',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updated_at TIMESTAMP,
-    last_accessed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, total_chunks BIGINT NOT NULL DEFAULT 0, chunking_started_at TIMESTAMP NULL,
+    last_accessed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, total_chunks BIGINT NOT NULL DEFAULT 0, chunking_started_at TIMESTAMP NULL, verified_at TIMESTAMP,
     UNIQUE (hash, compression, "query")
 );
 CREATE INDEX idx_nar_files_last_accessed_at ON nar_files (last_accessed_at);
@@ -75,4 +75,5 @@ INSERT INTO "schema_migrations" (version) VALUES
   ('20260127223000'),
   ('20260131021850'),
   ('20260205063651'),
-  ('20260217071237');
+  ('20260217071237'),
+  ('20260301000000');

--- a/pkg/database/generated_models.go
+++ b/pkg/database/generated_models.go
@@ -93,6 +93,7 @@ type GetAllNarFilesRow struct {
 	CreatedAt         time.Time
 	UpdatedAt         sql.NullTime
 	LastAccessedAt    sql.NullTime
+	VerifiedAt        sql.NullTime
 }
 
 type GetChunkByNarFileIDAndIndexParams struct {
@@ -169,6 +170,7 @@ type NarFile struct {
 	LastAccessedAt    sql.NullTime
 	TotalChunks       int64
 	ChunkingStartedAt sql.NullTime
+	VerifiedAt        sql.NullTime
 }
 
 type NarInfo struct {

--- a/pkg/database/generated_querier.go
+++ b/pkg/database/generated_querier.go
@@ -78,7 +78,8 @@ type Querier interface {
 	//      updated_at,
 	//      last_accessed_at,
 	//      total_chunks,
-	//      chunking_started_at
+	//      chunking_started_at,
+	//      verified_at
 	CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error)
 	//CreateNarInfo
 	//
@@ -151,7 +152,7 @@ type Querier interface {
 	GetAllChunks(ctx context.Context) ([]Chunk, error)
 	// Returns all nar_files for storage existence verification.
 	//
-	//  SELECT id, hash, compression, query, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+	//  SELECT id, hash, compression, query, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at, verified_at
 	//  FROM nar_files
 	GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow, error)
 	//GetChunkByHash
@@ -217,7 +218,7 @@ type Querier interface {
 	GetMigratedNarInfoHashes(ctx context.Context) ([]string, error)
 	//GetNarFileByHashAndCompressionAndQuery
 	//
-	//  SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
+	//  SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at, verified_at
 	//  FROM nar_files
 	//  WHERE hash = $1 AND compression = $2 AND query = $3
 	GetNarFileByHashAndCompressionAndQuery(ctx context.Context, arg GetNarFileByHashAndCompressionAndQueryParams) (NarFile, error)
@@ -225,7 +226,7 @@ type Querier interface {
 	GetNarFileByID(ctx context.Context, id int64) (NarFile, error)
 	//GetNarFileByNarInfoID
 	//
-	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.query, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.query, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 	//  FROM nar_files nf
 	//  INNER JOIN narinfo_nar_files nnf ON nf.id = nnf.nar_file_id
 	//  WHERE nnf.narinfo_id = $1
@@ -317,7 +318,7 @@ type Querier interface {
 	GetOrphanedChunks(ctx context.Context) ([]GetOrphanedChunksRow, error)
 	// Find files that have no relationship to any narinfo
 	//
-	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.query, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.query, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 	//  FROM nar_files nf
 	//  LEFT JOIN narinfo_nar_files ninf ON nf.id = ninf.nar_file_id
 	//  WHERE ninf.narinfo_id IS NULL
@@ -412,6 +413,12 @@ type Querier interface {
 	//  SET total_chunks = $1, file_size = $2, updated_at = CURRENT_TIMESTAMP, chunking_started_at = NULL
 	//  WHERE id = $3
 	UpdateNarFileTotalChunks(ctx context.Context, arg UpdateNarFileTotalChunksParams) error
+	//UpdateNarFileVerifiedAt
+	//
+	//  UPDATE nar_files
+	//  SET verified_at = CURRENT_TIMESTAMP
+	//  WHERE id = $1
+	UpdateNarFileVerifiedAt(ctx context.Context, id int64) error
 	//UpdateNarInfo
 	//
 	//  UPDATE narinfos

--- a/pkg/database/generated_wrapper_mysql.go
+++ b/pkg/database/generated_wrapper_mysql.go
@@ -353,6 +353,8 @@ func (w *mysqlWrapper) GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow,
 			UpdatedAt: v.UpdatedAt,
 
 			LastAccessedAt: v.LastAccessedAt,
+
+			VerifiedAt: v.VerifiedAt,
 		}
 	}
 	return items, nil
@@ -669,13 +671,15 @@ func (w *mysqlWrapper) GetNarFileByHashAndCompressionAndQuery(ctx context.Contex
 		TotalChunks: res.TotalChunks,
 
 		ChunkingStartedAt: res.ChunkingStartedAt,
+
+		VerifiedAt: res.VerifiedAt,
 	}, nil
 }
 
 func (w *mysqlWrapper) GetNarFileByID(ctx context.Context, id int64) (NarFile, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	query := "SELECT `id`, `hash`, `compression`, `file_size`, `created_at`, `updated_at`, `last_accessed_at`, `query`, `total_chunks`, `chunking_started_at` FROM nar_files WHERE id = ?"
+	query := "SELECT `id`, `hash`, `compression`, `file_size`, `created_at`, `updated_at`, `last_accessed_at`, `query`, `total_chunks`, `chunking_started_at`, `verified_at` FROM nar_files WHERE id = ?"
 	row := w.adapter.DBTX().QueryRowContext(ctx, query, id)
 	var res mysqldb.NarFile
 	err := row.Scan(
@@ -699,6 +703,8 @@ func (w *mysqlWrapper) GetNarFileByID(ctx context.Context, id int64) (NarFile, e
 		&res.TotalChunks,
 
 		&res.ChunkingStartedAt,
+
+		&res.VerifiedAt,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -729,6 +735,8 @@ func (w *mysqlWrapper) GetNarFileByID(ctx context.Context, id int64) (NarFile, e
 		TotalChunks: res.TotalChunks,
 
 		ChunkingStartedAt: res.ChunkingStartedAt,
+
+		VerifiedAt: res.VerifiedAt,
 	}, nil
 }
 
@@ -767,6 +775,8 @@ func (w *mysqlWrapper) GetNarFileByNarInfoID(ctx context.Context, narinfoID int6
 		TotalChunks: res.TotalChunks,
 
 		ChunkingStartedAt: res.ChunkingStartedAt,
+
+		VerifiedAt: res.VerifiedAt,
 	}, nil
 }
 
@@ -1145,6 +1155,8 @@ func (w *mysqlWrapper) GetOrphanedNarFiles(ctx context.Context) ([]NarFile, erro
 			TotalChunks: v.TotalChunks,
 
 			ChunkingStartedAt: v.ChunkingStartedAt,
+
+			VerifiedAt: v.VerifiedAt,
 		}
 	}
 	return items, nil
@@ -1288,6 +1300,12 @@ func (w *mysqlWrapper) UpdateNarFileTotalChunks(ctx context.Context, arg UpdateN
 		FileSize:    arg.FileSize,
 		ID:          arg.ID,
 	})
+}
+
+func (w *mysqlWrapper) UpdateNarFileVerifiedAt(ctx context.Context, id int64) error {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.UpdateNarFileVerifiedAt(ctx, id)
 }
 
 func (w *mysqlWrapper) UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (NarInfo, error) {

--- a/pkg/database/generated_wrapper_postgres.go
+++ b/pkg/database/generated_wrapper_postgres.go
@@ -156,6 +156,8 @@ func (w *postgresWrapper) CreateNarFile(ctx context.Context, arg CreateNarFilePa
 		TotalChunks: res.TotalChunks,
 
 		ChunkingStartedAt: res.ChunkingStartedAt,
+
+		VerifiedAt: res.VerifiedAt,
 	}, nil
 }
 
@@ -359,6 +361,8 @@ func (w *postgresWrapper) GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesR
 			UpdatedAt: v.UpdatedAt,
 
 			LastAccessedAt: v.LastAccessedAt,
+
+			VerifiedAt: v.VerifiedAt,
 		}
 	}
 	return items, nil
@@ -675,13 +679,15 @@ func (w *postgresWrapper) GetNarFileByHashAndCompressionAndQuery(ctx context.Con
 		TotalChunks: res.TotalChunks,
 
 		ChunkingStartedAt: res.ChunkingStartedAt,
+
+		VerifiedAt: res.VerifiedAt,
 	}, nil
 }
 
 func (w *postgresWrapper) GetNarFileByID(ctx context.Context, id int64) (NarFile, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	query := "SELECT \"id\", \"hash\", \"compression\", \"file_size\", \"query\", \"created_at\", \"updated_at\", \"last_accessed_at\", \"total_chunks\", \"chunking_started_at\" FROM nar_files WHERE id = $1"
+	query := "SELECT \"id\", \"hash\", \"compression\", \"file_size\", \"query\", \"created_at\", \"updated_at\", \"last_accessed_at\", \"total_chunks\", \"chunking_started_at\", \"verified_at\" FROM nar_files WHERE id = $1"
 	row := w.adapter.DBTX().QueryRowContext(ctx, query, id)
 	var res postgresdb.NarFile
 	err := row.Scan(
@@ -705,6 +711,8 @@ func (w *postgresWrapper) GetNarFileByID(ctx context.Context, id int64) (NarFile
 		&res.TotalChunks,
 
 		&res.ChunkingStartedAt,
+
+		&res.VerifiedAt,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -735,6 +743,8 @@ func (w *postgresWrapper) GetNarFileByID(ctx context.Context, id int64) (NarFile
 		TotalChunks: res.TotalChunks,
 
 		ChunkingStartedAt: res.ChunkingStartedAt,
+
+		VerifiedAt: res.VerifiedAt,
 	}, nil
 }
 
@@ -773,6 +783,8 @@ func (w *postgresWrapper) GetNarFileByNarInfoID(ctx context.Context, narinfoID i
 		TotalChunks: res.TotalChunks,
 
 		ChunkingStartedAt: res.ChunkingStartedAt,
+
+		VerifiedAt: res.VerifiedAt,
 	}, nil
 }
 
@@ -1151,6 +1163,8 @@ func (w *postgresWrapper) GetOrphanedNarFiles(ctx context.Context) ([]NarFile, e
 			TotalChunks: v.TotalChunks,
 
 			ChunkingStartedAt: v.ChunkingStartedAt,
+
+			VerifiedAt: v.VerifiedAt,
 		}
 	}
 	return items, nil
@@ -1285,6 +1299,12 @@ func (w *postgresWrapper) UpdateNarFileTotalChunks(ctx context.Context, arg Upda
 		FileSize:    arg.FileSize,
 		ID:          arg.ID,
 	})
+}
+
+func (w *postgresWrapper) UpdateNarFileVerifiedAt(ctx context.Context, id int64) error {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.UpdateNarFileVerifiedAt(ctx, id)
 }
 
 func (w *postgresWrapper) UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (NarInfo, error) {

--- a/pkg/database/generated_wrapper_sqlite.go
+++ b/pkg/database/generated_wrapper_sqlite.go
@@ -174,6 +174,8 @@ func (w *sqliteWrapper) CreateNarFile(ctx context.Context, arg CreateNarFilePara
 		TotalChunks: res.TotalChunks,
 
 		ChunkingStartedAt: res.ChunkingStartedAt,
+
+		VerifiedAt: res.VerifiedAt,
 	}, nil
 }
 
@@ -377,6 +379,8 @@ func (w *sqliteWrapper) GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow
 			UpdatedAt: v.UpdatedAt,
 
 			LastAccessedAt: v.LastAccessedAt,
+
+			VerifiedAt: v.VerifiedAt,
 		}
 	}
 	return items, nil
@@ -693,13 +697,15 @@ func (w *sqliteWrapper) GetNarFileByHashAndCompressionAndQuery(ctx context.Conte
 		TotalChunks: res.TotalChunks,
 
 		ChunkingStartedAt: res.ChunkingStartedAt,
+
+		VerifiedAt: res.VerifiedAt,
 	}, nil
 }
 
 func (w *sqliteWrapper) GetNarFileByID(ctx context.Context, id int64) (NarFile, error) {
 	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
 
-	query := "SELECT \"id\", \"hash\", \"compression\", \"file_size\", \"query\", \"created_at\", \"updated_at\", \"last_accessed_at\", \"total_chunks\", \"chunking_started_at\" FROM nar_files WHERE id = ?"
+	query := "SELECT \"id\", \"hash\", \"compression\", \"file_size\", \"query\", \"created_at\", \"updated_at\", \"last_accessed_at\", \"total_chunks\", \"chunking_started_at\", \"verified_at\" FROM nar_files WHERE id = ?"
 	row := w.adapter.DBTX().QueryRowContext(ctx, query, id)
 	var res sqlitedb.NarFile
 	err := row.Scan(
@@ -723,6 +729,8 @@ func (w *sqliteWrapper) GetNarFileByID(ctx context.Context, id int64) (NarFile, 
 		&res.TotalChunks,
 
 		&res.ChunkingStartedAt,
+
+		&res.VerifiedAt,
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -753,6 +761,8 @@ func (w *sqliteWrapper) GetNarFileByID(ctx context.Context, id int64) (NarFile, 
 		TotalChunks: res.TotalChunks,
 
 		ChunkingStartedAt: res.ChunkingStartedAt,
+
+		VerifiedAt: res.VerifiedAt,
 	}, nil
 }
 
@@ -791,6 +801,8 @@ func (w *sqliteWrapper) GetNarFileByNarInfoID(ctx context.Context, narinfoID int
 		TotalChunks: res.TotalChunks,
 
 		ChunkingStartedAt: res.ChunkingStartedAt,
+
+		VerifiedAt: res.VerifiedAt,
 	}, nil
 }
 
@@ -1169,6 +1181,8 @@ func (w *sqliteWrapper) GetOrphanedNarFiles(ctx context.Context) ([]NarFile, err
 			TotalChunks: v.TotalChunks,
 
 			ChunkingStartedAt: v.ChunkingStartedAt,
+
+			VerifiedAt: v.VerifiedAt,
 		}
 	}
 	return items, nil
@@ -1312,6 +1326,12 @@ func (w *sqliteWrapper) UpdateNarFileTotalChunks(ctx context.Context, arg Update
 		FileSize:    arg.FileSize,
 		ID:          arg.ID,
 	})
+}
+
+func (w *sqliteWrapper) UpdateNarFileVerifiedAt(ctx context.Context, id int64) error {
+	/* --- Auto-Loop for Bulk Insert on Non-Postgres --- */
+
+	return w.adapter.UpdateNarFileVerifiedAt(ctx, id)
 }
 
 func (w *sqliteWrapper) UpdateNarInfo(ctx context.Context, arg UpdateNarInfoParams) (NarInfo, error) {

--- a/pkg/database/mysqldb/models.go
+++ b/pkg/database/mysqldb/models.go
@@ -37,6 +37,7 @@ type NarFile struct {
 	Query             string
 	TotalChunks       int64
 	ChunkingStartedAt sql.NullTime
+	VerifiedAt        sql.NullTime
 }
 
 type NarFileChunk struct {

--- a/pkg/database/mysqldb/querier.go
+++ b/pkg/database/mysqldb/querier.go
@@ -126,7 +126,7 @@ type Querier interface {
 	GetAllChunks(ctx context.Context) ([]Chunk, error)
 	// Returns all nar_files for storage existence verification.
 	//
-	//  SELECT id, hash, compression, `query`, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+	//  SELECT id, hash, compression, `query`, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at, verified_at
 	//  FROM nar_files
 	GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow, error)
 	//GetChunkByHash
@@ -188,13 +188,13 @@ type Querier interface {
 	GetMigratedNarInfoHashes(ctx context.Context) ([]string, error)
 	//GetNarFileByHashAndCompressionAndQuery
 	//
-	//  SELECT id, hash, compression, file_size, `query`, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
+	//  SELECT id, hash, compression, file_size, `query`, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at, verified_at
 	//  FROM nar_files
 	//  WHERE hash = ? AND compression = ? AND `query` = ?
 	GetNarFileByHashAndCompressionAndQuery(ctx context.Context, arg GetNarFileByHashAndCompressionAndQueryParams) (GetNarFileByHashAndCompressionAndQueryRow, error)
 	//GetNarFileByNarInfoID
 	//
-	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.`query`, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.`query`, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 	//  FROM nar_files nf
 	//  INNER JOIN narinfo_nar_files nnf ON nf.id = nnf.nar_file_id
 	//  WHERE nnf.narinfo_id = ?
@@ -284,7 +284,7 @@ type Querier interface {
 	GetOrphanedChunks(ctx context.Context) ([]GetOrphanedChunksRow, error)
 	// Find files that have no relationship to any narinfo
 	//
-	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.`query`, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.`query`, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 	//  FROM nar_files nf
 	//  LEFT JOIN narinfo_nar_files ninf ON nf.id = ninf.nar_file_id
 	//  WHERE ninf.narinfo_id IS NULL
@@ -376,6 +376,12 @@ type Querier interface {
 	//  SET total_chunks = ?, file_size = ?, updated_at = CURRENT_TIMESTAMP, chunking_started_at = NULL
 	//  WHERE id = ?
 	UpdateNarFileTotalChunks(ctx context.Context, arg UpdateNarFileTotalChunksParams) error
+	//UpdateNarFileVerifiedAt
+	//
+	//  UPDATE nar_files
+	//  SET verified_at = CURRENT_TIMESTAMP
+	//  WHERE id = ?
+	UpdateNarFileVerifiedAt(ctx context.Context, id int64) error
 	//UpdateNarInfo
 	//
 	//  UPDATE narinfos

--- a/pkg/database/postgresdb/models.go
+++ b/pkg/database/postgresdb/models.go
@@ -37,6 +37,7 @@ type NarFile struct {
 	LastAccessedAt    sql.NullTime
 	TotalChunks       int64
 	ChunkingStartedAt sql.NullTime
+	VerifiedAt        sql.NullTime
 }
 
 type NarFileChunk struct {

--- a/pkg/database/postgresdb/querier.go
+++ b/pkg/database/postgresdb/querier.go
@@ -81,7 +81,8 @@ type Querier interface {
 	//      updated_at,
 	//      last_accessed_at,
 	//      total_chunks,
-	//      chunking_started_at
+	//      chunking_started_at,
+	//      verified_at
 	CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error)
 	//CreateNarInfo
 	//
@@ -154,7 +155,7 @@ type Querier interface {
 	GetAllChunks(ctx context.Context) ([]Chunk, error)
 	// Returns all nar_files for storage existence verification.
 	//
-	//  SELECT id, hash, compression, query, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+	//  SELECT id, hash, compression, query, file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at, verified_at
 	//  FROM nar_files
 	GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow, error)
 	//GetChunkByHash
@@ -216,13 +217,13 @@ type Querier interface {
 	GetMigratedNarInfoHashes(ctx context.Context) ([]string, error)
 	//GetNarFileByHashAndCompressionAndQuery
 	//
-	//  SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
+	//  SELECT id, hash, compression, file_size, query, created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at, verified_at
 	//  FROM nar_files
 	//  WHERE hash = $1 AND compression = $2 AND query = $3
 	GetNarFileByHashAndCompressionAndQuery(ctx context.Context, arg GetNarFileByHashAndCompressionAndQueryParams) (NarFile, error)
 	//GetNarFileByNarInfoID
 	//
-	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.query, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.query, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 	//  FROM nar_files nf
 	//  INNER JOIN narinfo_nar_files nnf ON nf.id = nnf.nar_file_id
 	//  WHERE nnf.narinfo_id = $1
@@ -312,7 +313,7 @@ type Querier interface {
 	GetOrphanedChunks(ctx context.Context) ([]GetOrphanedChunksRow, error)
 	// Find files that have no relationship to any narinfo
 	//
-	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.query, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf.query, nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 	//  FROM nar_files nf
 	//  LEFT JOIN narinfo_nar_files ninf ON nf.id = ninf.nar_file_id
 	//  WHERE ninf.narinfo_id IS NULL
@@ -407,6 +408,12 @@ type Querier interface {
 	//  SET total_chunks = $1, file_size = $2, updated_at = CURRENT_TIMESTAMP, chunking_started_at = NULL
 	//  WHERE id = $3
 	UpdateNarFileTotalChunks(ctx context.Context, arg UpdateNarFileTotalChunksParams) error
+	//UpdateNarFileVerifiedAt
+	//
+	//  UPDATE nar_files
+	//  SET verified_at = CURRENT_TIMESTAMP
+	//  WHERE id = $1
+	UpdateNarFileVerifiedAt(ctx context.Context, id int64) error
 	//UpdateNarInfo
 	//
 	//  UPDATE narinfos

--- a/pkg/database/sqlitedb/models.go
+++ b/pkg/database/sqlitedb/models.go
@@ -37,6 +37,7 @@ type NarFile struct {
 	LastAccessedAt    sql.NullTime
 	TotalChunks       int64
 	ChunkingStartedAt sql.NullTime
+	VerifiedAt        sql.NullTime
 }
 
 type NarFileChunk struct {

--- a/pkg/database/sqlitedb/querier.go
+++ b/pkg/database/sqlitedb/querier.go
@@ -67,7 +67,8 @@ type Querier interface {
 	//      updated_at,
 	//      last_accessed_at,
 	//      total_chunks,
-	//      chunking_started_at
+	//      chunking_started_at,
+	//      verified_at
 	CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error)
 	//CreateNarInfo
 	//
@@ -140,7 +141,7 @@ type Querier interface {
 	GetAllChunks(ctx context.Context) ([]Chunk, error)
 	// Returns all nar_files for storage existence verification.
 	//
-	//  SELECT id, hash, compression, "query", file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+	//  SELECT id, hash, compression, "query", file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at, verified_at
 	//  FROM nar_files
 	GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow, error)
 	//GetChunkByHash
@@ -202,13 +203,13 @@ type Querier interface {
 	GetMigratedNarInfoHashes(ctx context.Context) ([]string, error)
 	//GetNarFileByHashAndCompressionAndQuery
 	//
-	//  SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
+	//  SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at, verified_at
 	//  FROM nar_files
 	//  WHERE hash = ? AND compression = ? AND "query" = ?
 	GetNarFileByHashAndCompressionAndQuery(ctx context.Context, arg GetNarFileByHashAndCompressionAndQueryParams) (NarFile, error)
 	//GetNarFileByNarInfoID
 	//
-	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 	//  FROM nar_files nf
 	//  INNER JOIN narinfo_nar_files nnf ON nf.id = nnf.nar_file_id
 	//  WHERE nnf.narinfo_id = ?
@@ -298,7 +299,7 @@ type Querier interface {
 	GetOrphanedChunks(ctx context.Context) ([]GetOrphanedChunksRow, error)
 	// Find files that have no relationship to any narinfo
 	//
-	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+	//  SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 	//  FROM nar_files nf
 	//  LEFT JOIN narinfo_nar_files ninf ON nf.id = ninf.nar_file_id
 	//  WHERE ninf.narinfo_id IS NULL
@@ -394,6 +395,12 @@ type Querier interface {
 	//  SET total_chunks = ?, file_size = ?, updated_at = CURRENT_TIMESTAMP, chunking_started_at = NULL
 	//  WHERE id = ?
 	UpdateNarFileTotalChunks(ctx context.Context, arg UpdateNarFileTotalChunksParams) error
+	//UpdateNarFileVerifiedAt
+	//
+	//  UPDATE nar_files
+	//  SET verified_at = CURRENT_TIMESTAMP
+	//  WHERE id = ?
+	UpdateNarFileVerifiedAt(ctx context.Context, id int64) error
 	//UpdateNarInfo
 	//
 	//  UPDATE narinfos

--- a/pkg/database/sqlitedb/query.sqlite.sql.go
+++ b/pkg/database/sqlitedb/query.sqlite.sql.go
@@ -159,7 +159,8 @@ RETURNING
     updated_at,
     last_accessed_at,
     total_chunks,
-    chunking_started_at
+    chunking_started_at,
+    verified_at
 `
 
 type CreateNarFileParams struct {
@@ -189,7 +190,8 @@ type CreateNarFileParams struct {
 //	    updated_at,
 //	    last_accessed_at,
 //	    total_chunks,
-//	    chunking_started_at
+//	    chunking_started_at,
+//	    verified_at
 func (q *Queries) CreateNarFile(ctx context.Context, arg CreateNarFileParams) (NarFile, error) {
 	row := q.db.QueryRowContext(ctx, createNarFile,
 		arg.Hash,
@@ -210,6 +212,7 @@ func (q *Queries) CreateNarFile(ctx context.Context, arg CreateNarFileParams) (N
 		&i.LastAccessedAt,
 		&i.TotalChunks,
 		&i.ChunkingStartedAt,
+		&i.VerifiedAt,
 	)
 	return i, err
 }
@@ -479,7 +482,7 @@ func (q *Queries) GetAllChunks(ctx context.Context) ([]Chunk, error) {
 }
 
 const getAllNarFiles = `-- name: GetAllNarFiles :many
-SELECT id, hash, compression, "query", file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+SELECT id, hash, compression, "query", file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at, verified_at
 FROM nar_files
 `
 
@@ -494,11 +497,12 @@ type GetAllNarFilesRow struct {
 	CreatedAt         time.Time
 	UpdatedAt         sql.NullTime
 	LastAccessedAt    sql.NullTime
+	VerifiedAt        sql.NullTime
 }
 
 // Returns all nar_files for storage existence verification.
 //
-//	SELECT id, hash, compression, "query", file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at
+//	SELECT id, hash, compression, "query", file_size, total_chunks, chunking_started_at, created_at, updated_at, last_accessed_at, verified_at
 //	FROM nar_files
 func (q *Queries) GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow, error) {
 	rows, err := q.db.QueryContext(ctx, getAllNarFiles)
@@ -520,6 +524,7 @@ func (q *Queries) GetAllNarFiles(ctx context.Context) ([]GetAllNarFilesRow, erro
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.LastAccessedAt,
+			&i.VerifiedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -791,7 +796,7 @@ func (q *Queries) GetMigratedNarInfoHashes(ctx context.Context) ([]string, error
 }
 
 const getNarFileByHashAndCompressionAndQuery = `-- name: GetNarFileByHashAndCompressionAndQuery :one
-SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
+SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at, verified_at
 FROM nar_files
 WHERE hash = ? AND compression = ? AND "query" = ?
 `
@@ -804,7 +809,7 @@ type GetNarFileByHashAndCompressionAndQueryParams struct {
 
 // GetNarFileByHashAndCompressionAndQuery
 //
-//	SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at
+//	SELECT id, hash, compression, file_size, "query", created_at, updated_at, last_accessed_at, total_chunks, chunking_started_at, verified_at
 //	FROM nar_files
 //	WHERE hash = ? AND compression = ? AND "query" = ?
 func (q *Queries) GetNarFileByHashAndCompressionAndQuery(ctx context.Context, arg GetNarFileByHashAndCompressionAndQueryParams) (NarFile, error) {
@@ -821,12 +826,13 @@ func (q *Queries) GetNarFileByHashAndCompressionAndQuery(ctx context.Context, ar
 		&i.LastAccessedAt,
 		&i.TotalChunks,
 		&i.ChunkingStartedAt,
+		&i.VerifiedAt,
 	)
 	return i, err
 }
 
 const getNarFileByNarInfoID = `-- name: GetNarFileByNarInfoID :one
-SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 FROM nar_files nf
 INNER JOIN narinfo_nar_files nnf ON nf.id = nnf.nar_file_id
 WHERE nnf.narinfo_id = ?
@@ -834,7 +840,7 @@ WHERE nnf.narinfo_id = ?
 
 // GetNarFileByNarInfoID
 //
-//	SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+//	SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 //	FROM nar_files nf
 //	INNER JOIN narinfo_nar_files nnf ON nf.id = nnf.nar_file_id
 //	WHERE nnf.narinfo_id = ?
@@ -852,6 +858,7 @@ func (q *Queries) GetNarFileByNarInfoID(ctx context.Context, narinfoID int64) (N
 		&i.LastAccessedAt,
 		&i.TotalChunks,
 		&i.ChunkingStartedAt,
+		&i.VerifiedAt,
 	)
 	return i, err
 }
@@ -1263,7 +1270,7 @@ func (q *Queries) GetOrphanedChunks(ctx context.Context) ([]GetOrphanedChunksRow
 }
 
 const getOrphanedNarFiles = `-- name: GetOrphanedNarFiles :many
-SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 FROM nar_files nf
 LEFT JOIN narinfo_nar_files ninf ON nf.id = ninf.nar_file_id
 WHERE ninf.narinfo_id IS NULL
@@ -1271,7 +1278,7 @@ WHERE ninf.narinfo_id IS NULL
 
 // Find files that have no relationship to any narinfo
 //
-//	SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at
+//	SELECT nf.id, nf.hash, nf.compression, nf.file_size, nf."query", nf.created_at, nf.updated_at, nf.last_accessed_at, nf.total_chunks, nf.chunking_started_at, nf.verified_at
 //	FROM nar_files nf
 //	LEFT JOIN narinfo_nar_files ninf ON nf.id = ninf.nar_file_id
 //	WHERE ninf.narinfo_id IS NULL
@@ -1295,6 +1302,7 @@ func (q *Queries) GetOrphanedNarFiles(ctx context.Context) ([]NarFile, error) {
 			&i.LastAccessedAt,
 			&i.TotalChunks,
 			&i.ChunkingStartedAt,
+			&i.VerifiedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -1606,6 +1614,22 @@ type UpdateNarFileTotalChunksParams struct {
 //	WHERE id = ?
 func (q *Queries) UpdateNarFileTotalChunks(ctx context.Context, arg UpdateNarFileTotalChunksParams) error {
 	_, err := q.db.ExecContext(ctx, updateNarFileTotalChunks, arg.TotalChunks, arg.FileSize, arg.ID)
+	return err
+}
+
+const updateNarFileVerifiedAt = `-- name: UpdateNarFileVerifiedAt :exec
+UPDATE nar_files
+SET verified_at = CURRENT_TIMESTAMP
+WHERE id = ?
+`
+
+// UpdateNarFileVerifiedAt
+//
+//	UPDATE nar_files
+//	SET verified_at = CURRENT_TIMESTAMP
+//	WHERE id = ?
+func (q *Queries) UpdateNarFileVerifiedAt(ctx context.Context, id int64) error {
+	_, err := q.db.ExecContext(ctx, updateNarFileVerifiedAt, id)
 	return err
 }
 


### PR DESCRIPTION
Bot-based backport to `release-0.9`, triggered by a label in #998.

This change introduces a verified_at timestamp to the nar_files table and a new --verified-since flag to the fsck command. This allows the tool to skip NARs that have been verified recently, significantly reducing the time required for subsequent fsck runs, especially for large chunked NARs.

How:
1. Created database migrations for SQLite, PostgreSQL, and MySQL to add the verified_at column.
2. Updated SQL queries and regenerated Go code to support the new column.
3. Added a shouldCheckNar helper and updated fsck logic to skip NARs verified within the specified duration.
4. Updated fsck to update verified_at whenever a successful check is performed.
5. Added a new test case TestFsckBackends/.../VerifiedSince to verify the optimization works as expected.