### PR TITLE
refactor(testhelper): switch to migrate.Up for schema setup

### DIFF
--- a/testhelper/mysql.go
+++ b/testhelper/mysql.go
@@ -3,54 +3,39 @@ package testhelper
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/kalbasit/ncps/migrations"
 	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/database/migrate"
 )
 
-// MigrateMySQLDatabase will migrate the MySQL database using dbmate.
+// MigrateMySQLDatabase runs the same migrate.Up flow `ncps migrate up`
+// uses in production: empty DB → ent.Schema.Create → final schema
+// including the §10b surrogate-id columns on weak entities. Replaces
+// the legacy dbmate invocation.
 // The database URL should be in the format: mysql://user:password@host:port/database
 func MigrateMySQLDatabase(t *testing.T, dbURL string) {
 	t.Helper()
 
-	_, thisFile, _, ok := runtime.Caller(0)
-	require.True(t, ok)
+	db, err := database.Open(dbURL, nil)
+	require.NoError(t, err)
 
-	dbMigrationsDir := filepath.Join(
-		filepath.Dir(filepath.Dir(thisFile)),
-		"db",
-		"migrations",
-		"mysql",
-	)
+	defer db.DB().Close()
 
-	dbSchema := filepath.Join(
-		filepath.Dir(filepath.Dir(thisFile)),
-		"db",
-		"schema",
-		"mysql.sql",
-	)
+	sub, err := fs.Sub(migrations.FS, "mysql")
+	require.NoError(t, err)
 
-	//nolint:gosec
-	cmd := exec.CommandContext(context.Background(),
-		"dbmate",
-		"--no-dump-schema",
-		"--url="+dbURL,
-		"--migrations-dir="+dbMigrationsDir,
-		"--schema-file="+dbSchema,
-		"up",
-	)
-
-	output, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "Running %q has failed", cmd.String())
-
-	t.Logf("%s: %s", cmd.String(), output)
+	require.NoError(t, migrate.Up(context.Background(), migrate.Options{
+		DB:           db.DB(),
+		Dialect:      database.TypeMySQL,
+		MigrationsFS: sub,
+	}))
 }
 
 // SetupMySQL sets up a new temporary MySQL database for testing.

--- a/testhelper/postgres.go
+++ b/testhelper/postgres.go
@@ -3,54 +3,39 @@ package testhelper
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"net/url"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/kalbasit/ncps/migrations"
 	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/database/migrate"
 )
 
-// MigratePostgresDatabase will migrate the PostgreSQL database using dbmate.
+// MigratePostgresDatabase runs the same migrate.Up flow `ncps migrate
+// up` uses in production: empty DB → ent.Schema.Create → final
+// schema including the §10b surrogate-id columns on weak entities.
+// Replaces the legacy dbmate invocation.
 // The database URL should be in the format: postgresql://user:password@host:port/database
 func MigratePostgresDatabase(t *testing.T, dbURL string) {
 	t.Helper()
 
-	_, thisFile, _, ok := runtime.Caller(0)
-	require.True(t, ok)
+	db, err := database.Open(dbURL, nil)
+	require.NoError(t, err)
 
-	dbMigrationsDir := filepath.Join(
-		filepath.Dir(filepath.Dir(thisFile)),
-		"db",
-		"migrations",
-		"postgres",
-	)
+	defer db.DB().Close()
 
-	dbSchema := filepath.Join(
-		filepath.Dir(filepath.Dir(thisFile)),
-		"db",
-		"schema",
-		"postgres.sql",
-	)
+	sub, err := fs.Sub(migrations.FS, "postgres")
+	require.NoError(t, err)
 
-	//nolint:gosec
-	cmd := exec.CommandContext(context.Background(),
-		"dbmate",
-		"--no-dump-schema",
-		"--url="+dbURL,
-		"--migrations-dir="+dbMigrationsDir,
-		"--schema-file="+dbSchema,
-		"up",
-	)
-
-	output, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "Running %q has failed. Output:\n%s", cmd.String(), string(output))
-
-	t.Logf("%s: %s", cmd.String(), output)
+	require.NoError(t, migrate.Up(context.Background(), migrate.Options{
+		DB:           db.DB(),
+		Dialect:      database.TypePostgreSQL,
+		MigrationsFS: sub,
+	}))
 }
 
 // SetupPostgres sets up a new temporary PostgreSQL database for testing.

--- a/testhelper/sqlite.go
+++ b/testhelper/sqlite.go
@@ -4,68 +4,52 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/nix-community/go-nix/pkg/narinfo"
 	"github.com/stretchr/testify/require"
 
+	"github.com/kalbasit/ncps/migrations"
 	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/database/migrate"
 	"github.com/kalbasit/ncps/pkg/nar"
 )
 
-// CreateMigrateDatabase will create all necessary directories, and will create
-// the sqlite3 database (if necessary) and migrate it.
+// CreateMigrateDatabase creates the parent directory tree and a fresh
+// SQLite database, then runs the same migrate.Up flow `ncps migrate up`
+// uses in production. Empty DB → ent.Schema.Create → final schema
+// including the §10b surrogate-id columns on weak entities. Tests can
+// now perform Ent edge traversals (WithReferences/WithSignatures/
+// WithNarInfoNarFiles) that the legacy dbmate-only schema didn't
+// support.
 func CreateMigrateDatabase(t testing.TB, dbFile string) {
 	t.Helper()
 
 	require.NoError(t, os.MkdirAll(filepath.Dir(dbFile), 0o700))
 
-	_, thisFile, _, ok := runtime.Caller(0)
-	require.True(t, ok)
-
-	dbMigrationsDir := filepath.Join(
-		filepath.Dir(filepath.Dir(thisFile)),
-		"db",
-		"migrations",
-		"sqlite",
-	)
-
-	dbSchema := filepath.Join(
-		filepath.Dir(filepath.Dir(thisFile)),
-		"db",
-		"schema",
-		"sqlite.sql",
-	)
-
-	//nolint:gosec
-	cmd := exec.CommandContext(context.Background(),
-		"dbmate",
-		"--no-dump-schema",
-		"--url=sqlite:"+dbFile,
-		"--migrations-dir="+dbMigrationsDir,
-		"--schema-file="+dbSchema,
-		"up",
-	)
-
-	output, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "Running %q has failed", cmd.String())
-
-	t.Logf("%s: %s", cmd.String(), output)
-
-	// IMPORTANT: Checkpoint the WAL to ensure all changes are written to the main database file.
-	// While not strictly necessary for correctness (SQLite handles this automatically), it ensures
-	// that all migration changes are immediately visible to new connections without relying on
-	// WAL file reads. This can prevent subtle issues in test environments with rapid database
-	// create/destroy cycles. See: https://www.sqlite.org/wal.html#checkpointing
-	db, err := sql.Open("sqlite3", dbFile)
+	db, err := sql.Open("sqlite3",
+		"file:"+dbFile+"?_fk=1&_journal_mode=WAL&_busy_timeout=10000")
 	require.NoError(t, err)
 
 	defer db.Close()
 
+	sub, err := fs.Sub(migrations.FS, "sqlite")
+	require.NoError(t, err)
+
+	require.NoError(t, migrate.Up(context.Background(), migrate.Options{
+		DB:           db,
+		Dialect:      database.TypeSQLite,
+		MigrationsFS: sub,
+	}))
+
+	// Checkpoint the WAL so on-disk file content is visible to other
+	// connections immediately. Not strictly required for correctness
+	// — SQLite handles WAL transparently — but prevents subtle
+	// rapid-create/destroy timing issues in tests. See
+	// https://www.sqlite.org/wal.html#checkpointing
 	_, err = db.ExecContext(context.Background(), "PRAGMA wal_checkpoint(TRUNCATE)")
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Replace the dbmate exec.Command invocations in
CreateMigrateDatabase / MigratePostgresDatabase /
MigrateMySQLDatabase with the same pkg/database/migrate.Up
flow `ncps migrate up` uses in production: empty DB →
ent.Schema.Create → final schema. Three motivations:

1. The dbmate-only path produces a schema without the §10b
   surrogate `id` columns on weak entities
   (narinfo_references, narinfo_signatures,
   narinfo_nar_files, nar_file_chunks). Ent's edge traversals
   (WithReferences / WithSignatures /
   WithNarInfoNarFiles) generate SQL that selects those
   columns; tests against the dbmate schema fail with
   "no such column: narinfo_references.id". Blocked
   §11.2's cascading conversions in pkg/cache. Now unblocked.

2. Eliminates the external dbmate binary dependency from
   the test path. Tests now exercise the production migrate
   code on every run, so schema-bug regressions surface in
   unit tests instead of integration.

3. Drops the need for `runtime.Caller`-derived
   `db/migrations/<dialect>/` path lookups. The migrations
   are loaded from `migrations/` via the embedded
   `migrations.FS`, the same source of truth ncps ships in
   its binary.

Required prerequisite: the previous commit's Ent schema fix
for `last_accessed_at DEFAULT CURRENT_TIMESTAMP`. Without it,
contract tests that read `LastAccessedAt.Time` would see
NULL instead of the expected insert-time timestamp.

Full -race test suite passes against SQLite + Postgres +
MySQL with the deps stack running. Lint clean.