### PR TITLE
feat(cache): convert remaining GetNarInfo* read paths to Ent

### DIFF
--- a/openspec/changes/migrate-to-ent-and-atlas/tasks.md
+++ b/openspec/changes/migrate-to-ent-and-atlas/tasks.md
@@ -114,7 +114,7 @@ Per design D6 (Option E), the adoption decision tree has four branches: empty DB
 ## 11. Caller migration
 
 - [x] 11.1 Rewrite `pkg/cache/cache.go` storage of `database.Querier` to `*database.Client`; convert call sites one method at a time (added `*Client` field + `dbClient` param threaded through `cache.New`, testhelpers, and all call sites; call-site method conversions in §11.2-§11.8)
-- [ ] 11.2 Convert `GetNarInfo*` paths in `pkg/cache/` to Ent fluent API; run package tests
+- [x] 11.2 Convert `GetNarInfo*` paths in `pkg/cache/` to Ent fluent API; run package tests
 - [ ] 11.3 Convert `PutNarInfo*` paths; run package tests
 - [ ] 11.4 Convert `GetNarFile*` / `PutNarFile*` paths (including CDC chunk insertion); run package tests
 - [ ] 11.5 Convert chunk and orphan-cleanup queries; run package tests

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -3696,10 +3696,10 @@ func (c *Cache) getNarInfoFromStore(ctx context.Context, hash string) (*narinfo.
 		return nil, errNarInfoPurged
 	}
 
-	err = c.withTransaction(ctx, "getNarInfoFromStore", func(qtx database.Querier) error {
-		nir, err := qtx.GetNarInfoByHash(ctx, hash)
+	err = c.withEntTransaction(ctx, "getNarInfoFromStore", func(tx *ent.Tx) error {
+		nir, err := tx.NarInfo.Query().Where(entnarinfo.HashEQ(hash)).Only(ctx)
 		if err != nil {
-			if database.IsNotFoundError(err) {
+			if ent.IsNotFound(err) {
 				c.backgroundMigrateNarInfo(ctx, hash, ni)
 
 				return nil
@@ -3709,7 +3709,7 @@ func (c *Cache) getNarInfoFromStore(ctx context.Context, hash string) (*narinfo.
 		}
 
 		// Migrate narinfos from storage to the database.
-		if !nir.URL.Valid {
+		if nir.URL == nil || *nir.URL == "" {
 			c.backgroundMigrateNarInfo(ctx, hash, ni)
 		}
 
@@ -3717,8 +3717,11 @@ func (c *Cache) getNarInfoFromStore(ctx context.Context, hash string) (*narinfo.
 			c.BackgroundMigrateNarToChunks(ctx, narURL)
 		}
 
-		if lat, err := nir.LastAccessedAt.Value(); err == nil && time.Since(lat.(time.Time)) > c.recordAgeIgnoreTouch {
-			if _, err := qtx.TouchNarInfo(ctx, hash); err != nil {
+		if nir.LastAccessedAt == nil || time.Since(*nir.LastAccessedAt) > c.recordAgeIgnoreTouch {
+			if _, err := tx.NarInfo.Update().
+				Where(entnarinfo.HashEQ(hash)).
+				SetLastAccessedAt(time.Now()).
+				Save(ctx); err != nil {
 				return fmt.Errorf("error touching the narinfo record: %w", err)
 			}
 		}
@@ -4282,21 +4285,21 @@ func (c *Cache) getNarActualSize(ctx context.Context, nu nar.URL) (int64, error)
 func (c *Cache) CheckAndFixNarInfo(ctx context.Context, hash string) error {
 	// First check if we have the NarInfo in DB using direct DB access
 	// to avoid higher-level cache logic (like purging or storage checks)
-	niRow, err := c.db.GetNarInfoByHash(ctx, hash)
+	niRow, err := c.dbClient.Ent().NarInfo.Query().Where(entnarinfo.HashEQ(hash)).Only(ctx)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if ent.IsNotFound(err) {
 			return nil
 		}
 
 		return fmt.Errorf("failed to get narinfo from db: %w", err)
 	}
 
-	if !niRow.URL.Valid {
+	if niRow.URL == nil || *niRow.URL == "" {
 		// No URL means not migrated or partial, can't check
 		return nil
 	}
 
-	nu, err := nar.ParseURL(niRow.URL.String)
+	nu, err := nar.ParseURL(*niRow.URL)
 	if err != nil {
 		return fmt.Errorf("failed to parse nar url from narinfo: %w", err)
 	}
@@ -4333,10 +4336,11 @@ func (c *Cache) CheckAndFixNarInfo(ctx context.Context, hash string) error {
 		return nil
 	}
 
-	if size != niRow.FileSize.Int64 {
+	currentFileSize := derefInt64Ptr(niRow.FileSize)
+	if size != currentFileSize {
 		zerolog.Ctx(ctx).
 			Info().
-			Int64("current_size", niRow.FileSize.Int64).
+			Int64("current_size", currentFileSize).
 			Int64("actual_size", size).
 			Msg("mismatch detected, fixing narinfo file size")
 
@@ -4346,36 +4350,40 @@ func (c *Cache) CheckAndFixNarInfo(ctx context.Context, hash string) error {
 	return nil
 }
 
-func (c *Cache) checkAndFixNarInfoNoCompression(ctx context.Context, hash string, niRow database.NarInfo) error {
-	// For compression=none, FileSize must be 0. If it's not, fix it.
-	if niRow.FileSize.Valid && niRow.FileSize.Int64 != 0 {
+func (c *Cache) checkAndFixNarInfoNoCompression(ctx context.Context, hash string, niRow *ent.NarInfo) error {
+	// For compression=none, FileSize must be 0/NULL. If it's not, fix it.
+	if niRow.FileSize != nil && *niRow.FileSize != 0 {
 		zerolog.Ctx(ctx).
 			Info().
-			Int64("current_size", niRow.FileSize.Int64).
+			Int64("current_size", *niRow.FileSize).
 			Msg("mismatch detected for compression=none, fixing narinfo file size to NULL")
 
-		if err := c.withTransaction(ctx, "fixNarInfoFileSizeToNull", func(qtx database.Querier) error {
-			return qtx.UpdateNarInfoFileSize(ctx, database.UpdateNarInfoFileSizeParams{
-				Hash:     hash,
-				FileSize: sql.NullInt64{Int64: 0, Valid: false},
-			})
+		if err := c.withEntTransaction(ctx, "fixNarInfoFileSizeToNull", func(tx *ent.Tx) error {
+			_, err := tx.NarInfo.Update().
+				Where(entnarinfo.HashEQ(hash)).
+				ClearFileSize().
+				Save(ctx)
+
+			return err
 		}); err != nil {
 			return fmt.Errorf("failed to fix narinfo file size to NULL: %w", err)
 		}
 	}
 
 	// For compression=none, FileHash must be NULL. If it's not, fix it.
-	if niRow.FileHash.Valid || niRow.FileHash.String != "" {
+	if niRow.FileHash != nil && *niRow.FileHash != "" {
 		zerolog.Ctx(ctx).
 			Info().
-			Str("current_file_hash", niRow.FileHash.String).
+			Str("current_file_hash", *niRow.FileHash).
 			Msg("mismatch detected for compression=none, fixing narinfo file hash to NULL")
 
-		if err := c.withTransaction(ctx, "fixNarInfoFileHashToNull", func(qtx database.Querier) error {
-			return qtx.UpdateNarInfoFileHash(ctx, database.UpdateNarInfoFileHashParams{
-				Hash:     hash,
-				FileHash: sql.NullString{String: "", Valid: false},
-			})
+		if err := c.withEntTransaction(ctx, "fixNarInfoFileHashToNull", func(tx *ent.Tx) error {
+			_, err := tx.NarInfo.Update().
+				Where(entnarinfo.HashEQ(hash)).
+				ClearFileHash().
+				Save(ctx)
+
+			return err
 		}); err != nil {
 			return fmt.Errorf("failed to fix narinfo file hash to NULL: %w", err)
 		}
@@ -6990,23 +6998,21 @@ func (c *Cache) GetPinnedClosureHashes(ctx context.Context) (map[string]struct{}
 			currentHash := queue[0]
 			queue = queue[1:]
 
-			// Get the narinfo by hash
-			ni, err := c.db.GetNarInfoByHash(ctx, currentHash)
+			// Get the narinfo + its references in one round-trip
+			ni, err := c.dbClient.Ent().NarInfo.Query().
+				Where(entnarinfo.HashEQ(currentHash)).
+				WithReferences().
+				Only(ctx)
 			if err != nil {
-				if database.IsNotFoundError(err) {
+				if ent.IsNotFound(err) {
 					continue // Narinfo not in database, skip
 				}
 
 				return nil, fmt.Errorf("failed to get narinfo %s: %w", currentHash, err)
 			}
 
-			// Get references for this narinfo
-			refs, err := c.db.GetNarInfoReferences(ctx, ni.ID)
-			if err != nil {
-				return nil, fmt.Errorf("failed to get references for narinfo %s: %w", currentHash, err)
-			}
-
-			for _, ref := range refs {
+			for _, refEdge := range ni.Edges.References {
+				ref := refEdge.Reference
 				// Extract hash from reference (format: <hash>-<name>-<version>)
 				// Hash is the first 52 characters
 				if len(ref) < narInfoHashLength {


### PR DESCRIPTION
feat(cache): convert remaining GetNarInfo* read paths to Ent

§11.2 completion. Three call sites that were left unconverted
by the prior commits because they read row fields downstream
(the "row-shape cascade") and so couldn't move in isolation.
All three now run through the Ent fluent API.

- `getNarInfoFromStore` (line 3699): inside-tx GetNarInfoByHash
  + TouchNarInfo path. Switched from c.withTransaction
  (qtx-style) to c.withEntTransaction (Ent-tx style). The
  TouchNarInfo call becomes
  `tx.NarInfo.Update().Where(HashEQ).SetLastAccessedAt(time.Now())
  .Save(ctx)`, matching the same pattern populateNarInfoFromDatabase
  uses for touch.

- `CheckAndFixNarInfo` + `checkAndFixNarInfoNoCompression` (line
  4285): consumes the entire narinfo row to inspect URL,
  FileSize, FileHash. Now reads from `*ent.NarInfo` (pointer
  fields) via the new `derefInt64Ptr` helper and direct
  pointer dereferences. The two "fix to NULL" paths in
  checkAndFixNarInfoNoCompression use
  `tx.NarInfo.Update().ClearFileSize()` / `.ClearFileHash()`
  to set the columns NULL — Ent's idiomatic way to do what
  `UpdateNarInfoFileSize`/`UpdateNarInfoFileHash` did with
  sql.NullInt64/sql.NullString{Valid: false}.

- Closure-pinning BFS (line 7002): combines GetNarInfoByHash +
  GetNarInfoReferences(narinfo.ID) into one round-trip via
  `tx.NarInfo.Query().Where(HashEQ).WithReferences().Only(ctx)`,
  iterating `ni.Edges.References` directly. Avoids the surrogate-id
  lookup the legacy path needed (sqlc's GetNarInfoReferences
  takes narinfo_id, which is irrelevant under Ent's edge model).

After this commit no `c.db.GetNarInfo*` or `qtx.GetNarInfo*`
call site remains in pkg/cache — §11.2 is complete and tasks.md
gets ticked. The same downstream-row-shape pattern (deref helpers
+ Ent UpdateOne mutators) will be reused for §11.3 (PutNarInfo)
and §11.4 (GetNarFile).

`go test -race ./pkg/cache/...` passes against SQLite + Postgres +
MySQL + Redis. Lint clean.

docs(openspec): mark §11.2 tasks complete

§11.2 (Convert GetNarInfo* paths in pkg/cache/ to Ent fluent
API) finished across feat-cache-getnarinfo-to-ent, feat-cache-
populate-narinfo-ent, and feat-cache-getnarinfo-ent-finish. No
`c.db.GetNarInfo*` or `qtx.GetNarInfo*` call site remains
in pkg/cache.