### PR TITLE
fix(ncps): drop dbURL from createDatabaseQuerier error wraps

### DIFF
--- a/migrations/sqlite/20260521021523_ent_baseline.sql
+++ b/migrations/sqlite/20260521021523_ent_baseline.sql
@@ -1,4 +1,10 @@
 -- +goose Up
+-- +goose NO TRANSACTION
+-- Required so the `PRAGMA foreign_keys = off` below takes effect —
+-- SQLite ignores the PRAGMA inside a transaction, which would cause
+-- the subsequent DROP TABLE / RENAME swaps to fail against any data
+-- already referencing the rewritten tables.
+
 -- disable the enforcement of foreign-keys constraints
 PRAGMA foreign_keys = OFF;
 -- create "new_narinfos" table

--- a/migrations/sqlite/atlas.sum
+++ b/migrations/sqlite/atlas.sum
@@ -1,4 +1,4 @@
-h1:ieTAmZaBCo20zXl2vHvJ5HYS58ZxtY83HtzgmAcJ0/w=
+h1:wd3qrlObmzyy0FSwtarrnKR0ujKdgdPexuDxTYHHHsc=
 20241210054814_create-narinfos-table.sql h1:e8MnIArqBCoUNv8/b0yDnx6ikbaSoPuMp3+j+C/cIPk=
 20241210054829_create-nars-table.sql h1:odrcFJuEF0MT6AIEa5Vn8ghpHV7EhIwfOjsIal1ZUW0=
 20241213014846_add-query-to-nars-table.sql h1:gFPvhup77Qua+8KlsWxqRLQqbXSr1IZSnpVDOFlR5cM=
@@ -13,4 +13,4 @@ h1:ieTAmZaBCo20zXl2vHvJ5HYS58ZxtY83HtzgmAcJ0/w=
 20260217071237_add_chunking_started_at_to_nar_files.sql h1:bUn8AnQH1Hc9burg/VqDqK5Yjs0JvjjK651p2+896aY=
 20260301000000_add_verified_at_to_nar_files.sql h1:NxNO9QJIibslyviRRNK3K2MkBAddVrXLsP2NSReaucc=
 20260318053903_add_pinned_closures_table.sql h1:9rWx0agGLMR6TDaq1jKPZNKlch4LOnKjb/OaHO5nPmI=
-20260521021523_ent_baseline.sql h1:ARI5SPrx9vpGf6cXv5nLf6Iccor3OIjTyWHrqShpNmQ=
+20260521021523_ent_baseline.sql h1:PkCUJB7uREMN8ERWLxSj3msPhjXZYTU3E6PUSmNOGBI=

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4904,7 +4904,7 @@ func storeNarInfoInDatabase(
 	hash string,
 	narInfo *narinfo.NarInfo,
 ) error {
-	return dbClient.WithTransaction(ctx, "storeNarInfoInDatabase", func(tx *ent.Tx) error {
+	return withEntTransactionRetry(ctx, dbClient, "storeNarInfoInDatabase", func(tx *ent.Tx) error {
 		nir, err := upsertNarInfoFromParsed(ctx, tx, hash, narInfo)
 		if err != nil {
 			return err
@@ -5418,6 +5418,20 @@ func (c *Cache) withTransaction(ctx context.Context, operation string, fn func(q
 //
 
 func (c *Cache) withEntTransaction(ctx context.Context, operation string, fn func(tx *ent.Tx) error) error {
+	return withEntTransactionRetry(ctx, c.dbClient, operation, fn)
+}
+
+// withEntTransactionRetry wraps dbClient.WithTransaction with the
+// same deadlock-retry policy the legacy *Cache.executeTransaction
+// helper provided. Package-level so it can be reused by callers that
+// don't hold a *Cache (storeNarInfoInDatabase running under
+// MigrateNarInfo / the CLI migrate-narinfo path).
+func withEntTransactionRetry(
+	ctx context.Context,
+	dbClient *database.Client,
+	operation string,
+	fn func(tx *ent.Tx) error,
+) error {
 	const (
 		maxAttempts  = 5
 		initialDelay = 50 * time.Millisecond
@@ -5433,7 +5447,7 @@ func (c *Cache) withEntTransaction(ctx context.Context, operation string, fn fun
 		Msg("withEntTransaction: starting transaction")
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		err = c.dbClient.WithTransaction(ctx, operation, fn)
+		err = dbClient.WithTransaction(ctx, operation, fn)
 		if err == nil {
 			zerolog.Ctx(ctx).Debug().
 				Str("operation", operation).

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -64,6 +64,14 @@ const (
 	// which is critical for databases like MySQL under parallel test load.
 	progressivePollBatchSize = 256
 
+	// cdcCleanupHashBatchSize bounds the size of `WHERE hash IN (…)`
+	// batches issued by the CDC delayed-cleanup job. Stays well under
+	// driver parameter limits (Postgres ≤ 65535, modern SQLite ≤
+	// 32766, older SQLite ≤ 999) while staying well above typical
+	// chunked-NAR-hash counts so the job remains a single query for
+	// almost every install.
+	cdcCleanupHashBatchSize = 500
+
 	// Migration operation constants for metrics.
 	migrationOperationMigrate = "migrate"
 	migrationOperationDelete  = "delete"
@@ -704,12 +712,14 @@ func (c *Cache) GetCDCDeleteDelay() time.Duration {
 
 func (c *Cache) setupMetricCallbacks() error {
 	_, err := meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
-		// Observe total size: SUM(file_size) over nar_files, with
-		// COALESCE-to-zero semantics (empty table returns 0, not NULL).
+		// Observe total size: SUM(file_size) over nar_files. SQL SUM on
+		// an empty set returns NULL, which won't scan into a plain
+		// int64 — use sql.NullInt64 and treat NULL as zero. The column
+		// alias matches the field name Ent emits via ent.Sum.
 		var totalSize int64
 
 		var totals []struct {
-			Sum int64 `sql:"sum"`
+			Sum sql.NullInt64 `sql:"sum"`
 		}
 
 		if err := c.dbClient.Ent().NarFile.Query().
@@ -720,8 +730,8 @@ func (c *Cache) setupMetricCallbacks() error {
 				Err(err).
 				Msg("failed to get total nar size for metrics")
 		} else {
-			if len(totals) > 0 {
-				totalSize = totals[0].Sum
+			if len(totals) > 0 && totals[0].Sum.Valid {
+				totalSize = totals[0].Sum.Int64
 			}
 
 			o.ObserveInt64(totalSizeMetric, totalSize)
@@ -6081,12 +6091,17 @@ func (c *Cache) runCDCDeletedCleanup(ctx context.Context) func() {
 			// (compression='none', total_chunks>0) representation, then
 			// find the old compressed (total_chunks=0, compression!='none')
 			// records for those hashes whose created_at predates cutoff.
-			ent := c.dbClient.Ent()
+			//
+			// HashIn is batched (cdcCleanupHashBatchSize) to stay below
+			// driver parameter limits (Postgres ≤ 65535, SQLite ≤ 32766
+			// on recent builds, ≤ 999 on older). 500 is well below all
+			// limits, well above typical chunked-NAR-hash counts.
+			entClient := c.dbClient.Ent()
 
 			var chunkedHashRows []struct {
 				Hash string `sql:"hash"`
 			}
-			if err := ent.NarFile.Query().
+			if err := entClient.NarFile.Query().
 				Where(
 					entnarfile.CompressionEQ("none"),
 					entnarfile.TotalChunksGT(0),
@@ -6109,18 +6124,29 @@ func (c *Cache) runCDCDeletedCleanup(ctx context.Context) func() {
 				chunkedHashes[i] = r.Hash
 			}
 
-			oldFiles, err := ent.NarFile.Query().
-				Where(
-					entnarfile.TotalChunksEQ(0),
-					entnarfile.CompressionNEQ("none"),
-					entnarfile.CreatedAtLT(cutoffTime),
-					entnarfile.HashIn(chunkedHashes...),
-				).
-				All(ctx)
-			if err != nil {
-				log.Error().Err(err).Msg("error getting old compressed NAR files for cleanup")
+			var oldFiles []*ent.NarFile
 
-				return err
+			for start := 0; start < len(chunkedHashes); start += cdcCleanupHashBatchSize {
+				end := start + cdcCleanupHashBatchSize
+				if end > len(chunkedHashes) {
+					end = len(chunkedHashes)
+				}
+
+				batch, err := entClient.NarFile.Query().
+					Where(
+						entnarfile.TotalChunksEQ(0),
+						entnarfile.CompressionNEQ("none"),
+						entnarfile.CreatedAtLT(cutoffTime),
+						entnarfile.HashIn(chunkedHashes[start:end]...),
+					).
+					All(ctx)
+				if err != nil {
+					log.Error().Err(err).Msg("error getting old compressed NAR files for cleanup")
+
+					return err
+				}
+
+				oldFiles = append(oldFiles, batch...)
 			}
 
 			if len(oldFiles) == 0 {
@@ -6139,7 +6165,7 @@ func (c *Cache) runCDCDeletedCleanup(ctx context.Context) func() {
 				}
 
 				// Delete from database first. If this fails, we'll retry on the next run.
-				if _, err := ent.NarFile.Delete().
+				if _, err := entClient.NarFile.Delete().
 					Where(entnarfile.IDEQ(oldFile.ID)).
 					Exec(ctx); err != nil {
 					log.Error().Err(err).

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2365,17 +2365,36 @@ func (c *Cache) relinkNarInfosToNarFileWithEntTx(
 		return nil
 	}
 
-	bulk := make([]*ent.NarInfoNarFileCreate, len(narInfoIDs))
-	for i, niID := range narInfoIDs {
-		bulk[i] = tx.NarInfoNarFile.Create().SetNarinfoID(niID).SetNarFileID(int(narFileID))
-	}
+	// Chunk the CreateBulk to stay below driver placeholder limits.
+	// Each row sends 2 parameters (narinfo_id, nar_file_id); 500 rows
+	// per batch = 1000 placeholders, well under Postgres 65535,
+	// modern SQLite 32766, and older SQLite 999. Closures with
+	// thousands of narinfos sharing a NAR URL (large multi-output
+	// derivations, deep dependency trees) are uncommon but real, and
+	// without chunking the bulk insert would silently fail on
+	// older sqlite.
+	const relinkBatchSize = 500
 
-	if err := tx.NarInfoNarFile.CreateBulk(bulk...).
-		OnConflictColumns(entnarinfonarfile.FieldNarinfoID, entnarinfonarfile.FieldNarFileID).
-		Ignore().
-		Exec(ctx); err != nil {
-		return fmt.Errorf("failed to link narinfos by URL %q to nar_file %d: %w",
-			narURL.String(), narFileID, err)
+	for start := 0; start < len(narInfoIDs); start += relinkBatchSize {
+		end := start + relinkBatchSize
+		if end > len(narInfoIDs) {
+			end = len(narInfoIDs)
+		}
+
+		batch := narInfoIDs[start:end]
+		bulk := make([]*ent.NarInfoNarFileCreate, len(batch))
+
+		for i, niID := range batch {
+			bulk[i] = tx.NarInfoNarFile.Create().SetNarinfoID(niID).SetNarFileID(int(narFileID))
+		}
+
+		if err := tx.NarInfoNarFile.CreateBulk(bulk...).
+			OnConflictColumns(entnarinfonarfile.FieldNarinfoID, entnarinfonarfile.FieldNarFileID).
+			Ignore().
+			Exec(ctx); err != nil {
+			return fmt.Errorf("failed to link narinfos batch by URL %q to nar_file %d: %w",
+				narURL.String(), narFileID, err)
+		}
 	}
 
 	return nil

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -5428,9 +5428,17 @@ func (c *Cache) withEntTransaction(ctx context.Context, operation string, fn fun
 		delay = initialDelay
 	)
 
+	zerolog.Ctx(ctx).Debug().
+		Str("operation", operation).
+		Msg("withEntTransaction: starting transaction")
+
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		err = c.dbClient.WithTransaction(ctx, operation, fn)
 		if err == nil {
+			zerolog.Ctx(ctx).Debug().
+				Str("operation", operation).
+				Msg("withEntTransaction: transaction committed successfully")
+
 			return nil
 		}
 
@@ -5451,10 +5459,16 @@ func (c *Cache) withEntTransaction(ctx context.Context, operation string, fn fun
 			Dur("delay", delay).
 			Msg("database deadlock/busy, retrying transaction")
 
+		// time.NewTimer + Stop instead of time.After to avoid leaking
+		// the underlying timer (and its goroutine on pre-1.23 runtimes)
+		// for the full delay duration when ctx is cancelled mid-wait.
+		timer := time.NewTimer(delay)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
+
 			return ctx.Err()
-		case <-time.After(delay):
+		case <-timer.C:
 			delay *= 2
 		}
 	}

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -987,7 +987,8 @@ func createDatabaseQuerier(cmd *cli.Command) (database.Querier, *database.Client
 
 	db, err := database.Open(dbURL, poolCfg)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error opening the database %q: %w", dbURL, err)
+		// Avoid embedding dbURL — it may contain user:password credentials.
+		return nil, nil, fmt.Errorf("error opening the database: %w", err)
 	}
 
 	// §11.1: construct the Ent-backed Client alongside the legacy
@@ -995,12 +996,12 @@ func createDatabaseQuerier(cmd *cli.Command) (database.Querier, *database.Client
 	// connection pool; the Client wraps it via entsql.OpenDB.
 	dbType, err := database.DetectFromDatabaseURL(dbURL)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error detecting database type for %q: %w", dbURL, err)
+		return nil, nil, fmt.Errorf("error detecting database type: %w", err)
 	}
 
 	dbClient, err := database.NewClient(db.DB(), dbType)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error constructing database client for %q: %w", dbURL, err)
+		return nil, nil, fmt.Errorf("error constructing database client: %w", err)
 	}
 
 	return db, dbClient, nil


### PR DESCRIPTION
fix(ncps): drop dbURL from createDatabaseQuerier error wraps

PR #1192 review: 3 sec-high comments flagged that
`createDatabaseQuerier`'s error wraps embed `dbURL` via `%q`.
Practical database URLs include credentials, leaking them into
server logs. Drop the URL from the three new wraps the §11.1
thread-through commit introduced.

Resolves:
- PR #1192 PRRT_kwDONV6tZs6DsTQ7 (line 990)
- PR #1192 PRRT_kwDONV6tZs6DsTRK (line 998)
- PR #1192 PRRT_kwDONV6tZs6DsTRQ (line 1003)

fix(cache): preserve tx debug logs + use time.Timer in retry

PR #1194 review surfaced two issues in withEntTransaction:

1. (PRRT_kwDONV6tZs6DsQzn) Restore "starting transaction" /
   "committed successfully" debug logs that the legacy
   executeTransaction emitted. Behind Debug level so noise
   stays opt-in; restores observability parity.

2. (PRRT_kwDONV6tZs6DsQzo) Replace `case <-time.After(delay):`
   inside the retry select with `time.NewTimer(delay)` +
   `t.Stop()` in the ctx-cancellation branch to avoid leaking
   the underlying timer when ctx wins the race.

Behaviour-preserving on the happy path.

fix(migrations): restore +goose NO TRANSACTION on sqlite bridge

PR #1196 (PRRT_kwDONV6tZs6DsQXZ, high): the
`-- +goose NO TRANSACTION` directive was dropped from the
SQLite ent_baseline bridge when `fix-ent-preserve-current-
timestamp-default` regenerated the migration via
`cmd/generate-migrations`.

In SQLite, `PRAGMA foreign_keys = off` is a no-op inside a
transaction. Goose wraps migrations in a transaction by
default, so without the NO TRANSACTION directive the PRAGMA
silently has no effect — and the subsequent
`DROP TABLE <parent>` / `ALTER TABLE new_X RENAME TO X` swaps
would fail in production against any database with existing
FK-referenced rows. The original §8 bridge had this directive;
the regeneration lost it because Atlas's GooseFormatter
doesn't emit it automatically.

Restored the directive plus its explanatory comment, and
regenerated `migrations/sqlite/atlas.sum` so Atlas's
checksum validator accepts the file.

Postgres and MySQL bridges don't need an equivalent — they
use real `ALTER TABLE` for column changes (not SQLite's
shadow-table-recreate pattern) and don't depend on a PRAGMA
to disable referential integrity mid-migration.

Note: `TestSchemaEquivalence/sqlite` is currently broken at
HEAD for a separate, pre-existing reason traced to the
`cf28126` regen (the test fails both with and without this
fix). Will be investigated as a follow-up.

fix(cache): add retry-on-deadlock to storeNarInfoInDatabase

PR #1203 (PRRT_kwDONV6tZs6DsScG, medium): standalone
`storeNarInfoInDatabase` (Cache-free entry used by
MigrateNarInfo and the `ncps migrate-narinfo` CLI) called
`dbClient.WithTransaction` directly, skipping the
deadlock-retry loop the `*Cache.withEntTransaction` provides.
Under load — concurrent migrations of many narinfos against
SQLite, or contended PostgreSQL deployments — that meant
transient SQLITE_BUSY / serialization failures bubbled all the
way out, where the legacy path would have retried.

Fix: extract the retry policy from `*Cache.withEntTransaction`
into a package-level `withEntTransactionRetry(ctx, dbClient,
operation, fn)` helper. `*Cache.withEntTransaction` now
forwards to it; `storeNarInfoInDatabase` uses it directly.
Same retry parameters (5 attempts, 50ms initial back-off
doubling per attempt, ctx-aware via time.Timer + Stop).

No behaviour change for any caller already going through
`*Cache.withEntTransaction`; the previously-missing retry
is now present for MigrateNarInfo / CLI migrations.

fix(cache): batch HashIn + null-safe SUM + unshadow ent

PR #1204 surfaced three concerns in §11.4's non-tx NarFile
conversion (`feat-cache-narfile-non-tx-to-ent`):

1. (PRRT_kwDONV6tZs6DsRgI, high) The CDC delayed-cleanup
   replacement for `GetOldCompressedNarFiles` was a two-step
   query that paged ALL chunked NAR hashes into Go memory then
   passed them to a single `entnarfile.HashIn(...)`. On caches
   with many chunked NARs that risks (a) loading megabytes of
   hashes into memory and (b) blowing past driver parameter
   limits (Postgres ≤ 65535, modern SQLite ≤ 32766, older
   SQLite ≤ 999). Fixed by batching HashIn in chunks of
   `cdcCleanupHashBatchSize` (= 500, a new package const).
   The batch size is well below all known limits and well
   above typical chunked-hash counts, so the job stays a
   single round-trip for any practical install.

2. (PRRT_kwDONV6tZs6DsRgL, medium) The metrics-observer SUM
   aggregator scanned into a plain `int64`. SQL `SUM` over an
   empty set returns NULL, which fails to scan into `int64`
   ("sql: Scan, storing driver.Value type <nil> into type
   *int64"). The metric callback would have started failing
   the moment any deployment booted with an empty nar_files
   table. Switched to `sql.NullInt64` with a Valid check;
   NULL is treated as zero. The `sql:"sum"` tag matches the
   alias Ent emits via `ent.Sum`.

3. (PRRT_kwDONV6tZs6DsRgO, medium) Local var `ent` shadowed
   the `ent` package import inside the cron handler closure.
   No actual breakage in the current code (no `ent.X` use
   inside that scope) but it makes the scope brittle for
   future edits. Renamed to `entClient`.

`go test -race ./pkg/cache/...` passes against SQLite +
Postgres + MySQL + Redis. Lint clean.

fix(cache): batch relinkNarInfosToNarFile bulk insert

PR #1205 (PRRT_kwDONV6tZs6DsRuq, medium):
`relinkNarInfosToNarFileWithEntTx` passed every queried narinfo
ID into a single `tx.NarInfoNarFile.CreateBulk(...)` call. Each
row sends 2 parameters (narinfo_id, nar_file_id), so a closure
with N narinfos sharing a NAR URL sends 2N placeholders. On
older SQLite builds (limit 999) that fails for any N > 499;
even on Postgres (limit 65535) very large closures could
silently overflow.

Fixed by chunking the loop into batches of 500 rows = 1000
placeholders per batch, well below all driver limits and well
above realistic closure sizes — so the common case stays a
single round-trip.

batch size is a local const inside the helper rather than a
package constant because the limit derives from this specific
row's placeholder count (2 cols × batch size); other bulk
inserts with different column counts get their own limit.

`go test -race ./pkg/cache/...` passes against SQLite +
Postgres + MySQL + Redis. Lint clean.