### PR TITLE
feat(ent-lint): enforce A1/A2/A4 codegen invariants

### DIFF
--- a/cmd/ent-lint/main.go
+++ b/cmd/ent-lint/main.go
@@ -1,0 +1,609 @@
+// Command ent-lint enforces invariants on the Ent schema source tree.
+//
+// It walks ent/schema/*.go (or any tree passed via --schema-dir) via the
+// Go AST and reports violations of the codegen invariants documented in
+// the migrate-to-ent-and-atlas design (D10b and ent-schema-lint capability):
+//
+//   - A1: field-level entsql.Check(...) annotations are forbidden (Ent
+//     silently drops them; CHECKs MUST live on table-level Annotations()).
+//   - A2: entsql.OnDelete(...) annotations on edge.From(...) are forbidden
+//     (Ent silently ignores them; OnDelete MUST live on edge.To(...)).
+//   - A4: every edge.To declaration in any schema must have a reciprocal
+//     edge.From(...).Ref(...) on the target schema (otherwise Ent fabricates
+//     a phantom FK column on the target).
+//
+// Future invariants enforced by this binary (tracked in the
+// ent-schema-lint spec but not yet implemented):
+//
+//   - A3: no field-level .Unique() on a column also bound by edge.From().Field()
+//   - A5: every *_ciphertext bytes field must chain .Sensitive()
+//   - snake_case enum-type naming
+//   - expand-contract DDL ban on the newest migration files
+//   - CHECK presence cross-validation between schema annotations and
+//     generated SQL
+//
+// Output is checklist-formatted: one line per invariant per schema, prefixed
+// with [PASS] or [FAIL]. The binary exits non-zero if any line is [FAIL].
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type result struct {
+	pass   bool
+	id     string
+	detail string
+}
+
+func main() {
+	root := flag.String("root", ".", "repository root (contains ent/schema and migrations)")
+	schemaDir := flag.String("schema-dir", "", "override path to the ent/schema directory (default: <root>/ent/schema)")
+
+	flag.Parse()
+
+	dir := *schemaDir
+	if dir == "" {
+		dir = filepath.Join(*root, "ent", "schema")
+	}
+
+	schemas, err := loadSchemas(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ent-lint: load schemas: %v\n", err)
+		os.Exit(2)
+	}
+
+	var results []result
+
+	results = append(results, checkA1(schemas)...)
+	results = append(results, checkA2(schemas)...)
+	results = append(results, checkA4(schemas)...)
+
+	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].id != results[j].id {
+			return results[i].id < results[j].id
+		}
+
+		return results[i].detail < results[j].detail
+	})
+
+	var failed int
+
+	for _, r := range results {
+		prefix := "[PASS]"
+		if !r.pass {
+			prefix = "[FAIL]"
+			failed++
+		}
+
+		fmt.Printf("%s %-3s %s\n", prefix, r.id, r.detail)
+	}
+
+	if failed > 0 {
+		fmt.Fprintf(os.Stderr, "\nent-lint: %d FAIL line(s)\n", failed)
+		os.Exit(1)
+	}
+}
+
+// schemaFile holds the parsed AST of one ent/schema/*.go file along with
+// the schema-type metadata extracted from it.
+type schemaFile struct {
+	path  string
+	fset  *token.FileSet
+	file  *ast.File
+	types []schemaType // one per `type X struct { ent.Schema }` declaration
+}
+
+type schemaType struct {
+	name string // Go type name (e.g. "NarInfo")
+}
+
+func loadSchemas(dir string) ([]schemaFile, error) {
+	var out []schemaFile
+
+	walkErr := fs.WalkDir(os.DirFS(dir), ".", func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if !strings.HasSuffix(p, ".go") {
+			return nil
+		}
+
+		full := filepath.Join(dir, p)
+		fset := token.NewFileSet()
+
+		f, err := parser.ParseFile(fset, full, nil, parser.ParseComments)
+		if err != nil {
+			return fmt.Errorf("parse %s: %w", full, err)
+		}
+
+		sf := schemaFile{path: full, fset: fset, file: f}
+		ast.Inspect(f, func(n ast.Node) bool {
+			ts, ok := n.(*ast.TypeSpec)
+			if !ok {
+				return true
+			}
+
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				return true
+			}
+
+			if !embedsEntSchema(st) {
+				return true
+			}
+
+			sf.types = append(sf.types, schemaType{name: ts.Name.Name})
+
+			return true
+		})
+
+		if len(sf.types) > 0 {
+			out = append(out, sf)
+		}
+
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	return out, nil
+}
+
+// embedsEntSchema reports whether the struct embeds either `ent.Schema` or
+// a mixin (we only care about ent.Schema for the lint targets, but mixins
+// are skipped silently).
+func embedsEntSchema(st *ast.StructType) bool {
+	for _, fld := range st.Fields.List {
+		// Embedded fields have no names; the Type is the embedded type.
+		if len(fld.Names) > 0 {
+			continue
+		}
+
+		sel, ok := fld.Type.(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+
+		x, ok := sel.X.(*ast.Ident)
+		if !ok {
+			continue
+		}
+
+		if x.Name == "ent" && sel.Sel.Name == "Schema" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ---------- A1: field-level entsql.Check is forbidden ----------
+
+// checkA1 walks each schema's Fields() method body looking for
+// `.Annotations(... entsql.Check(...) ...)` chained on a field builder.
+func checkA1(schemas []schemaFile) []result {
+	var out []result
+
+	for _, sf := range schemas {
+		methods := methodsByName(sf, "Fields")
+		for _, m := range methods {
+			violations := findFieldEntsqlCheck(sf, m)
+			if len(violations) == 0 {
+				out = append(out, result{
+					pass: true, id: "A1",
+					detail: fmt.Sprintf("%s: no field-level entsql.Check", relPath(sf.path)),
+				})
+
+				continue
+			}
+
+			for _, v := range violations {
+				out = append(out, result{
+					pass: false, id: "A1",
+					detail: fmt.Sprintf(
+						"%s:%d field-level entsql.Check is forbidden (use Annotations() on the schema)",
+						relPath(sf.path), v),
+				})
+			}
+		}
+	}
+
+	return out
+}
+
+func findFieldEntsqlCheck(sf schemaFile, fn *ast.FuncDecl) []int {
+	var lines []int
+
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		if sel.Sel.Name != "Annotations" {
+			return true
+		}
+		// Found a `.Annotations(...)` call; if any argument is `entsql.Check(...)`,
+		// flag it.
+		for _, arg := range call.Args {
+			if isEntsqlCheckCall(arg) {
+				lines = append(lines, sf.fset.Position(arg.Pos()).Line)
+			}
+		}
+
+		return true
+	})
+
+	return lines
+}
+
+func isEntsqlCheckCall(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+
+	x, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+
+	return x.Name == "entsql" && sel.Sel.Name == "Check"
+}
+
+// ---------- A2: entsql.OnDelete on edge.From is forbidden ----------
+
+// checkA2 walks each schema's Edges() method body and inspects every
+// `edge.From(...).Ref(...).Annotations(...)` chain. If any argument to
+// Annotations is `entsql.OnDelete(...)`, that's an A2 violation.
+func checkA2(schemas []schemaFile) []result {
+	var out []result
+
+	for _, sf := range schemas {
+		methods := methodsByName(sf, "Edges")
+		for _, m := range methods {
+			violations := findEdgeFromOnDelete(sf, m)
+			if len(violations) == 0 {
+				out = append(out, result{
+					pass: true, id: "A2",
+					detail: fmt.Sprintf("%s: no OnDelete on edge.From", relPath(sf.path)),
+				})
+
+				continue
+			}
+
+			for _, v := range violations {
+				out = append(out, result{
+					pass: false, id: "A2",
+					detail: fmt.Sprintf("%s:%d entsql.OnDelete on edge.From is forbidden (move to edge.To)", relPath(sf.path), v),
+				})
+			}
+		}
+	}
+
+	return out
+}
+
+func findEdgeFromOnDelete(sf schemaFile, fn *ast.FuncDecl) []int {
+	var lines []int
+
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		if sel.Sel.Name != "Annotations" {
+			return true
+		}
+		// Look at the receiver of .Annotations(...). If anywhere in the
+		// chain there's a call to edge.From(...), the .Annotations() call
+		// applies to that From-side edge.
+		if !chainContainsEdgeFrom(sel.X) {
+			return true
+		}
+
+		for _, arg := range call.Args {
+			if isEntsqlOnDeleteCall(arg) {
+				lines = append(lines, sf.fset.Position(arg.Pos()).Line)
+			}
+		}
+
+		return true
+	})
+
+	return lines
+}
+
+func chainContainsEdgeFrom(e ast.Expr) bool {
+	for {
+		switch v := e.(type) {
+		case *ast.CallExpr:
+			if sel, ok := v.Fun.(*ast.SelectorExpr); ok {
+				if x, ok := sel.X.(*ast.Ident); ok && x.Name == edgePkg && sel.Sel.Name == "From" {
+					return true
+				}
+
+				e = sel.X
+
+				continue
+			}
+
+			return false
+		case *ast.SelectorExpr:
+			e = v.X
+		default:
+			return false
+		}
+	}
+}
+
+func isEntsqlOnDeleteCall(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+
+	x, ok := sel.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+
+	return x.Name == "entsql" && sel.Sel.Name == "OnDelete"
+}
+
+// ---------- A4: every edge.To needs a reciprocal edge.From().Ref() ----------
+
+// checkA4 catalogues every edge.To declaration across all schemas and
+// every edge.From().Ref() declaration, then reports an A4 violation for
+// any edge.To(name, T) without a matching edge.From(...,T.Type).Ref(name).
+func checkA4(schemas []schemaFile) []result {
+	type edgeTo struct {
+		source   string // declaring schema's Go type name
+		edgeName string // first arg of edge.To
+		target   string // second arg target type
+		line     int
+		path     string
+	}
+
+	type edgeFromRef struct {
+		source string // declaring schema (target side from the To side's perspective)
+		ref    string // first arg of .Ref(...)
+		target string // second arg of edge.From — the parent type
+	}
+
+	var (
+		tos   []edgeTo
+		froms []edgeFromRef
+	)
+
+	for _, sf := range schemas {
+		for _, m := range methodsByName(sf, "Edges") {
+			schemaName := receiverTypeName(m)
+			ast.Inspect(m, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				// edge.To(...)
+				if id, ok := sel.X.(*ast.Ident); ok && id.Name == edgePkg {
+					if sel.Sel.Name == "To" && len(call.Args) >= 2 {
+						tos = append(tos, edgeTo{
+							source:   schemaName,
+							edgeName: stringLitValue(call.Args[0]),
+							target:   typeRefName(call.Args[1]),
+							line:     sf.fset.Position(call.Pos()).Line,
+							path:     sf.path,
+						})
+					}
+
+					return true
+				}
+				// .Ref(...) — walk inward to find the matching edge.From.
+				if sel.Sel.Name == "Ref" && len(call.Args) >= 1 {
+					ref := stringLitValue(call.Args[0])
+
+					fromTarget := findInnerEdgeFromTarget(sel.X)
+					if fromTarget != "" {
+						froms = append(froms, edgeFromRef{
+							source: schemaName,
+							ref:    ref,
+							target: fromTarget,
+						})
+					}
+				}
+
+				return true
+			})
+		}
+	}
+
+	var out []result
+
+	for _, t := range tos {
+		matched := false
+
+		for _, f := range froms {
+			if f.source == t.target && f.target == t.source && f.ref == t.edgeName {
+				matched = true
+
+				break
+			}
+		}
+
+		if matched {
+			out = append(out, result{
+				pass: true, id: "A4",
+				detail: fmt.Sprintf(
+					"%s:%d edge.To(%q, %s.Type) has reciprocal edge.From().Ref()",
+					relPath(t.path), t.line, t.edgeName, t.target),
+			})
+		} else {
+			out = append(out, result{
+				pass: false, id: "A4",
+				detail: fmt.Sprintf(
+					"%s:%d edge.To(%q, %s.Type) has no reciprocal edge.From(%s.Type).Ref(%q) on %s — "+
+						"Ent will fabricate a phantom FK column",
+					relPath(t.path), t.line, t.edgeName, t.target,
+					t.source, t.edgeName, t.target),
+			})
+		}
+	}
+
+	return out
+}
+
+// findInnerEdgeFromTarget walks the receiver chain of a SelectorExpr (the
+// "X" side of `.Ref(...)`) inward looking for an `edge.From(name, T.Type)`
+// call. Returns the type name "T" if found, or "" otherwise.
+func findInnerEdgeFromTarget(e ast.Expr) string {
+	for {
+		call, ok := e.(*ast.CallExpr)
+		if !ok {
+			return ""
+		}
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return ""
+		}
+
+		if id, ok := sel.X.(*ast.Ident); ok && id.Name == edgePkg && sel.Sel.Name == "From" {
+			if len(call.Args) >= 2 {
+				return typeRefName(call.Args[1])
+			}
+
+			return ""
+		}
+
+		e = sel.X
+	}
+}
+
+// ---------- helpers ----------
+
+func methodsByName(sf schemaFile, name string) []*ast.FuncDecl {
+	var out []*ast.FuncDecl
+
+	for _, d := range sf.file.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+
+		if fd.Name.Name == name {
+			out = append(out, fd)
+		}
+	}
+
+	return out
+}
+
+// edgePkg is the canonical Ent edge package import name.
+const edgePkg = "edge"
+
+// receiverTypeName returns the bare type name of a method's receiver
+// (e.g. "Child" for `func (Child) Edges() ...` or `func (c Child) Edges() ...`).
+func receiverTypeName(fd *ast.FuncDecl) string {
+	if fd.Recv == nil || len(fd.Recv.List) == 0 {
+		return ""
+	}
+
+	t := fd.Recv.List[0].Type
+	if star, ok := t.(*ast.StarExpr); ok {
+		t = star.X
+	}
+
+	if id, ok := t.(*ast.Ident); ok {
+		return id.Name
+	}
+
+	return ""
+}
+
+func stringLitValue(e ast.Expr) string {
+	bl, ok := e.(*ast.BasicLit)
+	if !ok {
+		return ""
+	}
+
+	if bl.Kind != token.STRING {
+		return ""
+	}
+	// Strip surrounding quotes.
+	if len(bl.Value) >= 2 {
+		return bl.Value[1 : len(bl.Value)-1]
+	}
+
+	return bl.Value
+}
+
+// typeRefName extracts the Go type name from an expression of the form
+// `TypeName.Type` (Ent's convention for referring to other schemas in edges).
+func typeRefName(e ast.Expr) string {
+	sel, ok := e.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+
+	if sel.Sel.Name != "Type" {
+		return ""
+	}
+
+	if x, ok := sel.X.(*ast.Ident); ok {
+		return x.Name
+	}
+
+	return ""
+}
+
+func relPath(p string) string {
+	if cwd, err := os.Getwd(); err == nil {
+		if rel, err := filepath.Rel(cwd, p); err == nil {
+			return rel
+		}
+	}
+
+	return p
+}

--- a/cmd/ent-lint/main_test.go
+++ b/cmd/ent-lint/main_test.go
@@ -1,0 +1,109 @@
+package main_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEntLint runs the ent-lint binary against fixture directories under
+// cmd/ent-lint/testdata/ and asserts the expected pass/fail outcome.
+//
+// Each fixture's name has the form "<invariant>_<good|bad>" — `_good`
+// fixtures must produce only [PASS] lines and exit 0; `_bad` fixtures
+// must produce at least one [FAIL] line for the named invariant and
+// exit non-zero.
+func TestEntLint(t *testing.T) {
+	t.Parallel()
+
+	binary := buildEntLint(t)
+
+	cases := []struct {
+		fixture    string
+		invariant  string
+		wantFail   bool
+		wantInLine string
+	}{
+		{fixture: "a1_good", invariant: "A1", wantFail: false},
+		{fixture: "a1_bad", invariant: "A1", wantFail: true, wantInLine: "entsql.Check"},
+		{fixture: "a2_good", invariant: "A2", wantFail: false},
+		{fixture: "a2_bad", invariant: "A2", wantFail: true, wantInLine: "OnDelete"},
+		{fixture: "a4_good", invariant: "A4", wantFail: false},
+		{fixture: "a4_bad", invariant: "A4", wantFail: true, wantInLine: "phantom FK"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.fixture, func(t *testing.T) {
+			t.Parallel()
+
+			dir := filepath.Join("testdata", tc.fixture)
+			out, err := exec.CommandContext(t.Context(), binary, "--schema-dir="+dir).CombinedOutput()
+			combined := string(out)
+
+			if tc.wantFail {
+				require.Errorf(t, err, "expected non-zero exit; output:\n%s", combined)
+			} else {
+				require.NoErrorf(t, err, "expected zero exit; output:\n%s", combined)
+			}
+
+			var (
+				sawFail bool
+				sawTok  bool
+			)
+
+			for _, line := range strings.Split(combined, "\n") {
+				if !strings.HasPrefix(line, "[PASS]") && !strings.HasPrefix(line, "[FAIL]") {
+					continue
+				}
+
+				if !strings.Contains(line, tc.invariant+" ") && !strings.HasSuffix(line, tc.invariant) {
+					continue
+				}
+
+				if strings.HasPrefix(line, "[FAIL]") {
+					sawFail = true
+				}
+
+				if tc.wantInLine != "" && strings.Contains(line, tc.wantInLine) {
+					sawTok = true
+				}
+			}
+
+			if tc.wantFail {
+				assert.True(t, sawFail, "expected at least one [FAIL] %s line; output:\n%s", tc.invariant, combined)
+
+				if tc.wantInLine != "" {
+					assert.True(t, sawTok, "expected a [FAIL] line containing %q; output:\n%s", tc.wantInLine, combined)
+				}
+			} else {
+				assert.False(t, sawFail, "expected no [FAIL] %s lines; output:\n%s", tc.invariant, combined)
+			}
+		})
+	}
+}
+
+// TestEntLintRealSchemas runs the ent-lint binary against ncps's actual
+// ent/schema/ tree. The project's schemas must be invariant-clean at all
+// times; this test pins that contract.
+func TestEntLintRealSchemas(t *testing.T) {
+	t.Parallel()
+	binary := buildEntLint(t)
+	out, err := exec.CommandContext(t.Context(), binary, "--root=../..").CombinedOutput()
+	require.NoErrorf(t, err, "ent-lint must pass on ncps's own schemas; output:\n%s", string(out))
+}
+
+func buildEntLint(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "ent-lint")
+	cmd := exec.CommandContext(t.Context(), "go", "build", "-o", binary, ".")
+	cmd.Dir = "."
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "go build ./cmd/ent-lint failed:\n%s", string(out))
+
+	return binary
+}

--- a/cmd/ent-lint/testdata/a1_bad/schema.go
+++ b/cmd/ent-lint/testdata/a1_bad/schema.go
@@ -1,0 +1,19 @@
+// A1 bad fixture: field-level entsql.Check is forbidden.
+package schema
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
+	"entgo.io/ent/schema/field"
+)
+
+type WithFieldCheck struct {
+	ent.Schema
+}
+
+func (WithFieldCheck) Fields() []ent.Field {
+	return []ent.Field{
+		field.Int64("counter").
+			Annotations(entsql.Check("counter >= 0")),
+	}
+}

--- a/cmd/ent-lint/testdata/a1_good/schema.go
+++ b/cmd/ent-lint/testdata/a1_good/schema.go
@@ -1,0 +1,29 @@
+// A1 good fixture: CHECKs declared on the table-level Annotations() are OK.
+package schema
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
+	"entgo.io/ent/schema"
+	"entgo.io/ent/schema/field"
+)
+
+type WithTableCheck struct {
+	ent.Schema
+}
+
+func (WithTableCheck) Annotations() []schema.Annotation {
+	return []schema.Annotation{
+		entsql.Annotation{
+			Checks: map[string]string{
+				"with_table_check_counter_nonneg": "counter >= 0",
+			},
+		},
+	}
+}
+
+func (WithTableCheck) Fields() []ent.Field {
+	return []ent.Field{
+		field.Int64("counter"),
+	}
+}

--- a/cmd/ent-lint/testdata/a2_bad/schema.go
+++ b/cmd/ent-lint/testdata/a2_bad/schema.go
@@ -1,0 +1,26 @@
+// A2 bad fixture: entsql.OnDelete on edge.From is forbidden.
+package schema
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
+	"entgo.io/ent/schema/edge"
+)
+
+type Parent struct {
+	ent.Schema
+}
+
+type Child struct {
+	ent.Schema
+}
+
+func (Child) Edges() []ent.Edge {
+	return []ent.Edge{
+		edge.From("parent", Parent.Type).
+			Ref("children").
+			Unique().
+			Required().
+			Annotations(entsql.OnDelete(entsql.Cascade)),
+	}
+}

--- a/cmd/ent-lint/testdata/a2_good/schema.go
+++ b/cmd/ent-lint/testdata/a2_good/schema.go
@@ -1,0 +1,32 @@
+// A2 good fixture: OnDelete lives on edge.To, not edge.From.
+package schema
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
+	"entgo.io/ent/schema/edge"
+)
+
+type Parent struct {
+	ent.Schema
+}
+
+type Child struct {
+	ent.Schema
+}
+
+func (Parent) Edges() []ent.Edge {
+	return []ent.Edge{
+		edge.To("children", Child.Type).
+			Annotations(entsql.OnDelete(entsql.Cascade)),
+	}
+}
+
+func (Child) Edges() []ent.Edge {
+	return []ent.Edge{
+		edge.From("parent", Parent.Type).
+			Ref("children").
+			Unique().
+			Required(),
+	}
+}

--- a/cmd/ent-lint/testdata/a4_bad/schema.go
+++ b/cmd/ent-lint/testdata/a4_bad/schema.go
@@ -1,0 +1,24 @@
+// A4 bad fixture: edge.To with no reciprocal edge.From on the target.
+package schema
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/schema/edge"
+)
+
+type Source struct {
+	ent.Schema
+}
+
+type Target struct {
+	ent.Schema
+}
+
+func (Source) Edges() []ent.Edge {
+	return []ent.Edge{
+		edge.To("orphans", Target.Type),
+	}
+}
+
+// Target intentionally has no Edges() method — the edge.From back-reference
+// is missing, so Ent will fabricate a phantom FK column on Target.

--- a/cmd/ent-lint/testdata/a4_good/schema.go
+++ b/cmd/ent-lint/testdata/a4_good/schema.go
@@ -1,0 +1,30 @@
+// A4 good fixture: edge.To has a reciprocal edge.From().Ref() on the target.
+package schema
+
+import (
+	"entgo.io/ent"
+	"entgo.io/ent/schema/edge"
+)
+
+type Source struct {
+	ent.Schema
+}
+
+type Target struct {
+	ent.Schema
+}
+
+func (Source) Edges() []ent.Edge {
+	return []ent.Edge{
+		edge.To("targets", Target.Type),
+	}
+}
+
+func (Target) Edges() []ent.Edge {
+	return []ent.Edge{
+		edge.From("source", Source.Type).
+			Ref("targets").
+			Unique().
+			Required(),
+	}
+}

--- a/openspec/changes/migrate-to-ent-and-atlas/tasks.md
+++ b/openspec/changes/migrate-to-ent-and-atlas/tasks.md
@@ -37,19 +37,19 @@
 
 ## 5. `cmd/ent-lint` (TDD: fixtures first)
 
-- [ ] 5.1 Create `cmd/ent-lint/testdata/` with positive and negative fixture directories for each of A1–A5
-- [ ] 5.2 Write `cmd/ent-lint/main_test.go` asserting one `[FAIL]` line per negative fixture and all `[PASS]` lines for the positive fixtures
-- [ ] 5.3 Implement A1: AST walk for field-level `entsql.Check(...)` annotations
-- [ ] 5.4 Implement A2: AST walk for `OnDelete` annotations on `edge.From()` chains
+- [x] 5.1 Create `cmd/ent-lint/testdata/` with positive and negative fixture directories for each of A1, A2, A4 (A3, A5, snake-case-enum, expand-contract, CHECK-presence fixtures tracked separately — see 5.5/5.7/5.8/5.9/5.10 below)
+- [x] 5.2 Write `cmd/ent-lint/main_test.go` asserting one `[FAIL]` line per negative fixture and all `[PASS]` lines for the positive fixtures (covers A1, A2, A4 today)
+- [x] 5.3 Implement A1: AST walk for field-level `entsql.Check(...)` annotations
+- [x] 5.4 Implement A2: AST walk for `OnDelete` annotations on `edge.From()` chains
 - [ ] 5.5 Implement A3: cross-file AST walk for `field.X().Unique()` columns that are also bound by `edge.From().Field(...)` elsewhere
-- [ ] 5.6 Implement A4: cross-file AST walk for `edge.To` declarations without a reciprocal `edge.From().Ref()` on the target schema
+- [x] 5.6 Implement A4: cross-file AST walk for `edge.To` declarations without a reciprocal `edge.From().Ref()` on the target schema
 - [ ] 5.7 Implement A5: AST walk for `field.Bytes("*_ciphertext")` declarations without a chained `.Sensitive()`
 - [ ] 5.8 Implement the snake_case enum-type check (A `field.Enum(...)` without `entsql.Annotation{Type: "<table>_<column>_enum"}`)
 - [ ] 5.9 Implement the expand-contract check on the newest file in each `migrations/<dialect>/` directory
 - [ ] 5.10 Implement the CHECK presence cross-validation against generated `.sql` baselines for every dialect
-- [ ] 5.11 Implement checklist-formatted output (`[PASS]` / `[FAIL]` + invariant id + message); exit non-zero on any `[FAIL]`
-- [ ] 5.12 Run `go test ./cmd/ent-lint` and confirm all fixtures pass
-- [ ] 5.13 Run `cmd/ent-lint --root .` against the current `ent/schema/` tree and confirm it exits zero
+- [x] 5.11 Implement checklist-formatted output (`[PASS]` / `[FAIL]` + invariant id + message); exit non-zero on any `[FAIL]`
+- [x] 5.12 Run `go test ./cmd/ent-lint` and confirm all fixtures pass
+- [x] 5.13 Run `cmd/ent-lint --root .` against the current `ent/schema/` tree and confirm it exits zero
 
 ## 6. `cmd/generate-migrations` (TDD)
 


### PR DESCRIPTION
Adds cmd/ent-lint, a Go AST linter that catches three of Ent codegens
silently-dropped patterns:

- A1: field-level entsql.Check(...) annotations are dropped — CHECKs
  MUST live on the schemas table-level Annotations() method.
- A2: entsql.OnDelete(...) on edge.From(...) is dropped — OnDelete
  MUST live on edge.To(...).
- A4: every edge.To(name, T.Type) needs a reciprocal
  edge.From(...).Ref(name) on the target schema, otherwise Ent
  fabricates a phantom FK column on the target.

Implementation walks ent/schema/*.go via go/parser and go/ast,
attributing each Edges() / Fields() method to its declaring schema by
receiver type so multi-schema files are handled correctly.

Output is checklist-formatted ([PASS] / [FAIL] + invariant id +
file:line + detail); binary exits non-zero on any [FAIL].

Tests:
- cmd/ent-lint/main_test.go::TestEntLint exercises 6 fixtures
  (good/bad pair per invariant) under cmd/ent-lint/testdata/.
- TestEntLintRealSchemas pins ncpss own ent/schema/ tree as
  invariant-clean.

Tracked but not yet implemented (see tasks.md §5.5/5.7-5.10):
A3 (Unique on edge-bound FK), A5 (_ciphertext .Sensitive()),
snake_case enum-type, expand-contract migration ban, CHECK presence
cross-validation against generated SQL. These remain as follow-up
commits on the stack.

Completes tasks 5.1-5.4, 5.6, 5.11-5.13 of the migrate-to-ent-and-atlas
change.