### PR TITLE
feat(cache): add withEntTransaction infrastructure helper

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -5175,6 +5175,62 @@ func (c *Cache) withTransaction(ctx context.Context, operation string, fn func(q
 	return fmt.Errorf("transaction for %s failed after %d attempts: %w", operation, maxAttempts, err)
 }
 
+// withEntTransaction is the Ent-backed counterpart to withTransaction.
+// It wraps c.dbClient.WithTransaction with the same deadlock-retry
+// policy. Once §11.2-§11.5 finish converting every call site away
+// from the qtx-style Querier closures, withTransaction (and the
+// underlying executeTransaction) can be deleted.
+//
+// the first batch of conversions in §11.2 still uses the legacy
+// helper because the closures cascade through sqlc row-shape
+// consumers. Will become live as those callers convert.
+//
+//nolint:unused // exposed for the in-progress §11 caller migration;
+func (c *Cache) withEntTransaction(ctx context.Context, operation string, fn func(tx *ent.Tx) error) error {
+	const (
+		maxAttempts  = 5
+		initialDelay = 50 * time.Millisecond
+	)
+
+	var (
+		err   error
+		delay = initialDelay
+	)
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		err = c.dbClient.WithTransaction(ctx, operation, fn)
+		if err == nil {
+			return nil
+		}
+
+		// Only retry on deadlock/busy errors
+		if !database.IsDeadlockError(err) {
+			return err
+		}
+
+		if attempt == maxAttempts {
+			break
+		}
+
+		zerolog.Ctx(ctx).
+			Warn().
+			Err(err).
+			Str("operation", operation).
+			Int("attempt", attempt).
+			Dur("delay", delay).
+			Msg("database deadlock/busy, retrying transaction")
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+			delay *= 2
+		}
+	}
+
+	return fmt.Errorf("transaction for %s failed after %d attempts: %w", operation, maxAttempts, err)
+}
+
 func (c *Cache) executeTransaction(ctx context.Context, operation string, fn func(qtx database.Querier) error) error {
 	zerolog.Ctx(ctx).Debug().
 		Str("operation", operation).


### PR DESCRIPTION
Adds the Ent-backed counterpart to *Cache.withTransaction so
upcoming §11.2-§11.5 caller-migration commits can convert
qtx-style closures one at a time without rewriting the
deadlock-retry policy each time.

The helper:

- delegates the lifecycle (begin → fn(tx) → commit / rollback
  / panic-rollback) to *database.Client.WithTransaction added
  in §10
- preserves the existing retry-on-deadlock loop verbatim (5
  attempts, 50ms initial back-off doubling per try, ctx-aware
  pacing, deadlock detection via database.IsDeadlockError) so
  conversions are behavior-preserving
- is annotated //nolint:unused because no call site is
  converted yet; the annotation will come off as soon as the
  first qtx-style block migrates over

Once every withTransaction call site moves off the Querier
closure shape, the legacy withTransaction (and the underlying
executeTransaction) become dead code and are removed in §12.

No behavior change. Lint clean, full pkg/cache -race test
suite passes against SQLite + Postgres + MySQL + MinIO + Redis.