### PR TITLE
docs(openspec): mark §11.5-11.9 and §12.4-12.5 complete

### DIFF
--- a/openspec/changes/migrate-to-ent-and-atlas/tasks.md
+++ b/openspec/changes/migrate-to-ent-and-atlas/tasks.md
@@ -117,19 +117,19 @@ Per design D6 (Option E), the adoption decision tree has four branches: empty DB
 - [x] 11.2 Convert `GetNarInfo*` paths in `pkg/cache/` to Ent fluent API; run package tests
 - [x] 11.3 Convert `PutNarInfo*` paths; run package tests
 - [x] 11.4 Convert `GetNarFile*` / `PutNarFile*` paths (including CDC chunk insertion); run package tests
-- [ ] 11.5 Convert chunk and orphan-cleanup queries; run package tests
-- [ ] 11.6 Convert `pkg/ncps/` paths (migration tooling, fsck, closure pinning); run package tests
-- [ ] 11.7 Convert `pkg/server/` paths; run package tests
-- [ ] 11.8 Convert `cmd/` paths; run integration tests
-- [ ] 11.9 Run `go test -race ./...` against all three engines and confirm parity with the pre-change baseline
+- [x] 11.5 Convert chunk and orphan-cleanup queries; run package tests
+- [x] 11.6 Convert `pkg/ncps/` paths (migration tooling, fsck, closure pinning); run package tests
+- [x] 11.7 Convert `pkg/server/` paths; run package tests
+- [x] 11.8 Convert `cmd/` paths; run integration tests
+- [x] 11.9 Run `go test -race ./...` against all three engines and confirm parity with the pre-change baseline
 
 ## 12. Cleanup
 
 - [ ] 12.1 Delete `db/query.sqlite.sql`, `db/query.postgres.sql`, `db/query.mysql.sql`
 - [ ] 12.2 Delete `db/schema/sqlite.sql`, `db/schema/postgres.sql`, `db/schema/mysql.sql`
 - [ ] 12.3 Delete `db/migrations/sqlite/`, `db/migrations/postgres/`, `db/migrations/mysql/` (after confirming the translated files are committed under `migrations/<dialect>/`)
-- [ ] 12.4 Delete `pkg/database/sqlitedb/`, `pkg/database/postgresdb/`, `pkg/database/mysqldb/`
-- [ ] 12.5 Delete `pkg/database/generated_models.go`, `pkg/database/generated_errors.go`, `pkg/database/generated_querier.go`, `pkg/database/generated_wrapper_{sqlite,postgres,mysql}.go`
+- [x] 12.4 Delete `pkg/database/sqlitedb/`, `pkg/database/postgresdb/`, `pkg/database/mysqldb/`
+- [x] 12.5 Delete `pkg/database/generated_models.go`, `pkg/database/generated_errors.go`, `pkg/database/generated_querier.go`, `pkg/database/generated_wrapper_{sqlite,postgres,mysql}.go`
 - [ ] 12.6 Delete `nix/dbmate-wrapper/` and remove `dbmate-wrapper` from any Nix package or dev-shell reference
 - [ ] 12.7 Remove `dbmate` from the dev shell and Docker images
 - [ ] 12.8 Remove `github.com/kalbasit/sqlc-multi-db` from the `tool ()` directive and from `go.mod`'s indirect requires (run `go mod tidy`)


### PR DESCRIPTION
Catch the tasks file up to the implementation:

* §11.5 - chunk + orphan cleanup conversion (commits a8b593b, 01121a7)
* §11.6 - pkg/ncps conversion (commits 22f5aff, 89113e1, b986614)
* §11.7 - pkg/server conversion (no production Querier; tests landed
  in the sqlc-removal cleanup commit)
* §11.8 - cmd/ conversion (no Querier usage in cmd/ to begin with;
  createDatabaseQuerier signature swap landed in 7088e79)
* §11.9 - full -race sweep against SQLite + Postgres + MySQL is green
  in every commit on this branch
* §12.4, §12.5 - sqlitedb/postgresdb/mysqldb subpackages and
  generated_*.go files deleted in 7088e79

Remaining: §12.1-12.3, §12.6-12.9 (filesystem + nix cleanup);
§13 (CI integration); §14 (docs + skills); §8.7 (wire §8 into
nix flake check, also slated for §13).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>