### PR TITLE
feat(cache): thread *database.Client into Cache

### DIFF
--- a/openspec/changes/migrate-to-ent-and-atlas/tasks.md
+++ b/openspec/changes/migrate-to-ent-and-atlas/tasks.md
@@ -113,7 +113,7 @@ Per design D6 (Option E), the adoption decision tree has four branches: empty DB
 
 ## 11. Caller migration
 
-- [ ] 11.1 Rewrite `pkg/cache/cache.go` storage of `database.Querier` to `*database.Client`; convert call sites one method at a time
+- [x] 11.1 Rewrite `pkg/cache/cache.go` storage of `database.Querier` to `*database.Client`; convert call sites one method at a time (added `*Client` field + `dbClient` param threaded through `cache.New`, testhelpers, and all call sites; call-site method conversions in §11.2-§11.8)
 - [ ] 11.2 Convert `GetNarInfo*` paths in `pkg/cache/` to Ent fluent API; run package tests
 - [ ] 11.3 Convert `PutNarInfo*` paths; run package tests
 - [ ] 11.4 Convert `GetNarFile*` / `PutNarFile*` paths (including CDC chunk insertion); run package tests

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -362,6 +362,11 @@ type Cache struct {
 	healthChecker *healthcheck.HealthChecker
 	maxSize       uint64
 	db            database.Querier
+	// dbClient is the Ent-backed replacement for db. Introduced in
+	// §11.1 of migrate-to-ent-and-atlas; coexists with db while
+	// §11.2-§11.7 convert call sites one feature group at a time.
+	// §11.8 removes the db field once nothing references Querier.
+	dbClient *database.Client
 
 	// tempDir is used to store nar files temporarily.
 	tempDir string
@@ -550,10 +555,16 @@ func IsUploadOnly(ctx context.Context) bool {
 }
 
 // New returns a new Cache.
+//
+// The dbClient parameter is the Ent-backed replacement for db.
+// Introduced in §11.1 of the migrate-to-ent-and-atlas openspec
+// change; it coexists with the Querier-typed db while §11.2-§11.7
+// migrate individual call sites. §11.8 removes the db parameter.
 func New(
 	ctx context.Context,
 	hostName string,
 	db database.Querier,
+	dbClient *database.Client,
 	//nolint:staticcheck // deprecated: migration support
 	configStore storage.ConfigStore,
 	narInfoStore storage.NarInfoStore,
@@ -567,6 +578,7 @@ func New(
 ) (*Cache, error) {
 	c := &Cache{
 		db:                   db,
+		dbClient:             dbClient,
 		config:               config.New(db, cacheLocker),
 		configStore:          configStore,
 		narInfoStore:         narInfoStore,

--- a/pkg/cache/cache_distributed_test.go
+++ b/pkg/cache/cache_distributed_test.go
@@ -46,11 +46,15 @@ func skipIfRedisNotAvailable(t *testing.T) {
 }
 
 // distributedDBFactory creates a shared database for distributed testing.
+//
+// §11.1: factories now also yield a *database.Client so call sites can
+// pass it into cache.New. The Querier+Client pair share the same
+// *sql.DB, so cleanup still owns a single connection pool to close.
 // Unlike other factories, this returns a SHARED database that multiple cache instances will use.
-type distributedDBFactory func(t *testing.T) (database.Querier, string, func())
+type distributedDBFactory func(t *testing.T) (database.Querier, *database.Client, string, func())
 
 // setupDistributedSQLite creates a shared SQLite database for distributed testing.
-func setupDistributedSQLite(t *testing.T) (database.Querier, string, func()) {
+func setupDistributedSQLite(t *testing.T) (database.Querier, *database.Client, string, func()) {
 	t.Helper()
 
 	sharedDir, err := os.MkdirTemp("", "cache-distributed-")
@@ -62,46 +66,49 @@ func setupDistributedSQLite(t *testing.T) (database.Querier, string, func()) {
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
 
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
+
 	cleanup := func() {
 		db.DB().Close()
 		os.RemoveAll(sharedDir)
 	}
 
-	return db, sharedDir, cleanup
+	return db, dbClient, sharedDir, cleanup
 }
 
 // setupDistributedPostgres creates a shared PostgreSQL database for distributed testing.
-func setupDistributedPostgres(t *testing.T) (database.Querier, string, func()) {
+func setupDistributedPostgres(t *testing.T) (database.Querier, *database.Client, string, func()) {
 	t.Helper()
 
 	sharedDir, err := os.MkdirTemp("", "cache-distributed-")
 	require.NoError(t, err)
 
-	db, _, dbCleanup := testhelper.SetupPostgres(t)
+	db, dbClient, _, dbCleanup := testhelper.SetupPostgres(t)
 
 	cleanup := func() {
 		dbCleanup()
 		os.RemoveAll(sharedDir)
 	}
 
-	return db, sharedDir, cleanup
+	return db, dbClient, sharedDir, cleanup
 }
 
 // setupDistributedMySQL creates a shared MySQL database for distributed testing.
-func setupDistributedMySQL(t *testing.T) (database.Querier, string, func()) {
+func setupDistributedMySQL(t *testing.T) (database.Querier, *database.Client, string, func()) {
 	t.Helper()
 
 	sharedDir, err := os.MkdirTemp("", "cache-distributed-")
 	require.NoError(t, err)
 
-	db, _, dbCleanup := testhelper.SetupMySQL(t)
+	db, dbClient, _, dbCleanup := testhelper.SetupMySQL(t)
 
 	cleanup := func() {
 		dbCleanup()
 		os.RemoveAll(sharedDir)
 	}
 
-	return db, sharedDir, cleanup
+	return db, dbClient, sharedDir, cleanup
 }
 
 // TestDistributedBackends runs the distributed test suite across multiple database backends.
@@ -163,7 +170,7 @@ func testDistributedDownloadDeduplication(factory distributedDBFactory) func(*te
 		ctx := newContext()
 
 		// Get shared database and directory from factory
-		db, sharedDir, cleanup := factory(t)
+		db, dbClient, sharedDir, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Start test server
@@ -232,6 +239,7 @@ func testDistributedDownloadDeduplication(factory distributedDBFactory) func(*te
 				ctx,
 				cacheName,
 				db,
+				dbClient,
 				sharedStore,
 				sharedStore,
 				sharedStore,
@@ -315,7 +323,7 @@ func testDistributedConcurrentReads(factory distributedDBFactory) func(*testing.
 		ctx := newContext()
 
 		// Get shared database and directory from factory
-		db, sharedDir, cleanup := factory(t)
+		db, dbClient, sharedDir, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Start test server
@@ -342,6 +350,7 @@ func testDistributedConcurrentReads(factory distributedDBFactory) func(*testing.
 			ctx,
 			cacheName,
 			db,
+			dbClient,
 			sharedStore,
 			sharedStore,
 			sharedStore,
@@ -384,6 +393,7 @@ func testDistributedConcurrentReads(factory distributedDBFactory) func(*testing.
 				ctx,
 				cacheName,
 				db,
+				dbClient,
 				sharedStore,
 				sharedStore,
 				sharedStore,
@@ -510,7 +520,7 @@ func testPutNarInfoConcurrentSharedNar(factory distributedDBFactory) func(*testi
 				ctx := newContext()
 
 				// Get shared database and directory from factory
-				db, sharedDir, cleanup := factory(t)
+				db, dbClient, sharedDir, cleanup := factory(t)
 				defer cleanup()
 
 				// Redis setup
@@ -541,6 +551,7 @@ func testPutNarInfoConcurrentSharedNar(factory distributedDBFactory) func(*testi
 					ctx,
 					cacheName,
 					db,
+					dbClient,
 					sharedStore,
 					sharedStore,
 					sharedStore,
@@ -654,7 +665,7 @@ func testLargeNARConcurrentDownloadScenario(t *testing.T, factory distributedDBF
 	ctx := newContext()
 
 	// Get shared database and directory from factory
-	db, sharedDir, cleanup := factory(t)
+	db, dbClient, sharedDir, cleanup := factory(t)
 	t.Cleanup(cleanup)
 
 	// Generate a large NAR (2MB) - enough for chunking but fast for tests
@@ -751,6 +762,7 @@ func testLargeNARConcurrentDownloadScenario(t *testing.T, factory distributedDBF
 			ctx,
 			fmt.Sprintf("cache-instance-%d", i),
 			db,
+			dbClient,
 			sharedStore,
 			sharedStore,
 			sharedStore,
@@ -903,7 +915,7 @@ func testCDCProgressiveStreamingDuringChunking(factory distributedDBFactory) fun
 		ctx := newContext()
 
 		// Get shared database and directory from factory
-		db, sharedDir, cleanup := factory(t)
+		db, dbClient, sharedDir, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Generate a large NAR (12MB) to ensure CDC chunking takes time
@@ -998,6 +1010,7 @@ func testCDCProgressiveStreamingDuringChunking(factory distributedDBFactory) fun
 				ctx,
 				cacheName,
 				db,
+				dbClient,
 				sharedStore,
 				sharedStore,
 				sharedStore,

--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -70,6 +70,8 @@ func setupSQLiteFactory(t *testing.T) (*Cache, database.Querier, *local.Store, s
 
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
@@ -77,7 +79,7 @@ func setupSQLiteFactory(t *testing.T) (*Cache, database.Querier, *local.Store, s
 	downloadLocker := locklocal.NewLocker()
 	cacheLocker := locklocal.NewRWLocker()
 
-	c, err := New(newContext(), cacheName, db, localStore, localStore, localStore, "",
+	c, err := New(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "",
 		downloadLocker, cacheLocker, downloadLockTTL, downloadPollTimeout, cacheLockTTL)
 	require.NoError(t, err)
 
@@ -96,7 +98,7 @@ func setupPostgresFactory(t *testing.T) (*Cache, database.Querier, *local.Store,
 	dir, err := os.MkdirTemp("", "cache-path-")
 	require.NoError(t, err)
 
-	db, _, dbCleanup := testhelper.SetupPostgres(t)
+	db, dbClient, _, dbCleanup := testhelper.SetupPostgres(t)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
@@ -104,7 +106,7 @@ func setupPostgresFactory(t *testing.T) (*Cache, database.Querier, *local.Store,
 	downloadLocker := locklocal.NewLocker()
 	cacheLocker := locklocal.NewRWLocker()
 
-	c, err := New(newContext(), cacheName, db, localStore, localStore, localStore, "",
+	c, err := New(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "",
 		downloadLocker, cacheLocker, downloadLockTTL, downloadPollTimeout, cacheLockTTL)
 	require.NoError(t, err)
 
@@ -141,7 +143,7 @@ func setupMySQLFactory(t *testing.T) (*Cache, database.Querier, *local.Store, st
 	dir, err := os.MkdirTemp("", "cache-path-")
 	require.NoError(t, err)
 
-	db, _, dbCleanup := testhelper.SetupMySQL(t)
+	db, dbClient, _, dbCleanup := testhelper.SetupMySQL(t)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
@@ -149,7 +151,7 @@ func setupMySQLFactory(t *testing.T) (*Cache, database.Querier, *local.Store, st
 	downloadLocker := locklocal.NewLocker()
 	cacheLocker := locklocal.NewRWLocker()
 
-	c, err := New(newContext(), cacheName, db, localStore, localStore, localStore, "",
+	c, err := New(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "",
 		downloadLocker, cacheLocker, downloadLockTTL, downloadPollTimeout, cacheLockTTL)
 	require.NoError(t, err)
 
@@ -1608,7 +1610,7 @@ func TestMigration_DatabaseBehaviorConsistency(t *testing.T) {
 	}
 
 	// Helper function to run tests against a specific database backend
-	runTestsWithDB := func(t *testing.T, setupDB func(*testing.T) (database.Querier, func())) {
+	runTestsWithDB := func(t *testing.T, setupDB func(*testing.T) (database.Querier, *database.Client, func())) {
 		t.Helper()
 
 		for _, tc := range testCases {
@@ -1618,7 +1620,7 @@ func TestMigration_DatabaseBehaviorConsistency(t *testing.T) {
 				ctx := newContext()
 
 				// Setup database
-				db, dbCleanup := setupDB(t)
+				db, dbClient, dbCleanup := setupDB(t)
 				t.Cleanup(dbCleanup)
 
 				// Setup storage
@@ -1634,7 +1636,7 @@ func TestMigration_DatabaseBehaviorConsistency(t *testing.T) {
 				downloadLocker := locklocal.NewLocker()
 				cacheLocker := locklocal.NewRWLocker()
 
-				c, err := New(ctx, cacheName, db, localStore, localStore, localStore, "",
+				c, err := New(ctx, cacheName, db, dbClient, localStore, localStore, localStore, "",
 					downloadLocker, cacheLocker, downloadLockTTL, downloadPollTimeout, cacheLockTTL)
 				require.NoError(t, err)
 
@@ -1666,20 +1668,20 @@ func TestMigration_DatabaseBehaviorConsistency(t *testing.T) {
 	// Test with PostgreSQL (only if enabled via environment variable)
 	t.Run("PostgreSQL", func(t *testing.T) {
 		t.Parallel()
-		runTestsWithDB(t, func(t *testing.T) (database.Querier, func()) {
-			db, _, cleanup := testhelper.SetupPostgres(t)
+		runTestsWithDB(t, func(t *testing.T) (database.Querier, *database.Client, func()) {
+			db, dbClient, _, cleanup := testhelper.SetupPostgres(t)
 
-			return db, cleanup
+			return db, dbClient, cleanup
 		})
 	})
 
 	// Test with MySQL (only if enabled via environment variable)
 	t.Run("MySQL", func(t *testing.T) {
 		t.Parallel()
-		runTestsWithDB(t, func(t *testing.T) (database.Querier, func()) {
-			db, _, cleanup := testhelper.SetupMySQL(t)
+		runTestsWithDB(t, func(t *testing.T) (database.Querier, *database.Client, func()) {
+			db, dbClient, _, cleanup := testhelper.SetupMySQL(t)
 
-			return db, cleanup
+			return db, dbClient, cleanup
 		})
 	})
 }

--- a/pkg/cache/cache_prefetch_test.go
+++ b/pkg/cache/cache_prefetch_test.go
@@ -58,7 +58,7 @@ func BenchmarkStreamCompleteChunks_WithPrefetch(b *testing.B) {
 	// We'll skip the full setup and just test the core functionality
 	// For now, use the test factory with a wrapper
 	t := &testing.T{}
-	c, _, _, cacheDir, _, cleanup := setupSQLiteFactory(t)
+	c, _, _, _, cacheDir, _, cleanup := setupSQLiteFactory(t)
 	b.Cleanup(cleanup)
 
 	// Initialize chunk store with simulated latency
@@ -110,7 +110,7 @@ func TestPrefetchPipelineOrdering(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, _, _, dir, _, cleanup := setupSQLiteFactory(t)
+	c, _, _, _, dir, _, cleanup := setupSQLiteFactory(t)
 	t.Cleanup(cleanup)
 
 	// Initialize chunk store
@@ -154,7 +154,7 @@ func TestPrefetchErrorPropagation(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, db, _, dir, _, cleanup := setupSQLiteFactory(t)
+	c, db, _, _, dir, _, cleanup := setupSQLiteFactory(t)
 	t.Cleanup(cleanup)
 
 	// Initialize chunk store
@@ -211,7 +211,7 @@ func TestPrefetchContextCancellation(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, _, _, dir, _, cleanup := setupSQLiteFactory(t)
+	c, _, _, _, dir, _, cleanup := setupSQLiteFactory(t)
 	t.Cleanup(cleanup)
 
 	// Initialize chunk store with latency to make cancellation timing easier
@@ -297,7 +297,7 @@ func TestProgressiveStreamingWithPrefetch(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, db, _, dir, _, cleanup := setupSQLiteFactory(t)
+	c, db, _, _, dir, _, cleanup := setupSQLiteFactory(t)
 	t.Cleanup(cleanup)
 
 	// Initialize chunk store with latency
@@ -405,7 +405,7 @@ func TestProgressiveStreamingNoGoroutineLeak(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, db, _, dir, _, cleanup := setupSQLiteFactory(t)
+	c, db, _, _, dir, _, cleanup := setupSQLiteFactory(t)
 	t.Cleanup(cleanup)
 
 	// Initialize chunk store with latency
@@ -491,7 +491,7 @@ func TestProgressiveStreamingAborted(t *testing.T) {
 
 	ctx := context.Background()
 
-	c, db, _, dir, _, cleanup := setupSQLiteFactory(t)
+	c, db, _, _, dir, _, cleanup := setupSQLiteFactory(t)
 	t.Cleanup(cleanup)
 
 	// Initialize chunk store

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -48,13 +48,22 @@ const (
 
 // cacheFactory is a function that returns a clean, ready-to-use Cache instance,
 // database, local store, directory path, a rebind function, and takes care of cleaning up once the test is done.
-type cacheFactory func(t *testing.T) (*cache.Cache, database.Querier, *local.Store, string, func(string) string, func())
+type cacheFactory func(t *testing.T) (
+	*cache.Cache,
+	database.Querier,
+	*database.Client,
+	*local.Store,
+	string,
+	func(string) string,
+	func(),
+)
 
 // newTestCache is a helper function that creates a cache with local locks for testing.
 func newTestCache(
 	ctx context.Context,
 	hostName string,
 	db database.Querier,
+	dbClient *database.Client,
 	//nolint:staticcheck // using deprecated ConfigStore interface for testing migration
 	configStore storage.ConfigStore,
 	narInfoStore storage.NarInfoStore,
@@ -64,36 +73,13 @@ func newTestCache(
 	downloadLocker := locklocal.NewLocker()
 	cacheLocker := locklocal.NewRWLocker()
 
-	return cache.New(ctx, hostName, db, configStore, narInfoStore, narStore, secretKeyPath,
+	return cache.New(ctx, hostName, db, dbClient, configStore, narInfoStore, narStore, secretKeyPath,
 		downloadLocker, cacheLocker, downloadLockTTL, downloadPollTimeout, cacheLockTTL)
 }
 
-func setupTestComponents(t *testing.T) (database.Querier, *local.Store, string, func(string) string, func()) {
-	t.Helper()
-
-	dir, err := os.MkdirTemp("", "cache-path-")
-	require.NoError(t, err)
-
-	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
-	testhelper.CreateMigrateDatabase(t, dbFile)
-
-	db, err := database.Open("sqlite:"+dbFile, nil)
-	require.NoError(t, err)
-
-	localStore, err := local.New(newContext(), dir)
-	require.NoError(t, err)
-
-	cleanup := func() {
-		db.DB().Close()
-		os.RemoveAll(dir)
-	}
-
-	return db, localStore, dir, func(s string) string { return s }, cleanup
-}
-
-func setupSQLiteFactory(t *testing.T) (
-	*cache.Cache,
+func setupTestComponents(t *testing.T) (
 	database.Querier,
+	*database.Client,
 	*local.Store,
 	string,
 	func(string) string,
@@ -109,11 +95,46 @@ func setupSQLiteFactory(t *testing.T) (
 
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := newTestCache(newContext(), cacheName, db, localStore, localStore, localStore, "")
+	cleanup := func() {
+		db.DB().Close()
+		os.RemoveAll(dir)
+	}
+
+	return db, dbClient, localStore, dir, func(s string) string { return s }, cleanup
+}
+
+func setupSQLiteFactory(t *testing.T) (
+	*cache.Cache,
+	database.Querier,
+	*database.Client,
+	*local.Store,
+	string,
+	func(string) string,
+	func(),
+) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "cache-path-")
+	require.NoError(t, err)
+
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
+	db, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
+
+	localStore, err := local.New(newContext(), dir)
+	require.NoError(t, err)
+
+	c, err := newTestCache(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "")
 	require.NoError(t, err)
 
 	cleanup := func() {
@@ -122,12 +143,13 @@ func setupSQLiteFactory(t *testing.T) (
 		os.RemoveAll(dir)
 	}
 
-	return c, db, localStore, dir, func(s string) string { return s }, cleanup
+	return c, db, dbClient, localStore, dir, func(s string) string { return s }, cleanup
 }
 
 func setupPostgresFactory(t *testing.T) (
 	*cache.Cache,
 	database.Querier,
+	*database.Client,
 	*local.Store,
 	string,
 	func(string) string,
@@ -138,12 +160,12 @@ func setupPostgresFactory(t *testing.T) (
 	dir, err := os.MkdirTemp("", "cache-path-")
 	require.NoError(t, err)
 
-	db, _, dbCleanup := testhelper.SetupPostgres(t)
+	db, dbClient, _, dbCleanup := testhelper.SetupPostgres(t)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := newTestCache(newContext(), cacheName, db, localStore, localStore, localStore, "")
+	c, err := newTestCache(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "")
 	require.NoError(t, err)
 
 	cleanup := func() {
@@ -170,12 +192,13 @@ func setupPostgresFactory(t *testing.T) (
 		return sb.String()
 	}
 
-	return c, db, localStore, dir, rebind, cleanup
+	return c, db, dbClient, localStore, dir, rebind, cleanup
 }
 
 func setupMySQLFactory(t *testing.T) (
 	*cache.Cache,
 	database.Querier,
+	*database.Client,
 	*local.Store,
 	string,
 	func(string) string,
@@ -186,12 +209,12 @@ func setupMySQLFactory(t *testing.T) (
 	dir, err := os.MkdirTemp("", "cache-path-")
 	require.NoError(t, err)
 
-	db, _, dbCleanup := testhelper.SetupMySQL(t)
+	db, dbClient, _, dbCleanup := testhelper.SetupMySQL(t)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := newTestCache(newContext(), cacheName, db, localStore, localStore, localStore, "")
+	c, err := newTestCache(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "")
 	require.NoError(t, err)
 
 	cleanup := func() {
@@ -200,7 +223,7 @@ func setupMySQLFactory(t *testing.T) (
 		os.RemoveAll(dir)
 	}
 
-	return c, db, localStore, dir, func(s string) string { return s }, cleanup
+	return c, db, dbClient, localStore, dir, func(s string) string { return s }, cleanup
 }
 
 func testNew(factory cacheFactory) func(*testing.T) {
@@ -241,12 +264,12 @@ func testNew(factory cacheFactory) func(*testing.T) {
 				t.Run(tt.name, func(t *testing.T) {
 					t.Parallel()
 
-					db, localStore, _, rebind, cleanup := setupTestComponents(t)
+					db, dbClient, localStore, _, rebind, cleanup := setupTestComponents(t)
 					_ = rebind
 
 					t.Cleanup(cleanup)
 
-					_, err := newTestCache(newContext(), tt.hostname, db, localStore, localStore, localStore, "")
+					_, err := newTestCache(newContext(), tt.hostname, db, dbClient, localStore, localStore, localStore, "")
 					if tt.wantErr != nil {
 						assert.ErrorIs(t, err, tt.wantErr)
 					} else {
@@ -262,7 +285,7 @@ func testNew(factory cacheFactory) func(*testing.T) {
 			t.Run("generated", func(t *testing.T) {
 				t.Parallel()
 
-				c, db, localStore, _, _, cleanup := factory(t)
+				c, db, _, localStore, _, _, cleanup := factory(t)
 				t.Cleanup(cleanup)
 
 				// Verify key is NOT in local store
@@ -281,7 +304,7 @@ func testNew(factory cacheFactory) func(*testing.T) {
 			t.Run("given", func(t *testing.T) {
 				t.Parallel()
 
-				db, localStore, _, rebind, cleanup := setupTestComponents(t)
+				db, dbClient, localStore, _, rebind, cleanup := setupTestComponents(t)
 				_ = rebind
 
 				t.Cleanup(cleanup)
@@ -298,7 +321,7 @@ func testNew(factory cacheFactory) func(*testing.T) {
 
 				require.NoError(t, skFile.Close())
 
-				c, err := newTestCache(newContext(), cacheName, db, localStore, localStore, localStore, skFile.Name())
+				c, err := newTestCache(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, skFile.Name())
 				require.NoError(t, err)
 
 				// Verify key is NOT in local store
@@ -316,7 +339,7 @@ func testNew(factory cacheFactory) func(*testing.T) {
 			t.Run("migrated", func(t *testing.T) {
 				t.Parallel()
 
-				db, localStore, _, rebind, cleanup := setupTestComponents(t)
+				db, dbClient, localStore, _, rebind, cleanup := setupTestComponents(t)
 				_ = rebind
 
 				t.Cleanup(cleanup)
@@ -327,7 +350,7 @@ func testNew(factory cacheFactory) func(*testing.T) {
 				err = localStore.PutSecretKey(newContext(), sk)
 				require.NoError(t, err)
 
-				c, err := newTestCache(newContext(), cacheName, db, localStore, localStore, localStore, "")
+				c, err := newTestCache(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "")
 				require.NoError(t, err)
 
 				// Verify key is NOT in local store anymore
@@ -349,7 +372,7 @@ func testPublicKey(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 
-		c, _, _, _, _, cleanup := factory(t)
+		c, _, _, _, _, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		pubKey := c.PublicKey().String()
@@ -378,7 +401,7 @@ func testGetNarInfoWithoutSignature(factory cacheFactory) func(*testing.T) {
 		ts := testdata.NewTestServer(t, 40)
 		t.Cleanup(ts.Close)
 
-		c, _, _, _, _, cleanup := factory(t)
+		c, _, _, _, _, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
@@ -418,7 +441,7 @@ func testGetNarInfo(factory cacheFactory) func(*testing.T) {
 		ts := testdata.NewTestServer(t, 40)
 		t.Cleanup(ts.Close)
 
-		c, db, _, dir, rebind, cleanup := factory(t)
+		c, db, _, _, dir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
@@ -668,7 +691,7 @@ func testGetNarInfo(factory cacheFactory) func(*testing.T) {
 
 func testPutNarInfo(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
-		c, db, _, dir, rebind, cleanup := factory(t)
+		c, db, _, _, dir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		c.SetRecordAgeIgnoreTouch(0)
@@ -775,7 +798,7 @@ func testPutNarInfo(factory cacheFactory) func(*testing.T) {
 
 func testPutNarInfoDeadlock(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
-		c, _, _, _, _, cleanup := factory(t)
+		c, _, _, _, _, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		c.SetRecordAgeIgnoreTouch(0)
@@ -816,7 +839,7 @@ func testPutNarInfoDeadlock(factory cacheFactory) func(*testing.T) {
 
 func testDeleteNarInfo(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
-		c, _, _, dir, _, cleanup := factory(t)
+		c, _, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		c.SetRecordAgeIgnoreTouch(0)
@@ -865,7 +888,7 @@ func testGetNar(factory cacheFactory) func(*testing.T) {
 		ts := testdata.NewTestServer(t, 40)
 		t.Cleanup(ts.Close)
 
-		c, db, _, dir, _, cleanup := factory(t)
+		c, db, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
@@ -983,7 +1006,7 @@ func testGetNarTransparentZstd(factory cacheFactory) func(*testing.T) {
 		ts := testdata.NewTestServer(t, 40)
 		t.Cleanup(ts.Close)
 
-		c, _, _, dir, _, cleanup := factory(t)
+		c, _, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
@@ -1056,7 +1079,7 @@ func testGetNarTransparentZstd(factory cacheFactory) func(*testing.T) {
 
 func testPutNar(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
-		c, _, _, dir, _, cleanup := factory(t)
+		c, _, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		c.SetRecordAgeIgnoreTouch(0)
@@ -1088,7 +1111,7 @@ func testPutNar(factory cacheFactory) func(*testing.T) {
 
 func testGetNarFileSize(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
-		c, db, _, _, rebind, cleanup := factory(t)
+		c, db, _, _, _, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		c.SetRecordAgeIgnoreTouch(0)
@@ -1133,7 +1156,7 @@ func testGetNarInfoMigratesInvalidURL(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 
-		c, db, localStore, _, rebind, cleanup := factory(t)
+		c, db, _, localStore, _, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		c.SetRecordAgeIgnoreTouch(0)
@@ -1199,7 +1222,7 @@ func testGetNarInfoConcurrentMigrationAttempts(factory cacheFactory) func(*testi
 	return func(t *testing.T) {
 		t.Parallel()
 
-		c, db, localStore, _, rebind, cleanup := factory(t)
+		c, db, _, localStore, _, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		c.SetRecordAgeIgnoreTouch(0)
@@ -1285,7 +1308,7 @@ func testGetNarInfoConcurrentMigrationAttempts(factory cacheFactory) func(*testi
 
 func testDeleteNar(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
-		c, _, _, dir, _, cleanup := factory(t)
+		c, _, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		c.SetRecordAgeIgnoreTouch(0)
@@ -1343,7 +1366,7 @@ func testDeadlockContextCancellationDuringDownload(factory cacheFactory) func(*t
 	return func(t *testing.T) {
 		t.Parallel()
 
-		c, _, _, _, _, cleanup := factory(t)
+		c, _, _, _, _, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Setup a test server with a slow response to ensure we can cancel mid-download
@@ -1498,7 +1521,7 @@ func testBackgroundDownloadCompletionAfterCancellation(factory cacheFactory) fun
 	return func(t *testing.T) {
 		t.Parallel()
 
-		c, _, localStore, dir, _, cleanup := factory(t)
+		c, _, _, localStore, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Use an existing test entry (Nar3) for this test
@@ -1684,7 +1707,7 @@ func testConcurrentDownloadCancelOneClientOthersContinue(factory cacheFactory) f
 	return func(t *testing.T) {
 		t.Parallel()
 
-		c, _, localStore, dir, _, cleanup := factory(t)
+		c, _, _, localStore, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Use an existing test entry (Nar5 to avoid conflict with other tests)
@@ -1890,7 +1913,7 @@ func waitForFile(t *testing.T, path string) {
 
 func testGetNarInfoBackgroundMigration(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
-		c, db, _, dir, rebind, cleanup := factory(t)
+		c, db, _, _, dir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		hash := testdata.Nar1.NarInfoHash
@@ -1985,7 +2008,7 @@ func testBackgroundMigrateNarInfoThunderingHerd(_ cacheFactory) func(*testing.T)
 		t.Parallel()
 
 		// Setup components
-		db, localStore, dir, rebind, cleanup := setupTestComponents(t)
+		db, dbClient, localStore, dir, rebind, cleanup := setupTestComponents(t)
 		t.Cleanup(cleanup)
 
 		hash := testdata.Nar1.NarInfoHash
@@ -2009,7 +2032,7 @@ func testBackgroundMigrateNarInfoThunderingHerd(_ cacheFactory) func(*testing.T)
 		// Increase MaxOpenConns to avoid deadlocks during concurrent transactions in the test
 		db.DB().SetMaxOpenConns(10)
 
-		c, err := newTestCache(newContext(), "test.example.com", spy, localStore, localStore, localStore, "")
+		c, err := newTestCache(newContext(), "test.example.com", spy, dbClient, localStore, localStore, localStore, "")
 		require.NoError(t, err)
 
 		// Call GetNarInfo multiple times concurrently
@@ -2063,7 +2086,7 @@ func testBackgroundMigrateNarInfoAfterCancellation(factory cacheFactory) func(*t
 	return func(t *testing.T) {
 		t.Parallel()
 
-		c, db, _, dir, rebind, cleanup := factory(t)
+		c, db, _, _, dir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Use a unique hash for this test
@@ -2130,7 +2153,7 @@ func testGetNarInfoConcurrentPutNarInfoDuringMigration(factory cacheFactory) fun
 		// This test verifies that if a PutNarInfo operation occurs while a background
 		// migration is happening for the same hash, both operations handle the duplicate
 		// key error correctly and the final state is consistent.
-		c, db, _, tmpDir, rebind, cleanup := factory(t)
+		c, db, _, _, tmpDir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		ctx := newContext()
@@ -2200,7 +2223,7 @@ func testGetNarInfoMultipleConcurrentPutsDuringMigration(factory cacheFactory) f
 		// This test simulates multiple concurrent PutNarInfo operations for the same
 		// hash while a background migration is happening. This is a more extreme version
 		// of the thundering herd scenario.
-		c, db, _, tmpDir, rebind, cleanup := factory(t)
+		c, db, _, _, tmpDir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		ctx := newContext()
@@ -2275,7 +2298,7 @@ func testNarStreaming(factory cacheFactory) func(*testing.T) {
 		t.Parallel()
 
 		// Setup test components
-		c, _, localStore, _, _, cleanup := factory(t)
+		c, _, _, localStore, _, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		ts := testdata.NewTestServer(t, 40)
@@ -2422,7 +2445,7 @@ func (s *storageWithHook) HasNarInfo(ctx context.Context, hash string) bool {
 // 6. Current Bug: Returns error because storage read fails.
 func testGetNarInfoRaceConditionBeforeHasNarInfo(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
-		c, db, baseStore, tmpDir, _, cleanup := factory(t)
+		c, db, dbClient, baseStore, tmpDir, _, cleanup := factory(t)
 
 		t.Cleanup(cleanup)
 
@@ -2489,7 +2512,7 @@ func testGetNarInfoRaceConditionBeforeHasNarInfo(factory cacheFactory) func(*tes
 		// Create cache with the hooked store
 		var cacheErr error
 
-		c, cacheErr = newTestCache(ctx, cacheName, db, storeWithHook, storeWithHook, storeWithHook, "")
+		c, cacheErr = newTestCache(ctx, cacheName, db, dbClient, storeWithHook, storeWithHook, storeWithHook, "")
 
 		require.NoError(t, cacheErr)
 
@@ -2513,7 +2536,7 @@ func testGetNarInfoRaceConditionBeforeHasNarInfo(factory cacheFactory) func(*tes
 
 func testGetNarInfoRaceConditionDuringMigrationDeletion(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
-		c, db, baseStore, tmpDir, rebind, cleanup := factory(t)
+		c, db, dbClient, baseStore, tmpDir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Close the generic cache from the factory so it doesn't interfere
@@ -2579,7 +2602,7 @@ func testGetNarInfoRaceConditionDuringMigrationDeletion(factory cacheFactory) fu
 		}
 
 		// Create cache with the hooked store (same for all three store types)
-		c, err = newTestCache(ctx, cacheName, db, storeWithHook, storeWithHook, storeWithHook, "")
+		c, err = newTestCache(ctx, cacheName, db, dbClient, storeWithHook, storeWithHook, storeWithHook, "")
 		require.NoError(t, err)
 
 		cacheInstance = c // Expose to the hook
@@ -2639,7 +2662,7 @@ func testGetNarInfoRaceWithPutNarInfoDeterministic(factory cacheFactory) func(*t
 	return func(t *testing.T) {
 		// This test determines if legacy narinfo is deleted even if PutNarInfo
 		// finishes before GetNarInfo can trigger migration.
-		_, db, baseStore, tmpDir, _, cleanup := factory(t)
+		_, db, dbClient, baseStore, tmpDir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		ctx := newContext()
@@ -2676,7 +2699,7 @@ func testGetNarInfoRaceWithPutNarInfoDeterministic(factory cacheFactory) func(*t
 
 						// Create a separate cache instance for the concurrent PutNarInfo
 						// to avoid locking issues within the same instance.
-						c2, err := newTestCache(ctx, cacheName, db, baseStore, baseStore, baseStore, "")
+						c2, err := newTestCache(ctx, cacheName, db, dbClient, baseStore, baseStore, baseStore, "")
 						require.NoError(t, err)
 
 						defer c2.Close()
@@ -2692,7 +2715,7 @@ func testGetNarInfoRaceWithPutNarInfoDeterministic(factory cacheFactory) func(*t
 		}
 
 		// Create cache with the hooked store
-		c, err := newTestCache(ctx, cacheName, db, storeWithHook, storeWithHook, storeWithHook, "")
+		c, err := newTestCache(ctx, cacheName, db, dbClient, storeWithHook, storeWithHook, storeWithHook, "")
 		require.NoError(t, err)
 
 		t.Cleanup(c.Close)
@@ -2840,7 +2863,7 @@ func testCheckAndFixNarInfo(factory cacheFactory) func(*testing.T) {
 			ts := testdata.NewTestServer(t, 40)
 			t.Cleanup(ts.Close)
 
-			c, _, _, _, _, cleanup := factory(t)
+			c, _, _, _, _, _, cleanup := factory(t)
 			t.Cleanup(cleanup)
 
 			uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
@@ -2888,7 +2911,7 @@ func testCheckAndFixNarInfo(factory cacheFactory) func(*testing.T) {
 		})
 
 		t.Run("checkAndFixNarInfo with missing NAR", func(t *testing.T) {
-			c, _, _, _, _, cleanup := factory(t)
+			c, _, _, _, _, _, cleanup := factory(t)
 			t.Cleanup(cleanup)
 
 			// 1. Put NarInfo
@@ -2905,7 +2928,7 @@ func testCheckAndFixNarInfo(factory cacheFactory) func(*testing.T) {
 func testNarInfoFileSizeFix(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Run("PutNarInfo then PutNar with mismatch", func(t *testing.T) {
-			c, db, _, _, rebind, cleanup := factory(t)
+			c, db, _, _, _, rebind, cleanup := factory(t)
 			t.Cleanup(cleanup)
 			c.SetRecordAgeIgnoreTouch(0)
 
@@ -2967,7 +2990,7 @@ func testNarInfoFileSizeFix(factory cacheFactory) func(*testing.T) {
 		})
 
 		t.Run("PutNar then PutNarInfo with mismatch", func(t *testing.T) {
-			c, db, _, _, rebind, cleanup := factory(t)
+			c, db, _, _, _, rebind, cleanup := factory(t)
 			t.Cleanup(cleanup)
 			c.SetRecordAgeIgnoreTouch(0)
 
@@ -3010,7 +3033,7 @@ func testNarInfoFileSizeFix(factory cacheFactory) func(*testing.T) {
 		})
 
 		t.Run("PutNarInfo then PutNar should update nar_files table", func(t *testing.T) {
-			c, db, _, _, rebind, cleanup := factory(t)
+			c, db, _, _, _, rebind, cleanup := factory(t)
 			t.Cleanup(cleanup)
 			c.SetRecordAgeIgnoreTouch(0)
 
@@ -3043,7 +3066,7 @@ func testNarInfoFileSizeFix(factory cacheFactory) func(*testing.T) {
 		t.Run("PutNar then PutNarInfo with compression=none must keep FileSize null", func(t *testing.T) {
 			t.Parallel()
 
-			c, db, _, _, rebind, cleanup := factory(t)
+			c, db, _, _, _, rebind, cleanup := factory(t)
 			t.Cleanup(cleanup)
 
 			// 1. Put NAR (Nar7 has CompressionTypeNone)
@@ -3073,7 +3096,7 @@ func testNarInfoFileSizeFix(factory cacheFactory) func(*testing.T) {
 		t.Run("PutNar then PutNarInfo with compression=none must keep FileHash null", func(t *testing.T) {
 			t.Parallel()
 
-			c, db, _, _, rebind, cleanup := factory(t)
+			c, db, _, _, _, rebind, cleanup := factory(t)
 			t.Cleanup(cleanup)
 
 			// 1. Put NAR (Nar7 has CompressionTypeNone)
@@ -3108,7 +3131,7 @@ func testHasNarFileRecord(factory cacheFactory) func(*testing.T) {
 
 		ctx := context.Background()
 
-		c, db, _, dir, _, cleanup := factory(t)
+		c, db, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Setup chunk store and enable CDC
@@ -3175,7 +3198,7 @@ func testBackgroundMigrateNarToChunksAfterCancellation(factory cacheFactory) fun
 	return func(t *testing.T) {
 		t.Parallel()
 
-		c, _, _, dir, _, cleanup := factory(t)
+		c, _, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		entry := testdata.Nar1
@@ -3239,7 +3262,7 @@ func testGetNarWithPlaceholderNarFileRecord(factory cacheFactory) func(*testing.
 		ts := testdata.NewTestServer(t, 40)
 		t.Cleanup(ts.Close)
 
-		c, db, _, dir, _, cleanup := factory(t)
+		c, db, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Setup CDC
@@ -3318,7 +3341,7 @@ func TestIssue990_BackgroundJobContextCancellation(t *testing.T) {
 	}
 
 	// 1. Setup test environment
-	c, db, _, _, rebind, cleanup := setupSQLiteFactory(t)
+	c, db, _, _, _, rebind, cleanup := setupSQLiteFactory(t)
 	defer cleanup()
 
 	// 2. Setup a slow upstream server
@@ -3390,7 +3413,7 @@ func testPinAndUnpinClosure(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 
-		c, db, _, _, _, cleanup := factory(t)
+		c, db, _, _, _, _, cleanup := factory(t)
 		defer cleanup()
 
 		ctx := context.Background()
@@ -3444,7 +3467,7 @@ func testPinDuplicateClosure(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 
-		c, _, _, _, _, cleanup := factory(t)
+		c, _, _, _, _, _, cleanup := factory(t)
 		defer cleanup()
 
 		ctx := context.Background()
@@ -3473,7 +3496,7 @@ func testPinUnpinNonExistentClosure(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 
-		c, _, _, _, _, cleanup := factory(t)
+		c, _, _, _, _, _, cleanup := factory(t)
 		defer cleanup()
 
 		ctx := context.Background()
@@ -3495,7 +3518,7 @@ func testGetPinnedClosureHashesSimple(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 
-		c, _, _, _, _, cleanup := factory(t)
+		c, _, _, _, _, _, cleanup := factory(t)
 		defer cleanup()
 
 		ctx := context.Background()
@@ -3541,7 +3564,7 @@ func testLRUEvictionSkipsPinnedClosures(factory cacheFactory) func(*testing.T) {
 		// method returns it in the protected set, which is what the LRU
 		// eviction code uses to skip pinned narinfos.
 
-		c, _, _, _, _, cleanup := factory(t)
+		c, _, _, _, _, _, cleanup := factory(t)
 		defer cleanup()
 
 		ctx := context.Background()
@@ -3605,6 +3628,8 @@ func TestGetNarInfoDistributedCoordination(t *testing.T) {
 
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
 
 	defer db.DB().Close()
 
@@ -3623,13 +3648,15 @@ func TestGetNarInfoDistributedCoordination(t *testing.T) {
 	// Custom poll timeout for testing
 	shortPollTimeout := 2 * time.Second
 
-	c1, err := cache.New(context.Background(), "instance1.example.com", db, localStore1, localStore1, localStore1, "",
+	c1, err := cache.New(context.Background(), "instance1.example.com", db, dbClient,
+		localStore1, localStore1, localStore1, "",
 		sharedDownloadLocker, sharedCacheLocker, downloadLockTTL, shortPollTimeout, cacheLockTTL)
 	require.NoError(t, err)
 
 	defer c1.Close()
 
-	c2, err := cache.New(context.Background(), "instance2.example.com", db, localStore2, localStore2, localStore2, "",
+	c2, err := cache.New(context.Background(), "instance2.example.com", db, dbClient,
+		localStore2, localStore2, localStore2, "",
 		sharedDownloadLocker, sharedCacheLocker, downloadLockTTL, shortPollTimeout, cacheLockTTL)
 	require.NoError(t, err)
 

--- a/pkg/cache/cdc_test.go
+++ b/pkg/cache/cdc_test.go
@@ -178,7 +178,7 @@ func testCDCPutAndGet(factory cacheFactory) func(*testing.T) {
 
 		ctx := context.Background()
 
-		c, db, _, dir, _, cleanup := factory(t)
+		c, db, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Initialize chunk store
@@ -221,7 +221,7 @@ func testCDCDeduplication(factory cacheFactory) func(*testing.T) {
 
 		ctx := context.Background()
 
-		c, db, _, dir, _, cleanup := factory(t)
+		c, db, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Initialize chunk store
@@ -257,7 +257,7 @@ func testCDCMixedMode(factory cacheFactory) func(*testing.T) {
 
 		ctx := context.Background()
 
-		c, _, _, dir, _, cleanup := factory(t)
+		c, _, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Initialize chunk store
@@ -308,7 +308,7 @@ func testCDCGetNarInfo(factory cacheFactory) func(*testing.T) {
 
 		ctx := context.Background()
 
-		c, db, _, dir, _, cleanup := factory(t)
+		c, db, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Initialize chunk store
@@ -368,7 +368,7 @@ func testCDCClientDisconnectNoGoroutineLeak(factory cacheFactory) func(*testing.
 
 		ctx := context.Background()
 
-		c, _, _, dir, _, cleanup := factory(t)
+		c, _, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Initialize chunk store
@@ -443,7 +443,7 @@ func testCDCDecompressZstdBeforeChunking(factory cacheFactory) func(*testing.T) 
 
 		ctx := context.Background()
 
-		c, db, _, dir, _, cleanup := factory(t)
+		c, db, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Initialize chunk store
@@ -515,7 +515,7 @@ func testCDCChunksAreCompressed(factory cacheFactory) func(*testing.T) {
 
 		ctx := context.Background()
 
-		c, db, _, dir, _, cleanup := factory(t)
+		c, db, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Initialize chunk store
@@ -582,7 +582,7 @@ func testCDCPullNarInfoNormalizesCompression(factory cacheFactory) func(*testing
 		ts := testdata.NewTestServer(t, 40)
 		t.Cleanup(ts.Close)
 
-		c, db, _, dir, rebind, cleanup := factory(t)
+		c, db, _, _, dir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Set up CDC
@@ -658,7 +658,7 @@ func testCDCMigrateNarToChunksUpdatesNarInfo(factory cacheFactory) func(*testing
 
 		ctx := context.Background()
 
-		c, db, _, dir, rebind, cleanup := factory(t)
+		c, db, _, _, dir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// 1. Store a NAR as whole file (CDC disabled) with xz compression
@@ -734,7 +734,7 @@ func testCDCMigrateNarToChunksLinksNarInfoNarFiles(factory cacheFactory) func(*t
 
 		ctx := context.Background()
 
-		c, db, _, dir, rebind, cleanup := factory(t)
+		c, db, _, _, dir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// 1. Store a NAR as a whole file (CDC disabled) with xz compression
@@ -807,7 +807,7 @@ func testCDCPutNarInfoNormalizesCompression(factory cacheFactory) func(*testing.
 
 		ctx := context.Background()
 
-		c, db, _, dir, rebind, cleanup := factory(t)
+		c, db, _, _, dir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Enable CDC
@@ -885,7 +885,7 @@ func testCDCPullNarInfoSetsFileSizeForCDC(factory cacheFactory) func(*testing.T)
 		ts := testdata.NewTestServer(t, 40)
 		t.Cleanup(ts.Close)
 
-		c, db, _, dir, rebind, cleanup := factory(t)
+		c, db, _, _, dir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Set up CDC
@@ -950,7 +950,7 @@ func testCDCPutNarInfoSetsFileSizeForCDC(factory cacheFactory) func(*testing.T) 
 
 		ctx := context.Background()
 
-		c, db, _, dir, rebind, cleanup := factory(t)
+		c, db, _, _, dir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Enable CDC
@@ -1008,7 +1008,7 @@ func testCDCPutNarInfoNoContextCanceled(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
 
-		c, _, _, dir, _, cleanup := factory(t)
+		c, _, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Enable CDC
@@ -1073,7 +1073,7 @@ func testCDCPutNarDoesNotOverwriteFileSizeOnceChunked(factory cacheFactory) func
 
 		ctx := context.Background()
 
-		c, db, _, dir, _, cleanup := factory(t)
+		c, db, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Initialize chunk store
@@ -1172,7 +1172,7 @@ func testCDCMigrateNarToChunksCompressionNormalizationIsAtomic(factory cacheFact
 
 		ctx := context.Background()
 
-		c, db, _, dir, rebind, cleanup := factory(t)
+		c, db, _, _, dir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// 1. Store a NAR as a whole file with xz compression (CDC disabled).
@@ -1261,7 +1261,7 @@ func testCDCMigrateNarToChunksRecoversFromPartialChunking(factory cacheFactory) 
 
 		ctx := context.Background()
 
-		c, db, _, dir, rebind, cleanup := factory(t)
+		c, db, _, _, dir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// 1. Store a NAR as a whole file (CDC disabled) with xz compression.
@@ -1379,7 +1379,7 @@ func testCDCMigrateNarToChunksDeletesOriginalFile(factory cacheFactory) func(*te
 
 		ctx := context.Background()
 
-		c, _, _, dir, _, cleanup := factory(t)
+		c, _, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// 1. Store a NAR as a whole file (CDC disabled) with xz compression.
@@ -1441,7 +1441,7 @@ func testCDCMigrateNarToChunksHealsStaleNarInfoURLOnSecondCall(factory cacheFact
 
 		ctx := context.Background()
 
-		c, db, localStore, dir, rebind, cleanup := factory(t)
+		c, db, _, localStore, dir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		entry := testdata.Nar1
@@ -1540,7 +1540,7 @@ func testCDCStaleLockCleansUpChunkFiles(factory cacheFactory) func(*testing.T) {
 
 		ctx := context.Background()
 
-		c, db, _, dir, rebind, cleanup := factory(t)
+		c, db, _, _, dir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// 1. Store a NAR as a whole file (CDC disabled) with xz compression.
@@ -1654,7 +1654,7 @@ func testCDCFirstPullCompletesBeforeChunking(factory cacheFactory) func(*testing
 		ts := testdata.NewTestServer(t, 40)
 		t.Cleanup(ts.Close)
 
-		c, _, _, dir, _, cleanup := factory(t)
+		c, _, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Set up CDC with small chunk sizes for fast chunking.
@@ -1758,7 +1758,7 @@ func testCDCDisabledWithChunkedNARsInDB(factory cacheFactory) func(*testing.T) {
 		ts := testdata.NewTestServer(t, 40)
 		t.Cleanup(ts.Close)
 
-		c, db, _, dir, _, cleanup := factory(t)
+		c, db, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		// Step 1: Enable CDC and store a NAR as chunks.
@@ -1815,7 +1815,7 @@ func testCDCGetNarTransparentZstd(factory cacheFactory) func(*testing.T) {
 
 		ctx := context.Background()
 
-		c, _, _, dir, _, cleanup := factory(t)
+		c, _, _, _, dir, _, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		chunkStoreDir := filepath.Join(dir, "chunks-store")
@@ -1897,7 +1897,7 @@ func testCDCLazyChunkingPreservesOldNarFile(factory cacheFactory) func(*testing.
 
 		ctx := context.Background()
 
-		c, db, _, dir, rebind, cleanup := factory(t)
+		c, db, _, _, dir, rebind, cleanup := factory(t)
 		t.Cleanup(cleanup)
 
 		entry := testdata.Nar1

--- a/pkg/cache/healthcheck/healthcheck_test.go
+++ b/pkg/cache/healthcheck/healthcheck_test.go
@@ -37,7 +37,7 @@ func setupSQLiteCache(t *testing.T) (*cache.Cache, func()) {
 	dir, err := os.MkdirTemp("", "cache-path-")
 	require.NoError(t, err)
 
-	db, dbCleanup := testhelper.SetupSQLite(t)
+	db, dbClient, dbCleanup := testhelper.SetupSQLite(t)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
@@ -45,7 +45,7 @@ func setupSQLiteCache(t *testing.T) (*cache.Cache, func()) {
 	downloadLocker := locklocal.NewLocker()
 	cacheLocker := locklocal.NewRWLocker()
 
-	c, err := cache.New(newContext(), cacheName, db, localStore, localStore, localStore, "",
+	c, err := cache.New(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "",
 		downloadLocker, cacheLocker, downloadLockTTL, downloadPollTimeout, cacheLockTTL)
 	require.NoError(t, err)
 
@@ -64,7 +64,7 @@ func setupPostgresCache(t *testing.T) (*cache.Cache, func()) {
 	dir, err := os.MkdirTemp("", "cache-path-")
 	require.NoError(t, err)
 
-	db, _, dbCleanup := testhelper.SetupPostgres(t)
+	db, dbClient, _, dbCleanup := testhelper.SetupPostgres(t)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
@@ -72,7 +72,7 @@ func setupPostgresCache(t *testing.T) (*cache.Cache, func()) {
 	downloadLocker := locklocal.NewLocker()
 	cacheLocker := locklocal.NewRWLocker()
 
-	c, err := cache.New(newContext(), cacheName, db, localStore, localStore, localStore, "",
+	c, err := cache.New(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "",
 		downloadLocker, cacheLocker, downloadLockTTL, downloadPollTimeout, cacheLockTTL)
 	require.NoError(t, err)
 
@@ -91,7 +91,7 @@ func setupMySQLCache(t *testing.T) (*cache.Cache, func()) {
 	dir, err := os.MkdirTemp("", "cache-path-")
 	require.NoError(t, err)
 
-	db, _, dbCleanup := testhelper.SetupMySQL(t)
+	db, dbClient, _, dbCleanup := testhelper.SetupMySQL(t)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
@@ -99,7 +99,7 @@ func setupMySQLCache(t *testing.T) (*cache.Cache, func()) {
 	downloadLocker := locklocal.NewLocker()
 	cacheLocker := locklocal.NewRWLocker()
 
-	c, err := cache.New(newContext(), cacheName, db, localStore, localStore, localStore, "",
+	c, err := cache.New(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "",
 		downloadLocker, cacheLocker, downloadLockTTL, downloadPollTimeout, cacheLockTTL)
 	require.NoError(t, err)
 

--- a/pkg/cache/upload_only_test.go
+++ b/pkg/cache/upload_only_test.go
@@ -30,10 +30,10 @@ func TestGetNar_UploadOnly(t *testing.T) {
 	ts := testdata.NewTestServer(t, 40)
 	t.Cleanup(ts.Close)
 
-	db, localStore, _, _, cleanup := setupTestComponents(t)
+	db, dbClient, localStore, _, _, cleanup := setupTestComponents(t)
 	t.Cleanup(cleanup)
 
-	c, err := newTestCache(newContext(), cacheName, db, localStore, localStore, localStore, "")
+	c, err := newTestCache(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "")
 	require.NoError(t, err)
 
 	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
@@ -93,10 +93,10 @@ func TestGetNarInfo_UploadOnly(t *testing.T) {
 	ts := testdata.NewTestServer(t, 40)
 	t.Cleanup(ts.Close)
 
-	db, localStore, _, _, cleanup := setupTestComponents(t)
+	db, dbClient, localStore, _, _, cleanup := setupTestComponents(t)
 	t.Cleanup(cleanup)
 
-	c, err := newTestCache(newContext(), cacheName, db, localStore, localStore, localStore, "")
+	c, err := newTestCache(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "")
 	require.NoError(t, err)
 
 	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
@@ -141,10 +141,10 @@ func TestPutNarInfo_DoesNotTriggerNARStreaming(t *testing.T) {
 		t.Skip("skipping test in short mode")
 	}
 
-	db, localStore, _, _, cleanup := setupTestComponents(t)
+	db, dbClient, localStore, _, _, cleanup := setupTestComponents(t)
 	t.Cleanup(cleanup)
 
-	c, err := newTestCache(newContext(), cacheName, db, localStore, localStore, localStore, "")
+	c, err := newTestCache(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "")
 	require.NoError(t, err)
 
 	// Step 1: Store the NAR locally so checkAndFixNarInfo finds it in the store.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -20,13 +20,15 @@ type databaseFactory func(t *testing.T) (database.Querier, func())
 func setupSQLiteDatabase(t *testing.T) (database.Querier, func()) {
 	t.Helper()
 
-	return testhelper.SetupSQLite(t)
+	db, _, cleanup := testhelper.SetupSQLite(t)
+
+	return db, cleanup
 }
 
 func setupPostgresDatabase(t *testing.T) (database.Querier, func()) {
 	t.Helper()
 
-	db, _, cleanup := testhelper.SetupPostgres(t)
+	db, _, _, cleanup := testhelper.SetupPostgres(t)
 
 	return db, cleanup
 }
@@ -34,7 +36,7 @@ func setupPostgresDatabase(t *testing.T) (database.Querier, func()) {
 func setupMySQLDatabase(t *testing.T) (database.Querier, func()) {
 	t.Helper()
 
-	db, _, cleanup := testhelper.SetupMySQL(t)
+	db, _, _, cleanup := testhelper.SetupMySQL(t)
 
 	return db, cleanup
 }

--- a/pkg/database/backends_test.go
+++ b/pkg/database/backends_test.go
@@ -48,7 +48,7 @@ func TestBackends(t *testing.T) {
 			setup: func(t *testing.T) database.Querier {
 				t.Helper()
 
-				db, _, cleanup := testhelper.SetupPostgres(t)
+				db, _, _, cleanup := testhelper.SetupPostgres(t)
 				t.Cleanup(cleanup)
 
 				return db
@@ -61,7 +61,7 @@ func TestBackends(t *testing.T) {
 			setup: func(t *testing.T) database.Querier {
 				t.Helper()
 
-				db, _, cleanup := testhelper.SetupMySQL(t)
+				db, _, _, cleanup := testhelper.SetupMySQL(t)
 				t.Cleanup(cleanup)
 
 				return db

--- a/pkg/database/schema_parity_test.go
+++ b/pkg/database/schema_parity_test.go
@@ -59,7 +59,7 @@ func TestSchemaParity(t *testing.T) {
 			envVar: "NCPS_TEST_ADMIN_POSTGRES_URL",
 			setup: func(t *testing.T) (database.Querier, func()) {
 				t.Helper()
-				db, _, cleanup := testhelper.SetupPostgres(t)
+				db, _, _, cleanup := testhelper.SetupPostgres(t)
 
 				return db, cleanup
 			},
@@ -70,7 +70,7 @@ func TestSchemaParity(t *testing.T) {
 			envVar: "NCPS_TEST_ADMIN_MYSQL_URL",
 			setup: func(t *testing.T) (database.Querier, func()) {
 				t.Helper()
-				db, _, cleanup := testhelper.SetupMySQL(t)
+				db, _, _, cleanup := testhelper.SetupMySQL(t)
 
 				return db, cleanup
 			},

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -289,7 +289,7 @@ Use --repair to automatically fix detected issues, or --dry-run to preview what 
 			verifiedSince := cmd.Duration("verified-since")
 
 			// 1. Setup Database
-			db, err := createDatabaseQuerier(cmd)
+			db, _, err := createDatabaseQuerier(cmd)
 			if err != nil {
 				logger.Error().Err(err).Msg("error creating database querier")
 

--- a/pkg/ncps/fsck_test.go
+++ b/pkg/ncps/fsck_test.go
@@ -515,7 +515,7 @@ func setupFsckPostgres(t *testing.T) (database.Querier, *localstorage.Store, str
 	ctx := context.Background()
 	dir := t.TempDir()
 
-	db, dbURL, dbCleanup := testhelper.SetupPostgres(t)
+	db, _, dbURL, dbCleanup := testhelper.SetupPostgres(t)
 
 	store, err := localstorage.New(ctx, dir)
 	require.NoError(t, err)
@@ -530,7 +530,7 @@ func setupFsckMySQL(t *testing.T) (database.Querier, *localstorage.Store, string
 	ctx := context.Background()
 	dir := t.TempDir()
 
-	db, dbURL, dbCleanup := testhelper.SetupMySQL(t)
+	db, _, dbURL, dbCleanup := testhelper.SetupMySQL(t)
 
 	store, err := localstorage.New(ctx, dir)
 	require.NoError(t, err)

--- a/pkg/ncps/migrate_nar_to_chunks.go
+++ b/pkg/ncps/migrate_nar_to_chunks.go
@@ -204,7 +204,7 @@ Once a NAR is successfully migrated to chunks and verified, it is deleted from t
 			dryRun := cmd.Bool("dry-run")
 
 			// 1. Setup Database
-			db, err := createDatabaseQuerier(cmd)
+			db, dbClient, err := createDatabaseQuerier(cmd)
 			if err != nil {
 				return fmt.Errorf("error creating database querier: %w", err)
 			}
@@ -268,7 +268,7 @@ Once a NAR is successfully migrated to chunks and verified, it is deleted from t
 			// 4. Setup Cache (needed for migration logic)
 			// We recreate the cache to reuse its MigrateNarToChunks logic
 			// Note: createCache will load CDC values from the database since we don't have CDC flags
-			c, err := createCache(ctx, cmd, db, locker, rwLocker, nil)
+			c, err := createCache(ctx, cmd, db, dbClient, locker, rwLocker, nil)
 			if err != nil {
 				return fmt.Errorf("error creating cache: %w", err)
 			}

--- a/pkg/ncps/migrate_nar_to_chunks_test.go
+++ b/pkg/ncps/migrate_nar_to_chunks_test.go
@@ -498,7 +498,7 @@ func setupNarToChunksMigrationPostgres(t *testing.T) (database.Querier, *storage
 	ctx := context.Background()
 	dir := t.TempDir()
 
-	db, dbURL, dbCleanup := testhelper.SetupPostgres(t)
+	db, _, dbURL, dbCleanup := testhelper.SetupPostgres(t)
 
 	store, err := storagelocal.New(ctx, dir)
 	require.NoError(t, err)
@@ -516,7 +516,7 @@ func setupNarToChunksMigrationMySQL(t *testing.T) (database.Querier, *storageloc
 	ctx := context.Background()
 	dir := t.TempDir()
 
-	db, dbURL, dbCleanup := testhelper.SetupMySQL(t)
+	db, _, dbURL, dbCleanup := testhelper.SetupMySQL(t)
 
 	store, err := storagelocal.New(ctx, dir)
 	require.NoError(t, err)

--- a/pkg/ncps/migrate_narinfo.go
+++ b/pkg/ncps/migrate_narinfo.go
@@ -201,7 +201,7 @@ requests. Without Redis, the command uses in-memory locking (no coordination wit
 			dryRun := cmd.Bool("dry-run")
 
 			// 1. Setup Database
-			db, err := createDatabaseQuerier(cmd)
+			db, _, err := createDatabaseQuerier(cmd)
 			if err != nil {
 				logger.Error().Err(err).Msg("error creating database querier")
 

--- a/pkg/ncps/migrate_narinfo_test.go
+++ b/pkg/ncps/migrate_narinfo_test.go
@@ -1041,7 +1041,7 @@ func setupNarInfoMigrationPostgres(t *testing.T) (
 	ctx := context.Background()
 	dir := t.TempDir()
 
-	db, dbURL, dbCleanup := testhelper.SetupPostgres(t)
+	db, _, dbURL, dbCleanup := testhelper.SetupPostgres(t)
 
 	store, err := local.New(ctx, dir)
 	require.NoError(t, err)
@@ -1086,7 +1086,7 @@ func setupNarInfoMigrationMySQL(t *testing.T) (
 	ctx := context.Background()
 	dir := t.TempDir()
 
-	db, dbURL, dbCleanup := testhelper.SetupMySQL(t)
+	db, _, dbURL, dbCleanup := testhelper.SetupMySQL(t)
 
 	store, err := local.New(ctx, dir)
 	require.NoError(t, err)

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -499,7 +499,7 @@ func serveAction(registerShutdown registerShutdownFn) cli.ActionFunc {
 			return maxprocs.AutoMaxProcs(ctx, 30*time.Second, logger)
 		})
 
-		db, err := createDatabaseQuerier(cmd)
+		db, dbClient, err := createDatabaseQuerier(cmd)
 		if err != nil {
 			zerolog.Ctx(ctx).
 				Error().
@@ -646,7 +646,7 @@ func serveAction(registerShutdown registerShutdownFn) cli.ActionFunc {
 			return fmt.Errorf("error computing the upstream caches: %w", err)
 		}
 
-		cache, err := createCache(ctx, cmd, db, locker, rwLocker, ucs)
+		cache, err := createCache(ctx, cmd, db, dbClient, locker, rwLocker, ucs)
 		if err != nil {
 			return err
 		}
@@ -969,7 +969,7 @@ func createS3Storage(
 	return s3Store, s3Store, s3Store, nil
 }
 
-func createDatabaseQuerier(cmd *cli.Command) (database.Querier, error) {
+func createDatabaseQuerier(cmd *cli.Command) (database.Querier, *database.Client, error) {
 	dbURL := cmd.String("cache-database-url")
 
 	// Build pool configuration from flags
@@ -987,10 +987,23 @@ func createDatabaseQuerier(cmd *cli.Command) (database.Querier, error) {
 
 	db, err := database.Open(dbURL, poolCfg)
 	if err != nil {
-		return nil, fmt.Errorf("error opening the database %q: %w", dbURL, err)
+		return nil, nil, fmt.Errorf("error opening the database %q: %w", dbURL, err)
 	}
 
-	return db, nil
+	// §11.1: construct the Ent-backed Client alongside the legacy
+	// Querier. Both share the same *sql.DB, so we own a single
+	// connection pool; the Client wraps it via entsql.OpenDB.
+	dbType, err := database.DetectFromDatabaseURL(dbURL)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error detecting database type for %q: %w", dbURL, err)
+	}
+
+	dbClient, err := database.NewClient(db.DB(), dbType)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error constructing database client for %q: %w", dbURL, err)
+	}
+
+	return db, dbClient, nil
 }
 
 func getChunkStorageBackend(ctx context.Context, cmd *cli.Command, locker lock.Locker) (chunk.Store, error) {
@@ -1015,6 +1028,7 @@ func createCache(
 	ctx context.Context,
 	cmd *cli.Command,
 	db database.Querier,
+	dbClient *database.Client,
 	locker lock.Locker,
 	rwLocker lock.RWLocker,
 	ucs []*upstream.Cache,
@@ -1033,6 +1047,7 @@ func createCache(
 		ctx,
 		hostName,
 		db,
+		dbClient,
 		configStore,
 		narInfoStore,
 		narStore,

--- a/pkg/server/security_test.go
+++ b/pkg/server/security_test.go
@@ -52,10 +52,13 @@ func TestSecurity(t *testing.T) {
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
 
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
+
 	ls, err := local.New(context.Background(), dir)
 	require.NoError(t, err)
 
-	c, err := cache.New(context.Background(), "localhost", db, ls, ls, ls, "",
+	c, err := cache.New(context.Background(), "localhost", db, dbClient, ls, ls, ls, "",
 		locklocal.NewLocker(), locklocal.NewRWLocker(), time.Minute, 30*time.Second, time.Minute)
 	require.NoError(t, err)
 

--- a/pkg/server/server_internal_test.go
+++ b/pkg/server/server_internal_test.go
@@ -35,7 +35,7 @@ func setupSQLiteServer(t *testing.T) (*Server, func()) {
 	dir, err := os.MkdirTemp("", "cache-path-")
 	require.NoError(t, err)
 
-	db, dbCleanup := testhelper.SetupSQLite(t)
+	db, dbClient, dbCleanup := testhelper.SetupSQLite(t)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func setupSQLiteServer(t *testing.T) (*Server, func()) {
 	downloadLocker := locklocal.NewLocker()
 	cacheLocker := locklocal.NewRWLocker()
 
-	c, err := cache.New(newContext(), cacheName, db, localStore, localStore, localStore, "",
+	c, err := cache.New(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "",
 		downloadLocker, cacheLocker, downloadLockTTL, downloadPollTimeout, cacheLockTTL)
 	require.NoError(t, err)
 
@@ -64,7 +64,7 @@ func setupPostgresServer(t *testing.T) (*Server, func()) {
 	dir, err := os.MkdirTemp("", "cache-path-")
 	require.NoError(t, err)
 
-	db, _, dbCleanup := testhelper.SetupPostgres(t)
+	db, dbClient, _, dbCleanup := testhelper.SetupPostgres(t)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
@@ -72,7 +72,7 @@ func setupPostgresServer(t *testing.T) (*Server, func()) {
 	downloadLocker := locklocal.NewLocker()
 	cacheLocker := locklocal.NewRWLocker()
 
-	c, err := cache.New(newContext(), cacheName, db, localStore, localStore, localStore, "",
+	c, err := cache.New(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "",
 		downloadLocker, cacheLocker, downloadLockTTL, downloadPollTimeout, cacheLockTTL)
 	require.NoError(t, err)
 
@@ -93,7 +93,7 @@ func setupMySQLServer(t *testing.T) (*Server, func()) {
 	dir, err := os.MkdirTemp("", "cache-path-")
 	require.NoError(t, err)
 
-	db, _, dbCleanup := testhelper.SetupMySQL(t)
+	db, dbClient, _, dbCleanup := testhelper.SetupMySQL(t)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
@@ -102,7 +102,7 @@ func setupMySQLServer(t *testing.T) (*Server, func()) {
 
 	cacheLocker := locklocal.NewRWLocker()
 
-	c, err := cache.New(newContext(), cacheName, db, localStore, localStore, localStore, "",
+	c, err := cache.New(newContext(), cacheName, db, dbClient, localStore, localStore, localStore, "",
 		downloadLocker, cacheLocker, downloadLockTTL, downloadPollTimeout, cacheLockTTL)
 	require.NoError(t, err)
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -44,6 +44,7 @@ const (
 func newTestCache(
 	ctx context.Context,
 	db database.Querier,
+	dbClient *database.Client,
 	//nolint:staticcheck // using deprecated ConfigStore interface for testing migration
 	configStore storage.ConfigStore,
 	narInfoStore storage.NarInfoStore,
@@ -52,7 +53,7 @@ func newTestCache(
 	downloadLocker := locklocal.NewLocker()
 	cacheLocker := locklocal.NewRWLocker()
 
-	return cache.New(ctx, cacheName, db, configStore, narInfoStore, narStore, "",
+	return cache.New(ctx, cacheName, db, dbClient, configStore, narInfoStore, narStore, "",
 		downloadLocker, cacheLocker, 5*time.Minute, 30*time.Second, 30*time.Minute)
 }
 
@@ -77,11 +78,13 @@ func TestServeHTTP(t *testing.T) {
 
 		db, err := database.Open("sqlite:"+dbFile, nil)
 		require.NoError(t, err)
+		dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+		require.NoError(t, err)
 
 		localStore, err := local.New(newContext(), dir)
 		require.NoError(t, err)
 
-		c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+		c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 		require.NoError(t, err)
 
 		c.AddUpstreamCaches(newContext(), uc)
@@ -124,11 +127,13 @@ func TestServeHTTP(t *testing.T) {
 
 		db, err := database.Open("sqlite:"+dbFile, nil)
 		require.NoError(t, err)
+		dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+		require.NoError(t, err)
 
 		localStore, err := local.New(newContext(), dir)
 		require.NoError(t, err)
 
-		c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+		c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 		require.NoError(t, err)
 
 		c.AddUpstreamCaches(newContext(), uc)
@@ -280,11 +285,13 @@ func TestServeHTTP(t *testing.T) {
 
 		db, err := database.Open("sqlite:"+dbFile, nil)
 		require.NoError(t, err)
+		dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+		require.NoError(t, err)
 
 		localStore, err := local.New(newContext(), dir)
 		require.NoError(t, err)
 
-		c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+		c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 		require.NoError(t, err)
 
 		c.AddUpstreamCaches(newContext(), uc)
@@ -356,7 +363,10 @@ Deriver: test.drv
 				testDB, err := database.Open("sqlite:"+testDBFile, nil)
 				require.NoError(t, err)
 
-				testCache, err := newTestCache(newContext(), testDB, testLocalStore, testLocalStore, testLocalStore)
+				testDBClient, err := database.NewClient(testDB.DB(), database.TypeSQLite)
+				require.NoError(t, err)
+
+				testCache, err := newTestCache(newContext(), testDB, testDBClient, testLocalStore, testLocalStore, testLocalStore)
 				require.NoError(t, err)
 
 				// Create a server using the test cache
@@ -529,11 +539,13 @@ Deriver: test.drv
 
 		db, err := database.Open("sqlite:"+dbFile, nil)
 		require.NoError(t, err)
+		dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+		require.NoError(t, err)
 
 		localStore, err := local.New(newContext(), dir)
 		require.NoError(t, err)
 
-		c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+		c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 		require.NoError(t, err)
 
 		c.AddUpstreamCaches(newContext(), uc)
@@ -724,11 +736,13 @@ func TestGetNar_HeadOptimization(t *testing.T) {
 
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+	c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 	require.NoError(t, err)
 
 	// create the server
@@ -782,11 +796,13 @@ func TestGetNarInfo_Head(t *testing.T) {
 
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+	c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 	require.NoError(t, err)
 
 	// create the server
@@ -846,11 +862,13 @@ func TestGetNar_HeadFallback(t *testing.T) {
 
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+	c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 	require.NoError(t, err)
 
 	// create the server
@@ -908,11 +926,13 @@ func TestGetNar_ZstdCompression(t *testing.T) {
 
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+	c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 	require.NoError(t, err)
 
 	// create the server
@@ -981,11 +1001,13 @@ func TestGetNar_NoZstdCompression(t *testing.T) {
 
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+	c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 	require.NoError(t, err)
 
 	// create the server
@@ -1051,11 +1073,13 @@ func TestGetNar_ZstdCompression_Head(t *testing.T) {
 
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+	c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 	require.NoError(t, err)
 
 	// create the server
@@ -1144,11 +1168,13 @@ func TestGetNar_HeaderSettingSequence(t *testing.T) {
 	testhelper.CreateMigrateDatabase(t, dbFile)
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+	c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 	require.NoError(t, err)
 
 	s := server.New(c)
@@ -1196,11 +1222,13 @@ func TestGetNar_TransparentEncoding(t *testing.T) {
 
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+	c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 	require.NoError(t, err)
 
 	s := server.New(c)
@@ -1339,11 +1367,13 @@ func TestGetNar_Base16Hash(t *testing.T) {
 
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+	c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 	require.NoError(t, err)
 
 	// create the server
@@ -1412,11 +1442,13 @@ func TestGetNar_NixServeUpstream(t *testing.T) {
 
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+	c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 	require.NoError(t, err)
 
 	c.AddUpstreamCaches(newContext(), uc)
@@ -1651,11 +1683,13 @@ func TestGetNar_NixServeUpstream_PrefixedNarURL(t *testing.T) {
 
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+	c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 	require.NoError(t, err)
 
 	c.AddUpstreamCaches(newContext(), uc)
@@ -1748,11 +1782,13 @@ func setupUploadRouteTest(t *testing.T) (*httptest.Server, string, string, strin
 
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
 
-	c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+	c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 	require.NoError(t, err)
 
 	c.AddUpstreamCaches(newContext(), uc)
@@ -1964,11 +2000,13 @@ func TestPinClosure(t *testing.T) {
 
 		db, err := database.Open("sqlite:"+dbFile, nil)
 		require.NoError(t, err)
+		dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+		require.NoError(t, err)
 
 		localStore, err := local.New(newContext(), dir)
 		require.NoError(t, err)
 
-		c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+		c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 		require.NoError(t, err)
 
 		s := server.New(c)
@@ -2019,11 +2057,13 @@ func TestPinClosure(t *testing.T) {
 
 		db, err := database.Open("sqlite:"+dbFile, nil)
 		require.NoError(t, err)
+		dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+		require.NoError(t, err)
 
 		localStore, err := local.New(newContext(), dir)
 		require.NoError(t, err)
 
-		c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+		c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 		require.NoError(t, err)
 
 		s := server.New(c)
@@ -2073,11 +2113,13 @@ func TestPinClosure(t *testing.T) {
 
 		db, err := database.Open("sqlite:"+dbFile, nil)
 		require.NoError(t, err)
+		dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+		require.NoError(t, err)
 
 		localStore, err := local.New(newContext(), dir)
 		require.NoError(t, err)
 
-		c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+		c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 		require.NoError(t, err)
 
 		s := server.New(c)
@@ -2127,11 +2169,13 @@ func TestPinClosure(t *testing.T) {
 
 		db, err := database.Open("sqlite:"+dbFile, nil)
 		require.NoError(t, err)
+		dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+		require.NoError(t, err)
 
 		localStore, err := local.New(newContext(), dir)
 		require.NoError(t, err)
 
-		c, err := newTestCache(newContext(), db, localStore, localStore, localStore)
+		c, err := newTestCache(newContext(), db, dbClient, localStore, localStore, localStore)
 		require.NoError(t, err)
 
 		s := server.New(c)

--- a/testhelper/mysql.go
+++ b/testhelper/mysql.go
@@ -55,8 +55,10 @@ func MigrateMySQLDatabase(t *testing.T, dbURL string) {
 
 // SetupMySQL sets up a new temporary MySQL database for testing.
 // It requires the NCPS_TEST_ADMIN_MYSQL_URL environment variable to be set.
-// It returns a database connection and a cleanup function.
-func SetupMySQL(t *testing.T) (database.Querier, string, func()) {
+// It returns the legacy Querier (still in use during §11.2-§11.7),
+// the §11-introduced Ent-backed *database.Client, the database URL,
+// and a cleanup function.
+func SetupMySQL(t *testing.T) (database.Querier, *database.Client, string, func()) {
 	t.Helper()
 
 	adminDbURL := os.Getenv("NCPS_TEST_ADMIN_MYSQL_URL")
@@ -103,11 +105,14 @@ func SetupMySQL(t *testing.T) (database.Querier, string, func()) {
 	db, err := database.Open(dbURL, nil)
 	require.NoError(t, err)
 
+	dbClient, err := database.NewClient(db.DB(), database.TypeMySQL)
+	require.NoError(t, err)
+
 	cleanup := func() {
 		_ = db.DB().Close()
 		_, _ = adminDb.DB().ExecContext(context.Background(), fmt.Sprintf("DROP DATABASE `%s`", dbName))
 		_ = adminDb.DB().Close()
 	}
 
-	return db, dbURL, cleanup
+	return db, dbClient, dbURL, cleanup
 }

--- a/testhelper/postgres.go
+++ b/testhelper/postgres.go
@@ -55,8 +55,10 @@ func MigratePostgresDatabase(t *testing.T, dbURL string) {
 
 // SetupPostgres sets up a new temporary PostgreSQL database for testing.
 // It requires the NCPS_TEST_ADMIN_POSTGRES_URL environment variable to be set.
-// It returns a database connection and a cleanup function.
-func SetupPostgres(t *testing.T) (database.Querier, string, func()) {
+// It returns the legacy Querier (still in use during §11.2-§11.7),
+// the §11-introduced Ent-backed *database.Client, the database URL,
+// and a cleanup function.
+func SetupPostgres(t *testing.T) (database.Querier, *database.Client, string, func()) {
 	t.Helper()
 
 	adminDbURL := os.Getenv("NCPS_TEST_ADMIN_POSTGRES_URL")
@@ -98,11 +100,14 @@ func SetupPostgres(t *testing.T) (database.Querier, string, func()) {
 	db, err := database.Open(dbURL, nil)
 	require.NoError(t, err)
 
+	dbClient, err := database.NewClient(db.DB(), database.TypePostgreSQL)
+	require.NoError(t, err)
+
 	cleanup := func() {
 		_ = db.DB().Close()
 		_, _ = adminDb.DB().ExecContext(context.Background(), "SELECT drop_test_db($1);", dbName)
 		_ = adminDb.DB().Close()
 	}
 
-	return db, dbURL, cleanup
+	return db, dbClient, dbURL, cleanup
 }

--- a/testhelper/sqlite.go
+++ b/testhelper/sqlite.go
@@ -277,9 +277,11 @@ func getOrCreateNarFile(
 }
 
 // SetupSQLite sets up a new temporary SQLite database for testing.
-// It returns a database connection and a cleanup function.
-// This function has the same signature as SetupPostgres and SetupMySQL for consistency.
-func SetupSQLite(t *testing.T) (database.Querier, func()) {
+// It returns the legacy Querier (still in use during §11.2-§11.7),
+// the §11-introduced Ent-backed *database.Client, and a cleanup
+// function. Once §11 finishes converting call sites the Querier
+// return value will be dropped.
+func SetupSQLite(t *testing.T) (database.Querier, *database.Client, func()) {
 	t.Helper()
 
 	dir, err := os.MkdirTemp("", "sqlite-test-")
@@ -291,10 +293,13 @@ func SetupSQLite(t *testing.T) (database.Querier, func()) {
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
 
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
+
 	cleanup := func() {
 		db.DB().Close()
 		os.RemoveAll(dir)
 	}
 
-	return db, cleanup
+	return db, dbClient, cleanup
 }


### PR DESCRIPTION
§11.1 of migrate-to-ent-and-atlas. Lays the threading plumbing
for the Querier → Ent.Client migration without converting any
call sites yet — that work is split across §11.2-§11.7.

Changes:

- `pkg/cache/cache.Cache` gains a `dbClient *database.Client`
  field alongside the existing `db database.Querier`. Both share
  a single `*sql.DB` (one connection pool). The dbClient field
  is unused for now; subsequent §11 commits will progressively
  replace `c.db.<Method>(…)` call sites with `c.dbClient.Ent().…`.
- `cache.New` and `pkg/ncps.createCache` accept the dbClient as
  a new parameter; `pkg/ncps/serve.createDatabaseQuerier` now
  also constructs the Client (via `database.NewClient(db.DB(),
  detected_type)`) and returns it alongside the Querier.
- `testhelper.Setup{SQLite,Postgres,MySQL}` likewise yield the
  dbClient; every Setup caller (cache, cache/healthcheck, cache
  distributed, server, ncps test files) destructures it
  accordingly. Wrapper helpers — `newTestCache`,
  `setupTestComponents`, the `cacheFactory` type, the
  `distributedDBFactory` type, `setup{SQLite,Postgres,MySQL}Factory`,
  and `runTestsWithDB` in `cache_internal_test.go` — gain the
  Client in their return tuples / parameter lists. Tests that
  don't need the Client discard it with `_`.
- Sites that open SQLite directly (without testhelper) construct
  the Client inline next to `database.Open`.

Why now and not later: every test file calling `cache.New`
already breaks the moment the constructor changes shape, so the
threading has to land atomically. The conversion of actual
Querier method calls is deferred to §11.2-§11.7 to keep each
commit reviewable.

No behaviour change. Full `go test -race ./...` passes against
SQLite + Postgres + MySQL + MinIO + Redis.