### PR TITLE
feat: automate stack merges via merge-stack label

### DIFF
--- a/.github/workflows/merge-stack-continue.yml
+++ b/.github/workflows/merge-stack-continue.yml
@@ -1,0 +1,23 @@
+name: Merge Stack — Continue
+on:
+  pull_request:
+    types: [closed]
+permissions:
+  contents: write
+  pull-requests: write
+concurrency:
+  group: merge-stack-continue-${{ github.repository }}
+  cancel-in-progress: false
+defaults:
+  run:
+    shell: bash
+jobs:
+  continue:
+    if: >-
+      github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'merge-stack') && github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: kalbasit/stackmerge-action/continue@main
+        with:
+          token: ${{ secrets.GHA_PAT_TOKEN }}

--- a/.github/workflows/merge-stack-start.yml
+++ b/.github/workflows/merge-stack-start.yml
@@ -1,0 +1,26 @@
+name: Merge Stack — Start
+on:
+  pull_request:
+    types: [labeled]
+permissions:
+  contents: read
+  pull-requests: write
+concurrency:
+  group: merge-stack-start-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+defaults:
+  run:
+    shell: bash
+jobs:
+  start:
+    # Only act on human-applied `merge-stack` labels on non-fork PRs.
+    # The sender check prevents this from re-firing recursively when
+    # the action labels the next PR down the chain itself.
+    if: >-
+      github.event.label.name == 'merge-stack' && github.event.sender.type == 'User' && github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: kalbasit/stackmerge-action/start@main
+        with:
+          token: ${{ secrets.GHA_PAT_TOKEN }}


### PR DESCRIPTION
Two thin caller workflows delegate to kalbasit/stackmerge-action:

- merge-stack-start.yml fires on `pull_request: labeled` and
  propagates the `merge-stack` label down the base chain, then
  enables GitHub's squash-auto-merge on the bottom PR.
- merge-stack-continue.yml fires on `pull_request: closed` for
  merged labeled PRs. The action rebases the remaining labeled
  chain onto main with `git rebase --onto`, force-pushes with
  `--force-with-lease`, and enables auto-merge on the new bottom.
  It also rebases (but does not merge) any unlabeled PRs above
  the labeled chain so the rest of the stack stays current.

`GHA_PAT_TOKEN` is mapped to the action's `token` input on the
caller side — the existing secret name doesn't have to change.