### PR TITLE
feat: allow configuring concurrency policy for fsck cronjob

### DIFF
--- a/charts/ncps/templates/fsck-cronjob.yaml
+++ b/charts/ncps/templates/fsck-cronjob.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/component: fsck
 spec:
   schedule: {{ .Values.fsck.schedule | quote }}
+  concurrencyPolicy: {{ .Values.fsck.job.concurrencyPolicy }}
   {{- if .Values.fsck.timezone }}
   timeZone: {{ .Values.fsck.timezone | quote }}
   {{- end }}

--- a/charts/ncps/tests/fsck_cronjob_test.yaml
+++ b/charts/ncps/tests/fsck_cronjob_test.yaml
@@ -100,3 +100,24 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.ttlSecondsAfterFinished
           value: 0
+
+  - it: should configure concurrency policy
+    template: fsck-cronjob.yaml
+    set:
+      fsck.enabled: true
+      fsck.job.concurrencyPolicy: Replace
+      config.hostname: test.example.com
+    asserts:
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Replace
+
+  - it: should use default concurrency policy when not set
+    template: fsck-cronjob.yaml
+    set:
+      fsck.enabled: true
+      config.hostname: test.example.com
+    asserts:
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid

--- a/charts/ncps/values.schema.json
+++ b/charts/ncps/values.schema.json
@@ -721,6 +721,16 @@
               "minimum": 0,
               "description": "Backoff limit for job retries"
             },
+            "concurrencyPolicy": {
+              "type": "string",
+              "default": "Forbid",
+              "enum": [
+                "Allow",
+                "Forbid",
+                "Replace"
+              ],
+              "description": "Concurrency policy for the job: Allow, Forbid (default), or Replace"
+            },
             "ttlSecondsAfterFinished": {
               "type": "integer",
               "minimum": 0,

--- a/charts/ncps/values.yaml
+++ b/charts/ncps/values.yaml
@@ -539,6 +539,9 @@ fsck:
 
   # Job configuration
   job:
+    # Concurrency policy for the job: "Allow", "Forbid" (default), or "Replace"
+    concurrencyPolicy: Forbid
+
     # Backoff limit for job retries
     backoffLimit: 1
 

--- a/docs/docs/User Guide/Installation/Helm Chart.md
+++ b/docs/docs/User Guide/Installation/Helm Chart.md
@@ -454,6 +454,8 @@ fsck:
     requests:
       cpu: 1000m
       memory: 6Gi
+  job:
+    concurrencyPolicy: Forbid
 ```
 
 ## CDC Configuration (Experimental)

--- a/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
+++ b/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
@@ -320,6 +320,7 @@ When `config.redis.enabled=true`, the chart automatically sets the lock backend 
 | `fsck.resources` | Resources for fsck pod | `{}` |
 | `fsck.securityContext` | Security context for fsck pod | See values.yaml |
 | `fsck.job.backoffLimit` | Job backoff limit | `1` |
+| `fsck.job.concurrencyPolicy` | Job concurrency policy (`Allow`, `Forbid`, `Replace`) | `Forbid` |
 | `fsck.job.ttlSecondsAfterFinished` | Job TTL after finish (seconds) | `3600` |
 | `fsck.job.annotations` | Annotations for the Job | `{}` |
 | `fsck.job.nodeSelector` | Node selector for the Job | `{}` |

--- a/docs/docs/User Guide/Operations/Integrity Check (fsck).md
+++ b/docs/docs/User Guide/Operations/Integrity Check (fsck).md
@@ -273,6 +273,7 @@ fsck:
 
   # Optional: Job-specific settings
   job:
+    concurrencyPolicy: Forbid
     backoffLimit: 1
     ttlSecondsAfterFinished: 3600
 ```


### PR DESCRIPTION
This adds 'concurrencyPolicy' to the fsck job configuration in the Helm
chart. It defaults to 'Forbid' to prevent multiple instances of fsck
from running simultaneously, which could lead to resource exhaustion or
database lock contention if a check takes longer than the scheduled
interval.

Changes:
- Added 'fsck.job.concurrencyPolicy' to values.yaml.
- Updated 'fsck-cronjob.yaml' template to apply the policy.
- Added schema validation in 'values.schema.json'.
- Updated documentation in 'Installation/Helm Chart.md' and
  'Operations/Integrity Check (fsck).md'.
- Added unit tests in 'tests/fsck_cronjob_test.yaml'.