### PR TITLE
feat: add fsck CronJob to Helm Chart [backport #999]

### DIFF
--- a/charts/ncps/templates/fsck-cronjob.yaml
+++ b/charts/ncps/templates/fsck-cronjob.yaml
@@ -1,0 +1,181 @@
+{{- if .Values.fsck.enabled -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "ncps.fullname" . }}-fsck
+  labels:
+    {{- include "ncps.labels" . | nindent 4 }}
+    app.kubernetes.io/component: fsck
+spec:
+  schedule: {{ .Values.fsck.schedule | quote }}
+  {{- if .Values.fsck.timezone }}
+  timeZone: {{ .Values.fsck.timezone | quote }}
+  {{- end }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+            checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+            {{- with .Values.fsck.job.annotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          labels:
+            {{- include "ncps.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: fsck
+        spec:
+          restartPolicy: OnFailure
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ include "ncps.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          {{- with .Values.fsck.job.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.fsck.job.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.fsck.job.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if eq .Values.config.database.type "sqlite" }}
+          initContainers:
+            - name: create-db-dir
+              image: {{ include "ncps.initImage" . }}
+              imagePullPolicy: {{ .Values.initImage.pullPolicy }}
+              command:
+                - sh
+                - -c
+                - |
+                  mkdir -p $(dirname {{ .Values.config.database.sqlite.path | quote }})
+              volumeMounts:
+                {{- if or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite") }}
+                - name: storage
+                  mountPath: /storage
+                {{- end }}
+                - name: tmp
+                  mountPath: {{ .Values.config.cache.tempPath | quote }}
+              resources:
+                {{- toYaml .Values.initImage.resources | nindent 16 }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+          {{- end }}
+          containers:
+            - name: fsck
+              securityContext:
+                {{- toYaml .Values.fsck.securityContext | nindent 16 }}
+              image: {{ include "ncps.image" . }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command:
+                - /bin/ncps
+              args:
+                - --config
+                - /etc/ncps/config.yaml
+                - fsck
+                {{- if .Values.fsck.repair }}
+                - --repair
+                {{- end }}
+                {{- if .Values.fsck.verifiedSince }}
+                - --verified-since
+                - {{ .Values.fsck.verifiedSince | quote }}
+                {{- end }}
+              env:
+                {{- include "ncps.cacheDatabaseURLEnv" . | nindent 16 }}
+                {{- if and (eq .Values.config.storage.type "s3") (or .Values.config.storage.s3.existingSecret (and .Values.config.storage.s3.accessKeyId .Values.config.storage.s3.secretAccessKey)) }}
+                - name: CACHE_STORAGE_S3_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.config.storage.s3.existingSecret | default (include "ncps.fullname" .) }}
+                      key: {{ if .Values.config.storage.s3.existingSecret }}"access-key-id"{{ else }}"s3-access-key-id"{{ end }}
+                - name: CACHE_STORAGE_S3_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.config.storage.s3.existingSecret | default (include "ncps.fullname" .) }}
+                      key: {{ if .Values.config.storage.s3.existingSecret }}"secret-access-key"{{ else }}"s3-secret-access-key"{{ end }}
+                {{- end }}
+                {{- if .Values.config.redis.enabled }}
+                {{- if and .Values.config.redis.existingSecret (not .Values.config.redis.username) }}
+                - name: CACHE_REDIS_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.config.redis.existingSecret }}
+                      key: username
+                      optional: true
+                {{- end }}
+                {{- if or .Values.config.redis.existingSecret .Values.config.redis.password }}
+                - name: CACHE_REDIS_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ .Values.config.redis.existingSecret | default (include "ncps.fullname" .) }}
+                      key: {{ if .Values.config.redis.existingSecret }}"password"{{ else }}"redis-password"{{ end }}
+                {{- end }}
+                {{- end }}
+                {{- with .Values.extraEnvVars }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
+              resources:
+                {{- toYaml .Values.fsck.resources | nindent 16 }}
+              volumeMounts:
+                - name: config
+                  mountPath: /etc/ncps/config.yaml
+                  readOnly: true
+                  subPath: config.yaml
+                - name: tmp
+                  mountPath: {{ .Values.config.cache.tempPath | quote }}
+                {{- if or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite") }}
+                - name: storage
+                  mountPath: /storage
+                {{- end }}
+                {{- if or .Values.config.upstream.netrcFile .Values.config.upstream.existingNetrcSecret }}
+                - name: netrc
+                  mountPath: /etc/ncps/netrc
+                  subPath: netrc
+                  readOnly: true
+                {{- end }}
+                {{- with .Values.extraVolumeMounts }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
+          volumes:
+            - name: config
+              configMap:
+                name: {{ include "ncps.fullname" . }}
+            - name: tmp
+              emptyDir: {}
+            {{- if or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite") }}
+            - name: storage
+              {{- if or .Values.config.storage.local.persistence.enabled (eq .Values.config.database.type "sqlite") }}
+              persistentVolumeClaim:
+                claimName: {{ include "ncps.fullname" . }}
+              {{- else }}
+              emptyDir: {}
+              {{- end }}
+            {{- end }}
+            {{- if or .Values.config.upstream.netrcFile .Values.config.upstream.existingNetrcSecret }}
+            - name: netrc
+              secret:
+                secretName: {{ .Values.config.upstream.existingNetrcSecret | default (include "ncps.fullname" .) }}
+            {{- end }}
+            {{- with .Values.extraVolumes }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      {{- if not (kindIs "invalid" .Values.fsck.job.backoffLimit) }}
+      backoffLimit: {{ .Values.fsck.job.backoffLimit }}
+      {{- end }}
+      {{- if not (kindIs "invalid" .Values.fsck.job.ttlSecondsAfterFinished) }}
+      ttlSecondsAfterFinished: {{ .Values.fsck.job.ttlSecondsAfterFinished }}
+      {{- end }}
+{{- end }}

--- a/charts/ncps/tests/fsck_cronjob_test.yaml
+++ b/charts/ncps/tests/fsck_cronjob_test.yaml
@@ -1,0 +1,102 @@
+suite: test fsck cronjob rendering
+templates:
+  - fsck-cronjob.yaml
+  - configmap.yaml
+  - secret.yaml
+tests:
+  - it: should not create CronJob by default
+    template: fsck-cronjob.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create CronJob when enabled
+    template: fsck-cronjob.yaml
+    set:
+      fsck.enabled: true
+      config.hostname: test.example.com
+    asserts:
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-ncps-fsck
+      - equal:
+          path: spec.schedule
+          value: "0 1 * * *"
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args
+          value:
+            - --config
+            - /etc/ncps/config.yaml
+            - fsck
+
+  - it: should add repair flag when enabled
+    template: fsck-cronjob.yaml
+    set:
+      fsck.enabled: true
+      fsck.repair: true
+      config.hostname: test.example.com
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args
+          content: --repair
+
+  - it: should add verified-since flag when set
+    template: fsck-cronjob.yaml
+    set:
+      fsck.enabled: true
+      fsck.verifiedSince: "24h"
+      config.hostname: test.example.com
+    asserts:
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args
+          content: --verified-since
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].args
+          content: "24h"
+
+  - it: should configure job settings
+    template: fsck-cronjob.yaml
+    set:
+      fsck.enabled: true
+      fsck.job.backoffLimit: 3
+      fsck.job.ttlSecondsAfterFinished: 600
+      config.hostname: test.example.com
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.backoffLimit
+          value: 3
+      - equal:
+          path: spec.jobTemplate.spec.ttlSecondsAfterFinished
+          value: 600
+
+  - it: should use custom schedule and timezone
+    template: fsck-cronjob.yaml
+    set:
+      fsck.enabled: true
+      fsck.schedule: "0 0 * * 0"
+      fsck.timezone: "UTC"
+      config.hostname: test.example.com
+    asserts:
+      - equal:
+          path: spec.schedule
+          value: "0 0 * * 0"
+      - equal:
+          path: spec.timeZone
+          value: "UTC"
+
+  - it: should handle zero values for job settings
+    template: fsck-cronjob.yaml
+    set:
+      fsck.enabled: true
+      fsck.job.backoffLimit: 0
+      fsck.job.ttlSecondsAfterFinished: 0
+      config.hostname: test.example.com
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.backoffLimit
+          value: 0
+      - equal:
+          path: spec.jobTemplate.spec.ttlSecondsAfterFinished
+          value: 0

--- a/charts/ncps/values.schema.json
+++ b/charts/ncps/values.schema.json
@@ -680,6 +680,71 @@
           }
         }
       }
+    },
+    "fsck": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable periodic fsck"
+        },
+        "schedule": {
+          "type": "string",
+          "description": "Cron schedule for fsck"
+        },
+        "timezone": {
+          "type": "string",
+          "description": "Timezone for cron schedule"
+        },
+        "repair": {
+          "type": "boolean",
+          "description": "Automatically repair issues"
+        },
+        "verifiedSince": {
+          "type": "string",
+          "description": "Skip checking NARs that have been verified within this duration",
+          "pattern": "^([0-9]+(ns|us|ms|s|m|h))?$"
+        },
+        "resources": {
+          "type": "object",
+          "description": "Resources for fsck container/job"
+        },
+        "securityContext": {
+          "type": "object",
+          "description": "Security context for fsck container/job"
+        },
+        "job": {
+          "type": "object",
+          "properties": {
+            "backoffLimit": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Backoff limit for job retries"
+            },
+            "ttlSecondsAfterFinished": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "TTL after job finishes (in seconds)"
+            },
+            "annotations": {
+              "type": "object",
+              "description": "Annotations for the job"
+            },
+            "nodeSelector": {
+              "type": "object",
+              "description": "Node selector for fsck job"
+            },
+            "tolerations": {
+              "type": "array",
+              "description": "Tolerations for fsck job"
+            },
+            "affinity": {
+              "type": "object",
+              "description": "Affinity for fsck job"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/charts/ncps/values.yaml
+++ b/charts/ncps/values.yaml
@@ -123,7 +123,7 @@ config:
 
     # Timezone for cron schedule
     # Example: "America/Los_Angeles", "UTC"
-    lruTimezone: "Local"
+    lruTimezone: ""
 
     # Timeout for polling storage when waiting for download completion
     downloadPollTimeout: "30s"
@@ -497,6 +497,67 @@ migration:
     tolerations: []
 
     # Affinity for migration job
+    affinity: {}
+
+# FSCK (File System Consistency Check)
+fsck:
+  # Enable periodic fsck
+  enabled: false
+
+  # Schedule for fsck (cron expression)
+  # Example: "0 1 * * *" (daily at 1 AM)
+  schedule: "0 1 * * *"
+
+  # Timezone for cron schedule. If empty, uses the cluster's default timezone.
+  # Example: "America/Los_Angeles", "UTC"
+  timezone: ""
+
+  # Automatically repair issues
+  repair: false
+
+  # Skip checking NARs that have been verified within this duration
+  # Examples: "24h", "7d", "30d"
+  # Default is empty (verified-since will not be passed)
+  verifiedSince: ""
+
+  # Resources for fsck container/job
+  resources: {}
+    # limits:
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  # Security context for fsck container/job
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+
+  # Job configuration
+  job:
+    # Backoff limit for job retries
+    backoffLimit: 1
+
+    # TTL after job finishes (in seconds)
+    # Set to 0 to keep jobs indefinitely
+    ttlSecondsAfterFinished: 3600
+
+    # Annotations for the job
+    annotations: {}
+
+    # Node selector for fsck job
+    nodeSelector: {}
+
+    # Tolerations for fsck job
+    tolerations: []
+
+    # Affinity for fsck job
     affinity: {}
 
 # Helm tests


### PR DESCRIPTION
Bot-based backport to `release-0.9`, triggered by a label in #999.

Added a CronJob to the Helm chart to run periodic integrity checks (fsck). This allows users to automate the consistency checks between the database and storage.

The implementation includes:
- New 'fsck' section in values.yaml with comprehensive configuration options.
- Added JSON schema validation for all new fsck fields in values.schema.json.
- Created a new fsck-cronjob.yaml template that uses 'ncps fsck' with configurable '--repair' and '--verified-since' flags.
- Added a full suite of unit tests in fsck_cronjob_test.yaml to verify template rendering.

Verification:
- All 98 helm-unittest cases passed.
- Manual template rendering verified correct flag propagation and default behavior (disabled by default).