### PR TITLE
feat(ncps): convert migrate-narinfo + migrate-nar-to-chunks queries to Ent

### DIFF
--- a/pkg/ncps/migrate_nar_to_chunks.go
+++ b/pkg/ncps/migrate_nar_to_chunks.go
@@ -13,11 +13,13 @@ import (
 	"github.com/urfave/cli/v3"
 	"golang.org/x/sync/errgroup"
 
+	entnarfile "github.com/kalbasit/ncps/ent/narfile"
+	entnarinfo "github.com/kalbasit/ncps/ent/narinfo"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 
+	"github.com/kalbasit/ncps/ent"
 	"github.com/kalbasit/ncps/pkg/cache"
 	"github.com/kalbasit/ncps/pkg/config"
-	"github.com/kalbasit/ncps/pkg/database"
 	"github.com/kalbasit/ncps/pkg/nar"
 	"github.com/kalbasit/ncps/pkg/otel"
 	"github.com/kalbasit/ncps/pkg/storage"
@@ -287,9 +289,11 @@ Once a NAR is successfully migrated to chunks and verified, it is deleted from t
 			var unmigratedHashesCount int32
 
 			err = narInfoStore.WalkNarInfos(ctx, func(hash string) error {
-				ni, err := db.GetNarInfoByHash(ctx, hash)
+				ni, err := dbClient.Ent().NarInfo.Query().
+					Where(entnarinfo.HashEQ(hash)).
+					Only(ctx)
 				if err != nil {
-					if database.IsNotFoundError(err) {
+					if ent.IsNotFound(err) {
 						atomic.AddInt32(&unmigratedHashesCount, 1)
 
 						return nil
@@ -298,7 +302,7 @@ Once a NAR is successfully migrated to chunks and verified, it is deleted from t
 					return fmt.Errorf("failed to fetch narinfo from database: %w", err)
 				}
 
-				if !ni.URL.Valid {
+				if ni.URL == nil {
 					atomic.AddInt32(&unmigratedHashesCount, 1)
 				}
 
@@ -317,10 +321,14 @@ Once a NAR is successfully migrated to chunks and verified, it is deleted from t
 
 			startTime := time.Now()
 
-			totalToChunk, err := db.GetNarFilesToChunkCount(ctx)
+			totalToChunkInt, err := dbClient.Ent().NarFile.Query().
+				Where(entnarfile.TotalChunksEQ(0)).
+				Count(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to fetch total count of NAR files to chunk: %w", err)
 			}
+
+			totalToChunk := int64(totalToChunkInt)
 
 			var (
 				totalProcessed int32
@@ -375,7 +383,17 @@ Once a NAR is successfully migrated to chunks and verified, it is deleted from t
 				}
 			}()
 
-			narFiles, err := db.GetNarFilesToChunk(ctx)
+			narFiles, err := dbClient.Ent().NarFile.Query().
+				Where(entnarfile.TotalChunksEQ(0)).
+				Order(ent.Asc(entnarfile.FieldID)).
+				Select(
+					entnarfile.FieldID,
+					entnarfile.FieldHash,
+					entnarfile.FieldCompression,
+					entnarfile.FieldQuery,
+					entnarfile.FieldFileSize,
+				).
+				All(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to fetch candidate NAR files from database: %w", err)
 			}

--- a/pkg/ncps/migrate_narinfo.go
+++ b/pkg/ncps/migrate_narinfo.go
@@ -11,6 +11,7 @@ import (
 	"github.com/urfave/cli/v3"
 	"golang.org/x/sync/errgroup"
 
+	entnarinfo "github.com/kalbasit/ncps/ent/narinfo"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 
 	"github.com/kalbasit/ncps/pkg/cache"
@@ -268,12 +269,18 @@ requests. Without Redis, the command uses in-memory locking (no coordination wit
 
 			startTime := time.Now()
 
-			unmigratedHashes, err := db.GetUnmigratedNarInfoHashes(ctx)
+			unmigratedHashes, err := dbClient.Ent().NarInfo.Query().
+				Where(entnarinfo.URLIsNil()).
+				Select(entnarinfo.FieldHash).
+				Strings(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to fetch unmigrated hashes from database: %w", err)
 			}
 
-			migratedHashes, err := db.GetMigratedNarInfoHashes(ctx)
+			migratedHashes, err := dbClient.Ent().NarInfo.Query().
+				Where(entnarinfo.URLNotNil()).
+				Select(entnarinfo.FieldHash).
+				Strings(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to fetch migrated hashes from database: %w", err)
 			}


### PR DESCRIPTION
§11.6 second batch:

migrate-narinfo: GetUnmigratedNarInfoHashes + GetMigratedNarInfoHashes are now
NarInfo.Query() Where(URLIsNil/URLNotNil) with Select(FieldHash).Strings().

migrate-nar-to-chunks: GetNarInfoByHash (used for the per-walk staleness check)
is now NarInfo.Query Where(HashEQ). GetNarFilesToChunkCount + GetNarFilesToChunk
are NarFile.Query Where(TotalChunksEQ 0) Count()/All() with Select() limited to
the columns the loop actually reads. Database not-found switches from
database.IsNotFoundError to ent.IsNotFound; the nullable URL is now a *string
checked via ni.URL == nil instead of sql.NullString.Valid.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>