### PR TITLE
fix: make lazy chunking opt-in (default: false)

### DIFF
--- a/charts/ncps/tests/configmap_test.yaml
+++ b/charts/ncps/tests/configmap_test.yaml
@@ -77,14 +77,14 @@ tests:
           path: data["config.yaml"]
           pattern: "lazy-chunking-enabled: false"
 
-  - it: should default CDC lazy chunking to true
+  - it: should default CDC lazy chunking to false
     set:
       config.hostname: test.example.com
       config.cdc.enabled: true
     asserts:
       - matchRegex:
           path: data["config.yaml"]
-          pattern: "lazy-chunking-enabled: true"
+          pattern: "lazy-chunking-enabled: false"
 
   - it: should configure CDC background workers
     set:

--- a/charts/ncps/values.yaml
+++ b/charts/ncps/values.yaml
@@ -177,9 +177,9 @@ config:
     avg: 65536
     max: 262144
 
-    # Enable lazy chunking: store compressed NAR first, chunk in background (default: true)
+    # Enable lazy chunking: store compressed NAR first, chunk in background (default: false)
     # This improves TTFB by avoiding synchronous chunking during download
-    lazyChunkingEnabled: true
+    lazyChunkingEnabled: false
 
     # Number of background workers for lazy chunking (default: number of CPUs)
     backgroundWorkers: null

--- a/docs/docs/User Guide/Configuration/Reference.md
+++ b/docs/docs/User Guide/Configuration/Reference.md
@@ -171,7 +171,7 @@ Content-Defined Chunking (CDC) enables deduplication of NAR files by splitting t
 | `--cache-cdc-min` | Minimum chunk size in bytes | `CACHE_CDC_MIN` | 16384 |
 | `--cache-cdc-avg` | Average chunk size in bytes | `CACHE_CDC_AVG` | 65536 |
 | `--cache-cdc-max` | Maximum chunk size in bytes | `CACHE_CDC_MAX` | 262144 |
-| `--cache-cdc-lazy-chunking-enabled` | Enable lazy chunking (store NAR first, chunk in background) | `CACHE_CDC_LAZY_CHUNKING_ENABLED` | `true` |
+| `--cache-cdc-lazy-chunking-enabled` | Enable lazy chunking (store NAR first, chunk in background) | `CACHE_CDC_LAZY_CHUNKING_ENABLED` | `false` |
 | `--cache-cdc-background-workers` | Number of background workers for lazy chunking | `CACHE_CDC_BACKGROUND_WORKERS` | number of CPUs |
 | `--cache-cdc-delete-delay` | Delay before deleting compressed NAR files after chunking | `CACHE_CDC_DELETE_DELAY` | `24h` |
 | `--cache-cdc-lazy-recovery-schedule` | Cron schedule for recovering stuck NARs in lazy chunking mode | `CACHE_CDC_LAZY_RECOVERY_SCHEDULE` | `@every 5m` |

--- a/docs/docs/User Guide/Features/CDC.md
+++ b/docs/docs/User Guide/Features/CDC.md
@@ -54,7 +54,7 @@ cache:
 | `--cache-cdc-min` | Minimum chunk size in bytes | `CACHE_CDC_MIN` | 16384 |
 | `--cache-cdc-avg` | Average (target) chunk size in bytes | `CACHE_CDC_AVG` | 65536 |
 | `--cache-cdc-max` | Maximum chunk size in bytes | `CACHE_CDC_MAX` | 262144 |
-| `--cache-cdc-lazy-chunking-enabled` | Enable lazy chunking: store compressed NAR first, chunk in background | `CACHE_CDC_LAZY_CHUNKING_ENABLED` | `true` |
+| `--cache-cdc-lazy-chunking-enabled` | Enable lazy chunking: store compressed NAR first, chunk in background | `CACHE_CDC_LAZY_CHUNKING_ENABLED` | `false` |
 | `--cache-cdc-background-workers` | Number of background workers for lazy chunking | `CACHE_CDC_BACKGROUND_WORKERS` | (number of CPUs) |
 | `--cache-cdc-delete-delay` | Delay before deleting compressed NAR files after chunking completes | `CACHE_CDC_DELETE_DELAY` | `24h` |
 
@@ -84,7 +84,7 @@ cache:
     min: 16384    # 16 KB
     avg: 65536    # 64 KB
     max: 262144   # 256 KB
-    lazy-chunking-enabled: true
+    lazy-chunking-enabled: false
     background-workers: 4
     delete-delay: 24h
 ```

--- a/docs/docs/User Guide/Features/CDC.md
+++ b/docs/docs/User Guide/Features/CDC.md
@@ -60,7 +60,7 @@ cache:
 
 ### Lazy Chunking
 
-When lazy chunking is enabled (default), NAR files are stored in their original compressed format first, then chunked in the background. This improves Time To First Byte (TTFB) by avoiding synchronous chunking during download.
+When lazy chunking is enabled (opt-in, disabled by default), NAR files are stored in their original compressed format first, then chunked in the background. This improves Time To First Byte (TTFB) by avoiding synchronous chunking during download.
 
 **Behavior:**
 

--- a/docs/docs/User Guide/Installation/Helm Chart.md
+++ b/docs/docs/User Guide/Installation/Helm Chart.md
@@ -471,9 +471,9 @@ config:
     avg: 65536
     max: 262144
 
-    # Lazy chunking: store compressed NAR first, chunk in background (default: true)
+    # Lazy chunking: store compressed NAR first, chunk in background (default: false)
     # This improves TTFB by avoiding synchronous chunking during download
-    lazyChunkingEnabled: true
+    lazyChunkingEnabled: false
 
     # Number of background workers for lazy chunking (default: number of CPUs)
     backgroundWorkers: 4

--- a/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
+++ b/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
@@ -182,7 +182,7 @@ Configuration for the temporary directory used for downloads and transient opera
 | `config.cdc.min` | Minimum chunk size in bytes | `16384` |
 | `config.cdc.avg` | Average (target) chunk size in bytes | `65536` |
 | `config.cdc.max` | Maximum chunk size in bytes | `262144` |
-| `config.cdc.lazyChunkingEnabled` | Enable lazy chunking (store compressed NAR first, chunk in background) | `true` |
+| `config.cdc.lazyChunkingEnabled` | Enable lazy chunking (store compressed NAR first, chunk in background) | `false` |
 | `config.cdc.backgroundWorkers` | Number of background workers for lazy chunking | `null` (server default: number of CPUs) |
 | `config.cdc.deleteDelay` | Delay before deleting compressed NAR files after chunking completes | `24h` |
 | `config.cdc.iLoveTimeouts` | Bypass flag for HA validation without CDC | `false` |

--- a/openspec/changes/archive/2026-05-14-lazy-chunking-not-default/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-14-lazy-chunking-not-default/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/archive/2026-05-14-lazy-chunking-not-default/design.md
+++ b/openspec/changes/archive/2026-05-14-lazy-chunking-not-default/design.md
@@ -1,0 +1,27 @@
+## Context
+
+PR #1099 set `cache-cdc-lazy-chunking-enabled` default to `true` and mirrored that in the Helm chart. This silently activates lazy chunking for all CDC-enabled deployments on upgrade, starting background workers and a cleanup cron job without user consent.
+
+Current state: two files have diverging defaults (`Value: false` already partially reverted in the working tree), one usage string is stale, and the Helm chart test asserts the wrong default.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `--cache-cdc-lazy-chunking-enabled` defaults to `false` (opt-in)
+- Helm `values.yaml` defaults `lazyChunkingEnabled: false`
+- Usage string and Helm test reflect the correct default
+- Docs/chart-reference corrected
+
+**Non-Goals:**
+- No functional change to lazy chunking behavior when enabled
+- No removal of the feature or related flags
+
+## Decisions
+
+**Revert the default, keep the feature.** Lazy chunking is a valid performance optimization, but it changes operational behavior (extra workers, delayed file deletion, extra cron job). Defaults should not change silently across upgrades; users must explicitly opt in.
+
+**No deprecation path.** Users who upgraded after #1099 and relied on the implicit `true` default should re-check their config. This is unavoidable given the short window between #1099 and this revert.
+
+## Risks / Trade-offs
+
+- [Risk] Users who upgraded between #1099 and this revert and never set the flag explicitly will lose lazy chunking on next upgrade → Mitigation: release notes should call this out explicitly

--- a/openspec/changes/archive/2026-05-14-lazy-chunking-not-default/proposal.md
+++ b/openspec/changes/archive/2026-05-14-lazy-chunking-not-default/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Lazy chunking was made the default in PR #1099, but this is a breaking behavior change for existing deployments: users who haven't opted in now get background chunking, delayed compressed NAR deletion, and additional cron jobs running without their knowledge. An opt-in feature should not silently activate on upgrade.
+
+## What Changes
+
+- **BREAKING** (revert): `--cache-cdc-lazy-chunking-enabled` CLI flag default reverted from `true` → `false`
+- Helm `values.yaml`: `lazyChunkingEnabled` default reverted from `true` → `false`
+- CLI usage string corrected: "(default: true)" → "(default: false)"
+- Helm chart test updated: "should default CDC lazy chunking to true" → "should default CDC lazy chunking to false"
+- Helm chart docs/reference updated to reflect `false` default
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None — this is a default-value correction, not a requirement change. No spec-level behavior changes; the capability exists and works identically, it just no longer activates unless explicitly enabled.
+
+## Impact
+
+- **`pkg/ncps/serve.go`**: Change `Value: true` → `Value: false` and fix usage string
+- **`charts/ncps/values.yaml`**: Change `lazyChunkingEnabled: true` → `false` and fix comment
+- **`charts/ncps/tests/configmap_test.yaml`**: Fix "should default CDC lazy chunking to true" test assertion
+- **`docs/`**: Update any docs/chart-reference that state the default is `true`
+- No I/O, latency, or memory impact — lazy chunking simply won't run unless opted in
+
+**Non-goals**
+
+- Not removing lazy chunking or any related flags
+- Not changing how lazy chunking works when enabled
+- Not adding migration tooling for users who were relying on the previous default

--- a/openspec/changes/archive/2026-05-14-lazy-chunking-not-default/specs/no-capability-changes.md
+++ b/openspec/changes/archive/2026-05-14-lazy-chunking-not-default/specs/no-capability-changes.md
@@ -1,0 +1,3 @@
+# No Capability Changes
+
+This change reverts a default value only. No new capabilities are introduced and no existing spec-level requirements are modified.

--- a/openspec/changes/archive/2026-05-14-lazy-chunking-not-default/tasks.md
+++ b/openspec/changes/archive/2026-05-14-lazy-chunking-not-default/tasks.md
@@ -1,0 +1,22 @@
+## 1. CLI Flag Default
+
+- [x] 1.1 In `pkg/ncps/serve.go`: change `Value: true` → `Value: false` for `cache-cdc-lazy-chunking-enabled`
+- [x] 1.2 In `pkg/ncps/serve.go`: fix usage string from "(default: true)" → "(default: false)"
+
+## 2. Helm Chart
+
+- [x] 2.1 In `charts/ncps/values.yaml`: change `lazyChunkingEnabled: true` → `false` and fix the comment from "(default: true)" → "(default: false)"
+- [x] 2.2 In `charts/ncps/tests/configmap_test.yaml`: fix "should default CDC lazy chunking to true" test — change description and expected pattern to `false`
+
+## 3. Documentation
+
+- [x] 3.1 In `docs/docs/User Guide/Configuration/Reference.md`: change default column for `--cache-cdc-lazy-chunking-enabled` from `true` → `false`
+- [x] 3.2 In `docs/docs/User Guide/Features/CDC.md`: change default column from `true` → `false`; update example config to show `lazy-chunking-enabled: false` (or remove from default example)
+- [x] 3.3 In `docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md`: change default for `config.cdc.lazyChunkingEnabled` from `true` → `false`
+- [x] 3.4 In `docs/docs/User Guide/Installation/Helm Chart.md`: fix inline comment and example value from `true` → `false`
+
+## 4. Verify
+
+- [x] 4.1 Run `helm unittest charts/ncps` and confirm all tests pass
+- [x] 4.2 Run `go build .` to confirm no compilation errors
+- [x] 4.3 Run `golangci-lint run` and confirm no new lint issues

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -196,9 +196,9 @@ func serveCommand(
 			},
 			&cli.BoolFlag{
 				Name:    "cache-cdc-lazy-chunking-enabled",
-				Usage:   "Enable lazy chunking: store compressed NAR first, chunk in background (default: true)",
+				Usage:   "Enable lazy chunking: store compressed NAR first, chunk in background (default: false)",
 				Sources: flagSources("cache.cdc.lazy-chunking-enabled", "CACHE_CDC_LAZY_CHUNKING_ENABLED"),
-				Value:   true,
+				Value:   false,
 			},
 			&cli.IntFlag{
 				Name:    "cache-cdc-background-workers",


### PR DESCRIPTION
Lazy chunking was made the default in #1099, but enabling it
silently on upgrade is a behavior change: it starts background
workers, a cleanup cron job, and delays compressed NAR deletion
without user consent. Revert the default to false so users must
explicitly opt in.

Changes:
- pkg/ncps/serve.go: Value true->false, fix usage string
- charts/ncps/values.yaml: lazyChunkingEnabled true->false
- charts/ncps/tests/configmap_test.yaml: fix default assertion
- docs: update all references from default true to false