### PR TITLE
perf: improve memory consumption when chunking

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1694,7 +1694,7 @@ func (c *Cache) storeNarWithCDC(ctx context.Context, tempPath string, narURL *na
 		chunkCount int64
 	)
 
-	var batch []chunker.Chunk
+	var batch []*chunker.Chunk
 
 	flushTimer := time.NewTimer(cdcFirstBatchDelay)
 	defer flushTimer.Stop()
@@ -1986,7 +1986,7 @@ func (c *Cache) relinkNarInfosToNarFileWithQuerier(
 	return nil
 }
 
-func (c *Cache) recordChunkBatch(ctx context.Context, narFileID int64, startIndex int64, batch []chunker.Chunk) error {
+func (c *Cache) recordChunkBatch(ctx context.Context, narFileID int64, startIndex int64, batch []*chunker.Chunk) error {
 	if len(batch) == 0 {
 		return nil
 	}

--- a/pkg/cache/cdc_test.go
+++ b/pkg/cache/cdc_test.go
@@ -54,8 +54,8 @@ type slowChunker struct {
 	delay time.Duration
 }
 
-func (s *slowChunker) Chunk(ctx context.Context, r io.Reader) (<-chan chunker.Chunk, <-chan error) {
-	chunksChan := make(chan chunker.Chunk)
+func (s *slowChunker) Chunk(ctx context.Context, r io.Reader) (<-chan *chunker.Chunk, <-chan error) {
+	chunksChan := make(chan *chunker.Chunk)
 	errChan := make(chan error, 1)
 
 	go func() {

--- a/pkg/chunker/chunker_test.go
+++ b/pkg/chunker/chunker_test.go
@@ -118,10 +118,10 @@ func TestCDCChunker_Chunk(t *testing.T) {
 	})
 }
 
-func collectChunks(ctx context.Context, t *testing.T, c chunker.Chunker, r io.Reader) ([]chunker.Chunk, error) {
+func collectChunks(ctx context.Context, t *testing.T, c chunker.Chunker, r io.Reader) ([]*chunker.Chunk, error) {
 	chunksChan, errChan := c.Chunk(ctx, r)
 
-	var chunks []chunker.Chunk
+	var chunks []*chunker.Chunk
 
 	for {
 		select {


### PR DESCRIPTION
The chunking Free() was leaving bytes in memory instead of immediately
cleaning them up.