### PR TITLE
refactor(cache): drop legacy withTransaction + executeTransaction; finish MigrateNarInfo Ent move

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -379,11 +379,12 @@ type Cache struct {
 	secretKey     signature.SecretKey
 	healthChecker *healthcheck.HealthChecker
 	maxSize       uint64
-	db            database.Querier
-	// dbClient is the Ent-backed replacement for db. Introduced in
-	// §11.1 of migrate-to-ent-and-atlas; coexists with db while
-	// §11.2-§11.7 convert call sites one feature group at a time.
-	// §11.8 removes the db field once nothing references Querier.
+	// db is the legacy sqlc-style Querier; the production code path no
+	// longer uses it (everything reads/writes via dbClient + Ent), but
+	// the field is retained for test fixtures that still construct rows
+	// through the Querier API. §12 of migrate-to-ent-and-atlas deletes
+	// it alongside the sqlc dependency.
+	db       database.Querier
 	dbClient *database.Client
 
 	// tempDir is used to store nar files temporarily.
@@ -573,11 +574,6 @@ func IsUploadOnly(ctx context.Context) bool {
 }
 
 // New returns a new Cache.
-//
-// The dbClient parameter is the Ent-backed replacement for db.
-// Introduced in §11.1 of the migrate-to-ent-and-atlas openspec
-// change; it coexists with the Querier-typed db while §11.2-§11.7
-// migrate individual call sites. §11.8 removes the db parameter.
 func New(
 	ctx context.Context,
 	hostName string,
@@ -4798,7 +4794,7 @@ func (c *Cache) MigrateNarInfoToDatabase(
 		narInfoStore = c.narInfoStore
 	}
 
-	return MigrateNarInfo(ctx, c.downloadLocker, c.db, c.dbClient, narInfoStore, hash, ni)
+	return MigrateNarInfo(ctx, c.downloadLocker, c.dbClient, narInfoStore, hash, ni)
 }
 
 // MigrateNarInfo migrates a single narinfo from storage to the database.
@@ -4821,7 +4817,6 @@ func (c *Cache) MigrateNarInfoToDatabase(
 func MigrateNarInfo(
 	ctx context.Context,
 	locker lock.Locker,
-	db database.Querier,
 	dbClient *database.Client,
 	narInfoStore storage.NarInfoStore,
 	hash string,
@@ -4851,8 +4846,10 @@ func MigrateNarInfo(
 
 	// Double check if already migrated after acquiring the lock.
 	// This prevents multiple sequential migrations for the same narinfo.
-	nir, err := db.GetNarInfoByHash(ctx, hash)
-	if err == nil && nir.URL.Valid {
+	nir, err := dbClient.Ent().NarInfo.Query().
+		Where(entnarinfo.HashEQ(hash)).
+		Only(ctx)
+	if err == nil && nir.URL != nil && *nir.URL != "" {
 		zerolog.Ctx(ctx).Debug().
 			Str("narinfo_hash", hash).
 			Msg("migration completed by another instance while waiting for lock")
@@ -5398,64 +5395,9 @@ func (c *Cache) coordinateDownload(
 	return ds
 }
 
-// withTransaction executes fn within a database transaction.
-// It automatically handles transaction lifecycle: BeginTx, Rollback (on error or panic), and Commit.
-func (c *Cache) withTransaction(ctx context.Context, operation string, fn func(qtx database.Querier) error) error {
-	const (
-		maxAttempts  = 5
-		initialDelay = 50 * time.Millisecond
-	)
-
-	var (
-		err   error
-		delay = initialDelay
-	)
-
-	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		err = c.executeTransaction(ctx, operation, fn)
-		if err == nil {
-			return nil
-		}
-
-		// Only retry on deadlock/busy errors
-		if !database.IsDeadlockError(err) {
-			return err
-		}
-
-		if attempt == maxAttempts {
-			break
-		}
-
-		zerolog.Ctx(ctx).
-			Warn().
-			Err(err).
-			Str("operation", operation).
-			Int("attempt", attempt).
-			Dur("delay", delay).
-			Msg("database deadlock/busy, retrying transaction")
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(delay):
-			delay *= 2
-		}
-	}
-
-	return fmt.Errorf("transaction for %s failed after %d attempts: %w", operation, maxAttempts, err)
-}
-
-// withEntTransaction is the Ent-backed counterpart to withTransaction.
-// It wraps c.dbClient.WithTransaction with the same deadlock-retry
-// policy. Once §11.2-§11.5 finish converting every call site away
-// from the qtx-style Querier closures, withTransaction (and the
-// underlying executeTransaction) can be deleted.
-//
-// the first batch of conversions in §11.2 still uses the legacy
-// helper because the closures cascade through sqlc row-shape
-// consumers. Will become live as those callers convert.
-//
-
+// withEntTransaction wraps c.dbClient.WithTransaction with the same
+// deadlock/duplicate-key retry policy the package-level
+// withEntTransactionRetry provides.
 func (c *Cache) withEntTransaction(ctx context.Context, operation string, fn func(tx *ent.Tx) error) error {
 	return withEntTransactionRetry(ctx, c.dbClient, operation, fn)
 }
@@ -5532,58 +5474,6 @@ func withEntTransactionRetry(
 	}
 
 	return fmt.Errorf("transaction for %s failed after %d attempts: %w", operation, maxAttempts, err)
-}
-
-func (c *Cache) executeTransaction(ctx context.Context, operation string, fn func(qtx database.Querier) error) error {
-	zerolog.Ctx(ctx).Debug().
-		Str("operation", operation).
-		Msg("executeTransaction: starting transaction")
-
-	tx, err := c.db.DB().BeginTx(ctx, nil)
-	if err != nil {
-		zerolog.Ctx(ctx).Error().
-			Err(err).
-			Str("operation", operation).
-			Msg("executeTransaction: failed to begin transaction")
-
-		return fmt.Errorf("error beginning a transaction for %s: %w", operation, err)
-	}
-
-	defer func() {
-		if err := tx.Rollback(); err != nil {
-			if !errors.Is(err, sql.ErrTxDone) {
-				zerolog.Ctx(ctx).
-					Error().
-					Err(err).
-					Str("operation", operation).
-					Msg("executeTransaction: error rolling back the transaction")
-			}
-		}
-	}()
-
-	if err := fn(c.db.WithTx(tx)); err != nil {
-		zerolog.Ctx(ctx).Debug().
-			Err(err).
-			Str("operation", operation).
-			Msg("executeTransaction: transaction function returned error (will rollback)")
-
-		return err
-	}
-
-	if err := tx.Commit(); err != nil {
-		zerolog.Ctx(ctx).Error().
-			Err(err).
-			Str("operation", operation).
-			Msg("executeTransaction: failed to commit transaction")
-
-		return fmt.Errorf("error committing the transaction for %s: %w", operation, err)
-	}
-
-	zerolog.Ctx(ctx).Debug().
-		Str("operation", operation).
-		Msg("executeTransaction: transaction committed successfully")
-
-	return nil
 }
 
 // withReadLock executes fn while holding a read lock with the specified key.

--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -22,8 +22,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	entnarinfo "github.com/kalbasit/ncps/ent/narinfo"
 	locklocal "github.com/kalbasit/ncps/pkg/lock/local"
 
+	"github.com/kalbasit/ncps/ent"
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
 	"github.com/kalbasit/ncps/pkg/database"
 	"github.com/kalbasit/ncps/pkg/nar"
@@ -1336,30 +1338,28 @@ func testMigrationUpsertIdempotency(factory cacheFactory) func(*testing.T) {
 
 		// 2. Action: concurrent writes to trigger potential race/locking issues
 		// We use a transaction to wrap multiple operations to ensure the "abort" behavior would be caught if present
-		err = c.withTransaction(ctx, "test_transaction_safety", func(qtx database.Querier) error {
+		err = c.dbClient.WithTransaction(ctx, "test_transaction_safety", func(tx *ent.Tx) error {
 			// Attempt to store the same record again within a transaction
 			// If the logic is "try insert, fail, delete, insert", the "fail" part aborts the transaction in Postgres
 
 			// Note: we can't easily call storeInDatabase here because it starts its own transaction.
-			// Instead, we manually call the CreateNarInfo which is what storeInDatabase does.
-			createNarInfoParams := database.CreateNarInfoParams{
-				Hash: testdata.Nar1.NarInfoHash,
-				// ... other params irrelevant for the crash, it fails on Hash unique constraint
-			}
-
-			// In the *incorrect* impl, this returns an error, which aborts the tx.
-			// In the *correct* impl (UPSERT), this returns success (or 0 rows affected), guarding the tx.
-			_, err := qtx.CreateNarInfo(ctx, createNarInfoParams)
-
-			// With conditional upsert, if no update is performed, SQLite/Postgres might return ErrNoRows
-			// (if using RETURNING). This is NOT a transaction aborting error.
-			if err != nil && !database.IsNotFoundError(err) {
+			// Manually attempt the insert that storeInDatabase performs. The previous
+			// storeInDatabase call has already inserted this hash, so a plain Create
+			// would trip the unique constraint — exactly the abort-the-tx scenario we
+			// want to prove is handled by the OnConflict/Ignore upsert path.
+			err := tx.NarInfo.Create().
+				SetHash(testdata.Nar1.NarInfoHash).
+				OnConflictColumns(entnarinfo.FieldHash).
+				Ignore().
+				Exec(ctx)
+			// With conditional upsert, this should not be a transaction-aborting error.
+			if err != nil && !ent.IsNotFound(err) {
 				return err
 			}
 
-			// If we are using Postgres, and CreateNarInfo failed (aborted tx), this next query would fail
-			// with "current transaction is aborted"
-			_, _ = qtx.GetNarInfoByHash(ctx, testdata.Nar1.NarInfoHash)
+			// If we are using Postgres, and the insert above aborted the tx, this next
+			// query would fail with "current transaction is aborted".
+			_, _ = tx.NarInfo.Query().Where(entnarinfo.HashEQ(testdata.Nar1.NarInfoHash)).First(ctx)
 
 			return nil
 		})

--- a/pkg/ncps/migrate_narinfo.go
+++ b/pkg/ncps/migrate_narinfo.go
@@ -202,7 +202,7 @@ requests. Without Redis, the command uses in-memory locking (no coordination wit
 			dryRun := cmd.Bool("dry-run")
 
 			// 1. Setup Database
-			db, dbClient, err := createDatabaseQuerier(cmd)
+			_, dbClient, err := createDatabaseQuerier(cmd)
 			if err != nil {
 				logger.Error().Err(err).Msg("error creating database querier")
 
@@ -381,7 +381,7 @@ requests. Without Redis, the command uses in-memory locking (no coordination wit
 
 					// Use the shared migration function from pkg/cache
 					// Pass narInfoStore to enable deletion after migration
-					if err := cache.MigrateNarInfo(ctxWithLog, locker, db, dbClient, narInfoStore, hash, ni); err != nil {
+					if err := cache.MigrateNarInfo(ctxWithLog, locker, dbClient, narInfoStore, hash, ni); err != nil {
 						log.Error().Err(err).Msg("failed to migrate narinfo")
 						atomic.AddInt32(&totalFailed, 1)
 						RecordMigrationObject(ctxWithLog, MigrationTypeNarInfoToDB, MigrationOperationMigrate, MigrationResultFailure)


### PR DESCRIPTION
Now that every cache call site goes through the Ent-backed
withEntTransaction + withEntTransactionRetry path (§11.5 LRU
conversion was the last holdout), the legacy qtx-style helpers
have no production callers. Delete them:

  - *Cache.withTransaction (sqlc Querier closure + deadlock retry)
  - *Cache.executeTransaction (BeginTx/Rollback/Commit lifecycle)

MigrateNarInfo's remaining db.GetNarInfoByHash post-lock recheck
also flips to Ent: NarInfo.Query Where(HashEQ).Only, with the
nullable URL handled via *string == nil instead of sql.NullString.
The Querier parameter is removed from the function signature, the
sole CLI caller (migrate-narinfo.go) is updated, and the unused
db local from createDatabaseQuerier is now elided with _.

The one internal test that still drove the old withTransaction
(testStoreInDatabaseTransactionSafety) is converted to
dbClient.WithTransaction + Ent OnConflict/Ignore + Query.Where —
same scenario (concurrent UPSERT under a single tx), now via the
production code path.

The Cache.db Querier field is retained for now (a handful of
fixture tests still build rows via the legacy API); §12 deletes
it together with the sqlc dependency.

Full -race sweep against SQLite + Postgres + MySQL + Redis +
MinIO is clean.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>