### PR TITLE
docs: validate mysql ent+atlas+goose pipeline

### DIFF
--- a/openspec/changes/migrate-to-ent-and-atlas/design.md
+++ b/openspec/changes/migrate-to-ent-and-atlas/design.md
@@ -168,15 +168,21 @@ Action per state:
 
 **Why not require a manual operator migration**: ncps is self-hosted; there is no script-delivery mechanism. The adoption must be automatic and idempotent.
 
-### D7: MySQL/MariaDB validation
+### D7: MySQL/MariaDB validation — VALIDATED
 
-The reference repo handles only sqlite + postgres. ncps must validate three points before relying on the pipeline for MySQL:
+The reference repo handles only sqlite + postgres. ncps must validate three points before relying on the pipeline for MySQL. The spike (Tasks §1) confirmed all three against MariaDB 11.4.8:
 
-1. `entsql.Open("mysql", url)` and `dialect.MySQL` produce correct DDL for the existing schema (Ent's documented behaviour, but unproven in this combination locally).
-2. `ariga.io/atlas/sql/sqltool.GooseFormatter` emits MySQL-syntactic DDL (Atlas docs claim yes; verify by inspecting a generated baseline).
-3. `goose.DialectMySQL` correctly applies the generated baseline against MariaDB 11 (the version `process-compose-flake` ships).
+1. **`entsql.Open("mysql", dsn)` with `dialect.MySQL` produces correct DDL.** Ent's MySQL dialect emits `bigint`, `varchar(N)`, backtick-quoted identifiers, `CHARSET utf8mb4 COLLATE utf8mb4_bin` clauses, and `AUTO_INCREMENT` PKs — matching MariaDB expectations exactly.
+2. **`ariga.io/atlas/sql/sqltool.GooseFormatter` emits MySQL-syntactic DDL.** The spike's generated baseline file (under `schema.ModeReplay`) produced valid MySQL `CREATE TABLE` statements with `-- +goose Up` / `-- +goose Down` markers and reverse-order `DROP TABLE` for downgrade.
+3. **`goose.NewProvider(goose.DialectMySQL, db, fs, WithTableName("schema_migrations")).Up(ctx)` applies the baseline.** Goose created its tracking row, applied the DDL, and reported the migration with sub-millisecond apply time.
 
-If any fails, fall back is: use Ent's MySQL dialect for codegen + DDL diff, but write a small custom Goose formatter (≈50 LOC) that emits MySQL-quoted identifiers. Decision deferred until the spike in Tasks §1.
+Post-apply verification queries against `information_schema` confirmed every schema feature survived:
+
+- `CHECK_CONSTRAINTS` contains the named constraint declared via `entsql.Annotation{Checks: ...}`.
+- `REFERENTIAL_CONSTRAINTS` shows `DELETE_RULE = 'CASCADE'` on the foreign key declared via `edge.To(...).Annotations(entsql.OnDelete(entsql.Cascade))`.
+- `STATISTICS` shows `NON_UNIQUE = 0` on the `name` column index declared via `index.Fields("name").Unique()`.
+
+**Decision**: proceed with the pipeline as planned. No custom Goose formatter is required. The `cmd/spike-mysql/` exploration code and the two `ent/schema/spike_*.go` schemas were deleted after the validation.
 
 ### D8: `cmd/generate-migrations` shape
 

--- a/openspec/changes/migrate-to-ent-and-atlas/tasks.md
+++ b/openspec/changes/migrate-to-ent-and-atlas/tasks.md
@@ -1,9 +1,9 @@
 ## 1. MySQL spike (decision gate)
 
-- [ ] 1.1 Add a throwaway branch with a single `ent/schema/spike.go` declaring one toy entity with fields, an index, an edge, and a CHECK annotation
-- [ ] 1.2 Write a one-shot Go program that calls `entgo.io/ent/dialect/sql/schema.NewMigrate` with `dialect.MySQL`, `sqltool.GooseFormatter`, and `sqltool.NewGooseDir` against an empty MariaDB 11 dev DB; capture the generated `.sql` file
-- [ ] 1.3 Apply the generated file with `goose.NewProvider(goose.DialectMySQL, db, dir, WithTableName("schema_migrations")).Up(ctx)` and confirm the table is created exactly as Ent's `migrate.Tables` expects
-- [ ] 1.4 Decision gate: if the pipeline works end-to-end, document the result in `design.md` and delete the spike branch; if it fails, write a ~50-LOC custom Goose formatter for MySQL and validate the same flow before proceeding
+- [x] 1.1 Add a throwaway branch with a single `ent/schema/spike.go` declaring one toy entity with fields, an index, an edge, and a CHECK annotation
+- [x] 1.2 Write a one-shot Go program that calls `entgo.io/ent/dialect/sql/schema.NewMigrate` with `dialect.MySQL`, `sqltool.GooseFormatter`, and `sqltool.NewGooseDir` against an empty MariaDB 11 dev DB; capture the generated `.sql` file
+- [x] 1.3 Apply the generated file with `goose.NewProvider(goose.DialectMySQL, db, dir, WithTableName("schema_migrations")).Up(ctx)` and confirm the table is created exactly as Ent's `migrate.Tables` expects
+- [x] 1.4 Decision gate: if the pipeline works end-to-end, document the result in `design.md` and delete the spike branch; if it fails, write a ~50-LOC custom Goose formatter for MySQL and validate the same flow before proceeding
 
 ## 2. Foundation setup
 


### PR DESCRIPTION
The §1 MySQL spike (now removed) validated that ent v0.14.6 +
ariga.io/atlas v0.36.2-pre + pressly/goose/v3 v3.27.1 work end-to-end
against MariaDB 11.4.8:

- dialect.MySQL produces correct MariaDB DDL (bigint, varchar,
  backtick-quoted identifiers, utf8mb4 charset, AUTO_INCREMENT PK).
- sqltool.GooseFormatter emits valid MySQL syntax with proper
  -- +goose Up / -- +goose Down markers and reverse DROP TABLE
  ordering.
- goose.DialectMySQL applies the baseline cleanly via
  goose.NewProvider(..., WithTableName("schema_migrations")).Up(ctx).
- All schema features survive: CHECK constraints, ON DELETE CASCADE
  foreign keys, UNIQUE indexes, named indexes — verified via
  information_schema queries.

Decision gate result: proceed with the pipeline as planned in §6 and
§9. No custom Goose formatter is required for MySQL.

Updates design.md D7 with the validation evidence. The throwaway
spike (cmd/spike-mysql/ and ent/schema/spike_*.go) is deleted; this
commit captures only the documentation update.

Completes task 1.1-1.4 of the migrate-to-ent-and-atlas change.