### PR TITLE
refactor(database): share Schema.Create mutex across callers

### DIFF
--- a/pkg/database/client.go
+++ b/pkg/database/client.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sync"
 
 	"entgo.io/ent/dialect"
 
@@ -12,6 +13,16 @@ import (
 
 	"github.com/kalbasit/ncps/ent"
 )
+
+// SchemaCreateMu serialises Ent's Schema.Create across the process.
+// Ent mutates the package-level `migrate.Tables` slice during
+// Schema.Create; without a global lock, concurrent goroutines race on
+// that slice. Every code path that calls Schema.Create (fresh-install
+// in pkg/database/migrate, schema-bootstrap helpers in tests) must
+// acquire this mutex.
+//
+//nolint:gochecknoglobals // process-wide concurrency guard.
+var SchemaCreateMu sync.Mutex
 
 // ErrUnknownDialect is returned when a database.Type cannot be mapped to
 // an ent dialect string. Mirrors the sentinel in pkg/database/migrate.

--- a/pkg/database/client_test.go
+++ b/pkg/database/client_test.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"path/filepath"
-	"sync"
 	"testing"
 
 	"entgo.io/ent/dialect"
@@ -25,14 +24,6 @@ import (
 // errCallerSentinel is a static error returned by test callbacks to
 // verify rollback semantics.
 var errCallerSentinel = errors.New("caller error")
-
-// entCreateMu serialises Ent's Schema.Create across goroutines inside
-// this test binary (Ent mutates the package-level migrate.Tables slice
-// during Create — concurrent callers race). Mirrors the same guard in
-// pkg/database/migrate/fresh.go.
-//
-//nolint:gochecknoglobals // process-wide concurrency guard.
-var entCreateMu sync.Mutex
 
 func TestNewClient_NilDB(t *testing.T) {
 	t.Parallel()
@@ -237,24 +228,24 @@ func freshSchemaSQLite(t *testing.T) (*sql.DB, func()) {
 	sdb, err := sql.Open("sqlite3", "file:"+dbFile+"?_fk=1&_journal_mode=WAL&_busy_timeout=10000")
 	require.NoError(t, err)
 
-	entCreateMu.Lock()
+	database.SchemaCreateMu.Lock()
 
 	drv := entsql.OpenDB(dialect.SQLite, sdb)
 
 	m, err := entschema.NewMigrate(drv, entschema.WithDialect(dialect.SQLite))
 	if err != nil {
-		entCreateMu.Unlock()
+		database.SchemaCreateMu.Unlock()
 
 		t.Fatalf("NewMigrate: %v", err)
 	}
 
 	if createErr := m.Create(context.Background(), entmigrate.Tables...); createErr != nil {
-		entCreateMu.Unlock()
+		database.SchemaCreateMu.Unlock()
 
 		t.Fatalf("Schema.Create: %v", createErr)
 	}
 
-	entCreateMu.Unlock()
+	database.SchemaCreateMu.Unlock()
 
 	return sdb, func() { _ = sdb.Close() }
 }

--- a/pkg/database/migrate/fresh.go
+++ b/pkg/database/migrate/fresh.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"strconv"
 	"strings"
-	"sync"
 
 	"entgo.io/ent/dialect"
 	"github.com/pressly/goose/v3/database"
@@ -18,15 +17,10 @@ import (
 	ncpsdb "github.com/kalbasit/ncps/pkg/database"
 )
 
-// entCreateMu serialises Ent's Schema.Create across goroutines. Ent's
-// migrate.Tables is a package-level slice that Atlas's setupTables
-// mutates during Create, so concurrent fresh-install paths race. In
-// production only one ncps process calls migrate.Up at startup, but
-// the test suite runs many parallel scenarios — this mutex keeps the
-// tests honest without distorting production behaviour.
-//
-//nolint:gochecknoglobals // package-level synchronisation primitive
-var entCreateMu sync.Mutex
+// The Schema.Create serialisation mutex lives in pkg/database
+// (ncpsdb.SchemaCreateMu) so every caller in the process — this
+// package, pkg/database's own tests, and testhelper's
+// CreateMigrateDatabase — shares one source of truth.
 
 // freshInstall produces the entire Ent-expected schema on an empty
 // database via Ent's runtime `Schema.Create`, then seeds the goose
@@ -57,7 +51,7 @@ func freshInstall(
 	// 1. Ent's Schema.Create produces the application tables in one shot.
 	//    Serialise across goroutines — Ent mutates the package-level
 	//    migrate.Tables slice during Create, so concurrent callers race.
-	entCreateMu.Lock()
+	ncpsdb.SchemaCreateMu.Lock()
 
 	drv := entsql.OpenDB(entDialect, db)
 
@@ -65,14 +59,14 @@ func freshInstall(
 		entschema.WithDialect(entDialect),
 	)
 	if err != nil {
-		entCreateMu.Unlock()
+		ncpsdb.SchemaCreateMu.Unlock()
 
 		return fmt.Errorf("NewMigrate: %w", err)
 	}
 
 	createErr := m.Create(ctx, entmigrate.Tables...)
 
-	entCreateMu.Unlock()
+	ncpsdb.SchemaCreateMu.Unlock()
 
 	if createErr != nil {
 		return fmt.Errorf("Schema.Create: %w", createErr)


### PR DESCRIPTION
Ent's migrate.Tables is a package-level slice that Atlas's
setupTables mutates during Schema.Create. Anyone in the process
calling Schema.Create concurrently with a different mutex would
race on that slice, and the race detector would catch it the
moment a second caller is added.

Until now there was a single caller (pkg/database/migrate's
fresh-install path) plus an unrelated test helper in
pkg/database that used its own private sync.Mutex. They didn't
contend because the second never ran in the same test binary
as the first. The upcoming testhelper.CreateMigrateDatabase
rewrite (next commit) will add a third caller, at which point
the two mutexes would no longer be enough.

This commit consolidates them by lifting the mutex into
pkg/database as the exported `SchemaCreateMu`. Every code path
that calls Schema.Create acquires it. The lifted mutex lives
next to `Client` because both relate to Ent client lifecycle
and pkg/database is the natural home; pkg/database/migrate
already imports pkg/database so the dependency direction stays
clean.

No behaviour change beyond the test-time race elimination.