### PR TITLE
feat(cache): convert MigrateNarInfo + storeNarInfoInDatabase to Ent

### DIFF
--- a/openspec/changes/migrate-to-ent-and-atlas/tasks.md
+++ b/openspec/changes/migrate-to-ent-and-atlas/tasks.md
@@ -115,7 +115,7 @@ Per design D6 (Option E), the adoption decision tree has four branches: empty DB
 
 - [x] 11.1 Rewrite `pkg/cache/cache.go` storage of `database.Querier` to `*database.Client`; convert call sites one method at a time (added `*Client` field + `dbClient` param threaded through `cache.New`, testhelpers, and all call sites; call-site method conversions in §11.2-§11.8)
 - [x] 11.2 Convert `GetNarInfo*` paths in `pkg/cache/` to Ent fluent API; run package tests
-- [ ] 11.3 Convert `PutNarInfo*` paths; run package tests
+- [x] 11.3 Convert `PutNarInfo*` paths; run package tests
 - [ ] 11.4 Convert `GetNarFile*` / `PutNarFile*` paths (including CDC chunk insertion); run package tests
 - [ ] 11.5 Convert chunk and orphan-cleanup queries; run package tests
 - [ ] 11.6 Convert `pkg/ncps/` paths (migration tooling, fsck, closure pinning); run package tests

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4626,46 +4626,6 @@ func narFileSize(ni *narinfo.NarInfo) uint64 {
 	return ni.NarSize
 }
 
-func createOrUpdateNarFile(
-	ctx context.Context,
-	qtx database.Querier,
-	narURL nar.URL,
-	fileSize uint64,
-) (int64, error) {
-	zerolog.Ctx(ctx).Debug().
-		Str("hash", narURL.Hash).
-		Str("compression", narURL.Compression.String()).
-		Uint64("file_size", fileSize).
-		Msg("createOrUpdateNarFile: creating nar_file record")
-
-	// Create (or update existing) nar_file record.
-	// The query uses ON CONFLICT DO UPDATE (or ON DUPLICATE KEY UPDATE), so duplicates are handled
-	// by updating the timestamp and returning the record.
-	newNarFile, err := qtx.CreateNarFile(ctx, database.CreateNarFileParams{
-		Hash:        narURL.Hash,
-		Compression: narURL.Compression.String(),
-		Query:       narURL.Query.Encode(),
-		FileSize:    fileSize,
-	})
-	if err != nil {
-		zerolog.Ctx(ctx).Error().
-			Err(err).
-			Str("hash", narURL.Hash).
-			Str("compression", narURL.Compression.String()).
-			Msg("createOrUpdateNarFile: CreateNarFile failed")
-
-		return 0, fmt.Errorf("error creating or updating nar_file record in the database: %w", err)
-	}
-
-	zerolog.Ctx(ctx).Debug().
-		Int64("nar_file_id", newNarFile.ID).
-		Str("hash", narURL.Hash).
-		Str("compression", narURL.Compression.String()).
-		Msg("createOrUpdateNarFile: CreateNarFile succeeded")
-
-	return newNarFile.ID, nil
-}
-
 // MigrateNarInfoToDatabase migrates a single narinfo from storage to the database.
 // It uses distributed locking to coordinate with other instances (if Redis is configured).
 // This is a convenience wrapper around MigrateNarInfo for use within the Cache.
@@ -4680,7 +4640,7 @@ func (c *Cache) MigrateNarInfoToDatabase(
 		narInfoStore = c.narInfoStore
 	}
 
-	return MigrateNarInfo(ctx, c.downloadLocker, c.db, narInfoStore, hash, ni)
+	return MigrateNarInfo(ctx, c.downloadLocker, c.db, c.dbClient, narInfoStore, hash, ni)
 }
 
 // MigrateNarInfo migrates a single narinfo from storage to the database.
@@ -4690,7 +4650,10 @@ func (c *Cache) MigrateNarInfoToDatabase(
 // Parameters:
 //   - ctx: Context for the operation
 //   - locker: Distributed locker for coordination (can be in-memory for single-instance)
-//   - db: Database querier for storing the narinfo
+//   - db: Database querier (legacy; kept for the pre-lock double-check
+//     until §11 fully retires the Querier surface)
+//   - dbClient: Ent-backed client used by storeNarInfoInDatabase for
+//     the actual UPSERT pipeline
 //   - narInfoStore: Optional storage backend to delete from after migration (nil to skip deletion)
 //   - hash: The narinfo hash to migrate
 //   - ni: The parsed narinfo to migrate
@@ -4701,6 +4664,7 @@ func MigrateNarInfo(
 	ctx context.Context,
 	locker lock.Locker,
 	db database.Querier,
+	dbClient *database.Client,
 	narInfoStore storage.NarInfoStore,
 	hash string,
 	ni *narinfo.NarInfo,
@@ -4750,7 +4714,7 @@ func MigrateNarInfo(
 	}
 
 	// Store narinfo in database using the UPSERT logic from storeInDatabase
-	err = storeNarInfoInDatabase(ctx, db, hash, ni)
+	err = storeNarInfoInDatabase(ctx, dbClient, hash, ni)
 	if err != nil {
 		log.Error().Err(err).Msg("failed to migrate narinfo to database")
 
@@ -4810,121 +4774,57 @@ func MigrateNarInfo(
 	return nil
 }
 
-// storeNarInfoInDatabase is extracted from Cache.storeInDatabase for use by migration.
-// It contains the core UPSERT logic without Cache dependencies.
-func storeNarInfoInDatabase(ctx context.Context, db database.Querier, hash string, narInfo *narinfo.NarInfo) error {
-	tx, err := db.DB().BeginTx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("error beginning transaction: %w", err)
-	}
-
-	defer func() {
-		if err := tx.Rollback(); err != nil {
-			if !errors.Is(err, sql.ErrTxDone) {
-				zerolog.Ctx(ctx).Error().Err(err).Msg("error rolling back transaction")
-			}
+// storeNarInfoInDatabase is the Cache-free counterpart to
+// Cache.storeInDatabase. Used by MigrateNarInfo (which has no *Cache
+// reference). Shares the same Ent helpers — upsertNarInfoFromParsed,
+// addNarInfoReferences, addNarInfoSignatures, createOrUpdateNarFileEnt
+// — defined alongside Cache.storeInDatabase.
+func storeNarInfoInDatabase(
+	ctx context.Context,
+	dbClient *database.Client,
+	hash string,
+	narInfo *narinfo.NarInfo,
+) error {
+	return dbClient.WithTransaction(ctx, "storeNarInfoInDatabase", func(tx *ent.Tx) error {
+		nir, err := upsertNarInfoFromParsed(ctx, tx, hash, narInfo)
+		if err != nil {
+			return err
 		}
-	}()
 
-	qtx := db.WithTx(tx)
-
-	createNarInfoParams := database.CreateNarInfoParams{
-		Hash:        hash,
-		StorePath:   sql.NullString{String: narInfo.StorePath, Valid: narInfo.StorePath != ""},
-		URL:         sql.NullString{String: narInfo.URL, Valid: narInfo.URL != ""},
-		Compression: sql.NullString{String: narInfo.Compression, Valid: narInfo.Compression != ""},
-		FileSize:    sql.NullInt64{Int64: int64(narInfo.FileSize), Valid: true}, //nolint:gosec
-		NarSize:     sql.NullInt64{Int64: int64(narInfo.NarSize), Valid: true},  //nolint:gosec
-		Deriver:     sql.NullString{String: narInfo.Deriver, Valid: narInfo.Deriver != ""},
-		System:      sql.NullString{String: narInfo.System, Valid: narInfo.System != ""},
-		Ca:          sql.NullString{String: narInfo.CA, Valid: narInfo.CA != ""},
-	}
-
-	if narInfo.FileHash != nil {
-		createNarInfoParams.FileHash = sql.NullString{String: narInfo.FileHash.String(), Valid: true}
-	}
-
-	if narInfo.NarHash != nil {
-		createNarInfoParams.NarHash = sql.NullString{String: narInfo.NarHash.String(), Valid: true}
-	}
-
-	nir, err := qtx.CreateNarInfo(ctx, createNarInfoParams)
-	if err != nil {
-		// Handle UPSERT behavior (see Cache.storeInDatabase for full comments)
-		if database.IsNotFoundError(err) {
-			nir, err = qtx.GetNarInfoByHash(ctx, hash)
-			if err != nil {
-				return fmt.Errorf("upsert returned no rows (record exists with valid URL), failed to fetch: %w", err)
-			}
-		} else {
-			return fmt.Errorf("error inserting the narinfo record for hash %q in the database: %w", hash, err)
+		if err := addNarInfoReferences(ctx, tx, nir.ID, narInfo.References); err != nil {
+			return err
 		}
-	}
 
-	if len(narInfo.References) > 0 {
-		if err := qtx.AddNarInfoReferences(ctx, database.AddNarInfoReferencesParams{
-			NarInfoID: nir.ID,
-			Reference: narInfo.References,
-		}); err != nil {
-			// Duplicate key errors are expected with UPSERT
-			if !database.IsDuplicateKeyError(err) {
-				return fmt.Errorf("error inserting narinfo reference: %w", err)
-			}
+		if err := addNarInfoSignatures(ctx, tx, nir.ID, narInfo.Signatures); err != nil {
+			return err
 		}
-	}
 
-	// Signatures
-	sigStrings := make([]string, len(narInfo.Signatures))
-	for i, sig := range narInfo.Signatures {
-		sigStrings[i] = sig.String()
-	}
-
-	if len(sigStrings) > 0 {
-		if err := qtx.AddNarInfoSignatures(ctx, database.AddNarInfoSignaturesParams{
-			NarInfoID: nir.ID,
-			Signature: sigStrings,
-		}); err != nil {
-			// Duplicate key errors are expected with UPSERT
-			if !database.IsDuplicateKeyError(err) {
-				return fmt.Errorf("error inserting narinfo signature: %w", err)
-			}
+		narURL, err := nar.ParseURL(narInfo.URL)
+		if err != nil {
+			return fmt.Errorf("error parsing the nar URL: %w", err)
 		}
-	}
 
-	narURL, err := nar.ParseURL(narInfo.URL)
-	if err != nil {
-		return fmt.Errorf("error parsing the nar URL: %w", err)
-	}
+		normalizedNarURL, err := narURL.Normalize()
+		if err != nil {
+			return fmt.Errorf("error normalizing the nar URL: %w", err)
+		}
 
-	// Normalize the NAR URL to remove any narinfo hash prefix.
-	// This ensures nar_files.hash matches what's actually stored in the storage layer.
-	normalizedNarURL, err := narURL.Normalize()
-	if err != nil {
-		return fmt.Errorf("error normalizing the nar URL: %w", err)
-	}
+		narFileID, err := createOrUpdateNarFileEnt(ctx, tx, normalizedNarURL, narFileSize(narInfo))
+		if err != nil {
+			return err
+		}
 
-	// Create or get nar_file record
-	narFileID, err := createOrUpdateNarFile(ctx, qtx, normalizedNarURL, narFileSize(narInfo))
-	if err != nil {
-		return err
-	}
-
-	// Link narinfo to nar_file
-	if err := qtx.LinkNarInfoToNarFile(ctx, database.LinkNarInfoToNarFileParams{
-		NarInfoID: nir.ID,
-		NarFileID: narFileID,
-	}); err != nil {
-		// Duplicate key errors are expected with UPSERT
-		if !database.IsDuplicateKeyError(err) {
+		if err := tx.NarInfoNarFile.Create().
+			SetNarinfoID(nir.ID).
+			SetNarFileID(narFileID).
+			OnConflictColumns(entnarinfonarfile.FieldNarinfoID, entnarinfonarfile.FieldNarFileID).
+			Ignore().
+			Exec(ctx); err != nil {
 			return fmt.Errorf("error linking narinfo to nar_file: %w", err)
 		}
-	}
 
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("error committing transaction: %w", err)
-	}
-
-	return nil
+		return nil
+	})
 }
 
 func (c *Cache) backgroundMigrateNarInfo(ctx context.Context, hash string, ni *narinfo.NarInfo) {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -24,6 +24,7 @@ import (
 
 	locklocal "github.com/kalbasit/ncps/pkg/lock/local"
 
+	"github.com/kalbasit/ncps/ent"
 	"github.com/kalbasit/ncps/pkg/cache"
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
 	"github.com/kalbasit/ncps/pkg/database"
@@ -2021,7 +2022,10 @@ func testBackgroundMigrateNarInfoThunderingHerd(_ cacheFactory) func(*testing.T)
 		require.NoError(t, os.MkdirAll(filepath.Dir(narPath), 0o700))
 		require.NoError(t, os.WriteFile(narPath, []byte(testdata.Nar1.NarText), 0o600))
 
-		// Create a spy that captures calls to GetNarInfoByHash
+		// Create a spy that captures Querier-level GetNarInfoByHash
+		// calls (legacy observation hook). NarInfo create calls now
+		// flow through dbClient/Ent; we instrument them via an
+		// Ent NarInfo create hook below.
 		spy := &migrationSpy{
 			Querier:               db,
 			getNarInfoByHashCalls: new(int),
@@ -2031,6 +2035,23 @@ func testBackgroundMigrateNarInfoThunderingHerd(_ cacheFactory) func(*testing.T)
 
 		// Increase MaxOpenConns to avoid deadlocks during concurrent transactions in the test
 		db.DB().SetMaxOpenConns(10)
+
+		// Ent hook: count NarInfo create mutations. With §11.3's
+		// MigrateNarInfo conversion the create flows through dbClient
+		// rather than the Querier-shaped spy, so this is the only
+		// reliable observation point. Atomic since concurrent
+		// GetNarInfo goroutines may hit it simultaneously.
+		dbClient.Ent().NarInfo.Use(func(next ent.Mutator) ent.Mutator {
+			return ent.MutateFunc(func(ctx context.Context, m ent.Mutation) (ent.Value, error) {
+				if m.Op() == ent.OpCreate {
+					spy.mu.Lock()
+					*spy.createNarInfoCalls++
+					spy.mu.Unlock()
+				}
+
+				return next.Mutate(ctx, m)
+			})
+		})
 
 		c, err := newTestCache(newContext(), "test.example.com", spy, dbClient, localStore, localStore, localStore, "")
 		require.NoError(t, err)

--- a/pkg/ncps/migrate_narinfo.go
+++ b/pkg/ncps/migrate_narinfo.go
@@ -201,7 +201,7 @@ requests. Without Redis, the command uses in-memory locking (no coordination wit
 			dryRun := cmd.Bool("dry-run")
 
 			// 1. Setup Database
-			db, _, err := createDatabaseQuerier(cmd)
+			db, dbClient, err := createDatabaseQuerier(cmd)
 			if err != nil {
 				logger.Error().Err(err).Msg("error creating database querier")
 
@@ -374,7 +374,7 @@ requests. Without Redis, the command uses in-memory locking (no coordination wit
 
 					// Use the shared migration function from pkg/cache
 					// Pass narInfoStore to enable deletion after migration
-					if err := cache.MigrateNarInfo(ctxWithLog, locker, db, narInfoStore, hash, ni); err != nil {
+					if err := cache.MigrateNarInfo(ctxWithLog, locker, db, dbClient, narInfoStore, hash, ni); err != nil {
 						log.Error().Err(err).Msg("failed to migrate narinfo")
 						atomic.AddInt32(&totalFailed, 1)
 						RecordMigrationObject(ctxWithLog, MigrationTypeNarInfoToDB, MigrationOperationMigrate, MigrationResultFailure)


### PR DESCRIPTION
feat(cache): convert MigrateNarInfo + storeNarInfoInDatabase to Ent

§11.3 completion of the PutNarInfo write paths. The Cache-free
`storeNarInfoInDatabase` (used by `MigrateNarInfo` from the
background-migration goroutine and the CLI migrate-narinfo
command) is collapsed into the same Ent-fluent pipeline that
`Cache.storeInDatabase` adopted in the previous commit, reusing
`upsertNarInfoFromParsed`, `addNarInfoReferences`,
`addNarInfoSignatures`, and `createOrUpdateNarFileEnt`.

Key changes:

- `MigrateNarInfo` gains a `dbClient *database.Client` parameter
  alongside its existing `db database.Querier`. The Querier
  stays for the pre-lock double-check
  (`db.GetNarInfoByHash(ctx, hash)` looking for already-migrated
  rows) until §11.6 retires that surface entirely. Callers
  updated: `(*Cache).MigrateNarInfoToDatabase` already had the
  field; `pkg/ncps/migrate_narinfo.go`'s
  `migrateNarInfoCommand` extracts the Client out of
  `createDatabaseQuerier`'s second return value and passes it
  along.
- `storeNarInfoInDatabase`'s body is replaced wholesale with a
  `dbClient.WithTransaction(...)` block that runs the same Ent
  helpers as `Cache.storeInDatabase`. Same conflict-resolution
  primitives (OnConflictColumns + Ignore for references,
  signatures, and the narinfo<->nar_file link), same conditional
  read-then-update UPSERT for the narinfo row, same atomic
  Create+SetLastAccessedAt for nar_files.
- The legacy `createOrUpdateNarFile(qtx)` helper is now
  fully unused — both production call sites (the old
  storeInDatabase and storeNarInfoInDatabase) migrated to
  `createOrUpdateNarFileEnt(tx)`. Deleted.

Test infrastructure
-------------------

`testBackgroundMigrateNarInfoThunderingHerd` counts the number
of NarInfo create operations to detect "more than one
migration goroutine acquired the lock". The legacy spy
embedded `database.Querier` and counted `CreateNarInfo` calls;
since the migration path now flows through `dbClient` (Ent),
the spy never saw the conversion. The test now installs an
Ent mutation hook via
`dbClient.Ent().NarInfo.Use(func(next ent.Mutator) ent.Mutator
{ … if m.Op() == ent.OpCreate { spy.createNarInfoCalls++ } … })`
and keeps the spy struct purely for the
GetNarInfoByHash count (which still goes through Querier
during the pre-lock double-check).

After this commit no Querier-style CreateNarInfo /
AddNarInfoReference / AddNarInfoSignature /
LinkNarInfoToNarFile / DeleteNarInfoByHash call site remains
in pkg/cache. The §11.3 PutNarInfo* conversion is complete.

`go test -race ./pkg/cache/... ./pkg/ncps/...` passes against
SQLite + Postgres + MySQL + Redis. Lint clean.

docs(openspec): mark §11.3 tasks complete

§11.3 (Convert PutNarInfo* paths) finished across feat-cache-
delete-narinfo-ent, feat-cache-storeindatabase-ent, and feat-
cache-migrate-narinfo-ent. No qtx-style CreateNarInfo /
DeleteNarInfoBy* / AddNarInfoReferences / AddNarInfoSignatures /
LinkNarInfoToNarFile call site remains in pkg/cache.

Stack tip is feat-cache-migrate-narinfo-ent.