### PR TITLE
docs: document the fsck --verified-at flag and chart changes [backport #1004]

### DIFF
--- a/charts/ncps/values.yaml
+++ b/charts/ncps/values.yaml
@@ -516,7 +516,7 @@ fsck:
   repair: false
 
   # Skip checking NARs that have been verified within this duration
-  # Examples: "24h", "7d", "30d"
+  # Examples: "24h", "1h"
   # Default is empty (verified-since will not be passed)
   verifiedSince: ""
 

--- a/docs/docs/User Guide/Installation/Helm Chart.md
+++ b/docs/docs/User Guide/Installation/Helm Chart.md
@@ -13,7 +13,7 @@ Install ncps on Kubernetes using Helm for simplified configuration and managemen
 
 ### Install from OCI Registry
 
-```
+```sh
 # Create namespace
 kubectl create namespace ncps
 
@@ -26,7 +26,7 @@ helm install ncps oci://ghcr.io/kalbasit/helm/ncps \
 
 ### Install from Source
 
-```
+```sh
 git clone https://github.com/kalbasit/ncps.git
 cd ncps/charts/ncps
 helm install ncps . -f values.yaml --namespace ncps
@@ -41,7 +41,7 @@ This installs ncps with:
 
 ### Verify Installation
 
-```
+```sh
 # Check pod status
 kubectl -n ncps get pods
 
@@ -228,7 +228,7 @@ config:
 
 Create the secrets:
 
-```
+```sh
 # S3 credentials
 kubectl create secret generic ncps-s3-credentials -n ncps \
   --from-literal=access-key-id=YOUR_ACCESS_KEY \
@@ -438,6 +438,24 @@ config:
     allowDegradedMode: false  # Continue without Redis if connection fails
 ```
 
+## FSCK (Integrity Check) Settings
+
+Enable and configure the built-in CronJob for periodic integrity checks:
+
+```yaml
+fsck:
+  enabled: true
+  schedule: "0 1 * * *"
+  repair: true
+  verifiedSince: "168h" # 7 days
+  resources:
+    limits:
+      memory: 6Gi
+    requests:
+      cpu: 1000m
+      memory: 6Gi
+```
+
 ## CDC Configuration (Experimental)
 
 Content-Defined Chunking (CDC) for deduplication:
@@ -621,7 +639,7 @@ ingress:
 1. Enable Redis
 1. Increase replica count
 
-```
+```sh
 # Step 1: Backup SQLite database
 kubectl exec -n ncps ncps-0 -- /bin/sh -c \
   "sqlite3 /storage/db/ncps.db .dump" > backup.sql
@@ -651,7 +669,7 @@ strategy:
 
 ### Check Deployment Status
 
-```
+```sh
 # Check pod status
 kubectl -n ncps get pods
 

--- a/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
+++ b/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
@@ -17,7 +17,7 @@ This chart bootstraps a ncps deployment on a Kubernetes cluster using the Helm p
 
 ### Install from OCI Registry
 
-```
+```sh
 # Install with default values (single instance, local storage, SQLite)
 helm install ncps oci://ghcr.io/kalbasit/helm/ncps --version <chart-version>
 
@@ -30,7 +30,7 @@ helm install ncps oci://ghcr.io/kalbasit/helm/ncps \
 
 ### Install from Source
 
-```
+```sh
 git clone https://github.com/kalbasit/ncps.git
 cd ncps/charts/ncps
 helm install ncps . -f values.yaml
@@ -38,7 +38,7 @@ helm install ncps . -f values.yaml
 
 ## Upgrading
 
-```
+```sh
 # Upgrade to a new version
 helm upgrade ncps oci://ghcr.io/kalbasit/helm/ncps --version <new-chart-version>
 
@@ -50,7 +50,7 @@ helm upgrade ncps oci://ghcr.io/kalbasit/helm/ncps \
 
 ## Uninstalling
 
-```
+```sh
 helm uninstall ncps
 
 # To also delete PVCs (persistent volumes)
@@ -308,6 +308,27 @@ When `config.redis.enabled=true`, the chart automatically sets the lock backend 
 | `migration.job.tolerations` | Tolerations for migration job | `[]` |
 | `migration.job.affinity` | Affinity for migration job | `{}` |
 
+### FSCK (Integrity Check) Settings
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `fsck.enabled` | Enable periodic fsck CronJob | `false` |
+| `fsck.schedule` | Cron schedule for fsck | `0 1 * * *` |
+| `fsck.timezone` | Timezone for cron schedule | `""` |
+| `fsck.repair` | Automatically repair issues | `false` |
+| `fsck.verifiedSince` | Skip checking NARs verified within this duration (e.g., `24h`, `168h`) | `""` |
+| `fsck.resources` | Resources for fsck pod | `{}` |
+| `fsck.securityContext` | Security context for fsck pod | See values.yaml |
+| `fsck.job.backoffLimit` | Job backoff limit | `1` |
+| `fsck.job.ttlSecondsAfterFinished` | Job TTL after finish (seconds) | `3600` |
+| `fsck.job.annotations` | Annotations for the Job | `{}` |
+| `fsck.job.nodeSelector` | Node selector for the Job | `{}` |
+| `fsck.job.tolerations` | Tolerations for the Job | `[]` |
+| `fsck.job.affinity` | Affinity for the Job | `{}` |
+
+> [!NOTE]
+> The fsck CronJob is disabled by default. When enabled, it runs the `ncps fsck` command using the same database and storage configuration as the main application.
+
 > [!WARNING]
 > **Breaking Change for HA Upgrades:** With migrations enabled by default, upgrading an existing High Availability (HA) deployment (`replicaCount > 1`) will fail if you are using the default `migration.mode: initContainer`. To avoid this, explicitly set `migration.mode: job` or `migration.mode: argocd` in your values when upgrading.
 
@@ -469,7 +490,7 @@ config:
 
 Create secrets:
 
-```
+```sh
 # S3 credentials
 kubectl create secret generic ncps-s3-credentials \
   --from-literal=access-key-id=AKIA... \
@@ -555,7 +576,7 @@ The chart includes a connection test that verifies the service is responding on 
 
 When deploying with `helm install` or `helm upgrade`, you can enable and run tests:
 
-```
+```sh
 # Install with tests enabled
 helm install ncps oci://ghcr.io/kalbasit/helm/ncps \
   --set tests.enabled=true
@@ -587,7 +608,7 @@ tests:
 
 To test your deployment when using templating, use the readiness/liveness probes or manually verify:
 
-```
+```sh
 kubectl get pod -l app.kubernetes.io/instance=<release-name>
 kubectl port-forward svc/<release-name>-ncps 8501:8501
 curl http://localhost:8501/healthz

--- a/docs/docs/User Guide/Installation/Kubernetes.md
+++ b/docs/docs/User Guide/Installation/Kubernetes.md
@@ -13,7 +13,7 @@ Deploy ncps on Kubernetes for production-ready, scalable deployments with manual
 
 ## Quick Start
 
-For production deployments, we recommend using the <a class="reference-link" href="Helm%20Chart.md">Helm</a> for simplified management. This guide shows manual Kubernetes deployment for users who need fine-grained control.
+For production deployments, we recommend using the <a class="reference-link" href="Helm%20Chart.md">Helm Chart</a> for simplified management. This guide shows manual Kubernetes deployment for users who need fine-grained control.
 
 ## Basic Deployment (Single Instance)
 
@@ -491,11 +491,11 @@ See the <a class="reference-link" href="../Operations/Troubleshooting.md">Troub
 1. <a class="reference-link" href="../Usage/Client%20Setup.md">Client Setup</a> - Set up Nix clients
 1. <a class="reference-link" href="../Operations/Monitoring.md">Monitoring</a> - Set up observability
 1. <a class="reference-link" href="../Configuration/Reference.md">Reference</a> - Explore more options
-1. **Consider** <a class="reference-link" href="Helm%20Chart.md">Helm</a> - For simplified management
+1. **Consider** <a class="reference-link" href="Helm%20Chart.md">Helm Chart</a> - For simplified management
 
 ## Related Documentation
 
-- <a class="reference-link" href="Helm%20Chart.md">Helm</a> - Simplified Kubernetes deployment
+- <a class="reference-link" href="Helm%20Chart.md">Helm Chart</a> - Simplified Kubernetes deployment
 - <a class="reference-link" href="Docker%20Compose.md">Docker Compose</a> - For non-K8s environments
 - <a class="reference-link" href="../Deployment/High%20Availability.md">High Availability</a> - HA setup guide
 - <a class="reference-link" href="../Configuration/Reference.md">Reference</a> - All configuration options

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -106,7 +106,7 @@ Use --repair to automatically fix detected issues, or --dry-run to preview what 
 			},
 			&cli.DurationFlag{
 				Name:  "verified-since",
-				Usage: "Skip checking NARs that have been verified within this duration",
+				Usage: "Skip checking NARs that have been verified within this duration (e.g. 1h, 30m)",
 			},
 
 			// Storage Flags
@@ -256,6 +256,7 @@ Use --repair to automatically fix detected issues, or --dry-run to preview what 
 
 			dryRun := cmd.Bool("dry-run")
 			repair := cmd.Bool("repair")
+
 			verifiedSince := cmd.Duration("verified-since")
 
 			// 1. Setup Database

--- a/pkg/ncps/fsck_test.go
+++ b/pkg/ncps/fsck_test.go
@@ -462,12 +462,12 @@ func testFsckVerifiedSince(setup fsckSetupFn) func(*testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, verifiedAt1, nf.VerifiedAt.Time, "verified_at should NOT be updated when skipped")
 
-		// 3. Run fsck with --verified-since 1ns - should NOT skip checking
+		// 3. Run fsck with --verified-since 1s - should NOT skip checking
 		args = []string{
 			"ncps", "fsck",
 			"--cache-database-url", dbURL,
 			"--cache-storage-local", dir,
-			"--verified-since", "1ns",
+			"--verified-since", "1s",
 		}
 		require.NoError(t, app.Run(ctx, args))
 


### PR DESCRIPTION
Bot-based backport to `release-0.9`, triggered by a label in #1004.

The flag --verified-at was not documented nor was the Helm Chart
changes. Document both.