### PR TITLE
chore(ent): enable sql/upsert feature flag

### DIFF
--- a/ent/chunk_create.go
+++ b/ent/chunk_create.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/kalbasit/ncps/ent/chunk"
@@ -19,6 +20,7 @@ type ChunkCreate struct {
 	config
 	mutation *ChunkMutation
 	hooks    []Hook
+	conflict []sql.ConflictOption
 }
 
 // SetCreatedAt sets the "created_at" field.
@@ -180,6 +182,7 @@ func (_c *ChunkCreate) createSpec() (*Chunk, *sqlgraph.CreateSpec) {
 		_node = &Chunk{config: _c.config}
 		_spec = sqlgraph.NewCreateSpec(chunk.Table, sqlgraph.NewFieldSpec(chunk.FieldID, field.TypeInt))
 	)
+	_spec.OnConflict = _c.conflict
 	if value, ok := _c.mutation.CreatedAt(); ok {
 		_spec.SetField(chunk.FieldCreatedAt, field.TypeTime, value)
 		_node.CreatedAt = value
@@ -219,11 +222,282 @@ func (_c *ChunkCreate) createSpec() (*Chunk, *sqlgraph.CreateSpec) {
 	return _node, _spec
 }
 
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.Chunk.Create().
+//		SetCreatedAt(v).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.ChunkUpsert) {
+//			SetCreatedAt(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *ChunkCreate) OnConflict(opts ...sql.ConflictOption) *ChunkUpsertOne {
+	_c.conflict = opts
+	return &ChunkUpsertOne{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.Chunk.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *ChunkCreate) OnConflictColumns(columns ...string) *ChunkUpsertOne {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &ChunkUpsertOne{
+		create: _c,
+	}
+}
+
+type (
+	// ChunkUpsertOne is the builder for "upsert"-ing
+	//  one Chunk node.
+	ChunkUpsertOne struct {
+		create *ChunkCreate
+	}
+
+	// ChunkUpsert is the "OnConflict" setter.
+	ChunkUpsert struct {
+		*sql.UpdateSet
+	}
+)
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *ChunkUpsert) SetUpdatedAt(v time.Time) *ChunkUpsert {
+	u.Set(chunk.FieldUpdatedAt, v)
+	return u
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *ChunkUpsert) UpdateUpdatedAt() *ChunkUpsert {
+	u.SetExcluded(chunk.FieldUpdatedAt)
+	return u
+}
+
+// ClearUpdatedAt clears the value of the "updated_at" field.
+func (u *ChunkUpsert) ClearUpdatedAt() *ChunkUpsert {
+	u.SetNull(chunk.FieldUpdatedAt)
+	return u
+}
+
+// SetHash sets the "hash" field.
+func (u *ChunkUpsert) SetHash(v string) *ChunkUpsert {
+	u.Set(chunk.FieldHash, v)
+	return u
+}
+
+// UpdateHash sets the "hash" field to the value that was provided on create.
+func (u *ChunkUpsert) UpdateHash() *ChunkUpsert {
+	u.SetExcluded(chunk.FieldHash)
+	return u
+}
+
+// SetSize sets the "size" field.
+func (u *ChunkUpsert) SetSize(v uint32) *ChunkUpsert {
+	u.Set(chunk.FieldSize, v)
+	return u
+}
+
+// UpdateSize sets the "size" field to the value that was provided on create.
+func (u *ChunkUpsert) UpdateSize() *ChunkUpsert {
+	u.SetExcluded(chunk.FieldSize)
+	return u
+}
+
+// AddSize adds v to the "size" field.
+func (u *ChunkUpsert) AddSize(v uint32) *ChunkUpsert {
+	u.Add(chunk.FieldSize, v)
+	return u
+}
+
+// SetCompressedSize sets the "compressed_size" field.
+func (u *ChunkUpsert) SetCompressedSize(v uint32) *ChunkUpsert {
+	u.Set(chunk.FieldCompressedSize, v)
+	return u
+}
+
+// UpdateCompressedSize sets the "compressed_size" field to the value that was provided on create.
+func (u *ChunkUpsert) UpdateCompressedSize() *ChunkUpsert {
+	u.SetExcluded(chunk.FieldCompressedSize)
+	return u
+}
+
+// AddCompressedSize adds v to the "compressed_size" field.
+func (u *ChunkUpsert) AddCompressedSize(v uint32) *ChunkUpsert {
+	u.Add(chunk.FieldCompressedSize, v)
+	return u
+}
+
+// UpdateNewValues updates the mutable fields using the new values that were set on create.
+// Using this option is equivalent to using:
+//
+//	client.Chunk.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *ChunkUpsertOne) UpdateNewValues() *ChunkUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		if _, exists := u.create.mutation.CreatedAt(); exists {
+			s.SetIgnore(chunk.FieldCreatedAt)
+		}
+	}))
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.Chunk.Create().
+//	    OnConflict(sql.ResolveWithIgnore()).
+//	    Exec(ctx)
+func (u *ChunkUpsertOne) Ignore() *ChunkUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *ChunkUpsertOne) DoNothing() *ChunkUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the ChunkCreate.OnConflict
+// documentation for more info.
+func (u *ChunkUpsertOne) Update(set func(*ChunkUpsert)) *ChunkUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&ChunkUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *ChunkUpsertOne) SetUpdatedAt(v time.Time) *ChunkUpsertOne {
+	return u.Update(func(s *ChunkUpsert) {
+		s.SetUpdatedAt(v)
+	})
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *ChunkUpsertOne) UpdateUpdatedAt() *ChunkUpsertOne {
+	return u.Update(func(s *ChunkUpsert) {
+		s.UpdateUpdatedAt()
+	})
+}
+
+// ClearUpdatedAt clears the value of the "updated_at" field.
+func (u *ChunkUpsertOne) ClearUpdatedAt() *ChunkUpsertOne {
+	return u.Update(func(s *ChunkUpsert) {
+		s.ClearUpdatedAt()
+	})
+}
+
+// SetHash sets the "hash" field.
+func (u *ChunkUpsertOne) SetHash(v string) *ChunkUpsertOne {
+	return u.Update(func(s *ChunkUpsert) {
+		s.SetHash(v)
+	})
+}
+
+// UpdateHash sets the "hash" field to the value that was provided on create.
+func (u *ChunkUpsertOne) UpdateHash() *ChunkUpsertOne {
+	return u.Update(func(s *ChunkUpsert) {
+		s.UpdateHash()
+	})
+}
+
+// SetSize sets the "size" field.
+func (u *ChunkUpsertOne) SetSize(v uint32) *ChunkUpsertOne {
+	return u.Update(func(s *ChunkUpsert) {
+		s.SetSize(v)
+	})
+}
+
+// AddSize adds v to the "size" field.
+func (u *ChunkUpsertOne) AddSize(v uint32) *ChunkUpsertOne {
+	return u.Update(func(s *ChunkUpsert) {
+		s.AddSize(v)
+	})
+}
+
+// UpdateSize sets the "size" field to the value that was provided on create.
+func (u *ChunkUpsertOne) UpdateSize() *ChunkUpsertOne {
+	return u.Update(func(s *ChunkUpsert) {
+		s.UpdateSize()
+	})
+}
+
+// SetCompressedSize sets the "compressed_size" field.
+func (u *ChunkUpsertOne) SetCompressedSize(v uint32) *ChunkUpsertOne {
+	return u.Update(func(s *ChunkUpsert) {
+		s.SetCompressedSize(v)
+	})
+}
+
+// AddCompressedSize adds v to the "compressed_size" field.
+func (u *ChunkUpsertOne) AddCompressedSize(v uint32) *ChunkUpsertOne {
+	return u.Update(func(s *ChunkUpsert) {
+		s.AddCompressedSize(v)
+	})
+}
+
+// UpdateCompressedSize sets the "compressed_size" field to the value that was provided on create.
+func (u *ChunkUpsertOne) UpdateCompressedSize() *ChunkUpsertOne {
+	return u.Update(func(s *ChunkUpsert) {
+		s.UpdateCompressedSize()
+	})
+}
+
+// Exec executes the query.
+func (u *ChunkUpsertOne) Exec(ctx context.Context) error {
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for ChunkCreate.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *ChunkUpsertOne) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// Exec executes the UPSERT query and returns the inserted/updated ID.
+func (u *ChunkUpsertOne) ID(ctx context.Context) (id int, err error) {
+	node, err := u.create.Save(ctx)
+	if err != nil {
+		return id, err
+	}
+	return node.ID, nil
+}
+
+// IDX is like ID, but panics if an error occurs.
+func (u *ChunkUpsertOne) IDX(ctx context.Context) int {
+	id, err := u.ID(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
 // ChunkCreateBulk is the builder for creating many Chunk entities in bulk.
 type ChunkCreateBulk struct {
 	config
 	err      error
 	builders []*ChunkCreate
+	conflict []sql.ConflictOption
 }
 
 // Save creates the Chunk entities in the database.
@@ -253,6 +527,7 @@ func (_c *ChunkCreateBulk) Save(ctx context.Context) ([]*Chunk, error) {
 					_, err = mutators[i+1].Mutate(root, _c.builders[i+1].mutation)
 				} else {
 					spec := &sqlgraph.BatchCreateSpec{Nodes: specs}
+					spec.OnConflict = _c.conflict
 					// Invoke the actual operation on the latest mutation in the chain.
 					if err = sqlgraph.BatchCreate(ctx, _c.driver, spec); err != nil {
 						if sqlgraph.IsConstraintError(err) {
@@ -303,6 +578,194 @@ func (_c *ChunkCreateBulk) Exec(ctx context.Context) error {
 // ExecX is like Exec, but panics if an error occurs.
 func (_c *ChunkCreateBulk) ExecX(ctx context.Context) {
 	if err := _c.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.Chunk.CreateBulk(builders...).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.ChunkUpsert) {
+//			SetCreatedAt(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *ChunkCreateBulk) OnConflict(opts ...sql.ConflictOption) *ChunkUpsertBulk {
+	_c.conflict = opts
+	return &ChunkUpsertBulk{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.Chunk.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *ChunkCreateBulk) OnConflictColumns(columns ...string) *ChunkUpsertBulk {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &ChunkUpsertBulk{
+		create: _c,
+	}
+}
+
+// ChunkUpsertBulk is the builder for "upsert"-ing
+// a bulk of Chunk nodes.
+type ChunkUpsertBulk struct {
+	create *ChunkCreateBulk
+}
+
+// UpdateNewValues updates the mutable fields using the new values that
+// were set on create. Using this option is equivalent to using:
+//
+//	client.Chunk.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *ChunkUpsertBulk) UpdateNewValues() *ChunkUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		for _, b := range u.create.builders {
+			if _, exists := b.mutation.CreatedAt(); exists {
+				s.SetIgnore(chunk.FieldCreatedAt)
+			}
+		}
+	}))
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.Chunk.Create().
+//		OnConflict(sql.ResolveWithIgnore()).
+//		Exec(ctx)
+func (u *ChunkUpsertBulk) Ignore() *ChunkUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *ChunkUpsertBulk) DoNothing() *ChunkUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the ChunkCreateBulk.OnConflict
+// documentation for more info.
+func (u *ChunkUpsertBulk) Update(set func(*ChunkUpsert)) *ChunkUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&ChunkUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *ChunkUpsertBulk) SetUpdatedAt(v time.Time) *ChunkUpsertBulk {
+	return u.Update(func(s *ChunkUpsert) {
+		s.SetUpdatedAt(v)
+	})
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *ChunkUpsertBulk) UpdateUpdatedAt() *ChunkUpsertBulk {
+	return u.Update(func(s *ChunkUpsert) {
+		s.UpdateUpdatedAt()
+	})
+}
+
+// ClearUpdatedAt clears the value of the "updated_at" field.
+func (u *ChunkUpsertBulk) ClearUpdatedAt() *ChunkUpsertBulk {
+	return u.Update(func(s *ChunkUpsert) {
+		s.ClearUpdatedAt()
+	})
+}
+
+// SetHash sets the "hash" field.
+func (u *ChunkUpsertBulk) SetHash(v string) *ChunkUpsertBulk {
+	return u.Update(func(s *ChunkUpsert) {
+		s.SetHash(v)
+	})
+}
+
+// UpdateHash sets the "hash" field to the value that was provided on create.
+func (u *ChunkUpsertBulk) UpdateHash() *ChunkUpsertBulk {
+	return u.Update(func(s *ChunkUpsert) {
+		s.UpdateHash()
+	})
+}
+
+// SetSize sets the "size" field.
+func (u *ChunkUpsertBulk) SetSize(v uint32) *ChunkUpsertBulk {
+	return u.Update(func(s *ChunkUpsert) {
+		s.SetSize(v)
+	})
+}
+
+// AddSize adds v to the "size" field.
+func (u *ChunkUpsertBulk) AddSize(v uint32) *ChunkUpsertBulk {
+	return u.Update(func(s *ChunkUpsert) {
+		s.AddSize(v)
+	})
+}
+
+// UpdateSize sets the "size" field to the value that was provided on create.
+func (u *ChunkUpsertBulk) UpdateSize() *ChunkUpsertBulk {
+	return u.Update(func(s *ChunkUpsert) {
+		s.UpdateSize()
+	})
+}
+
+// SetCompressedSize sets the "compressed_size" field.
+func (u *ChunkUpsertBulk) SetCompressedSize(v uint32) *ChunkUpsertBulk {
+	return u.Update(func(s *ChunkUpsert) {
+		s.SetCompressedSize(v)
+	})
+}
+
+// AddCompressedSize adds v to the "compressed_size" field.
+func (u *ChunkUpsertBulk) AddCompressedSize(v uint32) *ChunkUpsertBulk {
+	return u.Update(func(s *ChunkUpsert) {
+		s.AddCompressedSize(v)
+	})
+}
+
+// UpdateCompressedSize sets the "compressed_size" field to the value that was provided on create.
+func (u *ChunkUpsertBulk) UpdateCompressedSize() *ChunkUpsertBulk {
+	return u.Update(func(s *ChunkUpsert) {
+		s.UpdateCompressedSize()
+	})
+}
+
+// Exec executes the query.
+func (u *ChunkUpsertBulk) Exec(ctx context.Context) error {
+	if u.create.err != nil {
+		return u.create.err
+	}
+	for i, b := range u.create.builders {
+		if len(b.conflict) != 0 {
+			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the ChunkCreateBulk instead", i)
+		}
+	}
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for ChunkCreateBulk.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *ChunkUpsertBulk) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
 		panic(err)
 	}
 }

--- a/ent/configentry_create.go
+++ b/ent/configentry_create.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/kalbasit/ncps/ent/configentry"
@@ -18,6 +19,7 @@ type ConfigEntryCreate struct {
 	config
 	mutation *ConfigEntryMutation
 	hooks    []Hook
+	conflict []sql.ConflictOption
 }
 
 // SetCreatedAt sets the "created_at" field.
@@ -148,6 +150,7 @@ func (_c *ConfigEntryCreate) createSpec() (*ConfigEntry, *sqlgraph.CreateSpec) {
 		_node = &ConfigEntry{config: _c.config}
 		_spec = sqlgraph.NewCreateSpec(configentry.Table, sqlgraph.NewFieldSpec(configentry.FieldID, field.TypeInt))
 	)
+	_spec.OnConflict = _c.conflict
 	if value, ok := _c.mutation.CreatedAt(); ok {
 		_spec.SetField(configentry.FieldCreatedAt, field.TypeTime, value)
 		_node.CreatedAt = value
@@ -167,11 +170,230 @@ func (_c *ConfigEntryCreate) createSpec() (*ConfigEntry, *sqlgraph.CreateSpec) {
 	return _node, _spec
 }
 
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.ConfigEntry.Create().
+//		SetCreatedAt(v).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.ConfigEntryUpsert) {
+//			SetCreatedAt(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *ConfigEntryCreate) OnConflict(opts ...sql.ConflictOption) *ConfigEntryUpsertOne {
+	_c.conflict = opts
+	return &ConfigEntryUpsertOne{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.ConfigEntry.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *ConfigEntryCreate) OnConflictColumns(columns ...string) *ConfigEntryUpsertOne {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &ConfigEntryUpsertOne{
+		create: _c,
+	}
+}
+
+type (
+	// ConfigEntryUpsertOne is the builder for "upsert"-ing
+	//  one ConfigEntry node.
+	ConfigEntryUpsertOne struct {
+		create *ConfigEntryCreate
+	}
+
+	// ConfigEntryUpsert is the "OnConflict" setter.
+	ConfigEntryUpsert struct {
+		*sql.UpdateSet
+	}
+)
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *ConfigEntryUpsert) SetUpdatedAt(v time.Time) *ConfigEntryUpsert {
+	u.Set(configentry.FieldUpdatedAt, v)
+	return u
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *ConfigEntryUpsert) UpdateUpdatedAt() *ConfigEntryUpsert {
+	u.SetExcluded(configentry.FieldUpdatedAt)
+	return u
+}
+
+// ClearUpdatedAt clears the value of the "updated_at" field.
+func (u *ConfigEntryUpsert) ClearUpdatedAt() *ConfigEntryUpsert {
+	u.SetNull(configentry.FieldUpdatedAt)
+	return u
+}
+
+// SetKey sets the "key" field.
+func (u *ConfigEntryUpsert) SetKey(v string) *ConfigEntryUpsert {
+	u.Set(configentry.FieldKey, v)
+	return u
+}
+
+// UpdateKey sets the "key" field to the value that was provided on create.
+func (u *ConfigEntryUpsert) UpdateKey() *ConfigEntryUpsert {
+	u.SetExcluded(configentry.FieldKey)
+	return u
+}
+
+// SetValue sets the "value" field.
+func (u *ConfigEntryUpsert) SetValue(v string) *ConfigEntryUpsert {
+	u.Set(configentry.FieldValue, v)
+	return u
+}
+
+// UpdateValue sets the "value" field to the value that was provided on create.
+func (u *ConfigEntryUpsert) UpdateValue() *ConfigEntryUpsert {
+	u.SetExcluded(configentry.FieldValue)
+	return u
+}
+
+// UpdateNewValues updates the mutable fields using the new values that were set on create.
+// Using this option is equivalent to using:
+//
+//	client.ConfigEntry.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *ConfigEntryUpsertOne) UpdateNewValues() *ConfigEntryUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		if _, exists := u.create.mutation.CreatedAt(); exists {
+			s.SetIgnore(configentry.FieldCreatedAt)
+		}
+	}))
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.ConfigEntry.Create().
+//	    OnConflict(sql.ResolveWithIgnore()).
+//	    Exec(ctx)
+func (u *ConfigEntryUpsertOne) Ignore() *ConfigEntryUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *ConfigEntryUpsertOne) DoNothing() *ConfigEntryUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the ConfigEntryCreate.OnConflict
+// documentation for more info.
+func (u *ConfigEntryUpsertOne) Update(set func(*ConfigEntryUpsert)) *ConfigEntryUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&ConfigEntryUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *ConfigEntryUpsertOne) SetUpdatedAt(v time.Time) *ConfigEntryUpsertOne {
+	return u.Update(func(s *ConfigEntryUpsert) {
+		s.SetUpdatedAt(v)
+	})
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *ConfigEntryUpsertOne) UpdateUpdatedAt() *ConfigEntryUpsertOne {
+	return u.Update(func(s *ConfigEntryUpsert) {
+		s.UpdateUpdatedAt()
+	})
+}
+
+// ClearUpdatedAt clears the value of the "updated_at" field.
+func (u *ConfigEntryUpsertOne) ClearUpdatedAt() *ConfigEntryUpsertOne {
+	return u.Update(func(s *ConfigEntryUpsert) {
+		s.ClearUpdatedAt()
+	})
+}
+
+// SetKey sets the "key" field.
+func (u *ConfigEntryUpsertOne) SetKey(v string) *ConfigEntryUpsertOne {
+	return u.Update(func(s *ConfigEntryUpsert) {
+		s.SetKey(v)
+	})
+}
+
+// UpdateKey sets the "key" field to the value that was provided on create.
+func (u *ConfigEntryUpsertOne) UpdateKey() *ConfigEntryUpsertOne {
+	return u.Update(func(s *ConfigEntryUpsert) {
+		s.UpdateKey()
+	})
+}
+
+// SetValue sets the "value" field.
+func (u *ConfigEntryUpsertOne) SetValue(v string) *ConfigEntryUpsertOne {
+	return u.Update(func(s *ConfigEntryUpsert) {
+		s.SetValue(v)
+	})
+}
+
+// UpdateValue sets the "value" field to the value that was provided on create.
+func (u *ConfigEntryUpsertOne) UpdateValue() *ConfigEntryUpsertOne {
+	return u.Update(func(s *ConfigEntryUpsert) {
+		s.UpdateValue()
+	})
+}
+
+// Exec executes the query.
+func (u *ConfigEntryUpsertOne) Exec(ctx context.Context) error {
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for ConfigEntryCreate.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *ConfigEntryUpsertOne) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// Exec executes the UPSERT query and returns the inserted/updated ID.
+func (u *ConfigEntryUpsertOne) ID(ctx context.Context) (id int, err error) {
+	node, err := u.create.Save(ctx)
+	if err != nil {
+		return id, err
+	}
+	return node.ID, nil
+}
+
+// IDX is like ID, but panics if an error occurs.
+func (u *ConfigEntryUpsertOne) IDX(ctx context.Context) int {
+	id, err := u.ID(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
 // ConfigEntryCreateBulk is the builder for creating many ConfigEntry entities in bulk.
 type ConfigEntryCreateBulk struct {
 	config
 	err      error
 	builders []*ConfigEntryCreate
+	conflict []sql.ConflictOption
 }
 
 // Save creates the ConfigEntry entities in the database.
@@ -201,6 +423,7 @@ func (_c *ConfigEntryCreateBulk) Save(ctx context.Context) ([]*ConfigEntry, erro
 					_, err = mutators[i+1].Mutate(root, _c.builders[i+1].mutation)
 				} else {
 					spec := &sqlgraph.BatchCreateSpec{Nodes: specs}
+					spec.OnConflict = _c.conflict
 					// Invoke the actual operation on the latest mutation in the chain.
 					if err = sqlgraph.BatchCreate(ctx, _c.driver, spec); err != nil {
 						if sqlgraph.IsConstraintError(err) {
@@ -251,6 +474,166 @@ func (_c *ConfigEntryCreateBulk) Exec(ctx context.Context) error {
 // ExecX is like Exec, but panics if an error occurs.
 func (_c *ConfigEntryCreateBulk) ExecX(ctx context.Context) {
 	if err := _c.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.ConfigEntry.CreateBulk(builders...).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.ConfigEntryUpsert) {
+//			SetCreatedAt(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *ConfigEntryCreateBulk) OnConflict(opts ...sql.ConflictOption) *ConfigEntryUpsertBulk {
+	_c.conflict = opts
+	return &ConfigEntryUpsertBulk{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.ConfigEntry.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *ConfigEntryCreateBulk) OnConflictColumns(columns ...string) *ConfigEntryUpsertBulk {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &ConfigEntryUpsertBulk{
+		create: _c,
+	}
+}
+
+// ConfigEntryUpsertBulk is the builder for "upsert"-ing
+// a bulk of ConfigEntry nodes.
+type ConfigEntryUpsertBulk struct {
+	create *ConfigEntryCreateBulk
+}
+
+// UpdateNewValues updates the mutable fields using the new values that
+// were set on create. Using this option is equivalent to using:
+//
+//	client.ConfigEntry.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *ConfigEntryUpsertBulk) UpdateNewValues() *ConfigEntryUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		for _, b := range u.create.builders {
+			if _, exists := b.mutation.CreatedAt(); exists {
+				s.SetIgnore(configentry.FieldCreatedAt)
+			}
+		}
+	}))
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.ConfigEntry.Create().
+//		OnConflict(sql.ResolveWithIgnore()).
+//		Exec(ctx)
+func (u *ConfigEntryUpsertBulk) Ignore() *ConfigEntryUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *ConfigEntryUpsertBulk) DoNothing() *ConfigEntryUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the ConfigEntryCreateBulk.OnConflict
+// documentation for more info.
+func (u *ConfigEntryUpsertBulk) Update(set func(*ConfigEntryUpsert)) *ConfigEntryUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&ConfigEntryUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *ConfigEntryUpsertBulk) SetUpdatedAt(v time.Time) *ConfigEntryUpsertBulk {
+	return u.Update(func(s *ConfigEntryUpsert) {
+		s.SetUpdatedAt(v)
+	})
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *ConfigEntryUpsertBulk) UpdateUpdatedAt() *ConfigEntryUpsertBulk {
+	return u.Update(func(s *ConfigEntryUpsert) {
+		s.UpdateUpdatedAt()
+	})
+}
+
+// ClearUpdatedAt clears the value of the "updated_at" field.
+func (u *ConfigEntryUpsertBulk) ClearUpdatedAt() *ConfigEntryUpsertBulk {
+	return u.Update(func(s *ConfigEntryUpsert) {
+		s.ClearUpdatedAt()
+	})
+}
+
+// SetKey sets the "key" field.
+func (u *ConfigEntryUpsertBulk) SetKey(v string) *ConfigEntryUpsertBulk {
+	return u.Update(func(s *ConfigEntryUpsert) {
+		s.SetKey(v)
+	})
+}
+
+// UpdateKey sets the "key" field to the value that was provided on create.
+func (u *ConfigEntryUpsertBulk) UpdateKey() *ConfigEntryUpsertBulk {
+	return u.Update(func(s *ConfigEntryUpsert) {
+		s.UpdateKey()
+	})
+}
+
+// SetValue sets the "value" field.
+func (u *ConfigEntryUpsertBulk) SetValue(v string) *ConfigEntryUpsertBulk {
+	return u.Update(func(s *ConfigEntryUpsert) {
+		s.SetValue(v)
+	})
+}
+
+// UpdateValue sets the "value" field to the value that was provided on create.
+func (u *ConfigEntryUpsertBulk) UpdateValue() *ConfigEntryUpsertBulk {
+	return u.Update(func(s *ConfigEntryUpsert) {
+		s.UpdateValue()
+	})
+}
+
+// Exec executes the query.
+func (u *ConfigEntryUpsertBulk) Exec(ctx context.Context) error {
+	if u.create.err != nil {
+		return u.create.err
+	}
+	for i, b := range u.create.builders {
+		if len(b.conflict) != 0 {
+			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the ConfigEntryCreateBulk instead", i)
+		}
+	}
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for ConfigEntryCreateBulk.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *ConfigEntryUpsertBulk) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
 		panic(err)
 	}
 }

--- a/ent/generate.go
+++ b/ent/generate.go
@@ -1,0 +1,9 @@
+// Package ent is the generated Ent client root.
+//
+// The Ent client and supporting code under this directory are produced from
+// the schemas in ./schema by `go generate ./ent/...` (equivalently
+// `task ent:generate`). The generated tree is committed; CI verifies it is
+// up to date via `git diff --exit-code ./ent/`.
+package ent
+
+//go:generate go tool ent generate --feature sql/upsert ./schema

--- a/ent/narfile_create.go
+++ b/ent/narfile_create.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/kalbasit/ncps/ent/narfile"
@@ -20,6 +21,7 @@ type NarFileCreate struct {
 	config
 	mutation *NarFileMutation
 	hooks    []Hook
+	conflict []sql.ConflictOption
 }
 
 // SetCreatedAt sets the "created_at" field.
@@ -284,6 +286,7 @@ func (_c *NarFileCreate) createSpec() (*NarFile, *sqlgraph.CreateSpec) {
 		_node = &NarFile{config: _c.config}
 		_spec = sqlgraph.NewCreateSpec(narfile.Table, sqlgraph.NewFieldSpec(narfile.FieldID, field.TypeInt))
 	)
+	_spec.OnConflict = _c.conflict
 	if value, ok := _c.mutation.CreatedAt(); ok {
 		_spec.SetField(narfile.FieldCreatedAt, field.TypeTime, value)
 		_node.CreatedAt = value
@@ -359,11 +362,451 @@ func (_c *NarFileCreate) createSpec() (*NarFile, *sqlgraph.CreateSpec) {
 	return _node, _spec
 }
 
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.NarFile.Create().
+//		SetCreatedAt(v).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.NarFileUpsert) {
+//			SetCreatedAt(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *NarFileCreate) OnConflict(opts ...sql.ConflictOption) *NarFileUpsertOne {
+	_c.conflict = opts
+	return &NarFileUpsertOne{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.NarFile.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *NarFileCreate) OnConflictColumns(columns ...string) *NarFileUpsertOne {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &NarFileUpsertOne{
+		create: _c,
+	}
+}
+
+type (
+	// NarFileUpsertOne is the builder for "upsert"-ing
+	//  one NarFile node.
+	NarFileUpsertOne struct {
+		create *NarFileCreate
+	}
+
+	// NarFileUpsert is the "OnConflict" setter.
+	NarFileUpsert struct {
+		*sql.UpdateSet
+	}
+)
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *NarFileUpsert) SetUpdatedAt(v time.Time) *NarFileUpsert {
+	u.Set(narfile.FieldUpdatedAt, v)
+	return u
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *NarFileUpsert) UpdateUpdatedAt() *NarFileUpsert {
+	u.SetExcluded(narfile.FieldUpdatedAt)
+	return u
+}
+
+// ClearUpdatedAt clears the value of the "updated_at" field.
+func (u *NarFileUpsert) ClearUpdatedAt() *NarFileUpsert {
+	u.SetNull(narfile.FieldUpdatedAt)
+	return u
+}
+
+// SetHash sets the "hash" field.
+func (u *NarFileUpsert) SetHash(v string) *NarFileUpsert {
+	u.Set(narfile.FieldHash, v)
+	return u
+}
+
+// UpdateHash sets the "hash" field to the value that was provided on create.
+func (u *NarFileUpsert) UpdateHash() *NarFileUpsert {
+	u.SetExcluded(narfile.FieldHash)
+	return u
+}
+
+// SetCompression sets the "compression" field.
+func (u *NarFileUpsert) SetCompression(v string) *NarFileUpsert {
+	u.Set(narfile.FieldCompression, v)
+	return u
+}
+
+// UpdateCompression sets the "compression" field to the value that was provided on create.
+func (u *NarFileUpsert) UpdateCompression() *NarFileUpsert {
+	u.SetExcluded(narfile.FieldCompression)
+	return u
+}
+
+// SetFileSize sets the "file_size" field.
+func (u *NarFileUpsert) SetFileSize(v uint64) *NarFileUpsert {
+	u.Set(narfile.FieldFileSize, v)
+	return u
+}
+
+// UpdateFileSize sets the "file_size" field to the value that was provided on create.
+func (u *NarFileUpsert) UpdateFileSize() *NarFileUpsert {
+	u.SetExcluded(narfile.FieldFileSize)
+	return u
+}
+
+// AddFileSize adds v to the "file_size" field.
+func (u *NarFileUpsert) AddFileSize(v uint64) *NarFileUpsert {
+	u.Add(narfile.FieldFileSize, v)
+	return u
+}
+
+// SetQuery sets the "query" field.
+func (u *NarFileUpsert) SetQuery(v string) *NarFileUpsert {
+	u.Set(narfile.FieldQuery, v)
+	return u
+}
+
+// UpdateQuery sets the "query" field to the value that was provided on create.
+func (u *NarFileUpsert) UpdateQuery() *NarFileUpsert {
+	u.SetExcluded(narfile.FieldQuery)
+	return u
+}
+
+// SetTotalChunks sets the "total_chunks" field.
+func (u *NarFileUpsert) SetTotalChunks(v int64) *NarFileUpsert {
+	u.Set(narfile.FieldTotalChunks, v)
+	return u
+}
+
+// UpdateTotalChunks sets the "total_chunks" field to the value that was provided on create.
+func (u *NarFileUpsert) UpdateTotalChunks() *NarFileUpsert {
+	u.SetExcluded(narfile.FieldTotalChunks)
+	return u
+}
+
+// AddTotalChunks adds v to the "total_chunks" field.
+func (u *NarFileUpsert) AddTotalChunks(v int64) *NarFileUpsert {
+	u.Add(narfile.FieldTotalChunks, v)
+	return u
+}
+
+// SetChunkingStartedAt sets the "chunking_started_at" field.
+func (u *NarFileUpsert) SetChunkingStartedAt(v time.Time) *NarFileUpsert {
+	u.Set(narfile.FieldChunkingStartedAt, v)
+	return u
+}
+
+// UpdateChunkingStartedAt sets the "chunking_started_at" field to the value that was provided on create.
+func (u *NarFileUpsert) UpdateChunkingStartedAt() *NarFileUpsert {
+	u.SetExcluded(narfile.FieldChunkingStartedAt)
+	return u
+}
+
+// ClearChunkingStartedAt clears the value of the "chunking_started_at" field.
+func (u *NarFileUpsert) ClearChunkingStartedAt() *NarFileUpsert {
+	u.SetNull(narfile.FieldChunkingStartedAt)
+	return u
+}
+
+// SetVerifiedAt sets the "verified_at" field.
+func (u *NarFileUpsert) SetVerifiedAt(v time.Time) *NarFileUpsert {
+	u.Set(narfile.FieldVerifiedAt, v)
+	return u
+}
+
+// UpdateVerifiedAt sets the "verified_at" field to the value that was provided on create.
+func (u *NarFileUpsert) UpdateVerifiedAt() *NarFileUpsert {
+	u.SetExcluded(narfile.FieldVerifiedAt)
+	return u
+}
+
+// ClearVerifiedAt clears the value of the "verified_at" field.
+func (u *NarFileUpsert) ClearVerifiedAt() *NarFileUpsert {
+	u.SetNull(narfile.FieldVerifiedAt)
+	return u
+}
+
+// SetLastAccessedAt sets the "last_accessed_at" field.
+func (u *NarFileUpsert) SetLastAccessedAt(v time.Time) *NarFileUpsert {
+	u.Set(narfile.FieldLastAccessedAt, v)
+	return u
+}
+
+// UpdateLastAccessedAt sets the "last_accessed_at" field to the value that was provided on create.
+func (u *NarFileUpsert) UpdateLastAccessedAt() *NarFileUpsert {
+	u.SetExcluded(narfile.FieldLastAccessedAt)
+	return u
+}
+
+// ClearLastAccessedAt clears the value of the "last_accessed_at" field.
+func (u *NarFileUpsert) ClearLastAccessedAt() *NarFileUpsert {
+	u.SetNull(narfile.FieldLastAccessedAt)
+	return u
+}
+
+// UpdateNewValues updates the mutable fields using the new values that were set on create.
+// Using this option is equivalent to using:
+//
+//	client.NarFile.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *NarFileUpsertOne) UpdateNewValues() *NarFileUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		if _, exists := u.create.mutation.CreatedAt(); exists {
+			s.SetIgnore(narfile.FieldCreatedAt)
+		}
+	}))
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.NarFile.Create().
+//	    OnConflict(sql.ResolveWithIgnore()).
+//	    Exec(ctx)
+func (u *NarFileUpsertOne) Ignore() *NarFileUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *NarFileUpsertOne) DoNothing() *NarFileUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the NarFileCreate.OnConflict
+// documentation for more info.
+func (u *NarFileUpsertOne) Update(set func(*NarFileUpsert)) *NarFileUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&NarFileUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *NarFileUpsertOne) SetUpdatedAt(v time.Time) *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetUpdatedAt(v)
+	})
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *NarFileUpsertOne) UpdateUpdatedAt() *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateUpdatedAt()
+	})
+}
+
+// ClearUpdatedAt clears the value of the "updated_at" field.
+func (u *NarFileUpsertOne) ClearUpdatedAt() *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.ClearUpdatedAt()
+	})
+}
+
+// SetHash sets the "hash" field.
+func (u *NarFileUpsertOne) SetHash(v string) *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetHash(v)
+	})
+}
+
+// UpdateHash sets the "hash" field to the value that was provided on create.
+func (u *NarFileUpsertOne) UpdateHash() *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateHash()
+	})
+}
+
+// SetCompression sets the "compression" field.
+func (u *NarFileUpsertOne) SetCompression(v string) *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetCompression(v)
+	})
+}
+
+// UpdateCompression sets the "compression" field to the value that was provided on create.
+func (u *NarFileUpsertOne) UpdateCompression() *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateCompression()
+	})
+}
+
+// SetFileSize sets the "file_size" field.
+func (u *NarFileUpsertOne) SetFileSize(v uint64) *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetFileSize(v)
+	})
+}
+
+// AddFileSize adds v to the "file_size" field.
+func (u *NarFileUpsertOne) AddFileSize(v uint64) *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.AddFileSize(v)
+	})
+}
+
+// UpdateFileSize sets the "file_size" field to the value that was provided on create.
+func (u *NarFileUpsertOne) UpdateFileSize() *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateFileSize()
+	})
+}
+
+// SetQuery sets the "query" field.
+func (u *NarFileUpsertOne) SetQuery(v string) *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetQuery(v)
+	})
+}
+
+// UpdateQuery sets the "query" field to the value that was provided on create.
+func (u *NarFileUpsertOne) UpdateQuery() *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateQuery()
+	})
+}
+
+// SetTotalChunks sets the "total_chunks" field.
+func (u *NarFileUpsertOne) SetTotalChunks(v int64) *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetTotalChunks(v)
+	})
+}
+
+// AddTotalChunks adds v to the "total_chunks" field.
+func (u *NarFileUpsertOne) AddTotalChunks(v int64) *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.AddTotalChunks(v)
+	})
+}
+
+// UpdateTotalChunks sets the "total_chunks" field to the value that was provided on create.
+func (u *NarFileUpsertOne) UpdateTotalChunks() *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateTotalChunks()
+	})
+}
+
+// SetChunkingStartedAt sets the "chunking_started_at" field.
+func (u *NarFileUpsertOne) SetChunkingStartedAt(v time.Time) *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetChunkingStartedAt(v)
+	})
+}
+
+// UpdateChunkingStartedAt sets the "chunking_started_at" field to the value that was provided on create.
+func (u *NarFileUpsertOne) UpdateChunkingStartedAt() *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateChunkingStartedAt()
+	})
+}
+
+// ClearChunkingStartedAt clears the value of the "chunking_started_at" field.
+func (u *NarFileUpsertOne) ClearChunkingStartedAt() *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.ClearChunkingStartedAt()
+	})
+}
+
+// SetVerifiedAt sets the "verified_at" field.
+func (u *NarFileUpsertOne) SetVerifiedAt(v time.Time) *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetVerifiedAt(v)
+	})
+}
+
+// UpdateVerifiedAt sets the "verified_at" field to the value that was provided on create.
+func (u *NarFileUpsertOne) UpdateVerifiedAt() *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateVerifiedAt()
+	})
+}
+
+// ClearVerifiedAt clears the value of the "verified_at" field.
+func (u *NarFileUpsertOne) ClearVerifiedAt() *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.ClearVerifiedAt()
+	})
+}
+
+// SetLastAccessedAt sets the "last_accessed_at" field.
+func (u *NarFileUpsertOne) SetLastAccessedAt(v time.Time) *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetLastAccessedAt(v)
+	})
+}
+
+// UpdateLastAccessedAt sets the "last_accessed_at" field to the value that was provided on create.
+func (u *NarFileUpsertOne) UpdateLastAccessedAt() *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateLastAccessedAt()
+	})
+}
+
+// ClearLastAccessedAt clears the value of the "last_accessed_at" field.
+func (u *NarFileUpsertOne) ClearLastAccessedAt() *NarFileUpsertOne {
+	return u.Update(func(s *NarFileUpsert) {
+		s.ClearLastAccessedAt()
+	})
+}
+
+// Exec executes the query.
+func (u *NarFileUpsertOne) Exec(ctx context.Context) error {
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for NarFileCreate.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *NarFileUpsertOne) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// Exec executes the UPSERT query and returns the inserted/updated ID.
+func (u *NarFileUpsertOne) ID(ctx context.Context) (id int, err error) {
+	node, err := u.create.Save(ctx)
+	if err != nil {
+		return id, err
+	}
+	return node.ID, nil
+}
+
+// IDX is like ID, but panics if an error occurs.
+func (u *NarFileUpsertOne) IDX(ctx context.Context) int {
+	id, err := u.ID(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
 // NarFileCreateBulk is the builder for creating many NarFile entities in bulk.
 type NarFileCreateBulk struct {
 	config
 	err      error
 	builders []*NarFileCreate
+	conflict []sql.ConflictOption
 }
 
 // Save creates the NarFile entities in the database.
@@ -393,6 +836,7 @@ func (_c *NarFileCreateBulk) Save(ctx context.Context) ([]*NarFile, error) {
 					_, err = mutators[i+1].Mutate(root, _c.builders[i+1].mutation)
 				} else {
 					spec := &sqlgraph.BatchCreateSpec{Nodes: specs}
+					spec.OnConflict = _c.conflict
 					// Invoke the actual operation on the latest mutation in the chain.
 					if err = sqlgraph.BatchCreate(ctx, _c.driver, spec); err != nil {
 						if sqlgraph.IsConstraintError(err) {
@@ -443,6 +887,285 @@ func (_c *NarFileCreateBulk) Exec(ctx context.Context) error {
 // ExecX is like Exec, but panics if an error occurs.
 func (_c *NarFileCreateBulk) ExecX(ctx context.Context) {
 	if err := _c.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.NarFile.CreateBulk(builders...).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.NarFileUpsert) {
+//			SetCreatedAt(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *NarFileCreateBulk) OnConflict(opts ...sql.ConflictOption) *NarFileUpsertBulk {
+	_c.conflict = opts
+	return &NarFileUpsertBulk{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.NarFile.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *NarFileCreateBulk) OnConflictColumns(columns ...string) *NarFileUpsertBulk {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &NarFileUpsertBulk{
+		create: _c,
+	}
+}
+
+// NarFileUpsertBulk is the builder for "upsert"-ing
+// a bulk of NarFile nodes.
+type NarFileUpsertBulk struct {
+	create *NarFileCreateBulk
+}
+
+// UpdateNewValues updates the mutable fields using the new values that
+// were set on create. Using this option is equivalent to using:
+//
+//	client.NarFile.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *NarFileUpsertBulk) UpdateNewValues() *NarFileUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		for _, b := range u.create.builders {
+			if _, exists := b.mutation.CreatedAt(); exists {
+				s.SetIgnore(narfile.FieldCreatedAt)
+			}
+		}
+	}))
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.NarFile.Create().
+//		OnConflict(sql.ResolveWithIgnore()).
+//		Exec(ctx)
+func (u *NarFileUpsertBulk) Ignore() *NarFileUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *NarFileUpsertBulk) DoNothing() *NarFileUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the NarFileCreateBulk.OnConflict
+// documentation for more info.
+func (u *NarFileUpsertBulk) Update(set func(*NarFileUpsert)) *NarFileUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&NarFileUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *NarFileUpsertBulk) SetUpdatedAt(v time.Time) *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetUpdatedAt(v)
+	})
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *NarFileUpsertBulk) UpdateUpdatedAt() *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateUpdatedAt()
+	})
+}
+
+// ClearUpdatedAt clears the value of the "updated_at" field.
+func (u *NarFileUpsertBulk) ClearUpdatedAt() *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.ClearUpdatedAt()
+	})
+}
+
+// SetHash sets the "hash" field.
+func (u *NarFileUpsertBulk) SetHash(v string) *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetHash(v)
+	})
+}
+
+// UpdateHash sets the "hash" field to the value that was provided on create.
+func (u *NarFileUpsertBulk) UpdateHash() *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateHash()
+	})
+}
+
+// SetCompression sets the "compression" field.
+func (u *NarFileUpsertBulk) SetCompression(v string) *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetCompression(v)
+	})
+}
+
+// UpdateCompression sets the "compression" field to the value that was provided on create.
+func (u *NarFileUpsertBulk) UpdateCompression() *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateCompression()
+	})
+}
+
+// SetFileSize sets the "file_size" field.
+func (u *NarFileUpsertBulk) SetFileSize(v uint64) *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetFileSize(v)
+	})
+}
+
+// AddFileSize adds v to the "file_size" field.
+func (u *NarFileUpsertBulk) AddFileSize(v uint64) *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.AddFileSize(v)
+	})
+}
+
+// UpdateFileSize sets the "file_size" field to the value that was provided on create.
+func (u *NarFileUpsertBulk) UpdateFileSize() *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateFileSize()
+	})
+}
+
+// SetQuery sets the "query" field.
+func (u *NarFileUpsertBulk) SetQuery(v string) *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetQuery(v)
+	})
+}
+
+// UpdateQuery sets the "query" field to the value that was provided on create.
+func (u *NarFileUpsertBulk) UpdateQuery() *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateQuery()
+	})
+}
+
+// SetTotalChunks sets the "total_chunks" field.
+func (u *NarFileUpsertBulk) SetTotalChunks(v int64) *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetTotalChunks(v)
+	})
+}
+
+// AddTotalChunks adds v to the "total_chunks" field.
+func (u *NarFileUpsertBulk) AddTotalChunks(v int64) *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.AddTotalChunks(v)
+	})
+}
+
+// UpdateTotalChunks sets the "total_chunks" field to the value that was provided on create.
+func (u *NarFileUpsertBulk) UpdateTotalChunks() *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateTotalChunks()
+	})
+}
+
+// SetChunkingStartedAt sets the "chunking_started_at" field.
+func (u *NarFileUpsertBulk) SetChunkingStartedAt(v time.Time) *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetChunkingStartedAt(v)
+	})
+}
+
+// UpdateChunkingStartedAt sets the "chunking_started_at" field to the value that was provided on create.
+func (u *NarFileUpsertBulk) UpdateChunkingStartedAt() *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateChunkingStartedAt()
+	})
+}
+
+// ClearChunkingStartedAt clears the value of the "chunking_started_at" field.
+func (u *NarFileUpsertBulk) ClearChunkingStartedAt() *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.ClearChunkingStartedAt()
+	})
+}
+
+// SetVerifiedAt sets the "verified_at" field.
+func (u *NarFileUpsertBulk) SetVerifiedAt(v time.Time) *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetVerifiedAt(v)
+	})
+}
+
+// UpdateVerifiedAt sets the "verified_at" field to the value that was provided on create.
+func (u *NarFileUpsertBulk) UpdateVerifiedAt() *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateVerifiedAt()
+	})
+}
+
+// ClearVerifiedAt clears the value of the "verified_at" field.
+func (u *NarFileUpsertBulk) ClearVerifiedAt() *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.ClearVerifiedAt()
+	})
+}
+
+// SetLastAccessedAt sets the "last_accessed_at" field.
+func (u *NarFileUpsertBulk) SetLastAccessedAt(v time.Time) *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.SetLastAccessedAt(v)
+	})
+}
+
+// UpdateLastAccessedAt sets the "last_accessed_at" field to the value that was provided on create.
+func (u *NarFileUpsertBulk) UpdateLastAccessedAt() *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.UpdateLastAccessedAt()
+	})
+}
+
+// ClearLastAccessedAt clears the value of the "last_accessed_at" field.
+func (u *NarFileUpsertBulk) ClearLastAccessedAt() *NarFileUpsertBulk {
+	return u.Update(func(s *NarFileUpsert) {
+		s.ClearLastAccessedAt()
+	})
+}
+
+// Exec executes the query.
+func (u *NarFileUpsertBulk) Exec(ctx context.Context) error {
+	if u.create.err != nil {
+		return u.create.err
+	}
+	for i, b := range u.create.builders {
+		if len(b.conflict) != 0 {
+			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the NarFileCreateBulk instead", i)
+		}
+	}
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for NarFileCreateBulk.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *NarFileUpsertBulk) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
 		panic(err)
 	}
 }

--- a/ent/narfilechunk_create.go
+++ b/ent/narfilechunk_create.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/kalbasit/ncps/ent/chunk"
@@ -19,6 +20,7 @@ type NarFileChunkCreate struct {
 	config
 	mutation *NarFileChunkMutation
 	hooks    []Hook
+	conflict []sql.ConflictOption
 }
 
 // SetNarFileID sets the "nar_file_id" field.
@@ -124,6 +126,7 @@ func (_c *NarFileChunkCreate) createSpec() (*NarFileChunk, *sqlgraph.CreateSpec)
 		_node = &NarFileChunk{config: _c.config}
 		_spec = sqlgraph.NewCreateSpec(narfilechunk.Table, sqlgraph.NewFieldSpec(narfilechunk.FieldID, field.TypeInt))
 	)
+	_spec.OnConflict = _c.conflict
 	if value, ok := _c.mutation.ChunkIndex(); ok {
 		_spec.SetField(narfilechunk.FieldChunkIndex, field.TypeInt, value)
 		_node.ChunkIndex = value
@@ -165,11 +168,225 @@ func (_c *NarFileChunkCreate) createSpec() (*NarFileChunk, *sqlgraph.CreateSpec)
 	return _node, _spec
 }
 
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.NarFileChunk.Create().
+//		SetNarFileID(v).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.NarFileChunkUpsert) {
+//			SetNarFileID(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *NarFileChunkCreate) OnConflict(opts ...sql.ConflictOption) *NarFileChunkUpsertOne {
+	_c.conflict = opts
+	return &NarFileChunkUpsertOne{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.NarFileChunk.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *NarFileChunkCreate) OnConflictColumns(columns ...string) *NarFileChunkUpsertOne {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &NarFileChunkUpsertOne{
+		create: _c,
+	}
+}
+
+type (
+	// NarFileChunkUpsertOne is the builder for "upsert"-ing
+	//  one NarFileChunk node.
+	NarFileChunkUpsertOne struct {
+		create *NarFileChunkCreate
+	}
+
+	// NarFileChunkUpsert is the "OnConflict" setter.
+	NarFileChunkUpsert struct {
+		*sql.UpdateSet
+	}
+)
+
+// SetNarFileID sets the "nar_file_id" field.
+func (u *NarFileChunkUpsert) SetNarFileID(v int) *NarFileChunkUpsert {
+	u.Set(narfilechunk.FieldNarFileID, v)
+	return u
+}
+
+// UpdateNarFileID sets the "nar_file_id" field to the value that was provided on create.
+func (u *NarFileChunkUpsert) UpdateNarFileID() *NarFileChunkUpsert {
+	u.SetExcluded(narfilechunk.FieldNarFileID)
+	return u
+}
+
+// SetChunkID sets the "chunk_id" field.
+func (u *NarFileChunkUpsert) SetChunkID(v int) *NarFileChunkUpsert {
+	u.Set(narfilechunk.FieldChunkID, v)
+	return u
+}
+
+// UpdateChunkID sets the "chunk_id" field to the value that was provided on create.
+func (u *NarFileChunkUpsert) UpdateChunkID() *NarFileChunkUpsert {
+	u.SetExcluded(narfilechunk.FieldChunkID)
+	return u
+}
+
+// SetChunkIndex sets the "chunk_index" field.
+func (u *NarFileChunkUpsert) SetChunkIndex(v int) *NarFileChunkUpsert {
+	u.Set(narfilechunk.FieldChunkIndex, v)
+	return u
+}
+
+// UpdateChunkIndex sets the "chunk_index" field to the value that was provided on create.
+func (u *NarFileChunkUpsert) UpdateChunkIndex() *NarFileChunkUpsert {
+	u.SetExcluded(narfilechunk.FieldChunkIndex)
+	return u
+}
+
+// AddChunkIndex adds v to the "chunk_index" field.
+func (u *NarFileChunkUpsert) AddChunkIndex(v int) *NarFileChunkUpsert {
+	u.Add(narfilechunk.FieldChunkIndex, v)
+	return u
+}
+
+// UpdateNewValues updates the mutable fields using the new values that were set on create.
+// Using this option is equivalent to using:
+//
+//	client.NarFileChunk.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *NarFileChunkUpsertOne) UpdateNewValues() *NarFileChunkUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.NarFileChunk.Create().
+//	    OnConflict(sql.ResolveWithIgnore()).
+//	    Exec(ctx)
+func (u *NarFileChunkUpsertOne) Ignore() *NarFileChunkUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *NarFileChunkUpsertOne) DoNothing() *NarFileChunkUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the NarFileChunkCreate.OnConflict
+// documentation for more info.
+func (u *NarFileChunkUpsertOne) Update(set func(*NarFileChunkUpsert)) *NarFileChunkUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&NarFileChunkUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetNarFileID sets the "nar_file_id" field.
+func (u *NarFileChunkUpsertOne) SetNarFileID(v int) *NarFileChunkUpsertOne {
+	return u.Update(func(s *NarFileChunkUpsert) {
+		s.SetNarFileID(v)
+	})
+}
+
+// UpdateNarFileID sets the "nar_file_id" field to the value that was provided on create.
+func (u *NarFileChunkUpsertOne) UpdateNarFileID() *NarFileChunkUpsertOne {
+	return u.Update(func(s *NarFileChunkUpsert) {
+		s.UpdateNarFileID()
+	})
+}
+
+// SetChunkID sets the "chunk_id" field.
+func (u *NarFileChunkUpsertOne) SetChunkID(v int) *NarFileChunkUpsertOne {
+	return u.Update(func(s *NarFileChunkUpsert) {
+		s.SetChunkID(v)
+	})
+}
+
+// UpdateChunkID sets the "chunk_id" field to the value that was provided on create.
+func (u *NarFileChunkUpsertOne) UpdateChunkID() *NarFileChunkUpsertOne {
+	return u.Update(func(s *NarFileChunkUpsert) {
+		s.UpdateChunkID()
+	})
+}
+
+// SetChunkIndex sets the "chunk_index" field.
+func (u *NarFileChunkUpsertOne) SetChunkIndex(v int) *NarFileChunkUpsertOne {
+	return u.Update(func(s *NarFileChunkUpsert) {
+		s.SetChunkIndex(v)
+	})
+}
+
+// AddChunkIndex adds v to the "chunk_index" field.
+func (u *NarFileChunkUpsertOne) AddChunkIndex(v int) *NarFileChunkUpsertOne {
+	return u.Update(func(s *NarFileChunkUpsert) {
+		s.AddChunkIndex(v)
+	})
+}
+
+// UpdateChunkIndex sets the "chunk_index" field to the value that was provided on create.
+func (u *NarFileChunkUpsertOne) UpdateChunkIndex() *NarFileChunkUpsertOne {
+	return u.Update(func(s *NarFileChunkUpsert) {
+		s.UpdateChunkIndex()
+	})
+}
+
+// Exec executes the query.
+func (u *NarFileChunkUpsertOne) Exec(ctx context.Context) error {
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for NarFileChunkCreate.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *NarFileChunkUpsertOne) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// Exec executes the UPSERT query and returns the inserted/updated ID.
+func (u *NarFileChunkUpsertOne) ID(ctx context.Context) (id int, err error) {
+	node, err := u.create.Save(ctx)
+	if err != nil {
+		return id, err
+	}
+	return node.ID, nil
+}
+
+// IDX is like ID, but panics if an error occurs.
+func (u *NarFileChunkUpsertOne) IDX(ctx context.Context) int {
+	id, err := u.ID(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
 // NarFileChunkCreateBulk is the builder for creating many NarFileChunk entities in bulk.
 type NarFileChunkCreateBulk struct {
 	config
 	err      error
 	builders []*NarFileChunkCreate
+	conflict []sql.ConflictOption
 }
 
 // Save creates the NarFileChunk entities in the database.
@@ -198,6 +415,7 @@ func (_c *NarFileChunkCreateBulk) Save(ctx context.Context) ([]*NarFileChunk, er
 					_, err = mutators[i+1].Mutate(root, _c.builders[i+1].mutation)
 				} else {
 					spec := &sqlgraph.BatchCreateSpec{Nodes: specs}
+					spec.OnConflict = _c.conflict
 					// Invoke the actual operation on the latest mutation in the chain.
 					if err = sqlgraph.BatchCreate(ctx, _c.driver, spec); err != nil {
 						if sqlgraph.IsConstraintError(err) {
@@ -248,6 +466,159 @@ func (_c *NarFileChunkCreateBulk) Exec(ctx context.Context) error {
 // ExecX is like Exec, but panics if an error occurs.
 func (_c *NarFileChunkCreateBulk) ExecX(ctx context.Context) {
 	if err := _c.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.NarFileChunk.CreateBulk(builders...).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.NarFileChunkUpsert) {
+//			SetNarFileID(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *NarFileChunkCreateBulk) OnConflict(opts ...sql.ConflictOption) *NarFileChunkUpsertBulk {
+	_c.conflict = opts
+	return &NarFileChunkUpsertBulk{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.NarFileChunk.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *NarFileChunkCreateBulk) OnConflictColumns(columns ...string) *NarFileChunkUpsertBulk {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &NarFileChunkUpsertBulk{
+		create: _c,
+	}
+}
+
+// NarFileChunkUpsertBulk is the builder for "upsert"-ing
+// a bulk of NarFileChunk nodes.
+type NarFileChunkUpsertBulk struct {
+	create *NarFileChunkCreateBulk
+}
+
+// UpdateNewValues updates the mutable fields using the new values that
+// were set on create. Using this option is equivalent to using:
+//
+//	client.NarFileChunk.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *NarFileChunkUpsertBulk) UpdateNewValues() *NarFileChunkUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.NarFileChunk.Create().
+//		OnConflict(sql.ResolveWithIgnore()).
+//		Exec(ctx)
+func (u *NarFileChunkUpsertBulk) Ignore() *NarFileChunkUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *NarFileChunkUpsertBulk) DoNothing() *NarFileChunkUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the NarFileChunkCreateBulk.OnConflict
+// documentation for more info.
+func (u *NarFileChunkUpsertBulk) Update(set func(*NarFileChunkUpsert)) *NarFileChunkUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&NarFileChunkUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetNarFileID sets the "nar_file_id" field.
+func (u *NarFileChunkUpsertBulk) SetNarFileID(v int) *NarFileChunkUpsertBulk {
+	return u.Update(func(s *NarFileChunkUpsert) {
+		s.SetNarFileID(v)
+	})
+}
+
+// UpdateNarFileID sets the "nar_file_id" field to the value that was provided on create.
+func (u *NarFileChunkUpsertBulk) UpdateNarFileID() *NarFileChunkUpsertBulk {
+	return u.Update(func(s *NarFileChunkUpsert) {
+		s.UpdateNarFileID()
+	})
+}
+
+// SetChunkID sets the "chunk_id" field.
+func (u *NarFileChunkUpsertBulk) SetChunkID(v int) *NarFileChunkUpsertBulk {
+	return u.Update(func(s *NarFileChunkUpsert) {
+		s.SetChunkID(v)
+	})
+}
+
+// UpdateChunkID sets the "chunk_id" field to the value that was provided on create.
+func (u *NarFileChunkUpsertBulk) UpdateChunkID() *NarFileChunkUpsertBulk {
+	return u.Update(func(s *NarFileChunkUpsert) {
+		s.UpdateChunkID()
+	})
+}
+
+// SetChunkIndex sets the "chunk_index" field.
+func (u *NarFileChunkUpsertBulk) SetChunkIndex(v int) *NarFileChunkUpsertBulk {
+	return u.Update(func(s *NarFileChunkUpsert) {
+		s.SetChunkIndex(v)
+	})
+}
+
+// AddChunkIndex adds v to the "chunk_index" field.
+func (u *NarFileChunkUpsertBulk) AddChunkIndex(v int) *NarFileChunkUpsertBulk {
+	return u.Update(func(s *NarFileChunkUpsert) {
+		s.AddChunkIndex(v)
+	})
+}
+
+// UpdateChunkIndex sets the "chunk_index" field to the value that was provided on create.
+func (u *NarFileChunkUpsertBulk) UpdateChunkIndex() *NarFileChunkUpsertBulk {
+	return u.Update(func(s *NarFileChunkUpsert) {
+		s.UpdateChunkIndex()
+	})
+}
+
+// Exec executes the query.
+func (u *NarFileChunkUpsertBulk) Exec(ctx context.Context) error {
+	if u.create.err != nil {
+		return u.create.err
+	}
+	for i, b := range u.create.builders {
+		if len(b.conflict) != 0 {
+			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the NarFileChunkCreateBulk instead", i)
+		}
+	}
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for NarFileChunkCreateBulk.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *NarFileChunkUpsertBulk) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
 		panic(err)
 	}
 }

--- a/ent/narinfo_create.go
+++ b/ent/narinfo_create.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/kalbasit/ncps/ent/narinfo"
@@ -21,6 +22,7 @@ type NarInfoCreate struct {
 	config
 	mutation *NarInfoMutation
 	hooks    []Hook
+	conflict []sql.ConflictOption
 }
 
 // SetCreatedAt sets the "created_at" field.
@@ -340,6 +342,7 @@ func (_c *NarInfoCreate) createSpec() (*NarInfo, *sqlgraph.CreateSpec) {
 		_node = &NarInfo{config: _c.config}
 		_spec = sqlgraph.NewCreateSpec(narinfo.Table, sqlgraph.NewFieldSpec(narinfo.FieldID, field.TypeInt))
 	)
+	_spec.OnConflict = _c.conflict
 	if value, ok := _c.mutation.CreatedAt(); ok {
 		_spec.SetField(narinfo.FieldCreatedAt, field.TypeTime, value)
 		_node.CreatedAt = value
@@ -447,11 +450,659 @@ func (_c *NarInfoCreate) createSpec() (*NarInfo, *sqlgraph.CreateSpec) {
 	return _node, _spec
 }
 
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.NarInfo.Create().
+//		SetCreatedAt(v).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.NarInfoUpsert) {
+//			SetCreatedAt(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *NarInfoCreate) OnConflict(opts ...sql.ConflictOption) *NarInfoUpsertOne {
+	_c.conflict = opts
+	return &NarInfoUpsertOne{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.NarInfo.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *NarInfoCreate) OnConflictColumns(columns ...string) *NarInfoUpsertOne {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &NarInfoUpsertOne{
+		create: _c,
+	}
+}
+
+type (
+	// NarInfoUpsertOne is the builder for "upsert"-ing
+	//  one NarInfo node.
+	NarInfoUpsertOne struct {
+		create *NarInfoCreate
+	}
+
+	// NarInfoUpsert is the "OnConflict" setter.
+	NarInfoUpsert struct {
+		*sql.UpdateSet
+	}
+)
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *NarInfoUpsert) SetUpdatedAt(v time.Time) *NarInfoUpsert {
+	u.Set(narinfo.FieldUpdatedAt, v)
+	return u
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *NarInfoUpsert) UpdateUpdatedAt() *NarInfoUpsert {
+	u.SetExcluded(narinfo.FieldUpdatedAt)
+	return u
+}
+
+// ClearUpdatedAt clears the value of the "updated_at" field.
+func (u *NarInfoUpsert) ClearUpdatedAt() *NarInfoUpsert {
+	u.SetNull(narinfo.FieldUpdatedAt)
+	return u
+}
+
+// SetHash sets the "hash" field.
+func (u *NarInfoUpsert) SetHash(v string) *NarInfoUpsert {
+	u.Set(narinfo.FieldHash, v)
+	return u
+}
+
+// UpdateHash sets the "hash" field to the value that was provided on create.
+func (u *NarInfoUpsert) UpdateHash() *NarInfoUpsert {
+	u.SetExcluded(narinfo.FieldHash)
+	return u
+}
+
+// SetStorePath sets the "store_path" field.
+func (u *NarInfoUpsert) SetStorePath(v string) *NarInfoUpsert {
+	u.Set(narinfo.FieldStorePath, v)
+	return u
+}
+
+// UpdateStorePath sets the "store_path" field to the value that was provided on create.
+func (u *NarInfoUpsert) UpdateStorePath() *NarInfoUpsert {
+	u.SetExcluded(narinfo.FieldStorePath)
+	return u
+}
+
+// ClearStorePath clears the value of the "store_path" field.
+func (u *NarInfoUpsert) ClearStorePath() *NarInfoUpsert {
+	u.SetNull(narinfo.FieldStorePath)
+	return u
+}
+
+// SetURL sets the "url" field.
+func (u *NarInfoUpsert) SetURL(v string) *NarInfoUpsert {
+	u.Set(narinfo.FieldURL, v)
+	return u
+}
+
+// UpdateURL sets the "url" field to the value that was provided on create.
+func (u *NarInfoUpsert) UpdateURL() *NarInfoUpsert {
+	u.SetExcluded(narinfo.FieldURL)
+	return u
+}
+
+// ClearURL clears the value of the "url" field.
+func (u *NarInfoUpsert) ClearURL() *NarInfoUpsert {
+	u.SetNull(narinfo.FieldURL)
+	return u
+}
+
+// SetCompression sets the "compression" field.
+func (u *NarInfoUpsert) SetCompression(v string) *NarInfoUpsert {
+	u.Set(narinfo.FieldCompression, v)
+	return u
+}
+
+// UpdateCompression sets the "compression" field to the value that was provided on create.
+func (u *NarInfoUpsert) UpdateCompression() *NarInfoUpsert {
+	u.SetExcluded(narinfo.FieldCompression)
+	return u
+}
+
+// ClearCompression clears the value of the "compression" field.
+func (u *NarInfoUpsert) ClearCompression() *NarInfoUpsert {
+	u.SetNull(narinfo.FieldCompression)
+	return u
+}
+
+// SetFileHash sets the "file_hash" field.
+func (u *NarInfoUpsert) SetFileHash(v string) *NarInfoUpsert {
+	u.Set(narinfo.FieldFileHash, v)
+	return u
+}
+
+// UpdateFileHash sets the "file_hash" field to the value that was provided on create.
+func (u *NarInfoUpsert) UpdateFileHash() *NarInfoUpsert {
+	u.SetExcluded(narinfo.FieldFileHash)
+	return u
+}
+
+// ClearFileHash clears the value of the "file_hash" field.
+func (u *NarInfoUpsert) ClearFileHash() *NarInfoUpsert {
+	u.SetNull(narinfo.FieldFileHash)
+	return u
+}
+
+// SetFileSize sets the "file_size" field.
+func (u *NarInfoUpsert) SetFileSize(v int64) *NarInfoUpsert {
+	u.Set(narinfo.FieldFileSize, v)
+	return u
+}
+
+// UpdateFileSize sets the "file_size" field to the value that was provided on create.
+func (u *NarInfoUpsert) UpdateFileSize() *NarInfoUpsert {
+	u.SetExcluded(narinfo.FieldFileSize)
+	return u
+}
+
+// AddFileSize adds v to the "file_size" field.
+func (u *NarInfoUpsert) AddFileSize(v int64) *NarInfoUpsert {
+	u.Add(narinfo.FieldFileSize, v)
+	return u
+}
+
+// ClearFileSize clears the value of the "file_size" field.
+func (u *NarInfoUpsert) ClearFileSize() *NarInfoUpsert {
+	u.SetNull(narinfo.FieldFileSize)
+	return u
+}
+
+// SetNarHash sets the "nar_hash" field.
+func (u *NarInfoUpsert) SetNarHash(v string) *NarInfoUpsert {
+	u.Set(narinfo.FieldNarHash, v)
+	return u
+}
+
+// UpdateNarHash sets the "nar_hash" field to the value that was provided on create.
+func (u *NarInfoUpsert) UpdateNarHash() *NarInfoUpsert {
+	u.SetExcluded(narinfo.FieldNarHash)
+	return u
+}
+
+// ClearNarHash clears the value of the "nar_hash" field.
+func (u *NarInfoUpsert) ClearNarHash() *NarInfoUpsert {
+	u.SetNull(narinfo.FieldNarHash)
+	return u
+}
+
+// SetNarSize sets the "nar_size" field.
+func (u *NarInfoUpsert) SetNarSize(v int64) *NarInfoUpsert {
+	u.Set(narinfo.FieldNarSize, v)
+	return u
+}
+
+// UpdateNarSize sets the "nar_size" field to the value that was provided on create.
+func (u *NarInfoUpsert) UpdateNarSize() *NarInfoUpsert {
+	u.SetExcluded(narinfo.FieldNarSize)
+	return u
+}
+
+// AddNarSize adds v to the "nar_size" field.
+func (u *NarInfoUpsert) AddNarSize(v int64) *NarInfoUpsert {
+	u.Add(narinfo.FieldNarSize, v)
+	return u
+}
+
+// ClearNarSize clears the value of the "nar_size" field.
+func (u *NarInfoUpsert) ClearNarSize() *NarInfoUpsert {
+	u.SetNull(narinfo.FieldNarSize)
+	return u
+}
+
+// SetDeriver sets the "deriver" field.
+func (u *NarInfoUpsert) SetDeriver(v string) *NarInfoUpsert {
+	u.Set(narinfo.FieldDeriver, v)
+	return u
+}
+
+// UpdateDeriver sets the "deriver" field to the value that was provided on create.
+func (u *NarInfoUpsert) UpdateDeriver() *NarInfoUpsert {
+	u.SetExcluded(narinfo.FieldDeriver)
+	return u
+}
+
+// ClearDeriver clears the value of the "deriver" field.
+func (u *NarInfoUpsert) ClearDeriver() *NarInfoUpsert {
+	u.SetNull(narinfo.FieldDeriver)
+	return u
+}
+
+// SetSystem sets the "system" field.
+func (u *NarInfoUpsert) SetSystem(v string) *NarInfoUpsert {
+	u.Set(narinfo.FieldSystem, v)
+	return u
+}
+
+// UpdateSystem sets the "system" field to the value that was provided on create.
+func (u *NarInfoUpsert) UpdateSystem() *NarInfoUpsert {
+	u.SetExcluded(narinfo.FieldSystem)
+	return u
+}
+
+// ClearSystem clears the value of the "system" field.
+func (u *NarInfoUpsert) ClearSystem() *NarInfoUpsert {
+	u.SetNull(narinfo.FieldSystem)
+	return u
+}
+
+// SetCa sets the "ca" field.
+func (u *NarInfoUpsert) SetCa(v string) *NarInfoUpsert {
+	u.Set(narinfo.FieldCa, v)
+	return u
+}
+
+// UpdateCa sets the "ca" field to the value that was provided on create.
+func (u *NarInfoUpsert) UpdateCa() *NarInfoUpsert {
+	u.SetExcluded(narinfo.FieldCa)
+	return u
+}
+
+// ClearCa clears the value of the "ca" field.
+func (u *NarInfoUpsert) ClearCa() *NarInfoUpsert {
+	u.SetNull(narinfo.FieldCa)
+	return u
+}
+
+// SetLastAccessedAt sets the "last_accessed_at" field.
+func (u *NarInfoUpsert) SetLastAccessedAt(v time.Time) *NarInfoUpsert {
+	u.Set(narinfo.FieldLastAccessedAt, v)
+	return u
+}
+
+// UpdateLastAccessedAt sets the "last_accessed_at" field to the value that was provided on create.
+func (u *NarInfoUpsert) UpdateLastAccessedAt() *NarInfoUpsert {
+	u.SetExcluded(narinfo.FieldLastAccessedAt)
+	return u
+}
+
+// ClearLastAccessedAt clears the value of the "last_accessed_at" field.
+func (u *NarInfoUpsert) ClearLastAccessedAt() *NarInfoUpsert {
+	u.SetNull(narinfo.FieldLastAccessedAt)
+	return u
+}
+
+// UpdateNewValues updates the mutable fields using the new values that were set on create.
+// Using this option is equivalent to using:
+//
+//	client.NarInfo.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *NarInfoUpsertOne) UpdateNewValues() *NarInfoUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		if _, exists := u.create.mutation.CreatedAt(); exists {
+			s.SetIgnore(narinfo.FieldCreatedAt)
+		}
+	}))
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.NarInfo.Create().
+//	    OnConflict(sql.ResolveWithIgnore()).
+//	    Exec(ctx)
+func (u *NarInfoUpsertOne) Ignore() *NarInfoUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *NarInfoUpsertOne) DoNothing() *NarInfoUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the NarInfoCreate.OnConflict
+// documentation for more info.
+func (u *NarInfoUpsertOne) Update(set func(*NarInfoUpsert)) *NarInfoUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&NarInfoUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *NarInfoUpsertOne) SetUpdatedAt(v time.Time) *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetUpdatedAt(v)
+	})
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *NarInfoUpsertOne) UpdateUpdatedAt() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateUpdatedAt()
+	})
+}
+
+// ClearUpdatedAt clears the value of the "updated_at" field.
+func (u *NarInfoUpsertOne) ClearUpdatedAt() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearUpdatedAt()
+	})
+}
+
+// SetHash sets the "hash" field.
+func (u *NarInfoUpsertOne) SetHash(v string) *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetHash(v)
+	})
+}
+
+// UpdateHash sets the "hash" field to the value that was provided on create.
+func (u *NarInfoUpsertOne) UpdateHash() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateHash()
+	})
+}
+
+// SetStorePath sets the "store_path" field.
+func (u *NarInfoUpsertOne) SetStorePath(v string) *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetStorePath(v)
+	})
+}
+
+// UpdateStorePath sets the "store_path" field to the value that was provided on create.
+func (u *NarInfoUpsertOne) UpdateStorePath() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateStorePath()
+	})
+}
+
+// ClearStorePath clears the value of the "store_path" field.
+func (u *NarInfoUpsertOne) ClearStorePath() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearStorePath()
+	})
+}
+
+// SetURL sets the "url" field.
+func (u *NarInfoUpsertOne) SetURL(v string) *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetURL(v)
+	})
+}
+
+// UpdateURL sets the "url" field to the value that was provided on create.
+func (u *NarInfoUpsertOne) UpdateURL() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateURL()
+	})
+}
+
+// ClearURL clears the value of the "url" field.
+func (u *NarInfoUpsertOne) ClearURL() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearURL()
+	})
+}
+
+// SetCompression sets the "compression" field.
+func (u *NarInfoUpsertOne) SetCompression(v string) *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetCompression(v)
+	})
+}
+
+// UpdateCompression sets the "compression" field to the value that was provided on create.
+func (u *NarInfoUpsertOne) UpdateCompression() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateCompression()
+	})
+}
+
+// ClearCompression clears the value of the "compression" field.
+func (u *NarInfoUpsertOne) ClearCompression() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearCompression()
+	})
+}
+
+// SetFileHash sets the "file_hash" field.
+func (u *NarInfoUpsertOne) SetFileHash(v string) *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetFileHash(v)
+	})
+}
+
+// UpdateFileHash sets the "file_hash" field to the value that was provided on create.
+func (u *NarInfoUpsertOne) UpdateFileHash() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateFileHash()
+	})
+}
+
+// ClearFileHash clears the value of the "file_hash" field.
+func (u *NarInfoUpsertOne) ClearFileHash() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearFileHash()
+	})
+}
+
+// SetFileSize sets the "file_size" field.
+func (u *NarInfoUpsertOne) SetFileSize(v int64) *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetFileSize(v)
+	})
+}
+
+// AddFileSize adds v to the "file_size" field.
+func (u *NarInfoUpsertOne) AddFileSize(v int64) *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.AddFileSize(v)
+	})
+}
+
+// UpdateFileSize sets the "file_size" field to the value that was provided on create.
+func (u *NarInfoUpsertOne) UpdateFileSize() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateFileSize()
+	})
+}
+
+// ClearFileSize clears the value of the "file_size" field.
+func (u *NarInfoUpsertOne) ClearFileSize() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearFileSize()
+	})
+}
+
+// SetNarHash sets the "nar_hash" field.
+func (u *NarInfoUpsertOne) SetNarHash(v string) *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetNarHash(v)
+	})
+}
+
+// UpdateNarHash sets the "nar_hash" field to the value that was provided on create.
+func (u *NarInfoUpsertOne) UpdateNarHash() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateNarHash()
+	})
+}
+
+// ClearNarHash clears the value of the "nar_hash" field.
+func (u *NarInfoUpsertOne) ClearNarHash() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearNarHash()
+	})
+}
+
+// SetNarSize sets the "nar_size" field.
+func (u *NarInfoUpsertOne) SetNarSize(v int64) *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetNarSize(v)
+	})
+}
+
+// AddNarSize adds v to the "nar_size" field.
+func (u *NarInfoUpsertOne) AddNarSize(v int64) *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.AddNarSize(v)
+	})
+}
+
+// UpdateNarSize sets the "nar_size" field to the value that was provided on create.
+func (u *NarInfoUpsertOne) UpdateNarSize() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateNarSize()
+	})
+}
+
+// ClearNarSize clears the value of the "nar_size" field.
+func (u *NarInfoUpsertOne) ClearNarSize() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearNarSize()
+	})
+}
+
+// SetDeriver sets the "deriver" field.
+func (u *NarInfoUpsertOne) SetDeriver(v string) *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetDeriver(v)
+	})
+}
+
+// UpdateDeriver sets the "deriver" field to the value that was provided on create.
+func (u *NarInfoUpsertOne) UpdateDeriver() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateDeriver()
+	})
+}
+
+// ClearDeriver clears the value of the "deriver" field.
+func (u *NarInfoUpsertOne) ClearDeriver() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearDeriver()
+	})
+}
+
+// SetSystem sets the "system" field.
+func (u *NarInfoUpsertOne) SetSystem(v string) *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetSystem(v)
+	})
+}
+
+// UpdateSystem sets the "system" field to the value that was provided on create.
+func (u *NarInfoUpsertOne) UpdateSystem() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateSystem()
+	})
+}
+
+// ClearSystem clears the value of the "system" field.
+func (u *NarInfoUpsertOne) ClearSystem() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearSystem()
+	})
+}
+
+// SetCa sets the "ca" field.
+func (u *NarInfoUpsertOne) SetCa(v string) *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetCa(v)
+	})
+}
+
+// UpdateCa sets the "ca" field to the value that was provided on create.
+func (u *NarInfoUpsertOne) UpdateCa() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateCa()
+	})
+}
+
+// ClearCa clears the value of the "ca" field.
+func (u *NarInfoUpsertOne) ClearCa() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearCa()
+	})
+}
+
+// SetLastAccessedAt sets the "last_accessed_at" field.
+func (u *NarInfoUpsertOne) SetLastAccessedAt(v time.Time) *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetLastAccessedAt(v)
+	})
+}
+
+// UpdateLastAccessedAt sets the "last_accessed_at" field to the value that was provided on create.
+func (u *NarInfoUpsertOne) UpdateLastAccessedAt() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateLastAccessedAt()
+	})
+}
+
+// ClearLastAccessedAt clears the value of the "last_accessed_at" field.
+func (u *NarInfoUpsertOne) ClearLastAccessedAt() *NarInfoUpsertOne {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearLastAccessedAt()
+	})
+}
+
+// Exec executes the query.
+func (u *NarInfoUpsertOne) Exec(ctx context.Context) error {
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for NarInfoCreate.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *NarInfoUpsertOne) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// Exec executes the UPSERT query and returns the inserted/updated ID.
+func (u *NarInfoUpsertOne) ID(ctx context.Context) (id int, err error) {
+	node, err := u.create.Save(ctx)
+	if err != nil {
+		return id, err
+	}
+	return node.ID, nil
+}
+
+// IDX is like ID, but panics if an error occurs.
+func (u *NarInfoUpsertOne) IDX(ctx context.Context) int {
+	id, err := u.ID(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
 // NarInfoCreateBulk is the builder for creating many NarInfo entities in bulk.
 type NarInfoCreateBulk struct {
 	config
 	err      error
 	builders []*NarInfoCreate
+	conflict []sql.ConflictOption
 }
 
 // Save creates the NarInfo entities in the database.
@@ -481,6 +1132,7 @@ func (_c *NarInfoCreateBulk) Save(ctx context.Context) ([]*NarInfo, error) {
 					_, err = mutators[i+1].Mutate(root, _c.builders[i+1].mutation)
 				} else {
 					spec := &sqlgraph.BatchCreateSpec{Nodes: specs}
+					spec.OnConflict = _c.conflict
 					// Invoke the actual operation on the latest mutation in the chain.
 					if err = sqlgraph.BatchCreate(ctx, _c.driver, spec); err != nil {
 						if sqlgraph.IsConstraintError(err) {
@@ -531,6 +1183,397 @@ func (_c *NarInfoCreateBulk) Exec(ctx context.Context) error {
 // ExecX is like Exec, but panics if an error occurs.
 func (_c *NarInfoCreateBulk) ExecX(ctx context.Context) {
 	if err := _c.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.NarInfo.CreateBulk(builders...).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.NarInfoUpsert) {
+//			SetCreatedAt(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *NarInfoCreateBulk) OnConflict(opts ...sql.ConflictOption) *NarInfoUpsertBulk {
+	_c.conflict = opts
+	return &NarInfoUpsertBulk{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.NarInfo.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *NarInfoCreateBulk) OnConflictColumns(columns ...string) *NarInfoUpsertBulk {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &NarInfoUpsertBulk{
+		create: _c,
+	}
+}
+
+// NarInfoUpsertBulk is the builder for "upsert"-ing
+// a bulk of NarInfo nodes.
+type NarInfoUpsertBulk struct {
+	create *NarInfoCreateBulk
+}
+
+// UpdateNewValues updates the mutable fields using the new values that
+// were set on create. Using this option is equivalent to using:
+//
+//	client.NarInfo.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *NarInfoUpsertBulk) UpdateNewValues() *NarInfoUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		for _, b := range u.create.builders {
+			if _, exists := b.mutation.CreatedAt(); exists {
+				s.SetIgnore(narinfo.FieldCreatedAt)
+			}
+		}
+	}))
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.NarInfo.Create().
+//		OnConflict(sql.ResolveWithIgnore()).
+//		Exec(ctx)
+func (u *NarInfoUpsertBulk) Ignore() *NarInfoUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *NarInfoUpsertBulk) DoNothing() *NarInfoUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the NarInfoCreateBulk.OnConflict
+// documentation for more info.
+func (u *NarInfoUpsertBulk) Update(set func(*NarInfoUpsert)) *NarInfoUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&NarInfoUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *NarInfoUpsertBulk) SetUpdatedAt(v time.Time) *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetUpdatedAt(v)
+	})
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *NarInfoUpsertBulk) UpdateUpdatedAt() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateUpdatedAt()
+	})
+}
+
+// ClearUpdatedAt clears the value of the "updated_at" field.
+func (u *NarInfoUpsertBulk) ClearUpdatedAt() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearUpdatedAt()
+	})
+}
+
+// SetHash sets the "hash" field.
+func (u *NarInfoUpsertBulk) SetHash(v string) *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetHash(v)
+	})
+}
+
+// UpdateHash sets the "hash" field to the value that was provided on create.
+func (u *NarInfoUpsertBulk) UpdateHash() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateHash()
+	})
+}
+
+// SetStorePath sets the "store_path" field.
+func (u *NarInfoUpsertBulk) SetStorePath(v string) *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetStorePath(v)
+	})
+}
+
+// UpdateStorePath sets the "store_path" field to the value that was provided on create.
+func (u *NarInfoUpsertBulk) UpdateStorePath() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateStorePath()
+	})
+}
+
+// ClearStorePath clears the value of the "store_path" field.
+func (u *NarInfoUpsertBulk) ClearStorePath() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearStorePath()
+	})
+}
+
+// SetURL sets the "url" field.
+func (u *NarInfoUpsertBulk) SetURL(v string) *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetURL(v)
+	})
+}
+
+// UpdateURL sets the "url" field to the value that was provided on create.
+func (u *NarInfoUpsertBulk) UpdateURL() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateURL()
+	})
+}
+
+// ClearURL clears the value of the "url" field.
+func (u *NarInfoUpsertBulk) ClearURL() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearURL()
+	})
+}
+
+// SetCompression sets the "compression" field.
+func (u *NarInfoUpsertBulk) SetCompression(v string) *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetCompression(v)
+	})
+}
+
+// UpdateCompression sets the "compression" field to the value that was provided on create.
+func (u *NarInfoUpsertBulk) UpdateCompression() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateCompression()
+	})
+}
+
+// ClearCompression clears the value of the "compression" field.
+func (u *NarInfoUpsertBulk) ClearCompression() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearCompression()
+	})
+}
+
+// SetFileHash sets the "file_hash" field.
+func (u *NarInfoUpsertBulk) SetFileHash(v string) *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetFileHash(v)
+	})
+}
+
+// UpdateFileHash sets the "file_hash" field to the value that was provided on create.
+func (u *NarInfoUpsertBulk) UpdateFileHash() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateFileHash()
+	})
+}
+
+// ClearFileHash clears the value of the "file_hash" field.
+func (u *NarInfoUpsertBulk) ClearFileHash() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearFileHash()
+	})
+}
+
+// SetFileSize sets the "file_size" field.
+func (u *NarInfoUpsertBulk) SetFileSize(v int64) *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetFileSize(v)
+	})
+}
+
+// AddFileSize adds v to the "file_size" field.
+func (u *NarInfoUpsertBulk) AddFileSize(v int64) *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.AddFileSize(v)
+	})
+}
+
+// UpdateFileSize sets the "file_size" field to the value that was provided on create.
+func (u *NarInfoUpsertBulk) UpdateFileSize() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateFileSize()
+	})
+}
+
+// ClearFileSize clears the value of the "file_size" field.
+func (u *NarInfoUpsertBulk) ClearFileSize() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearFileSize()
+	})
+}
+
+// SetNarHash sets the "nar_hash" field.
+func (u *NarInfoUpsertBulk) SetNarHash(v string) *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetNarHash(v)
+	})
+}
+
+// UpdateNarHash sets the "nar_hash" field to the value that was provided on create.
+func (u *NarInfoUpsertBulk) UpdateNarHash() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateNarHash()
+	})
+}
+
+// ClearNarHash clears the value of the "nar_hash" field.
+func (u *NarInfoUpsertBulk) ClearNarHash() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearNarHash()
+	})
+}
+
+// SetNarSize sets the "nar_size" field.
+func (u *NarInfoUpsertBulk) SetNarSize(v int64) *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetNarSize(v)
+	})
+}
+
+// AddNarSize adds v to the "nar_size" field.
+func (u *NarInfoUpsertBulk) AddNarSize(v int64) *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.AddNarSize(v)
+	})
+}
+
+// UpdateNarSize sets the "nar_size" field to the value that was provided on create.
+func (u *NarInfoUpsertBulk) UpdateNarSize() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateNarSize()
+	})
+}
+
+// ClearNarSize clears the value of the "nar_size" field.
+func (u *NarInfoUpsertBulk) ClearNarSize() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearNarSize()
+	})
+}
+
+// SetDeriver sets the "deriver" field.
+func (u *NarInfoUpsertBulk) SetDeriver(v string) *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetDeriver(v)
+	})
+}
+
+// UpdateDeriver sets the "deriver" field to the value that was provided on create.
+func (u *NarInfoUpsertBulk) UpdateDeriver() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateDeriver()
+	})
+}
+
+// ClearDeriver clears the value of the "deriver" field.
+func (u *NarInfoUpsertBulk) ClearDeriver() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearDeriver()
+	})
+}
+
+// SetSystem sets the "system" field.
+func (u *NarInfoUpsertBulk) SetSystem(v string) *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetSystem(v)
+	})
+}
+
+// UpdateSystem sets the "system" field to the value that was provided on create.
+func (u *NarInfoUpsertBulk) UpdateSystem() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateSystem()
+	})
+}
+
+// ClearSystem clears the value of the "system" field.
+func (u *NarInfoUpsertBulk) ClearSystem() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearSystem()
+	})
+}
+
+// SetCa sets the "ca" field.
+func (u *NarInfoUpsertBulk) SetCa(v string) *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetCa(v)
+	})
+}
+
+// UpdateCa sets the "ca" field to the value that was provided on create.
+func (u *NarInfoUpsertBulk) UpdateCa() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateCa()
+	})
+}
+
+// ClearCa clears the value of the "ca" field.
+func (u *NarInfoUpsertBulk) ClearCa() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearCa()
+	})
+}
+
+// SetLastAccessedAt sets the "last_accessed_at" field.
+func (u *NarInfoUpsertBulk) SetLastAccessedAt(v time.Time) *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.SetLastAccessedAt(v)
+	})
+}
+
+// UpdateLastAccessedAt sets the "last_accessed_at" field to the value that was provided on create.
+func (u *NarInfoUpsertBulk) UpdateLastAccessedAt() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.UpdateLastAccessedAt()
+	})
+}
+
+// ClearLastAccessedAt clears the value of the "last_accessed_at" field.
+func (u *NarInfoUpsertBulk) ClearLastAccessedAt() *NarInfoUpsertBulk {
+	return u.Update(func(s *NarInfoUpsert) {
+		s.ClearLastAccessedAt()
+	})
+}
+
+// Exec executes the query.
+func (u *NarInfoUpsertBulk) Exec(ctx context.Context) error {
+	if u.create.err != nil {
+		return u.create.err
+	}
+	for i, b := range u.create.builders {
+		if len(b.conflict) != 0 {
+			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the NarInfoCreateBulk instead", i)
+		}
+	}
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for NarInfoCreateBulk.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *NarInfoUpsertBulk) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
 		panic(err)
 	}
 }

--- a/ent/narinfonarfile_create.go
+++ b/ent/narinfonarfile_create.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/kalbasit/ncps/ent/narfile"
@@ -19,6 +20,7 @@ type NarInfoNarFileCreate struct {
 	config
 	mutation *NarInfoNarFileMutation
 	hooks    []Hook
+	conflict []sql.ConflictOption
 }
 
 // SetNarinfoID sets the "narinfo_id" field.
@@ -115,6 +117,7 @@ func (_c *NarInfoNarFileCreate) createSpec() (*NarInfoNarFile, *sqlgraph.CreateS
 		_node = &NarInfoNarFile{config: _c.config}
 		_spec = sqlgraph.NewCreateSpec(narinfonarfile.Table, sqlgraph.NewFieldSpec(narinfonarfile.FieldID, field.TypeInt))
 	)
+	_spec.OnConflict = _c.conflict
 	if nodes := _c.mutation.NarinfoIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
 			Rel:     sqlgraph.M2O,
@@ -152,11 +155,186 @@ func (_c *NarInfoNarFileCreate) createSpec() (*NarInfoNarFile, *sqlgraph.CreateS
 	return _node, _spec
 }
 
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.NarInfoNarFile.Create().
+//		SetNarinfoID(v).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.NarInfoNarFileUpsert) {
+//			SetNarinfoID(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *NarInfoNarFileCreate) OnConflict(opts ...sql.ConflictOption) *NarInfoNarFileUpsertOne {
+	_c.conflict = opts
+	return &NarInfoNarFileUpsertOne{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.NarInfoNarFile.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *NarInfoNarFileCreate) OnConflictColumns(columns ...string) *NarInfoNarFileUpsertOne {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &NarInfoNarFileUpsertOne{
+		create: _c,
+	}
+}
+
+type (
+	// NarInfoNarFileUpsertOne is the builder for "upsert"-ing
+	//  one NarInfoNarFile node.
+	NarInfoNarFileUpsertOne struct {
+		create *NarInfoNarFileCreate
+	}
+
+	// NarInfoNarFileUpsert is the "OnConflict" setter.
+	NarInfoNarFileUpsert struct {
+		*sql.UpdateSet
+	}
+)
+
+// SetNarinfoID sets the "narinfo_id" field.
+func (u *NarInfoNarFileUpsert) SetNarinfoID(v int) *NarInfoNarFileUpsert {
+	u.Set(narinfonarfile.FieldNarinfoID, v)
+	return u
+}
+
+// UpdateNarinfoID sets the "narinfo_id" field to the value that was provided on create.
+func (u *NarInfoNarFileUpsert) UpdateNarinfoID() *NarInfoNarFileUpsert {
+	u.SetExcluded(narinfonarfile.FieldNarinfoID)
+	return u
+}
+
+// SetNarFileID sets the "nar_file_id" field.
+func (u *NarInfoNarFileUpsert) SetNarFileID(v int) *NarInfoNarFileUpsert {
+	u.Set(narinfonarfile.FieldNarFileID, v)
+	return u
+}
+
+// UpdateNarFileID sets the "nar_file_id" field to the value that was provided on create.
+func (u *NarInfoNarFileUpsert) UpdateNarFileID() *NarInfoNarFileUpsert {
+	u.SetExcluded(narinfonarfile.FieldNarFileID)
+	return u
+}
+
+// UpdateNewValues updates the mutable fields using the new values that were set on create.
+// Using this option is equivalent to using:
+//
+//	client.NarInfoNarFile.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *NarInfoNarFileUpsertOne) UpdateNewValues() *NarInfoNarFileUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.NarInfoNarFile.Create().
+//	    OnConflict(sql.ResolveWithIgnore()).
+//	    Exec(ctx)
+func (u *NarInfoNarFileUpsertOne) Ignore() *NarInfoNarFileUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *NarInfoNarFileUpsertOne) DoNothing() *NarInfoNarFileUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the NarInfoNarFileCreate.OnConflict
+// documentation for more info.
+func (u *NarInfoNarFileUpsertOne) Update(set func(*NarInfoNarFileUpsert)) *NarInfoNarFileUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&NarInfoNarFileUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetNarinfoID sets the "narinfo_id" field.
+func (u *NarInfoNarFileUpsertOne) SetNarinfoID(v int) *NarInfoNarFileUpsertOne {
+	return u.Update(func(s *NarInfoNarFileUpsert) {
+		s.SetNarinfoID(v)
+	})
+}
+
+// UpdateNarinfoID sets the "narinfo_id" field to the value that was provided on create.
+func (u *NarInfoNarFileUpsertOne) UpdateNarinfoID() *NarInfoNarFileUpsertOne {
+	return u.Update(func(s *NarInfoNarFileUpsert) {
+		s.UpdateNarinfoID()
+	})
+}
+
+// SetNarFileID sets the "nar_file_id" field.
+func (u *NarInfoNarFileUpsertOne) SetNarFileID(v int) *NarInfoNarFileUpsertOne {
+	return u.Update(func(s *NarInfoNarFileUpsert) {
+		s.SetNarFileID(v)
+	})
+}
+
+// UpdateNarFileID sets the "nar_file_id" field to the value that was provided on create.
+func (u *NarInfoNarFileUpsertOne) UpdateNarFileID() *NarInfoNarFileUpsertOne {
+	return u.Update(func(s *NarInfoNarFileUpsert) {
+		s.UpdateNarFileID()
+	})
+}
+
+// Exec executes the query.
+func (u *NarInfoNarFileUpsertOne) Exec(ctx context.Context) error {
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for NarInfoNarFileCreate.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *NarInfoNarFileUpsertOne) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// Exec executes the UPSERT query and returns the inserted/updated ID.
+func (u *NarInfoNarFileUpsertOne) ID(ctx context.Context) (id int, err error) {
+	node, err := u.create.Save(ctx)
+	if err != nil {
+		return id, err
+	}
+	return node.ID, nil
+}
+
+// IDX is like ID, but panics if an error occurs.
+func (u *NarInfoNarFileUpsertOne) IDX(ctx context.Context) int {
+	id, err := u.ID(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
 // NarInfoNarFileCreateBulk is the builder for creating many NarInfoNarFile entities in bulk.
 type NarInfoNarFileCreateBulk struct {
 	config
 	err      error
 	builders []*NarInfoNarFileCreate
+	conflict []sql.ConflictOption
 }
 
 // Save creates the NarInfoNarFile entities in the database.
@@ -185,6 +363,7 @@ func (_c *NarInfoNarFileCreateBulk) Save(ctx context.Context) ([]*NarInfoNarFile
 					_, err = mutators[i+1].Mutate(root, _c.builders[i+1].mutation)
 				} else {
 					spec := &sqlgraph.BatchCreateSpec{Nodes: specs}
+					spec.OnConflict = _c.conflict
 					// Invoke the actual operation on the latest mutation in the chain.
 					if err = sqlgraph.BatchCreate(ctx, _c.driver, spec); err != nil {
 						if sqlgraph.IsConstraintError(err) {
@@ -235,6 +414,138 @@ func (_c *NarInfoNarFileCreateBulk) Exec(ctx context.Context) error {
 // ExecX is like Exec, but panics if an error occurs.
 func (_c *NarInfoNarFileCreateBulk) ExecX(ctx context.Context) {
 	if err := _c.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.NarInfoNarFile.CreateBulk(builders...).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.NarInfoNarFileUpsert) {
+//			SetNarinfoID(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *NarInfoNarFileCreateBulk) OnConflict(opts ...sql.ConflictOption) *NarInfoNarFileUpsertBulk {
+	_c.conflict = opts
+	return &NarInfoNarFileUpsertBulk{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.NarInfoNarFile.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *NarInfoNarFileCreateBulk) OnConflictColumns(columns ...string) *NarInfoNarFileUpsertBulk {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &NarInfoNarFileUpsertBulk{
+		create: _c,
+	}
+}
+
+// NarInfoNarFileUpsertBulk is the builder for "upsert"-ing
+// a bulk of NarInfoNarFile nodes.
+type NarInfoNarFileUpsertBulk struct {
+	create *NarInfoNarFileCreateBulk
+}
+
+// UpdateNewValues updates the mutable fields using the new values that
+// were set on create. Using this option is equivalent to using:
+//
+//	client.NarInfoNarFile.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *NarInfoNarFileUpsertBulk) UpdateNewValues() *NarInfoNarFileUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.NarInfoNarFile.Create().
+//		OnConflict(sql.ResolveWithIgnore()).
+//		Exec(ctx)
+func (u *NarInfoNarFileUpsertBulk) Ignore() *NarInfoNarFileUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *NarInfoNarFileUpsertBulk) DoNothing() *NarInfoNarFileUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the NarInfoNarFileCreateBulk.OnConflict
+// documentation for more info.
+func (u *NarInfoNarFileUpsertBulk) Update(set func(*NarInfoNarFileUpsert)) *NarInfoNarFileUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&NarInfoNarFileUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetNarinfoID sets the "narinfo_id" field.
+func (u *NarInfoNarFileUpsertBulk) SetNarinfoID(v int) *NarInfoNarFileUpsertBulk {
+	return u.Update(func(s *NarInfoNarFileUpsert) {
+		s.SetNarinfoID(v)
+	})
+}
+
+// UpdateNarinfoID sets the "narinfo_id" field to the value that was provided on create.
+func (u *NarInfoNarFileUpsertBulk) UpdateNarinfoID() *NarInfoNarFileUpsertBulk {
+	return u.Update(func(s *NarInfoNarFileUpsert) {
+		s.UpdateNarinfoID()
+	})
+}
+
+// SetNarFileID sets the "nar_file_id" field.
+func (u *NarInfoNarFileUpsertBulk) SetNarFileID(v int) *NarInfoNarFileUpsertBulk {
+	return u.Update(func(s *NarInfoNarFileUpsert) {
+		s.SetNarFileID(v)
+	})
+}
+
+// UpdateNarFileID sets the "nar_file_id" field to the value that was provided on create.
+func (u *NarInfoNarFileUpsertBulk) UpdateNarFileID() *NarInfoNarFileUpsertBulk {
+	return u.Update(func(s *NarInfoNarFileUpsert) {
+		s.UpdateNarFileID()
+	})
+}
+
+// Exec executes the query.
+func (u *NarInfoNarFileUpsertBulk) Exec(ctx context.Context) error {
+	if u.create.err != nil {
+		return u.create.err
+	}
+	for i, b := range u.create.builders {
+		if len(b.conflict) != 0 {
+			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the NarInfoNarFileCreateBulk instead", i)
+		}
+	}
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for NarInfoNarFileCreateBulk.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *NarInfoNarFileUpsertBulk) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
 		panic(err)
 	}
 }

--- a/ent/narinforeference_create.go
+++ b/ent/narinforeference_create.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/kalbasit/ncps/ent/narinfo"
@@ -18,6 +19,7 @@ type NarInfoReferenceCreate struct {
 	config
 	mutation *NarInfoReferenceMutation
 	hooks    []Hook
+	conflict []sql.ConflictOption
 }
 
 // SetNarinfoID sets the "narinfo_id" field.
@@ -111,6 +113,7 @@ func (_c *NarInfoReferenceCreate) createSpec() (*NarInfoReference, *sqlgraph.Cre
 		_node = &NarInfoReference{config: _c.config}
 		_spec = sqlgraph.NewCreateSpec(narinforeference.Table, sqlgraph.NewFieldSpec(narinforeference.FieldID, field.TypeInt))
 	)
+	_spec.OnConflict = _c.conflict
 	if value, ok := _c.mutation.Reference(); ok {
 		_spec.SetField(narinforeference.FieldReference, field.TypeString, value)
 		_node.Reference = value
@@ -135,11 +138,186 @@ func (_c *NarInfoReferenceCreate) createSpec() (*NarInfoReference, *sqlgraph.Cre
 	return _node, _spec
 }
 
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.NarInfoReference.Create().
+//		SetNarinfoID(v).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.NarInfoReferenceUpsert) {
+//			SetNarinfoID(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *NarInfoReferenceCreate) OnConflict(opts ...sql.ConflictOption) *NarInfoReferenceUpsertOne {
+	_c.conflict = opts
+	return &NarInfoReferenceUpsertOne{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.NarInfoReference.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *NarInfoReferenceCreate) OnConflictColumns(columns ...string) *NarInfoReferenceUpsertOne {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &NarInfoReferenceUpsertOne{
+		create: _c,
+	}
+}
+
+type (
+	// NarInfoReferenceUpsertOne is the builder for "upsert"-ing
+	//  one NarInfoReference node.
+	NarInfoReferenceUpsertOne struct {
+		create *NarInfoReferenceCreate
+	}
+
+	// NarInfoReferenceUpsert is the "OnConflict" setter.
+	NarInfoReferenceUpsert struct {
+		*sql.UpdateSet
+	}
+)
+
+// SetNarinfoID sets the "narinfo_id" field.
+func (u *NarInfoReferenceUpsert) SetNarinfoID(v int) *NarInfoReferenceUpsert {
+	u.Set(narinforeference.FieldNarinfoID, v)
+	return u
+}
+
+// UpdateNarinfoID sets the "narinfo_id" field to the value that was provided on create.
+func (u *NarInfoReferenceUpsert) UpdateNarinfoID() *NarInfoReferenceUpsert {
+	u.SetExcluded(narinforeference.FieldNarinfoID)
+	return u
+}
+
+// SetReference sets the "reference" field.
+func (u *NarInfoReferenceUpsert) SetReference(v string) *NarInfoReferenceUpsert {
+	u.Set(narinforeference.FieldReference, v)
+	return u
+}
+
+// UpdateReference sets the "reference" field to the value that was provided on create.
+func (u *NarInfoReferenceUpsert) UpdateReference() *NarInfoReferenceUpsert {
+	u.SetExcluded(narinforeference.FieldReference)
+	return u
+}
+
+// UpdateNewValues updates the mutable fields using the new values that were set on create.
+// Using this option is equivalent to using:
+//
+//	client.NarInfoReference.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *NarInfoReferenceUpsertOne) UpdateNewValues() *NarInfoReferenceUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.NarInfoReference.Create().
+//	    OnConflict(sql.ResolveWithIgnore()).
+//	    Exec(ctx)
+func (u *NarInfoReferenceUpsertOne) Ignore() *NarInfoReferenceUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *NarInfoReferenceUpsertOne) DoNothing() *NarInfoReferenceUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the NarInfoReferenceCreate.OnConflict
+// documentation for more info.
+func (u *NarInfoReferenceUpsertOne) Update(set func(*NarInfoReferenceUpsert)) *NarInfoReferenceUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&NarInfoReferenceUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetNarinfoID sets the "narinfo_id" field.
+func (u *NarInfoReferenceUpsertOne) SetNarinfoID(v int) *NarInfoReferenceUpsertOne {
+	return u.Update(func(s *NarInfoReferenceUpsert) {
+		s.SetNarinfoID(v)
+	})
+}
+
+// UpdateNarinfoID sets the "narinfo_id" field to the value that was provided on create.
+func (u *NarInfoReferenceUpsertOne) UpdateNarinfoID() *NarInfoReferenceUpsertOne {
+	return u.Update(func(s *NarInfoReferenceUpsert) {
+		s.UpdateNarinfoID()
+	})
+}
+
+// SetReference sets the "reference" field.
+func (u *NarInfoReferenceUpsertOne) SetReference(v string) *NarInfoReferenceUpsertOne {
+	return u.Update(func(s *NarInfoReferenceUpsert) {
+		s.SetReference(v)
+	})
+}
+
+// UpdateReference sets the "reference" field to the value that was provided on create.
+func (u *NarInfoReferenceUpsertOne) UpdateReference() *NarInfoReferenceUpsertOne {
+	return u.Update(func(s *NarInfoReferenceUpsert) {
+		s.UpdateReference()
+	})
+}
+
+// Exec executes the query.
+func (u *NarInfoReferenceUpsertOne) Exec(ctx context.Context) error {
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for NarInfoReferenceCreate.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *NarInfoReferenceUpsertOne) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// Exec executes the UPSERT query and returns the inserted/updated ID.
+func (u *NarInfoReferenceUpsertOne) ID(ctx context.Context) (id int, err error) {
+	node, err := u.create.Save(ctx)
+	if err != nil {
+		return id, err
+	}
+	return node.ID, nil
+}
+
+// IDX is like ID, but panics if an error occurs.
+func (u *NarInfoReferenceUpsertOne) IDX(ctx context.Context) int {
+	id, err := u.ID(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
 // NarInfoReferenceCreateBulk is the builder for creating many NarInfoReference entities in bulk.
 type NarInfoReferenceCreateBulk struct {
 	config
 	err      error
 	builders []*NarInfoReferenceCreate
+	conflict []sql.ConflictOption
 }
 
 // Save creates the NarInfoReference entities in the database.
@@ -168,6 +346,7 @@ func (_c *NarInfoReferenceCreateBulk) Save(ctx context.Context) ([]*NarInfoRefer
 					_, err = mutators[i+1].Mutate(root, _c.builders[i+1].mutation)
 				} else {
 					spec := &sqlgraph.BatchCreateSpec{Nodes: specs}
+					spec.OnConflict = _c.conflict
 					// Invoke the actual operation on the latest mutation in the chain.
 					if err = sqlgraph.BatchCreate(ctx, _c.driver, spec); err != nil {
 						if sqlgraph.IsConstraintError(err) {
@@ -218,6 +397,138 @@ func (_c *NarInfoReferenceCreateBulk) Exec(ctx context.Context) error {
 // ExecX is like Exec, but panics if an error occurs.
 func (_c *NarInfoReferenceCreateBulk) ExecX(ctx context.Context) {
 	if err := _c.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.NarInfoReference.CreateBulk(builders...).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.NarInfoReferenceUpsert) {
+//			SetNarinfoID(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *NarInfoReferenceCreateBulk) OnConflict(opts ...sql.ConflictOption) *NarInfoReferenceUpsertBulk {
+	_c.conflict = opts
+	return &NarInfoReferenceUpsertBulk{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.NarInfoReference.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *NarInfoReferenceCreateBulk) OnConflictColumns(columns ...string) *NarInfoReferenceUpsertBulk {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &NarInfoReferenceUpsertBulk{
+		create: _c,
+	}
+}
+
+// NarInfoReferenceUpsertBulk is the builder for "upsert"-ing
+// a bulk of NarInfoReference nodes.
+type NarInfoReferenceUpsertBulk struct {
+	create *NarInfoReferenceCreateBulk
+}
+
+// UpdateNewValues updates the mutable fields using the new values that
+// were set on create. Using this option is equivalent to using:
+//
+//	client.NarInfoReference.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *NarInfoReferenceUpsertBulk) UpdateNewValues() *NarInfoReferenceUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.NarInfoReference.Create().
+//		OnConflict(sql.ResolveWithIgnore()).
+//		Exec(ctx)
+func (u *NarInfoReferenceUpsertBulk) Ignore() *NarInfoReferenceUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *NarInfoReferenceUpsertBulk) DoNothing() *NarInfoReferenceUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the NarInfoReferenceCreateBulk.OnConflict
+// documentation for more info.
+func (u *NarInfoReferenceUpsertBulk) Update(set func(*NarInfoReferenceUpsert)) *NarInfoReferenceUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&NarInfoReferenceUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetNarinfoID sets the "narinfo_id" field.
+func (u *NarInfoReferenceUpsertBulk) SetNarinfoID(v int) *NarInfoReferenceUpsertBulk {
+	return u.Update(func(s *NarInfoReferenceUpsert) {
+		s.SetNarinfoID(v)
+	})
+}
+
+// UpdateNarinfoID sets the "narinfo_id" field to the value that was provided on create.
+func (u *NarInfoReferenceUpsertBulk) UpdateNarinfoID() *NarInfoReferenceUpsertBulk {
+	return u.Update(func(s *NarInfoReferenceUpsert) {
+		s.UpdateNarinfoID()
+	})
+}
+
+// SetReference sets the "reference" field.
+func (u *NarInfoReferenceUpsertBulk) SetReference(v string) *NarInfoReferenceUpsertBulk {
+	return u.Update(func(s *NarInfoReferenceUpsert) {
+		s.SetReference(v)
+	})
+}
+
+// UpdateReference sets the "reference" field to the value that was provided on create.
+func (u *NarInfoReferenceUpsertBulk) UpdateReference() *NarInfoReferenceUpsertBulk {
+	return u.Update(func(s *NarInfoReferenceUpsert) {
+		s.UpdateReference()
+	})
+}
+
+// Exec executes the query.
+func (u *NarInfoReferenceUpsertBulk) Exec(ctx context.Context) error {
+	if u.create.err != nil {
+		return u.create.err
+	}
+	for i, b := range u.create.builders {
+		if len(b.conflict) != 0 {
+			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the NarInfoReferenceCreateBulk instead", i)
+		}
+	}
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for NarInfoReferenceCreateBulk.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *NarInfoReferenceUpsertBulk) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
 		panic(err)
 	}
 }

--- a/ent/narinfosignature_create.go
+++ b/ent/narinfosignature_create.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/kalbasit/ncps/ent/narinfo"
@@ -18,6 +19,7 @@ type NarInfoSignatureCreate struct {
 	config
 	mutation *NarInfoSignatureMutation
 	hooks    []Hook
+	conflict []sql.ConflictOption
 }
 
 // SetNarinfoID sets the "narinfo_id" field.
@@ -111,6 +113,7 @@ func (_c *NarInfoSignatureCreate) createSpec() (*NarInfoSignature, *sqlgraph.Cre
 		_node = &NarInfoSignature{config: _c.config}
 		_spec = sqlgraph.NewCreateSpec(narinfosignature.Table, sqlgraph.NewFieldSpec(narinfosignature.FieldID, field.TypeInt))
 	)
+	_spec.OnConflict = _c.conflict
 	if value, ok := _c.mutation.Signature(); ok {
 		_spec.SetField(narinfosignature.FieldSignature, field.TypeString, value)
 		_node.Signature = value
@@ -135,11 +138,186 @@ func (_c *NarInfoSignatureCreate) createSpec() (*NarInfoSignature, *sqlgraph.Cre
 	return _node, _spec
 }
 
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.NarInfoSignature.Create().
+//		SetNarinfoID(v).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.NarInfoSignatureUpsert) {
+//			SetNarinfoID(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *NarInfoSignatureCreate) OnConflict(opts ...sql.ConflictOption) *NarInfoSignatureUpsertOne {
+	_c.conflict = opts
+	return &NarInfoSignatureUpsertOne{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.NarInfoSignature.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *NarInfoSignatureCreate) OnConflictColumns(columns ...string) *NarInfoSignatureUpsertOne {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &NarInfoSignatureUpsertOne{
+		create: _c,
+	}
+}
+
+type (
+	// NarInfoSignatureUpsertOne is the builder for "upsert"-ing
+	//  one NarInfoSignature node.
+	NarInfoSignatureUpsertOne struct {
+		create *NarInfoSignatureCreate
+	}
+
+	// NarInfoSignatureUpsert is the "OnConflict" setter.
+	NarInfoSignatureUpsert struct {
+		*sql.UpdateSet
+	}
+)
+
+// SetNarinfoID sets the "narinfo_id" field.
+func (u *NarInfoSignatureUpsert) SetNarinfoID(v int) *NarInfoSignatureUpsert {
+	u.Set(narinfosignature.FieldNarinfoID, v)
+	return u
+}
+
+// UpdateNarinfoID sets the "narinfo_id" field to the value that was provided on create.
+func (u *NarInfoSignatureUpsert) UpdateNarinfoID() *NarInfoSignatureUpsert {
+	u.SetExcluded(narinfosignature.FieldNarinfoID)
+	return u
+}
+
+// SetSignature sets the "signature" field.
+func (u *NarInfoSignatureUpsert) SetSignature(v string) *NarInfoSignatureUpsert {
+	u.Set(narinfosignature.FieldSignature, v)
+	return u
+}
+
+// UpdateSignature sets the "signature" field to the value that was provided on create.
+func (u *NarInfoSignatureUpsert) UpdateSignature() *NarInfoSignatureUpsert {
+	u.SetExcluded(narinfosignature.FieldSignature)
+	return u
+}
+
+// UpdateNewValues updates the mutable fields using the new values that were set on create.
+// Using this option is equivalent to using:
+//
+//	client.NarInfoSignature.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *NarInfoSignatureUpsertOne) UpdateNewValues() *NarInfoSignatureUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.NarInfoSignature.Create().
+//	    OnConflict(sql.ResolveWithIgnore()).
+//	    Exec(ctx)
+func (u *NarInfoSignatureUpsertOne) Ignore() *NarInfoSignatureUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *NarInfoSignatureUpsertOne) DoNothing() *NarInfoSignatureUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the NarInfoSignatureCreate.OnConflict
+// documentation for more info.
+func (u *NarInfoSignatureUpsertOne) Update(set func(*NarInfoSignatureUpsert)) *NarInfoSignatureUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&NarInfoSignatureUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetNarinfoID sets the "narinfo_id" field.
+func (u *NarInfoSignatureUpsertOne) SetNarinfoID(v int) *NarInfoSignatureUpsertOne {
+	return u.Update(func(s *NarInfoSignatureUpsert) {
+		s.SetNarinfoID(v)
+	})
+}
+
+// UpdateNarinfoID sets the "narinfo_id" field to the value that was provided on create.
+func (u *NarInfoSignatureUpsertOne) UpdateNarinfoID() *NarInfoSignatureUpsertOne {
+	return u.Update(func(s *NarInfoSignatureUpsert) {
+		s.UpdateNarinfoID()
+	})
+}
+
+// SetSignature sets the "signature" field.
+func (u *NarInfoSignatureUpsertOne) SetSignature(v string) *NarInfoSignatureUpsertOne {
+	return u.Update(func(s *NarInfoSignatureUpsert) {
+		s.SetSignature(v)
+	})
+}
+
+// UpdateSignature sets the "signature" field to the value that was provided on create.
+func (u *NarInfoSignatureUpsertOne) UpdateSignature() *NarInfoSignatureUpsertOne {
+	return u.Update(func(s *NarInfoSignatureUpsert) {
+		s.UpdateSignature()
+	})
+}
+
+// Exec executes the query.
+func (u *NarInfoSignatureUpsertOne) Exec(ctx context.Context) error {
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for NarInfoSignatureCreate.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *NarInfoSignatureUpsertOne) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// Exec executes the UPSERT query and returns the inserted/updated ID.
+func (u *NarInfoSignatureUpsertOne) ID(ctx context.Context) (id int, err error) {
+	node, err := u.create.Save(ctx)
+	if err != nil {
+		return id, err
+	}
+	return node.ID, nil
+}
+
+// IDX is like ID, but panics if an error occurs.
+func (u *NarInfoSignatureUpsertOne) IDX(ctx context.Context) int {
+	id, err := u.ID(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
 // NarInfoSignatureCreateBulk is the builder for creating many NarInfoSignature entities in bulk.
 type NarInfoSignatureCreateBulk struct {
 	config
 	err      error
 	builders []*NarInfoSignatureCreate
+	conflict []sql.ConflictOption
 }
 
 // Save creates the NarInfoSignature entities in the database.
@@ -168,6 +346,7 @@ func (_c *NarInfoSignatureCreateBulk) Save(ctx context.Context) ([]*NarInfoSigna
 					_, err = mutators[i+1].Mutate(root, _c.builders[i+1].mutation)
 				} else {
 					spec := &sqlgraph.BatchCreateSpec{Nodes: specs}
+					spec.OnConflict = _c.conflict
 					// Invoke the actual operation on the latest mutation in the chain.
 					if err = sqlgraph.BatchCreate(ctx, _c.driver, spec); err != nil {
 						if sqlgraph.IsConstraintError(err) {
@@ -218,6 +397,138 @@ func (_c *NarInfoSignatureCreateBulk) Exec(ctx context.Context) error {
 // ExecX is like Exec, but panics if an error occurs.
 func (_c *NarInfoSignatureCreateBulk) ExecX(ctx context.Context) {
 	if err := _c.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.NarInfoSignature.CreateBulk(builders...).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.NarInfoSignatureUpsert) {
+//			SetNarinfoID(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *NarInfoSignatureCreateBulk) OnConflict(opts ...sql.ConflictOption) *NarInfoSignatureUpsertBulk {
+	_c.conflict = opts
+	return &NarInfoSignatureUpsertBulk{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.NarInfoSignature.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *NarInfoSignatureCreateBulk) OnConflictColumns(columns ...string) *NarInfoSignatureUpsertBulk {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &NarInfoSignatureUpsertBulk{
+		create: _c,
+	}
+}
+
+// NarInfoSignatureUpsertBulk is the builder for "upsert"-ing
+// a bulk of NarInfoSignature nodes.
+type NarInfoSignatureUpsertBulk struct {
+	create *NarInfoSignatureCreateBulk
+}
+
+// UpdateNewValues updates the mutable fields using the new values that
+// were set on create. Using this option is equivalent to using:
+//
+//	client.NarInfoSignature.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *NarInfoSignatureUpsertBulk) UpdateNewValues() *NarInfoSignatureUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.NarInfoSignature.Create().
+//		OnConflict(sql.ResolveWithIgnore()).
+//		Exec(ctx)
+func (u *NarInfoSignatureUpsertBulk) Ignore() *NarInfoSignatureUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *NarInfoSignatureUpsertBulk) DoNothing() *NarInfoSignatureUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the NarInfoSignatureCreateBulk.OnConflict
+// documentation for more info.
+func (u *NarInfoSignatureUpsertBulk) Update(set func(*NarInfoSignatureUpsert)) *NarInfoSignatureUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&NarInfoSignatureUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetNarinfoID sets the "narinfo_id" field.
+func (u *NarInfoSignatureUpsertBulk) SetNarinfoID(v int) *NarInfoSignatureUpsertBulk {
+	return u.Update(func(s *NarInfoSignatureUpsert) {
+		s.SetNarinfoID(v)
+	})
+}
+
+// UpdateNarinfoID sets the "narinfo_id" field to the value that was provided on create.
+func (u *NarInfoSignatureUpsertBulk) UpdateNarinfoID() *NarInfoSignatureUpsertBulk {
+	return u.Update(func(s *NarInfoSignatureUpsert) {
+		s.UpdateNarinfoID()
+	})
+}
+
+// SetSignature sets the "signature" field.
+func (u *NarInfoSignatureUpsertBulk) SetSignature(v string) *NarInfoSignatureUpsertBulk {
+	return u.Update(func(s *NarInfoSignatureUpsert) {
+		s.SetSignature(v)
+	})
+}
+
+// UpdateSignature sets the "signature" field to the value that was provided on create.
+func (u *NarInfoSignatureUpsertBulk) UpdateSignature() *NarInfoSignatureUpsertBulk {
+	return u.Update(func(s *NarInfoSignatureUpsert) {
+		s.UpdateSignature()
+	})
+}
+
+// Exec executes the query.
+func (u *NarInfoSignatureUpsertBulk) Exec(ctx context.Context) error {
+	if u.create.err != nil {
+		return u.create.err
+	}
+	for i, b := range u.create.builders {
+		if len(b.conflict) != 0 {
+			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the NarInfoSignatureCreateBulk instead", i)
+		}
+	}
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for NarInfoSignatureCreateBulk.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *NarInfoSignatureUpsertBulk) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
 		panic(err)
 	}
 }

--- a/ent/pinnedclosure_create.go
+++ b/ent/pinnedclosure_create.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqlgraph"
 	"entgo.io/ent/schema/field"
 	"github.com/kalbasit/ncps/ent/pinnedclosure"
@@ -18,6 +19,7 @@ type PinnedClosureCreate struct {
 	config
 	mutation *PinnedClosureMutation
 	hooks    []Hook
+	conflict []sql.ConflictOption
 }
 
 // SetCreatedAt sets the "created_at" field.
@@ -134,6 +136,7 @@ func (_c *PinnedClosureCreate) createSpec() (*PinnedClosure, *sqlgraph.CreateSpe
 		_node = &PinnedClosure{config: _c.config}
 		_spec = sqlgraph.NewCreateSpec(pinnedclosure.Table, sqlgraph.NewFieldSpec(pinnedclosure.FieldID, field.TypeInt))
 	)
+	_spec.OnConflict = _c.conflict
 	if value, ok := _c.mutation.CreatedAt(); ok {
 		_spec.SetField(pinnedclosure.FieldCreatedAt, field.TypeTime, value)
 		_node.CreatedAt = value
@@ -149,11 +152,204 @@ func (_c *PinnedClosureCreate) createSpec() (*PinnedClosure, *sqlgraph.CreateSpe
 	return _node, _spec
 }
 
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.PinnedClosure.Create().
+//		SetCreatedAt(v).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.PinnedClosureUpsert) {
+//			SetCreatedAt(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *PinnedClosureCreate) OnConflict(opts ...sql.ConflictOption) *PinnedClosureUpsertOne {
+	_c.conflict = opts
+	return &PinnedClosureUpsertOne{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.PinnedClosure.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *PinnedClosureCreate) OnConflictColumns(columns ...string) *PinnedClosureUpsertOne {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &PinnedClosureUpsertOne{
+		create: _c,
+	}
+}
+
+type (
+	// PinnedClosureUpsertOne is the builder for "upsert"-ing
+	//  one PinnedClosure node.
+	PinnedClosureUpsertOne struct {
+		create *PinnedClosureCreate
+	}
+
+	// PinnedClosureUpsert is the "OnConflict" setter.
+	PinnedClosureUpsert struct {
+		*sql.UpdateSet
+	}
+)
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *PinnedClosureUpsert) SetUpdatedAt(v time.Time) *PinnedClosureUpsert {
+	u.Set(pinnedclosure.FieldUpdatedAt, v)
+	return u
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *PinnedClosureUpsert) UpdateUpdatedAt() *PinnedClosureUpsert {
+	u.SetExcluded(pinnedclosure.FieldUpdatedAt)
+	return u
+}
+
+// ClearUpdatedAt clears the value of the "updated_at" field.
+func (u *PinnedClosureUpsert) ClearUpdatedAt() *PinnedClosureUpsert {
+	u.SetNull(pinnedclosure.FieldUpdatedAt)
+	return u
+}
+
+// SetHash sets the "hash" field.
+func (u *PinnedClosureUpsert) SetHash(v string) *PinnedClosureUpsert {
+	u.Set(pinnedclosure.FieldHash, v)
+	return u
+}
+
+// UpdateHash sets the "hash" field to the value that was provided on create.
+func (u *PinnedClosureUpsert) UpdateHash() *PinnedClosureUpsert {
+	u.SetExcluded(pinnedclosure.FieldHash)
+	return u
+}
+
+// UpdateNewValues updates the mutable fields using the new values that were set on create.
+// Using this option is equivalent to using:
+//
+//	client.PinnedClosure.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *PinnedClosureUpsertOne) UpdateNewValues() *PinnedClosureUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		if _, exists := u.create.mutation.CreatedAt(); exists {
+			s.SetIgnore(pinnedclosure.FieldCreatedAt)
+		}
+	}))
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.PinnedClosure.Create().
+//	    OnConflict(sql.ResolveWithIgnore()).
+//	    Exec(ctx)
+func (u *PinnedClosureUpsertOne) Ignore() *PinnedClosureUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *PinnedClosureUpsertOne) DoNothing() *PinnedClosureUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the PinnedClosureCreate.OnConflict
+// documentation for more info.
+func (u *PinnedClosureUpsertOne) Update(set func(*PinnedClosureUpsert)) *PinnedClosureUpsertOne {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&PinnedClosureUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *PinnedClosureUpsertOne) SetUpdatedAt(v time.Time) *PinnedClosureUpsertOne {
+	return u.Update(func(s *PinnedClosureUpsert) {
+		s.SetUpdatedAt(v)
+	})
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *PinnedClosureUpsertOne) UpdateUpdatedAt() *PinnedClosureUpsertOne {
+	return u.Update(func(s *PinnedClosureUpsert) {
+		s.UpdateUpdatedAt()
+	})
+}
+
+// ClearUpdatedAt clears the value of the "updated_at" field.
+func (u *PinnedClosureUpsertOne) ClearUpdatedAt() *PinnedClosureUpsertOne {
+	return u.Update(func(s *PinnedClosureUpsert) {
+		s.ClearUpdatedAt()
+	})
+}
+
+// SetHash sets the "hash" field.
+func (u *PinnedClosureUpsertOne) SetHash(v string) *PinnedClosureUpsertOne {
+	return u.Update(func(s *PinnedClosureUpsert) {
+		s.SetHash(v)
+	})
+}
+
+// UpdateHash sets the "hash" field to the value that was provided on create.
+func (u *PinnedClosureUpsertOne) UpdateHash() *PinnedClosureUpsertOne {
+	return u.Update(func(s *PinnedClosureUpsert) {
+		s.UpdateHash()
+	})
+}
+
+// Exec executes the query.
+func (u *PinnedClosureUpsertOne) Exec(ctx context.Context) error {
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for PinnedClosureCreate.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *PinnedClosureUpsertOne) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// Exec executes the UPSERT query and returns the inserted/updated ID.
+func (u *PinnedClosureUpsertOne) ID(ctx context.Context) (id int, err error) {
+	node, err := u.create.Save(ctx)
+	if err != nil {
+		return id, err
+	}
+	return node.ID, nil
+}
+
+// IDX is like ID, but panics if an error occurs.
+func (u *PinnedClosureUpsertOne) IDX(ctx context.Context) int {
+	id, err := u.ID(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
 // PinnedClosureCreateBulk is the builder for creating many PinnedClosure entities in bulk.
 type PinnedClosureCreateBulk struct {
 	config
 	err      error
 	builders []*PinnedClosureCreate
+	conflict []sql.ConflictOption
 }
 
 // Save creates the PinnedClosure entities in the database.
@@ -183,6 +379,7 @@ func (_c *PinnedClosureCreateBulk) Save(ctx context.Context) ([]*PinnedClosure, 
 					_, err = mutators[i+1].Mutate(root, _c.builders[i+1].mutation)
 				} else {
 					spec := &sqlgraph.BatchCreateSpec{Nodes: specs}
+					spec.OnConflict = _c.conflict
 					// Invoke the actual operation on the latest mutation in the chain.
 					if err = sqlgraph.BatchCreate(ctx, _c.driver, spec); err != nil {
 						if sqlgraph.IsConstraintError(err) {
@@ -233,6 +430,152 @@ func (_c *PinnedClosureCreateBulk) Exec(ctx context.Context) error {
 // ExecX is like Exec, but panics if an error occurs.
 func (_c *PinnedClosureCreateBulk) ExecX(ctx context.Context) {
 	if err := _c.Exec(ctx); err != nil {
+		panic(err)
+	}
+}
+
+// OnConflict allows configuring the `ON CONFLICT` / `ON DUPLICATE KEY` clause
+// of the `INSERT` statement. For example:
+//
+//	client.PinnedClosure.CreateBulk(builders...).
+//		OnConflict(
+//			// Update the row with the new values
+//			// the was proposed for insertion.
+//			sql.ResolveWithNewValues(),
+//		).
+//		// Override some of the fields with custom
+//		// update values.
+//		Update(func(u *ent.PinnedClosureUpsert) {
+//			SetCreatedAt(v+v).
+//		}).
+//		Exec(ctx)
+func (_c *PinnedClosureCreateBulk) OnConflict(opts ...sql.ConflictOption) *PinnedClosureUpsertBulk {
+	_c.conflict = opts
+	return &PinnedClosureUpsertBulk{
+		create: _c,
+	}
+}
+
+// OnConflictColumns calls `OnConflict` and configures the columns
+// as conflict target. Using this option is equivalent to using:
+//
+//	client.PinnedClosure.Create().
+//		OnConflict(sql.ConflictColumns(columns...)).
+//		Exec(ctx)
+func (_c *PinnedClosureCreateBulk) OnConflictColumns(columns ...string) *PinnedClosureUpsertBulk {
+	_c.conflict = append(_c.conflict, sql.ConflictColumns(columns...))
+	return &PinnedClosureUpsertBulk{
+		create: _c,
+	}
+}
+
+// PinnedClosureUpsertBulk is the builder for "upsert"-ing
+// a bulk of PinnedClosure nodes.
+type PinnedClosureUpsertBulk struct {
+	create *PinnedClosureCreateBulk
+}
+
+// UpdateNewValues updates the mutable fields using the new values that
+// were set on create. Using this option is equivalent to using:
+//
+//	client.PinnedClosure.Create().
+//		OnConflict(
+//			sql.ResolveWithNewValues(),
+//		).
+//		Exec(ctx)
+func (u *PinnedClosureUpsertBulk) UpdateNewValues() *PinnedClosureUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithNewValues())
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(s *sql.UpdateSet) {
+		for _, b := range u.create.builders {
+			if _, exists := b.mutation.CreatedAt(); exists {
+				s.SetIgnore(pinnedclosure.FieldCreatedAt)
+			}
+		}
+	}))
+	return u
+}
+
+// Ignore sets each column to itself in case of conflict.
+// Using this option is equivalent to using:
+//
+//	client.PinnedClosure.Create().
+//		OnConflict(sql.ResolveWithIgnore()).
+//		Exec(ctx)
+func (u *PinnedClosureUpsertBulk) Ignore() *PinnedClosureUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWithIgnore())
+	return u
+}
+
+// DoNothing configures the conflict_action to `DO NOTHING`.
+// Supported only by SQLite and PostgreSQL.
+func (u *PinnedClosureUpsertBulk) DoNothing() *PinnedClosureUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.DoNothing())
+	return u
+}
+
+// Update allows overriding fields `UPDATE` values. See the PinnedClosureCreateBulk.OnConflict
+// documentation for more info.
+func (u *PinnedClosureUpsertBulk) Update(set func(*PinnedClosureUpsert)) *PinnedClosureUpsertBulk {
+	u.create.conflict = append(u.create.conflict, sql.ResolveWith(func(update *sql.UpdateSet) {
+		set(&PinnedClosureUpsert{UpdateSet: update})
+	}))
+	return u
+}
+
+// SetUpdatedAt sets the "updated_at" field.
+func (u *PinnedClosureUpsertBulk) SetUpdatedAt(v time.Time) *PinnedClosureUpsertBulk {
+	return u.Update(func(s *PinnedClosureUpsert) {
+		s.SetUpdatedAt(v)
+	})
+}
+
+// UpdateUpdatedAt sets the "updated_at" field to the value that was provided on create.
+func (u *PinnedClosureUpsertBulk) UpdateUpdatedAt() *PinnedClosureUpsertBulk {
+	return u.Update(func(s *PinnedClosureUpsert) {
+		s.UpdateUpdatedAt()
+	})
+}
+
+// ClearUpdatedAt clears the value of the "updated_at" field.
+func (u *PinnedClosureUpsertBulk) ClearUpdatedAt() *PinnedClosureUpsertBulk {
+	return u.Update(func(s *PinnedClosureUpsert) {
+		s.ClearUpdatedAt()
+	})
+}
+
+// SetHash sets the "hash" field.
+func (u *PinnedClosureUpsertBulk) SetHash(v string) *PinnedClosureUpsertBulk {
+	return u.Update(func(s *PinnedClosureUpsert) {
+		s.SetHash(v)
+	})
+}
+
+// UpdateHash sets the "hash" field to the value that was provided on create.
+func (u *PinnedClosureUpsertBulk) UpdateHash() *PinnedClosureUpsertBulk {
+	return u.Update(func(s *PinnedClosureUpsert) {
+		s.UpdateHash()
+	})
+}
+
+// Exec executes the query.
+func (u *PinnedClosureUpsertBulk) Exec(ctx context.Context) error {
+	if u.create.err != nil {
+		return u.create.err
+	}
+	for i, b := range u.create.builders {
+		if len(b.conflict) != 0 {
+			return fmt.Errorf("ent: OnConflict was set for builder %d. Set it on the PinnedClosureCreateBulk instead", i)
+		}
+	}
+	if len(u.create.conflict) == 0 {
+		return errors.New("ent: missing options for PinnedClosureCreateBulk.OnConflict")
+	}
+	return u.create.Exec(ctx)
+}
+
+// ExecX is like Exec, but panics if an error occurs.
+func (u *PinnedClosureUpsertBulk) ExecX(ctx context.Context) {
+	if err := u.create.Exec(ctx); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
§11.3 requires expressing PutNarInfo's UPSERT semantics
(`INSERT ... ON CONFLICT (hash) DO UPDATE ... WHERE url IS NULL`)
in Ent's fluent API. The OnConflict / UpsertOne / UpsertBulk
builders are only emitted when the `sql/upsert` feature flag
is on, so this commit turns it on and regenerates.

What changed:

- `ent/generate.go`: add `--feature sql/upsert` to the codegen
  invocation. Subsequent `go generate ./ent` invocations now
  always produce OnConflict-capable builders; CI's
  `git diff --exit-code ./ent/` check stays meaningful because
  the regenerated tree is committed here.
- Every `<entity>_create.go` file gains an OnConflict method,
  a Conflict type that exposes per-field
  Update/UpdateNewValues/Ignore handlers, and the corresponding
  Upsert / UpsertOne / UpsertBulk types. Pure additions; no
  existing API changes.

No call-site code uses OnConflict yet — §11.3's caller
migrations land in the next commit. Adding the feature flag in
its own commit keeps the §11.3 conversion diff focused on the
behavioural change, not the ~4k lines of mechanical codegen.

`go build ./...` succeeds, `golangci-lint run ./...` returns
zero issues, no other commit in the stack is affected.