### PR TITLE
feat(cache): convert NarInfo/NarFile delete paths to Ent

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4073,17 +4073,21 @@ func (c *Cache) purgeNarInfo(
 	)
 	defer span.End()
 
-	err := c.withTransaction(ctx, "purgeNarInfo", func(qtx database.Querier) error {
-		if _, err := qtx.DeleteNarInfoByHash(ctx, hash); err != nil {
+	err := c.withEntTransaction(ctx, "purgeNarInfo", func(tx *ent.Tx) error {
+		if _, err := tx.NarInfo.Delete().
+			Where(entnarinfo.HashEQ(hash)).
+			Exec(ctx); err != nil {
 			return fmt.Errorf("error deleting the narinfo record: %w", err)
 		}
 
 		if narURL.Hash != "" {
-			if _, err := qtx.DeleteNarFileByHash(ctx, database.DeleteNarFileByHashParams{
-				Hash:        narURL.Hash,
-				Compression: narURL.Compression.String(),
-				Query:       narURL.Query.Encode(),
-			}); err != nil {
+			if _, err := tx.NarFile.Delete().
+				Where(
+					entnarfile.HashEQ(narURL.Hash),
+					entnarfile.CompressionEQ(narURL.Compression.String()),
+					entnarfile.QueryEQ(narURL.Query.Encode()),
+				).
+				Exec(ctx); err != nil {
 				return fmt.Errorf("error deleting the nar record: %w", err)
 			}
 		}
@@ -4775,7 +4779,9 @@ func (c *Cache) deleteNarInfoFromStore(ctx context.Context, hash string) error {
 
 	// Delete from database (includes cascading deletes for references, signatures, and links)
 	if inDatabase {
-		if _, err := c.db.DeleteNarInfoByHash(ctx, hash); err != nil {
+		if _, err := c.dbClient.Ent().NarInfo.Delete().
+			Where(entnarinfo.HashEQ(hash)).
+			Exec(ctx); err != nil {
 			return fmt.Errorf("error deleting narinfo from the database: %w", err)
 		}
 


### PR DESCRIPTION
§11.3 partial. The simple delete sites in pkg/cache convert
cleanly without the UPSERT cascade that storeInDatabase
will need; landing them in a separate commit keeps each diff
reviewable.

Converted:

- `deleteNarInfoFromStore` (line 4778):
  `c.db.DeleteNarInfoByHash` →
  `c.dbClient.Ent().NarInfo.Delete().Where(HashEQ(hash)).Exec(ctx)`.
- `purgeNarInfo` (line 4076):
  switched the wrapper from `c.withTransaction(... qtx ...)`
  to `c.withEntTransaction(... tx *ent.Tx ...)`. The two
  inside-tx deletes (NarInfo + NarFile) become Ent Delete
  builders with the same predicates the sqlc query used
  (hash for NarInfo; hash + compression + query for NarFile).

Behaviour preservation:

- The cascading deletes the comment notes (references,
  signatures, narinfo_nar_files links) are still handled by
  the database-level ON DELETE CASCADE the §8 bridge
  migration set up. Ent's Delete builder doesn't need to do
  anything beyond DELETE FROM narinfos WHERE hash = ?.

Deferred to follow-up commits in §11.3:

- `storeInDatabase` and the second PutNarInfo helper (line
  4631) — both do a conditional UPSERT
  (`ON CONFLICT (hash) DO UPDATE ... WHERE url IS NULL`) plus
  bulk reference / signature inserts plus a NarFile UPSERT
  plus a NarFile<->NarInfo link. Substantial; their own
  commit.
- `DeleteNarInfoByID` inside the LRU eviction loop (line
  5535) — sits in a larger withTransaction block whose
  surrounding qtx calls belong to §11.5 (orphan cleanup).
  Leaving it qtx-style until that whole block converts as a
  unit.

`go test -race ./pkg/cache/...` passes against SQLite + Postgres
+ MySQL + Redis. Lint clean.