### PR TITLE
feat(nix-checks): add ent-codegen-drift-check + ent-lint-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,38 @@ jobs:
           sed -e "s#vendorHash =.*\$#vendorHash = \"$hash\";#g" -i nix/packages/ncps/default.nix
 
           git diff
+      - name: Update vendor hash for ent-codegen-drift-check
+        if: needs.filter.outputs.go_deps == 'true'
+        run: |
+          set +e
+          nix build --print-build-logs .#checks.x86_64-linux.ent-codegen-drift-check.goModules 2> /tmp/log
+          ret=$?
+          set -e
+
+          if [[ "$ret" -eq 0 ]]; then
+            set +e
+            nix build --print-build-logs .#checks.x86_64-linux.ent-codegen-drift-check.goModules --rebuild 2> /tmp/log
+            ret=$?
+            set -e
+          fi
+
+          if [[ "$ret" -eq 0 ]]; then
+            echo "::notice::Hash is up to date"
+            exit 0
+          fi
+
+          hash="$(grep 'got:' /tmp/log | awk '{print $2}')"
+          echo "hash=$hash"
+
+          if [[ -z "$hash" ]]; then
+            cat /tmp/log
+            echo "::error::hash is empty"
+            exit 1
+          fi
+
+          sed -e "s#vendorHash =.*\$#vendorHash = \"$hash\";#g" -i nix/checks/flake-module.nix
+
+          git diff
       - uses: stefanzweifel/git-auto-commit-action@v7
         if: needs.filter.outputs.go_deps == 'true'
         with:

--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -45,7 +45,7 @@
             src = ../../.;
             outputs = [ "out" ];
             proxyVendor = true;
-            vendorHash = "sha256-aMu071MyAkeWzRSj84DrMBbvf8aDw5x83hjsPSz9FKo=";
+            vendorHash = "sha256-FMRyM0NIzyXAmyTVIV1n5ZZ6MjKRLT8pjtc6kHxvyXA=";
             nativeBuildInputs = oa.nativeBuildInputs ++ [ pkgs.git ];
             buildPhase = ''
               HOME=$TMPDIR

--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -29,6 +29,79 @@
             doCheck = false;
           });
 
+          # ent-codegen-drift-check verifies that the committed Ent codegen
+          # output under ./ent matches what `go generate ./ent/...` would
+          # produce from the current ent/schema/*.go files. Fails the build
+          # if any file under ./ent differs after regeneration.
+          #
+          # The drift check uses `proxyVendor = true` so the Go module proxy
+          # cache is populated with *all* module dependencies (including the
+          # `tool` directive's `entgo.io/ent/cmd/ent`), then runs `go generate`
+          # in module-mode against that cache. The default `buildGoModule`
+          # vendor-mode setup is unusable here because Ent's tool dependency
+          # is intentionally not vendored.
+          ent-codegen-drift-check = config.packages.ncps.overrideAttrs (oa: {
+            name = "ent-codegen-drift-check";
+            src = ../../.;
+            outputs = [ "out" ];
+            proxyVendor = true;
+            vendorHash = "sha256-aMu071MyAkeWzRSj84DrMBbvf8aDw5x83hjsPSz9FKo=";
+            nativeBuildInputs = oa.nativeBuildInputs ++ [ pkgs.git ];
+            buildPhase = ''
+              HOME=$TMPDIR
+
+              # Materialize the source tree into a writable copy and turn it
+              # into a git repository so `git diff --exit-code` has something
+              # to compare against. buildGoModule's $src is read-only.
+              cp -r $src ./repo
+              chmod -R u+w ./repo
+              cd ./repo
+
+              git init --quiet
+              git add -A
+              git -c user.email=ci@example.invalid -c user.name=ci \
+                commit --quiet -m baseline
+
+              # Regenerate Ent code using the proxy module cache populated by
+              # buildGoModule (GOPROXY/GOFLAGS are set by the wrapper).
+              go generate ./ent/...
+
+              if ! git diff --exit-code ./ent/; then
+                echo "ent/ codegen is out of date — run 'go generate ./ent/...' and commit the result." >&2
+                exit 1
+              fi
+            '';
+            installPhase = ''
+              touch $out
+            '';
+            doCheck = false;
+          });
+
+          # ent-lint-check runs cmd/ent-lint against the Ent schema tree and
+          # fails if any [FAIL] line appears in the output.
+          ent-lint-check = config.packages.ncps.overrideAttrs (_oa: {
+            name = "ent-lint-check";
+            src = ../../.;
+            outputs = [ "out" ];
+            buildPhase = ''
+              HOME=$TMPDIR
+
+              # Build the lint binary, then run it against the schema tree.
+              # Capture output so we can both display it and grep for FAIL.
+              go build -o ./ent-lint ./cmd/ent-lint
+              ./ent-lint --root . | tee ent-lint.out
+
+              if grep -q '^\[FAIL\]' ent-lint.out; then
+                echo "ent-lint reported invariant violations — see [FAIL] lines above." >&2
+                exit 1
+              fi
+            '';
+            installPhase = ''
+              touch $out
+            '';
+            doCheck = false;
+          });
+
           helm-unittest-check = pkgs.stdenvNoCC.mkDerivation {
             name = "ncps-helm-unittest";
             src = ../../charts/ncps;

--- a/nix/formatter/flake-module.nix
+++ b/nix/formatter/flake-module.nix
@@ -35,11 +35,9 @@
         "ent/pinnedclosure/**/*.go"
         "ent/predicate/**/*.go"
         "ent/runtime/**/*.go"
-        # Goose-translated migration files: sqlfluff cannot parse the
-        # `-- +goose Up/Down` directives or the dialect-specific syntax
-        # (MySQL backticks, SQLite PRAGMA, etc.). Their integrity is
-        # protected by atlas.sum under each migrations/<dialect>/, so
-        # external formatting would invalidate the checksum anyway.
+        # Atlas-generated migration files: their integrity is sealed by
+        # atlas.sum under each migrations/<dialect>/. Reformatting the SQL
+        # would invalidate the sum and break the schema-equivalence check.
         "migrations/**/*.sql"
         "openspec/**/*.md"
         "renovate.json"

--- a/openspec/changes/migrate-to-ent-and-atlas/tasks.md
+++ b/openspec/changes/migrate-to-ent-and-atlas/tasks.md
@@ -137,8 +137,8 @@ Per design D6 (Option E), the adoption decision tree has four branches: empty DB
 
 ## 13. CI integration
 
-- [ ] 13.1 Add an `ent-codegen-drift-check` derivation in `nix/checks/` that runs `go generate ./ent/...` then `git diff --exit-code ./ent/`
-- [ ] 13.2 Add an `ent-lint-check` derivation that runs `cmd/ent-lint --root .` and asserts zero `[FAIL]` lines
+- [x] 13.1 Add an `ent-codegen-drift-check` derivation in `nix/checks/` that runs `go generate ./ent/...` then `git diff --exit-code ./ent/`
+- [x] 13.2 Add an `ent-lint-check` derivation that runs `cmd/ent-lint --root .` and asserts zero `[FAIL]` lines
 - [ ] 13.3 Add an `atlas-sum-check` derivation that verifies every `migrations/<dialect>/atlas.sum` matches the directory contents
 - [ ] 13.4 Add a `schema-equivalence-check` derivation that runs the §8 golden test for all three engines (uses process-compose deps)
 - [ ] 13.5 Verify `nix flake check` passes end-to-end with all four new derivations contributing


### PR DESCRIPTION
Adds two new derivations to the nix checks tree, both of which feed into
`nix flake check`:

- `ent-codegen-drift-check` materializes the source tree, runs
  `go generate ./ent/...`, and fails the build if any committed file
  under `./ent` differs after regeneration. Uses `proxyVendor = true`
  because Ents `tool` dependency (entgo.io/ent/cmd/ent) is not vendored.
- `ent-lint-check` builds and runs `cmd/ent-lint --root .` and fails
  if any `[FAIL]` lines appear in the output.

Drive-by fixes:

- Update vendor hash to match the post-cleanup go.sum (pre-existing
  drift after the sqlc removal).
- Drop the now-broken `cp -r db $out/share/ncps/db` from postInstall;
  the `db/` tree no longer exists.
- Add `ent/*.go`, `ent/<generated-pkg>/**/*.go`, and
  `migrations/**/*.sql` to treefmt-nixs global excludes so the
  formatter cannot fight the Ent generator or invalidate atlas.sum.

Marks tasks 13.1 and 13.2 complete in the migrate-to-ent-and-atlas
change.