### PR TITLE
fix: set deployment strategy to Recreate for SQLite [backport #1012]

### DIFF
--- a/charts/ncps/templates/deployment.yaml
+++ b/charts/ncps/templates/deployment.yaml
@@ -8,6 +8,16 @@ metadata:
     {{- include "ncps.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if eq .Values.config.database.type "sqlite" }}
+  strategy:
+    type: Recreate
+  {{- else if .Values.strategy }}
+  strategy:
+    {{- toYaml .Values.strategy | nindent 4 }}
+  {{- else }}
+  strategy:
+    type: RollingUpdate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "ncps.selectorLabels" . | nindent 6 }}

--- a/charts/ncps/tests/deployment_test.yaml
+++ b/charts/ncps/tests/deployment_test.yaml
@@ -432,8 +432,74 @@ tests:
       config.storage.type: local
       config.storage.local.persistence.enabled: false # Use emptyDir for this test
     asserts:
-      - isNotEmpty:
-          path: spec.template.spec.initContainers
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: create-db-dir
+
+  # Strategy tests
+  - it: should render strategy.type when strategy is provided
+    template: deployment.yaml
+    set:
+      mode: deployment
+      strategy:
+        type: Recreate
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: should render RollingUpdate strategy by default when strategy is not provided and database is not sqlite
+    template: deployment.yaml
+    set:
+      mode: deployment
+      config:
+        database:
+          type: postgresql
+          postgresql:
+            host: localhost
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+
+  - it: should set strategy type to Recreate for SQLite in Deployment
+    template: deployment.yaml
+    set:
+      mode: deployment
+      config.hostname: test.example.com
+      config.database.type: sqlite
+      config.storage.type: local
+      config.storage.local.persistence.enabled: false
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: should set strategy type to RollingUpdate for PostgreSQL in Deployment
+    template: deployment.yaml
+    set:
+      mode: deployment
+      config.hostname: test.example.com
+      config.database.type: postgresql
+      config.database.postgresql.host: postgres
+      config.database.postgresql.password: test123
+      config.storage.type: s3
+      config.storage.s3.bucket: my-bucket
+      config.storage.s3.endpoint: https://s3.amazonaws.com
+      config.storage.s3.accessKeyId: test-key
+      config.storage.s3.secretAccessKey: test-secret
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+  - it: should override user strategy to Recreate for SQLite
+    template: deployment.yaml
+    set:
+      mode: deployment
+      config.database.type: sqlite
+      strategy:
+        type: RollingUpdate
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate

--- a/charts/ncps/values.schema.json
+++ b/charts/ncps/values.schema.json
@@ -24,6 +24,10 @@
       ],
       "description": "Deployment mode"
     },
+    "strategy": {
+      "type": "object",
+      "description": "Deployment strategy (only for mode: deployment)"
+    },
     "image": {
       "type": "object",
       "properties": {

--- a/charts/ncps/values.yaml
+++ b/charts/ncps/values.yaml
@@ -19,6 +19,15 @@ replicaCount: 1
 # - statefulset: For single instance with local storage or HA with persistent state
 mode: statefulset
 
+# Deployment strategy for the "deployment" mode
+# Only applies when mode: deployment
+# For SQLite, this is always overridden to type: Recreate
+strategy: {}
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxSurge: 25%
+#     maxUnavailable: 25%
+
 image:
   # The image is also available at docker.io/kalbasit/ncps
   registry: ghcr.io

--- a/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
+++ b/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
@@ -68,6 +68,7 @@ The following table lists the configurable parameters of the ncps chart and thei
 | `global.imageRegistry` | Global image registry override | `""` |
 | `replicaCount` | Number of replicas (1 for single instance, 2+ for HA) | `1` |
 | `mode` | Deployment mode: `deployment` or `statefulset` | `statefulset` |
+| `strategy` | Deployment strategy (only for `mode: deployment`, auto-set to `Recreate` for SQLite) | `{}` |
 | `image.registry` | Image registry (also available on `docker.io`) | `ghcr.io` |
 | `image.repository` | Image repository | `kalbasit/ncps` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |


### PR DESCRIPTION
Bot-based backport to `release-0.9`, triggered by a label in #1012.

The Helm chart now uses the Recreate deployment strategy when mode is
set to deployment and SQLite is being used as the database.

Without this strategy, Kubernetes defaults to RollingUpdate, which can
cause rollouts to hang when a new pod is scheduled on a different node
than the old one but cannot mount the PersistentVolume (PV) because it
is ReadWriteOnce (RWO) and still attached to the old pod. This is
particularly relevant for SQLite which relies on a single PVC for
storage.

The change handles this by conditionally setting strategy.type based on
the database type in deployment.yaml. Unit tests have been added to
verify the correct rendering for both SQLite (Recreate) and other
databases (RollingUpdate).

fixes #1010