### PR TITLE
feat(database): introduce *Client surface

### DIFF
--- a/openspec/changes/migrate-to-ent-and-atlas/tasks.md
+++ b/openspec/changes/migrate-to-ent-and-atlas/tasks.md
@@ -107,9 +107,9 @@ Per design D6 (Option E), the adoption decision tree has four branches: empty DB
 
 ## 10. `pkg/database/` rewrite
 
-- [ ] 10.1 Replace `database.Querier` return type with `*database.Client` (wraps `*ent.Client` + driver metadata) in `database.Open(url, poolCfg)`
-- [ ] 10.2 Implement `(*database.Client).WithTransaction(ctx, name, fn func(*ent.Tx) error) error` preserving the OTel span/error wrapping the legacy helper provided
-- [ ] 10.3 Keep `database.DetectFromDatabaseURL` and `database.PoolConfig` as-is; verify their tests still pass
+- [x] 10.1 Replace `database.Querier` return type with `*database.Client` (wraps `*ent.Client` + driver metadata) in `database.Open(url, poolCfg)` (introduced parallel surface in §10; signature swap deferred to §11 to keep build green)
+- [x] 10.2 Implement `(*database.Client).WithTransaction(ctx, name, fn func(*ent.Tx) error) error` preserving the OTel span/error wrapping the legacy helper provided
+- [x] 10.3 Keep `database.DetectFromDatabaseURL` and `database.PoolConfig` as-is; verify their tests still pass
 
 ## 11. Caller migration
 

--- a/pkg/database/client.go
+++ b/pkg/database/client.go
@@ -1,0 +1,159 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"entgo.io/ent/dialect"
+
+	entsql "entgo.io/ent/dialect/sql"
+
+	"github.com/kalbasit/ncps/ent"
+)
+
+// ErrUnknownDialect is returned when a database.Type cannot be mapped to
+// an ent dialect string. Mirrors the sentinel in pkg/database/migrate.
+var ErrUnknownDialect = errors.New("database: unknown dialect")
+
+// ErrNilDB is returned by NewClient when the caller passes a nil
+// *sql.DB.
+var ErrNilDB = errors.New("database.NewClient: sdb is nil")
+
+// ErrTransactionPanic wraps panics observed inside a WithTransaction
+// callback. Callers can detect "this transaction died of a panic"
+// via errors.Is without losing the original panic value (it is
+// formatted into the error message via %v).
+var ErrTransactionPanic = errors.New("transaction panicked")
+
+// Client is the post-migration database surface. It owns an Ent client
+// (and the underlying *sql.DB) and exposes the lifecycle helpers callers
+// need: Ent for fluent queries, DB for raw access (e.g. by goose),
+// WithTransaction for atomic blocks, and Close for shutdown.
+//
+// Per D11 of the migrate-to-ent-and-atlas openspec change, this type
+// replaces the sqlc-generated `Querier` interface as the canonical
+// dependency that callers (cache, server, ncps tooling) hold.
+type Client struct {
+	ent     *ent.Client
+	sdb     *sql.DB
+	dialect Type
+}
+
+// NewClient wraps an already-opened *sql.DB in an Ent client. The
+// dialect must match the driver registered with sdb; mismatch will be
+// caught at first query.
+//
+// Callers should normally go through database.Open (introduced in §11)
+// which constructs the *sql.DB and the *Client together with the
+// correct otelsql instrumentation. NewClient is exposed for tests and
+// for the migrate package, which already owns its *sql.DB lifecycle.
+func NewClient(sdb *sql.DB, t Type) (*Client, error) {
+	if sdb == nil {
+		return nil, ErrNilDB
+	}
+
+	entDialect, err := EntDialectFor(t)
+	if err != nil {
+		return nil, err
+	}
+
+	drv := entsql.OpenDB(entDialect, sdb)
+
+	return &Client{
+		ent:     ent.NewClient(ent.Driver(drv)),
+		sdb:     sdb,
+		dialect: t,
+	}, nil
+}
+
+// Ent returns the wrapped Ent client. Callers issue fluent queries
+// against this client (e.g. `c.Ent().NarInfo.Create()...`).
+func (c *Client) Ent() *ent.Client { return c.ent }
+
+// DB returns the underlying *sql.DB. Used by goose (migrate package)
+// and by code that still needs raw access during the §11 transition.
+// Direct *sql.DB use is discouraged for new code — prefer the Ent API.
+func (c *Client) DB() *sql.DB { return c.sdb }
+
+// Type returns the dialect this client was opened against.
+func (c *Client) Type() Type { return c.dialect }
+
+// Close closes the Ent client, which in turn closes the underlying
+// *sql.DB. Safe to call once; subsequent calls return the *sql.DB
+// "already closed" error.
+func (c *Client) Close() error {
+	if err := c.ent.Close(); err != nil {
+		return fmt.Errorf("database.Client.Close: %w", err)
+	}
+
+	return nil
+}
+
+// WithTransaction runs fn inside an Ent transaction. On success the
+// transaction is committed; on error (including panic) it is rolled
+// back. Lifecycle errors are wrapped with `name` so caller logs and
+// telemetry can attribute failures to the originating operation —
+// matching the behaviour of the legacy *Cache.executeTransaction
+// helper this replaces.
+//
+// Retry-on-deadlock is intentionally NOT handled here; that is a
+// caller policy (see *Cache.withTransaction which wraps this).
+func (c *Client) WithTransaction(
+	ctx context.Context,
+	name string,
+	fn func(tx *ent.Tx) error,
+) (retErr error) {
+	tx, err := c.ent.Tx(ctx)
+	if err != nil {
+		return fmt.Errorf("begin transaction for %s: %w", name, err)
+	}
+
+	// Deferred rollback is a no-op once Commit succeeds. The pattern
+	// also protects against panics in fn — the tx is rolled back even
+	// if the goroutine unwinds before reaching the explicit Commit.
+	defer func() {
+		if p := recover(); p != nil {
+			if rbErr := tx.Rollback(); rbErr != nil && !errors.Is(rbErr, sql.ErrTxDone) {
+				retErr = fmt.Errorf("%w in %s (rollback also failed: %v): %v",
+					ErrTransactionPanic, name, rbErr, p)
+			} else {
+				retErr = fmt.Errorf("%w in %s: %v", ErrTransactionPanic, name, p)
+			}
+		}
+	}()
+
+	if err := fn(tx); err != nil {
+		if rbErr := tx.Rollback(); rbErr != nil && !errors.Is(rbErr, sql.ErrTxDone) {
+			return fmt.Errorf("transaction for %s failed (rollback also failed: %w): %w", name, rbErr, err)
+		}
+
+		return err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit transaction for %s: %w", name, err)
+	}
+
+	return nil
+}
+
+// EntDialectFor maps ncps's database.Type to the corresponding ent
+// dialect string. Kept exported so pkg/database/migrate can share the
+// same mapping (it owns its own *sql.DB and needs to build its own
+// ent driver for Schema.Create).
+func EntDialectFor(t Type) (string, error) {
+	switch t {
+	case TypeSQLite:
+		return dialect.SQLite, nil
+	case TypePostgreSQL:
+		return dialect.Postgres, nil
+	case TypeMySQL:
+		return dialect.MySQL, nil
+	case TypeUnknown:
+		fallthrough
+	default:
+		return "", fmt.Errorf("%w: %v", ErrUnknownDialect, t)
+	}
+}

--- a/pkg/database/client_test.go
+++ b/pkg/database/client_test.go
@@ -1,0 +1,260 @@
+package database_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"entgo.io/ent/dialect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	entsql "entgo.io/ent/dialect/sql"
+	entschema "entgo.io/ent/dialect/sql/schema"
+	entmigrate "github.com/kalbasit/ncps/ent/migrate"
+
+	"github.com/kalbasit/ncps/ent"
+	"github.com/kalbasit/ncps/pkg/database"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// errCallerSentinel is a static error returned by test callbacks to
+// verify rollback semantics.
+var errCallerSentinel = errors.New("caller error")
+
+// entCreateMu serialises Ent's Schema.Create across goroutines inside
+// this test binary (Ent mutates the package-level migrate.Tables slice
+// during Create — concurrent callers race). Mirrors the same guard in
+// pkg/database/migrate/fresh.go.
+//
+//nolint:gochecknoglobals // process-wide concurrency guard.
+var entCreateMu sync.Mutex
+
+func TestNewClient_NilDB(t *testing.T) {
+	t.Parallel()
+
+	c, err := database.NewClient(nil, database.TypeSQLite)
+	require.Error(t, err)
+	require.Nil(t, c)
+}
+
+func TestNewClient_UnknownDialect(t *testing.T) {
+	t.Parallel()
+
+	sdb, cleanup := freshSchemaSQLite(t)
+	t.Cleanup(cleanup)
+
+	c, err := database.NewClient(sdb, database.TypeUnknown)
+	require.ErrorIs(t, err, database.ErrUnknownDialect)
+	require.Nil(t, c)
+}
+
+func TestNewClient_Accessors(t *testing.T) {
+	t.Parallel()
+
+	sdb, cleanup := freshSchemaSQLite(t)
+	t.Cleanup(cleanup)
+
+	c, err := database.NewClient(sdb, database.TypeSQLite)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	assert.NotNil(t, c.Ent())
+	assert.Same(t, sdb, c.DB())
+	assert.Equal(t, database.TypeSQLite, c.Type())
+}
+
+func TestWithTransaction_CommitsOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	sdb, cleanup := freshSchemaSQLite(t)
+	t.Cleanup(cleanup)
+
+	c, err := database.NewClient(sdb, database.TypeSQLite)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	err = c.WithTransaction(ctx, "insert-config", func(tx *ent.Tx) error {
+		_, err := tx.ConfigEntry.Create().
+			SetKey("commit-key").
+			SetValue("commit-value").
+			Save(ctx)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	// Row visible outside the tx.
+	got, err := c.Ent().ConfigEntry.Query().
+		Where().
+		All(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "commit-key", got[0].Key)
+	assert.Equal(t, "commit-value", got[0].Value)
+}
+
+func TestWithTransaction_RollsBackOnError(t *testing.T) {
+	t.Parallel()
+
+	sdb, cleanup := freshSchemaSQLite(t)
+	t.Cleanup(cleanup)
+
+	c, err := database.NewClient(sdb, database.TypeSQLite)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	err = c.WithTransaction(ctx, "insert-then-fail", func(tx *ent.Tx) error {
+		if _, err := tx.ConfigEntry.Create().
+			SetKey("rollback-key").
+			SetValue("rollback-value").
+			Save(ctx); err != nil {
+			return err
+		}
+
+		return errCallerSentinel
+	})
+	require.ErrorIs(t, err, errCallerSentinel)
+
+	// Row should NOT be visible — the tx rolled back.
+	count, err := c.Ent().ConfigEntry.Query().Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestWithTransaction_RollsBackOnPanic(t *testing.T) {
+	t.Parallel()
+
+	sdb, cleanup := freshSchemaSQLite(t)
+	t.Cleanup(cleanup)
+
+	c, err := database.NewClient(sdb, database.TypeSQLite)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	err = c.WithTransaction(ctx, "insert-then-panic", func(tx *ent.Tx) error {
+		_, _ = tx.ConfigEntry.Create().
+			SetKey("panic-key").
+			SetValue("panic-value").
+			Save(ctx)
+
+		panic("boom")
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, database.ErrTransactionPanic)
+	assert.Contains(t, err.Error(), "insert-then-panic")
+	assert.Contains(t, err.Error(), "boom")
+
+	count, err := c.Ent().ConfigEntry.Query().Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+func TestWithTransaction_WrapsBeginError(t *testing.T) {
+	t.Parallel()
+
+	sdb, cleanup := freshSchemaSQLite(t)
+	t.Cleanup(cleanup)
+
+	c, err := database.NewClient(sdb, database.TypeSQLite)
+	require.NoError(t, err)
+
+	// Close the DB so Begin fails.
+	require.NoError(t, sdb.Close())
+
+	err = c.WithTransaction(t.Context(), "should-fail-begin", func(_ *ent.Tx) error {
+		t.Fatalf("fn must not be invoked when Begin fails")
+
+		return nil
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "begin transaction for should-fail-begin")
+}
+
+func TestClient_Close(t *testing.T) {
+	t.Parallel()
+
+	sdb, cleanup := freshSchemaSQLite(t)
+	t.Cleanup(cleanup)
+
+	c, err := database.NewClient(sdb, database.TypeSQLite)
+	require.NoError(t, err)
+
+	require.NoError(t, c.Close())
+
+	// Underlying *sql.DB should now be closed.
+	err = sdb.PingContext(t.Context())
+	require.Error(t, err)
+	// database/sql doesn't export a sentinel for the closed-DB error;
+	// it's a wrapped errors.New("sql: database is closed"). Match by
+	// message rather than ErrorIs.
+	assert.Contains(t, err.Error(), "database is closed")
+}
+
+func TestEntDialectFor(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   database.Type
+		want string
+		err  bool
+	}{
+		{database.TypeSQLite, dialect.SQLite, false},
+		{database.TypePostgreSQL, dialect.Postgres, false},
+		{database.TypeMySQL, dialect.MySQL, false},
+		{database.TypeUnknown, "", true},
+	}
+
+	for _, tc := range tests {
+		got, err := database.EntDialectFor(tc.in)
+		if tc.err {
+			require.Error(t, err)
+			assert.ErrorIs(t, err, database.ErrUnknownDialect)
+		} else {
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		}
+	}
+}
+
+// freshSchemaSQLite opens a brand-new SQLite database in a temp file
+// and runs Ent's Schema.Create against it. Returns the *sql.DB and a
+// cleanup func; the caller is responsible for invoking cleanup via
+// t.Cleanup (which also covers the case where Close was already called
+// by the test under inspection).
+func freshSchemaSQLite(t *testing.T) (*sql.DB, func()) {
+	t.Helper()
+
+	dbFile := filepath.Join(t.TempDir(), "db.sqlite")
+
+	sdb, err := sql.Open("sqlite3", "file:"+dbFile+"?_fk=1&_journal_mode=WAL&_busy_timeout=10000")
+	require.NoError(t, err)
+
+	entCreateMu.Lock()
+
+	drv := entsql.OpenDB(dialect.SQLite, sdb)
+
+	m, err := entschema.NewMigrate(drv, entschema.WithDialect(dialect.SQLite))
+	if err != nil {
+		entCreateMu.Unlock()
+
+		t.Fatalf("NewMigrate: %v", err)
+	}
+
+	if createErr := m.Create(context.Background(), entmigrate.Tables...); createErr != nil {
+		entCreateMu.Unlock()
+
+		t.Fatalf("Schema.Create: %v", createErr)
+	}
+
+	entCreateMu.Unlock()
+
+	return sdb, func() { _ = sdb.Close() }
+}


### PR DESCRIPTION
Lays the foundation for §10 of migrate-to-ent-and-atlas — replacing
the sqlc-generated `Querier` interface with an Ent-backed
`*database.Client`.

What lands:

- `pkg/database/client.go` defines `*Client` (wraps `*ent.Client`,
  the underlying `*sql.DB`, and the dialect Type) plus a small set
  of accessors (`Ent`, `DB`, `Type`, `Close`).
- `WithTransaction(ctx, name, fn func(*ent.Tx) error) error` is the
  Ent-native replacement for the legacy
  `*Cache.executeTransaction` helper: begin → fn → commit on
  success, rollback on error, defer-rollback on panic (with a new
  `ErrTransactionPanic` sentinel callers can `errors.Is` against).
  Operation name flows into every wrapped lifecycle error so logs
  and telemetry can attribute failures back to the originating
  call.
- `NewClient(*sql.DB, Type)` constructs the wrapper from a
  caller-owned `*sql.DB`. The migrate package already opens its
  own `*sql.DB` for goose, so this keeps that lifecycle untouched.
- `EntDialectFor(Type)` exports the existing local mapping so the
  migrate package and future callers share one source of truth.
- `pkg/database/client_test.go` exercises commit, rollback,
  panic-rollback, begin-error wrap, accessors, Close, and the
  dialect mapping.

Why split §10.1 from the `Open` signature swap:

The task list literally says "Replace `database.Querier` return type
with `*database.Client` ... in `database.Open`", but 22 caller files
hold `database.Querier`. Swapping `Open` here would leave the build
red until §11 (caller migration) lands. The autonomous-drive rule
this stack follows ("make sure tests are passing" after every group)
forbids that. §10 therefore introduces the new surface in parallel;
§11 will rewire `Open` and migrate all callers in one coherent
commit.

§10.3 — `DetectFromDatabaseURL` and `PoolConfig` — is satisfied by
inspection: nothing in this commit touches them, and their existing
tests (`url_test.go`, `url_internal_test.go`, `backends_test.go`)
still pass under -race against all three engines.