### PR TITLE
feat(config,ncps): convert pkg/config to Ent and thread *database.Client through callers

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -597,7 +597,7 @@ func New(
 	c := &Cache{
 		db:                   db,
 		dbClient:             dbClient,
-		config:               config.New(db, cacheLocker),
+		config:               config.New(dbClient, cacheLocker),
 		configStore:          configStore,
 		narInfoStore:         narInfoStore,
 		narStore:             narStore,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/rs/zerolog"
 
+	entconfigentry "github.com/kalbasit/ncps/ent/configentry"
+
+	"github.com/kalbasit/ncps/ent"
 	"github.com/kalbasit/ncps/pkg/database"
 	"github.com/kalbasit/ncps/pkg/lock"
 )
@@ -55,14 +58,14 @@ var (
 // Config provides access to the persistent configuration stored in the database.
 // It uses an RWLocker to ensure thread-safe access to configuration keys.
 type Config struct {
-	db       database.Querier
+	dbClient *database.Client
 	rwLocker lock.RWLocker
 }
 
 // New returns a new Config instance.
-func New(db database.Querier, rwLocker lock.RWLocker) *Config {
+func New(dbClient *database.Client, rwLocker lock.RWLocker) *Config {
 	return &Config{
-		db:       db,
+		dbClient: dbClient,
 		rwLocker: rwLocker,
 	}
 }
@@ -149,9 +152,11 @@ func (c *Config) getConfig(ctx context.Context, key string) (string, error) {
 		}
 	}()
 
-	cu, err := c.db.GetConfigByKey(ctx, key)
+	cu, err := c.dbClient.Ent().ConfigEntry.Query().
+		Where(entconfigentry.KeyEQ(key)).
+		Only(ctx)
 	if err != nil {
-		if database.IsNotFoundError(err) {
+		if ent.IsNotFound(err) {
 			return "", fmt.Errorf("%w: %s", ErrConfigNotFound, key)
 		}
 
@@ -183,10 +188,18 @@ func (c *Config) setConfig(ctx context.Context, key, value string) error {
 		}
 	}()
 
-	return c.db.SetConfig(ctx, database.SetConfigParams{
-		Key:   key,
-		Value: value,
-	})
+	// UPSERT on (key) — matches the legacy SetConfig
+	// `INSERT … ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value,
+	// updated_at = CURRENT_TIMESTAMP`.
+	return c.dbClient.Ent().ConfigEntry.Create().
+		SetKey(key).
+		SetValue(value).
+		OnConflictColumns(entconfigentry.FieldKey).
+		Update(func(u *ent.ConfigEntryUpsert) {
+			u.SetValue(value)
+			u.SetUpdatedAt(time.Now())
+		}).
+		Exec(ctx)
 }
 
 // ValidateOrStoreCDCConfig validates CDC configuration against stored values or stores them if not yet configured.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	entconfigentry "github.com/kalbasit/ncps/ent/configentry"
+
 	"github.com/kalbasit/ncps/pkg/config"
 	"github.com/kalbasit/ncps/pkg/database"
 	"github.com/kalbasit/ncps/pkg/lock/local"
@@ -15,30 +17,30 @@ import (
 )
 
 // databaseFactory is a function that returns a clean, ready-to-use database instance.
-type databaseFactory func(t *testing.T) (database.Querier, func())
+type databaseFactory func(t *testing.T) (*database.Client, func())
 
-func setupSQLiteDatabase(t *testing.T) (database.Querier, func()) {
+func setupSQLiteDatabase(t *testing.T) (*database.Client, func()) {
 	t.Helper()
 
-	db, _, cleanup := testhelper.SetupSQLite(t)
+	_, dbClient, cleanup := testhelper.SetupSQLite(t)
 
-	return db, cleanup
+	return dbClient, cleanup
 }
 
-func setupPostgresDatabase(t *testing.T) (database.Querier, func()) {
+func setupPostgresDatabase(t *testing.T) (*database.Client, func()) {
 	t.Helper()
 
-	db, _, _, cleanup := testhelper.SetupPostgres(t)
+	_, dbClient, _, cleanup := testhelper.SetupPostgres(t)
 
-	return db, cleanup
+	return dbClient, cleanup
 }
 
-func setupMySQLDatabase(t *testing.T) (database.Querier, func()) {
+func setupMySQLDatabase(t *testing.T) (*database.Client, func()) {
 	t.Helper()
 
-	db, _, _, cleanup := testhelper.SetupMySQL(t)
+	_, dbClient, _, cleanup := testhelper.SetupMySQL(t)
 
-	return db, cleanup
+	return dbClient, cleanup
 }
 
 func TestGetClusterUUIDBackends(t *testing.T) {
@@ -99,10 +101,10 @@ func testGetClusterUUIDExisting(factory databaseFactory) func(*testing.T) {
 
 		const expectedUUID = "abc-123"
 
-		_, err := db.CreateConfig(context.Background(), database.CreateConfigParams{
-			Key:   config.KeyClusterUUID,
-			Value: expectedUUID,
-		})
+		_, err := db.Ent().ConfigEntry.Create().
+			SetKey(config.KeyClusterUUID).
+			SetValue(expectedUUID).
+			Save(context.Background())
 		require.NoError(t, err)
 
 		actualUUID, err := c.GetClusterUUID(context.Background())
@@ -156,7 +158,9 @@ func testSetClusterUUIDNotExisting(factory databaseFactory) func(*testing.T) {
 		err := c.SetClusterUUID(context.Background(), "abc-123")
 		require.NoError(t, err)
 
-		conf, err := db.GetConfigByKey(context.Background(), config.KeyClusterUUID)
+		conf, err := db.Ent().ConfigEntry.Query().
+			Where(entconfigentry.KeyEQ(config.KeyClusterUUID)).
+			Only(context.Background())
 		require.NoError(t, err)
 
 		assert.Equal(t, config.KeyClusterUUID, conf.Key)
@@ -179,7 +183,9 @@ func testSetClusterUUIDExisting(factory databaseFactory) func(*testing.T) {
 		err = c.SetClusterUUID(context.Background(), "def-456")
 		require.NoError(t, err)
 
-		conf, err := db.GetConfigByKey(context.Background(), config.KeyClusterUUID)
+		conf, err := db.Ent().ConfigEntry.Query().
+			Where(entconfigentry.KeyEQ(config.KeyClusterUUID)).
+			Only(context.Background())
 		require.NoError(t, err)
 
 		assert.Equal(t, config.KeyClusterUUID, conf.Key)

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -289,7 +289,7 @@ Use --repair to automatically fix detected issues, or --dry-run to preview what 
 			verifiedSince := cmd.Duration("verified-since")
 
 			// 1. Setup Database
-			db, _, err := createDatabaseQuerier(cmd)
+			db, dbClient, err := createDatabaseQuerier(cmd)
 			if err != nil {
 				logger.Error().Err(err).Msg("error creating database querier")
 
@@ -305,7 +305,7 @@ Use --repair to automatically fix detected issues, or --dry-run to preview what 
 			}
 
 			// 3. Setup OTel
-			extraResourceAttrs, err := detectExtraResourceAttrs(ctx, cmd, db, rwLocker)
+			extraResourceAttrs, err := detectExtraResourceAttrs(ctx, cmd, dbClient, rwLocker)
 			if err != nil {
 				logger.Error().Err(err).Msg("error detecting extra resource attributes")
 

--- a/pkg/ncps/fsck_test.go
+++ b/pkg/ncps/fsck_test.go
@@ -31,8 +31,8 @@ import (
 	"github.com/kalbasit/ncps/testhelper"
 )
 
-// fsckSetupFn returns (db, localStore, storageDir, dbURL, cleanup).
-type fsckSetupFn func(t *testing.T) (database.Querier, *localstorage.Store, string, string, func())
+// fsckSetupFn returns (db, dbClient, localStore, storageDir, dbURL, cleanup).
+type fsckSetupFn func(t *testing.T) (database.Querier, *database.Client, *localstorage.Store, string, string, func())
 
 func TestFsckBackends(t *testing.T) {
 	t.Parallel()
@@ -93,7 +93,7 @@ func testFsckClean(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, store, dir, dbURL, cleanup := setup(t)
+		db, _, store, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
 		// Seed a fully consistent narinfo+narfile in DB and storage.
@@ -123,7 +123,7 @@ func testFsckNarInfosWithoutNarFiles(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, _, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
 		// Insert a narinfo in DB with a URL but with no linked nar_file.
@@ -168,7 +168,7 @@ func testFsckOrphanedNarFilesInDB(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, _, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
 		// Create a nar_file in DB with no linked narinfo.
@@ -212,7 +212,7 @@ func testFsckNarFileMissingInStorage(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, store, dir, dbURL, cleanup := setup(t)
+		db, _, store, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
 		// Write narinfo+nar to storage and fully migrate to DB.
@@ -249,7 +249,7 @@ func testFsckNarFileMissingCascadeRepair(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, store, dir, dbURL, cleanup := setup(t)
+		db, _, store, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
 		// Seed a fully consistent narinfo+narfile in DB and storage.
@@ -294,7 +294,7 @@ func testFsckOrphanedNarInStorage(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		_, _, dir, dbURL, cleanup := setup(t)
+		_, _, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
 		// Write a NAR file to storage without any DB record.
@@ -324,7 +324,7 @@ func testFsckRepair(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, store, dir, dbURL, cleanup := setup(t)
+		db, _, store, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
 		// Seed a consistent entry.
@@ -368,7 +368,7 @@ func testFsckDryRun(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, store, dir, dbURL, cleanup := setup(t)
+		db, _, store, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
 		// Seed a consistent entry.
@@ -409,7 +409,7 @@ func testFsckVerifiedSince(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, store, dir, dbURL, cleanup := setup(t)
+		db, _, store, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
 		// Seed a fully consistent narinfo+narfile in DB and storage.
@@ -487,7 +487,7 @@ func testFsckVerifiedSince(setup fsckSetupFn) func(*testing.T) {
 }
 
 // setupFsckSQLite creates a SQLite-backed test environment.
-func setupFsckSQLite(t *testing.T) (database.Querier, *localstorage.Store, string, string, func()) {
+func setupFsckSQLite(t *testing.T) (database.Querier, *database.Client, *localstorage.Store, string, string, func()) {
 	t.Helper()
 
 	ctx := context.Background()
@@ -498,6 +498,9 @@ func setupFsckSQLite(t *testing.T) (database.Querier, *localstorage.Store, strin
 	db, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
 
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
+	require.NoError(t, err)
+
 	store, err := localstorage.New(ctx, dir)
 	require.NoError(t, err)
 
@@ -505,37 +508,37 @@ func setupFsckSQLite(t *testing.T) (database.Querier, *localstorage.Store, strin
 		db.DB().Close()
 	}
 
-	return db, store, dir, "sqlite:" + dbFile, cleanup
+	return db, dbClient, store, dir, "sqlite:" + dbFile, cleanup
 }
 
 // setupFsckPostgres creates a PostgreSQL-backed test environment.
-func setupFsckPostgres(t *testing.T) (database.Querier, *localstorage.Store, string, string, func()) {
+func setupFsckPostgres(t *testing.T) (database.Querier, *database.Client, *localstorage.Store, string, string, func()) {
 	t.Helper()
 
 	ctx := context.Background()
 	dir := t.TempDir()
 
-	db, _, dbURL, dbCleanup := testhelper.SetupPostgres(t)
+	db, dbClient, dbURL, dbCleanup := testhelper.SetupPostgres(t)
 
 	store, err := localstorage.New(ctx, dir)
 	require.NoError(t, err)
 
-	return db, store, dir, dbURL, dbCleanup
+	return db, dbClient, store, dir, dbURL, dbCleanup
 }
 
 // setupFsckMySQL creates a MySQL-backed test environment.
-func setupFsckMySQL(t *testing.T) (database.Querier, *localstorage.Store, string, string, func()) {
+func setupFsckMySQL(t *testing.T) (database.Querier, *database.Client, *localstorage.Store, string, string, func()) {
 	t.Helper()
 
 	ctx := context.Background()
 	dir := t.TempDir()
 
-	db, _, dbURL, dbCleanup := testhelper.SetupMySQL(t)
+	db, dbClient, dbURL, dbCleanup := testhelper.SetupMySQL(t)
 
 	store, err := localstorage.New(ctx, dir)
 	require.NoError(t, err)
 
-	return db, store, dir, dbURL, dbCleanup
+	return db, dbClient, store, dir, dbURL, dbCleanup
 }
 
 // writeFsckNar1ToStorage writes Nar1's narinfo and NAR file to the storage directory.
@@ -572,11 +575,11 @@ func parseFsckNarInfoText(t *testing.T, text string) *narinfopkg.NarInfo {
 }
 
 // configureFsckCDCInDatabase sets up CDC configuration in the database for fsck tests.
-func configureFsckCDCInDatabase(ctx context.Context, t *testing.T, db database.Querier) {
+func configureFsckCDCInDatabase(ctx context.Context, t *testing.T, dbClient *database.Client) {
 	t.Helper()
 
 	rwLocker := locklocal.NewRWLocker()
-	cfg := config.New(db, rwLocker)
+	cfg := config.New(dbClient, rwLocker)
 
 	require.NoError(t, cfg.SetCDCEnabled(ctx, "true"), "failed to set CDC enabled")
 	require.NoError(t, cfg.SetCDCMin(ctx, "16384"), "failed to set CDC min")
@@ -700,10 +703,10 @@ func testFsckCDCClean(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -732,10 +735,10 @@ func testFsckCDCNarFileChunkCountMismatch(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -774,10 +777,10 @@ func testFsckCDCChunkMissingFromStorage(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -816,10 +819,10 @@ func testFsckCDCOrphanedChunkInStorage(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		_, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -853,10 +856,10 @@ func testFsckCDCRepairIncompleteNar(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -973,10 +976,10 @@ func testFsckCDCRepairOrphanedChunkInStorage(setup fsckSetupFn) func(*testing.T)
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		_, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -1024,7 +1027,7 @@ func testFsckCDCChunkedNarFilesNotFlaggedAsMissingWithoutCDCConfig(setup fsckSet
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, _, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
 		// Intentionally do NOT call configureFsckCDCInDatabase — simulates a DB where the
@@ -1062,10 +1065,10 @@ func testFsckCDCSizeMismatchDetected(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -1104,10 +1107,10 @@ func testFsckCDCSizeMismatchRepair(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -1158,10 +1161,10 @@ func testFsckCDCCorrectSizeNotFlagged(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -1191,10 +1194,10 @@ func testFsckCDCSizeMismatchRespectsVerifiedSince(setup fsckSetupFn) func(*testi
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -1333,10 +1336,10 @@ func testFsckCDCSizeMismatchDoesNotUpdateVerifiedAt(setup fsckSetupFn) func(*tes
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -1383,10 +1386,10 @@ func testFsckCDCVerifyContentSkipsWhenFlagAbsent(setup fsckSetupFn) func(*testin
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -1417,10 +1420,10 @@ func testFsckCDCCorruptChunkDetected(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -1453,10 +1456,10 @@ func testFsckCDCCleanChunksPassContentVerification(setup fsckSetupFn) func(*test
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -1490,10 +1493,10 @@ func testFsckCDCHashMismatchDetected(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -1549,10 +1552,10 @@ func testFsckCDCRepairCorruptChunk(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)
@@ -1603,10 +1606,10 @@ func testFsckCDCRepairHashMismatch(setup fsckSetupFn) func(*testing.T) {
 
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
 
-		db, _, dir, dbURL, cleanup := setup(t)
+		db, dbClient, _, dir, dbURL, cleanup := setup(t)
 		t.Cleanup(cleanup)
 
-		configureFsckCDCInDatabase(ctx, t, db)
+		configureFsckCDCInDatabase(ctx, t, dbClient)
 
 		cs, err := chunkstore.NewLocalStore(filepath.Join(dir, "store"))
 		require.NoError(t, err)

--- a/pkg/ncps/migrate_nar_to_chunks.go
+++ b/pkg/ncps/migrate_nar_to_chunks.go
@@ -216,7 +216,7 @@ Once a NAR is successfully migrated to chunks and verified, it is deleted from t
 				return fmt.Errorf("error creating lockers: %w", err)
 			}
 
-			cfg := config.New(db, rwLocker)
+			cfg := config.New(dbClient, rwLocker)
 
 			cdcEnabledStr, err := cfg.GetCDCEnabled(ctx)
 			if err != nil {
@@ -237,7 +237,7 @@ Once a NAR is successfully migrated to chunks and verified, it is deleted from t
 			}
 
 			// 3. Setup OTel
-			extraResourceAttrs, err := detectExtraResourceAttrs(ctx, cmd, db, rwLocker)
+			extraResourceAttrs, err := detectExtraResourceAttrs(ctx, cmd, dbClient, rwLocker)
 			if err != nil {
 				return fmt.Errorf("error detecting extra resource attributes: %w", err)
 			}

--- a/pkg/ncps/migrate_nar_to_chunks_test.go
+++ b/pkg/ncps/migrate_nar_to_chunks_test.go
@@ -22,10 +22,13 @@ import (
 	"github.com/kalbasit/ncps/testhelper"
 )
 
-// narToChunksMigrationFactory is a function that returns a clean, ready-to-use database,
-// local store, directory path, and database URL string for CLI commands,
-// and takes care of cleaning up once the test is done.
-type narToChunksMigrationFactory func(t *testing.T) (database.Querier, *storagelocal.Store, string, string, func())
+// narToChunksMigrationFactory is a function that returns a clean, ready-to-use database
+// (legacy Querier + §11-introduced Ent-backed *database.Client), local store, directory
+// path, and database URL string for CLI commands, and takes care of cleaning up once the
+// test is done.
+type narToChunksMigrationFactory func(t *testing.T) (
+	database.Querier, *database.Client, *storagelocal.Store, string, string, func(),
+)
 
 // TestMigrateNarToChunksBackends runs all NAR-to-chunks migration tests against all supported database backends.
 func TestMigrateNarToChunksBackends(t *testing.T) {
@@ -67,13 +70,13 @@ func TestMigrateNarToChunksBackends(t *testing.T) {
 
 // configureCDCInDatabase sets up CDC configuration in the database for testing.
 // This must be called before running migrate-nar-to-chunks command.
-func configureCDCInDatabase(ctx context.Context, t *testing.T, db database.Querier) {
+func configureCDCInDatabase(ctx context.Context, t *testing.T, dbClient *database.Client) {
 	t.Helper()
 
 	// Create a local RW locker for config access
 	rwLocker := locklocal.NewRWLocker()
 
-	cfg := config.New(db, rwLocker)
+	cfg := config.New(dbClient, rwLocker)
 
 	require.NoError(t, cfg.SetCDCEnabled(ctx, "true"), "failed to set CDC enabled")
 	require.NoError(t, cfg.SetCDCMin(ctx, "16384"), "failed to set CDC min")
@@ -98,9 +101,9 @@ func testMigrateNarToChunksSuccess(factory narToChunksMigrationFactory) func(*te
 
 		// Setup
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
-		db, _, dir, dbURL, cleanup := factory(t)
+		db, dbClient, _, dir, dbURL, cleanup := factory(t)
 		t.Cleanup(cleanup)
-		configureCDCInDatabase(ctx, t, db)
+		configureCDCInDatabase(ctx, t, dbClient)
 
 		// Pre-populate storage with NarInfo and NAR
 		narInfoPath := filepath.Join(dir, "store", "narinfo", testdata.Nar1.NarInfoPath)
@@ -158,9 +161,9 @@ func testMigrateNarToChunksUnmigratedNarInfoFailure(factory narToChunksMigration
 
 		// Setup
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
-		db, _, dir, dbURL, cleanup := factory(t)
+		_, dbClient, _, dir, dbURL, cleanup := factory(t)
 		t.Cleanup(cleanup)
-		configureCDCInDatabase(ctx, t, db)
+		configureCDCInDatabase(ctx, t, dbClient)
 
 		// Pre-populate storage with NarInfo (NOT migrated to DB)
 		narInfoPath := filepath.Join(dir, "store", "narinfo", testdata.Nar1.NarInfoPath)
@@ -190,9 +193,9 @@ func testMigrateNarToChunksDryRun(factory narToChunksMigrationFactory) func(*tes
 
 		// Setup
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
-		db, _, dir, dbURL, cleanup := factory(t)
+		db, dbClient, _, dir, dbURL, cleanup := factory(t)
 		t.Cleanup(cleanup)
-		configureCDCInDatabase(ctx, t, db)
+		configureCDCInDatabase(ctx, t, dbClient)
 
 		// Pre-populate storage with NarInfo and NAR
 		narInfoPath := filepath.Join(dir, "store", "narinfo", testdata.Nar1.NarInfoPath)
@@ -249,9 +252,9 @@ func testMigrateNarToChunksIdempotency(factory narToChunksMigrationFactory) func
 
 		// Setup
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
-		db, _, dir, dbURL, cleanup := factory(t)
+		db, dbClient, _, dir, dbURL, cleanup := factory(t)
 		t.Cleanup(cleanup)
-		configureCDCInDatabase(ctx, t, db)
+		configureCDCInDatabase(ctx, t, dbClient)
 
 		// Pre-populate storage with NarInfo and NAR
 		narInfoPath := filepath.Join(dir, "store", "narinfo", testdata.Nar1.NarInfoPath)
@@ -318,9 +321,9 @@ func testMigrateNarToChunksDeduplication(factory narToChunksMigrationFactory) fu
 
 		// Setup
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
-		db, _, dir, dbURL, cleanup := factory(t)
+		db, dbClient, _, dir, dbURL, cleanup := factory(t)
 		t.Cleanup(cleanup)
-		configureCDCInDatabase(ctx, t, db)
+		configureCDCInDatabase(ctx, t, dbClient)
 
 		// Create two narinfos pointing to the same NAR URL
 		narInfo1Text := testdata.Nar1.NarInfoText
@@ -411,9 +414,9 @@ func testMigrateNarToChunksMultipleNARs(factory narToChunksMigrationFactory) fun
 
 		// Setup
 		ctx := zerolog.New(os.Stderr).WithContext(context.Background())
-		db, _, dir, dbURL, cleanup := factory(t)
+		db, dbClient, _, dir, dbURL, cleanup := factory(t)
 		t.Cleanup(cleanup)
-		configureCDCInDatabase(ctx, t, db)
+		configureCDCInDatabase(ctx, t, dbClient)
 
 		// Pre-populate storage with multiple NARs
 		entries := []testdata.Entry{testdata.Nar1, testdata.Nar2, testdata.Nar3}
@@ -469,7 +472,9 @@ func testMigrateNarToChunksMultipleNARs(factory narToChunksMigrationFactory) fun
 	}
 }
 
-func setupNarToChunksMigrationSQLite(t *testing.T) (database.Querier, *storagelocal.Store, string, string, func()) {
+func setupNarToChunksMigrationSQLite(t *testing.T) (
+	database.Querier, *database.Client, *storagelocal.Store, string, string, func(),
+) {
 	t.Helper()
 
 	ctx := context.Background()
@@ -478,6 +483,9 @@ func setupNarToChunksMigrationSQLite(t *testing.T) (database.Querier, *storagelo
 	testhelper.CreateMigrateDatabase(t, dbFile)
 
 	db, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+
+	dbClient, err := database.NewClient(db.DB(), database.TypeSQLite)
 	require.NoError(t, err)
 
 	store, err := storagelocal.New(ctx, dir)
@@ -489,16 +497,18 @@ func setupNarToChunksMigrationSQLite(t *testing.T) (database.Querier, *storagelo
 		db.DB().Close()
 	}
 
-	return db, store, dir, dbURL, cleanup
+	return db, dbClient, store, dir, dbURL, cleanup
 }
 
-func setupNarToChunksMigrationPostgres(t *testing.T) (database.Querier, *storagelocal.Store, string, string, func()) {
+func setupNarToChunksMigrationPostgres(t *testing.T) (
+	database.Querier, *database.Client, *storagelocal.Store, string, string, func(),
+) {
 	t.Helper()
 
 	ctx := context.Background()
 	dir := t.TempDir()
 
-	db, _, dbURL, dbCleanup := testhelper.SetupPostgres(t)
+	db, dbClient, dbURL, dbCleanup := testhelper.SetupPostgres(t)
 
 	store, err := storagelocal.New(ctx, dir)
 	require.NoError(t, err)
@@ -507,16 +517,18 @@ func setupNarToChunksMigrationPostgres(t *testing.T) (database.Querier, *storage
 		dbCleanup()
 	}
 
-	return db, store, dir, dbURL, cleanup
+	return db, dbClient, store, dir, dbURL, cleanup
 }
 
-func setupNarToChunksMigrationMySQL(t *testing.T) (database.Querier, *storagelocal.Store, string, string, func()) {
+func setupNarToChunksMigrationMySQL(t *testing.T) (
+	database.Querier, *database.Client, *storagelocal.Store, string, string, func(),
+) {
 	t.Helper()
 
 	ctx := context.Background()
 	dir := t.TempDir()
 
-	db, _, dbURL, dbCleanup := testhelper.SetupMySQL(t)
+	db, dbClient, dbURL, dbCleanup := testhelper.SetupMySQL(t)
 
 	store, err := storagelocal.New(ctx, dir)
 	require.NoError(t, err)
@@ -525,5 +537,5 @@ func setupNarToChunksMigrationMySQL(t *testing.T) (database.Querier, *storageloc
 		dbCleanup()
 	}
 
-	return db, store, dir, dbURL, cleanup
+	return db, dbClient, store, dir, dbURL, cleanup
 }

--- a/pkg/ncps/migrate_narinfo.go
+++ b/pkg/ncps/migrate_narinfo.go
@@ -217,7 +217,7 @@ requests. Without Redis, the command uses in-memory locking (no coordination wit
 			}
 
 			// 3. Setup OTel
-			extraResourceAttrs, err := detectExtraResourceAttrs(ctx, cmd, db, rwLocker)
+			extraResourceAttrs, err := detectExtraResourceAttrs(ctx, cmd, dbClient, rwLocker)
 			if err != nil {
 				logger.
 					Error().

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -519,7 +519,7 @@ func serveAction(registerShutdown registerShutdownFn) cli.ActionFunc {
 			return err
 		}
 
-		extraResourceAttrs, err := detectExtraResourceAttrs(ctx, cmd, db, rwLocker)
+		extraResourceAttrs, err := detectExtraResourceAttrs(ctx, cmd, dbClient, rwLocker)
 		if err != nil {
 			logger.
 				Error().
@@ -1069,7 +1069,7 @@ func createCache(
 
 	c.SetCacheSignNarinfo(cmd.Bool("cache-sign-narinfo"))
 
-	cfg := config.New(db, rwLocker)
+	cfg := config.New(dbClient, rwLocker)
 
 	// Configure CDC
 	cdcEnabled := cmd.Bool("cache-cdc-enabled")
@@ -1297,7 +1297,7 @@ func loadCDCConfigFromDB(
 func detectExtraResourceAttrs(
 	ctx context.Context,
 	cmd *cli.Command,
-	db database.Querier,
+	dbClient *database.Client,
 	rwLocker lock.RWLocker,
 ) ([]attribute.KeyValue, error) {
 	var attrs []attribute.KeyValue
@@ -1319,7 +1319,7 @@ func detectExtraResourceAttrs(
 	attrs = append(attrs, attribute.String("ncps.lock_type", backend))
 
 	// 3. Set the cluster UUID
-	clusterUUID, err := getOrSetClusterUUID(ctx, db, rwLocker)
+	clusterUUID, err := getOrSetClusterUUID(ctx, dbClient, rwLocker)
 	if err != nil {
 		return nil, err
 	}
@@ -1348,8 +1348,8 @@ func detectExtraResourceAttrs(
 	return attrs, nil
 }
 
-func getOrSetClusterUUID(ctx context.Context, db database.Querier, rwLocker lock.RWLocker) (string, error) {
-	c := config.New(db, rwLocker)
+func getOrSetClusterUUID(ctx context.Context, dbClient *database.Client, rwLocker lock.RWLocker) (string, error) {
+	c := config.New(dbClient, rwLocker)
 
 	cu, err := c.GetClusterUUID(ctx)
 	if err != nil {


### PR DESCRIPTION
§11.6 first batch: pkg/config now wraps *database.Client (Ent-backed) instead
of the legacy database.Querier. GetConfigByKey + SetConfig switch to the Ent
fluent API (ConfigEntry.Query/Create with OnConflictColumns upsert), and
ErrConfigNotFound is now derived from ent.IsNotFound.

All callers in pkg/ncps (serve.go, migrate_narinfo.go, migrate_nar_to_chunks.go,
fsck.go) are updated to pass *database.Client into config.New and through
getOrSetClusterUUID + detectExtraResourceAttrs.

Test factories in pkg/config and pkg/ncps now expose *database.Client so
configureCDCInDatabase / configureFsckCDCInDatabase can build a real config
service. config_test.go switches its raw config-row helpers to the Ent client
API as well.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>