### PR TITLE
feat(nix-checks): add atlas-sum-check derivation + binary

### DIFF
--- a/cmd/atlas-sum-check/main.go
+++ b/cmd/atlas-sum-check/main.go
@@ -1,0 +1,104 @@
+// Command atlas-sum-check verifies that the on-disk `atlas.sum` file in
+// each `migrations/<dialect>/` directory matches the directory contents.
+//
+// Atlas uses the integrity file to detect tampering and to validate that a
+// migrations tree is internally consistent before replaying it. This check
+// gates that property in CI: it reads each dialect's directory via Atlas's
+// own `sqltool.NewGooseDir` helper, recomputes the checksum, and compares
+// the result against the on-disk `atlas.sum`. Any drift fails the build.
+//
+// Usage:
+//
+//	atlas-sum-check --root .
+//
+// The binary exits non-zero on the first mismatch and prints a diagnostic
+// pointing at the offending directory.
+package main
+
+import (
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"ariga.io/atlas/sql/sqltool"
+
+	atlasmigrate "ariga.io/atlas/sql/migrate"
+)
+
+// errSumMismatch is returned when a directory's recomputed checksum does
+// not match its on-disk atlas.sum. err113 wants a sentinel error, so this
+// is the canonical one for the lint pass.
+var errSumMismatch = errors.New("atlas.sum mismatch")
+
+func main() {
+	root := flag.String("root", ".", "repository root (contains migrations/<dialect>/)")
+
+	flag.Parse()
+
+	dialects := []string{"sqlite", "postgres", "mysql"}
+
+	var failed int
+
+	for _, d := range dialects {
+		dir := filepath.Join(*root, "migrations", d)
+		if err := checkDir(dir); err != nil {
+			fmt.Fprintf(os.Stderr, "[FAIL] %s: %v\n", dir, err)
+
+			failed++
+
+			continue
+		}
+
+		fmt.Printf("[PASS] %s: atlas.sum matches directory contents\n", dir)
+	}
+
+	if failed > 0 {
+		log.Fatalf("atlas-sum-check: %d dialect(s) failed", failed)
+	}
+}
+
+func checkDir(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("stat: %w", err)
+	}
+
+	if !info.IsDir() {
+		//nolint:err113 // diagnostic
+		return fmt.Errorf("%s is not a directory", dir)
+	}
+
+	gdir, err := sqltool.NewGooseDir(dir)
+	if err != nil {
+		return fmt.Errorf("NewGooseDir: %w", err)
+	}
+
+	got, err := gdir.Checksum()
+	if err != nil {
+		return fmt.Errorf("checksum: %w", err)
+	}
+
+	// Serialize the recomputed sum to atlas.sum's on-disk format so we can
+	// compare against the on-disk file byte-for-byte.
+	gotBytes, err := got.MarshalText()
+	if err != nil {
+		return fmt.Errorf("marshal recomputed sum: %w", err)
+	}
+
+	sumPath := filepath.Join(dir, atlasmigrate.HashFileName)
+
+	wantBytes, err := os.ReadFile(sumPath)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", sumPath, err)
+	}
+
+	if !bytes.Equal(bytes.TrimSpace(gotBytes), bytes.TrimSpace(wantBytes)) {
+		return fmt.Errorf("%w: regenerate via `go run ./cmd/generate-migrations`", errSumMismatch)
+	}
+
+	return nil
+}

--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -45,7 +45,7 @@
             src = ../../.;
             outputs = [ "out" ];
             proxyVendor = true;
-            vendorHash = "sha256-FMRyM0NIzyXAmyTVIV1n5ZZ6MjKRLT8pjtc6kHxvyXA=";
+            vendorHash = "sha256-17EwlKF2fGfgoVq1dtUmqvKvaZPmPmmpizMRvRe43JQ=";
             nativeBuildInputs = oa.nativeBuildInputs ++ [ pkgs.git ];
             buildPhase = ''
               HOME=$TMPDIR

--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -45,7 +45,7 @@
             src = ../../.;
             outputs = [ "out" ];
             proxyVendor = true;
-            vendorHash = "sha256-17EwlKF2fGfgoVq1dtUmqvKvaZPmPmmpizMRvRe43JQ=";
+            vendorHash = "sha256-FMRyM0NIzyXAmyTVIV1n5ZZ6MjKRLT8pjtc6kHxvyXA=";
             nativeBuildInputs = oa.nativeBuildInputs ++ [ pkgs.git ];
             buildPhase = ''
               HOME=$TMPDIR

--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -77,6 +77,27 @@
             doCheck = false;
           });
 
+          # atlas-sum-check verifies that the atlas.sum file in each
+          # migrations/<dialect>/ directory matches the directory's
+          # recomputed checksum. Drift indicates a hand-edit of a tracked
+          # migration without regenerating atlas.sum, which would break
+          # Atlas's replay validator.
+          atlas-sum-check = config.packages.ncps.overrideAttrs (_oa: {
+            name = "atlas-sum-check";
+            src = ../../.;
+            outputs = [ "out" ];
+            buildPhase = ''
+              HOME=$TMPDIR
+
+              go build -o ./atlas-sum-check ./cmd/atlas-sum-check
+              ./atlas-sum-check --root .
+            '';
+            installPhase = ''
+              touch $out
+            '';
+            doCheck = false;
+          });
+
           # ent-lint-check runs cmd/ent-lint against the Ent schema tree and
           # fails if any [FAIL] line appears in the output.
           ent-lint-check = config.packages.ncps.overrideAttrs (_oa: {

--- a/nix/packages/ncps/default.nix
+++ b/nix/packages/ncps/default.nix
@@ -16,7 +16,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-Z6HhUkanNwKZsiBEpIV3wou73eY8gfcWTtyXeeKzgzk=";
+          vendorHash = "sha256-Qvq3CAeSN0ytefM10bP3MfnQVtRzg3GTZygcnc+ClyY=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/nix/packages/ncps/default.nix
+++ b/nix/packages/ncps/default.nix
@@ -16,7 +16,7 @@
             in
             if tag != "" then tag else rev;
 
-          vendorHash = "sha256-Qvq3CAeSN0ytefM10bP3MfnQVtRzg3GTZygcnc+ClyY=";
+          vendorHash = "sha256-Z6HhUkanNwKZsiBEpIV3wou73eY8gfcWTtyXeeKzgzk=";
         in
         pkgs.buildGoModule {
           inherit version vendorHash;

--- a/openspec/changes/migrate-to-ent-and-atlas/tasks.md
+++ b/openspec/changes/migrate-to-ent-and-atlas/tasks.md
@@ -139,7 +139,7 @@ Per design D6 (Option E), the adoption decision tree has four branches: empty DB
 
 - [x] 13.1 Add an `ent-codegen-drift-check` derivation in `nix/checks/` that runs `go generate ./ent/...` then `git diff --exit-code ./ent/`
 - [x] 13.2 Add an `ent-lint-check` derivation that runs `cmd/ent-lint --root .` and asserts zero `[FAIL]` lines
-- [ ] 13.3 Add an `atlas-sum-check` derivation that verifies every `migrations/<dialect>/atlas.sum` matches the directory contents
+- [x] 13.3 Add an `atlas-sum-check` derivation that verifies every `migrations/<dialect>/atlas.sum` matches the directory contents
 - [ ] 13.4 Add a `schema-equivalence-check` derivation that runs the §8 golden test for all three engines (uses process-compose deps)
 - [ ] 13.5 Verify `nix flake check` passes end-to-end with all four new derivations contributing
 - [ ] 13.6 Confirm the existing `.github/workflows/ci.yml` still passes (no edits expected — the new checks plug into `nix flake check`)


### PR DESCRIPTION
Adds a new `cmd/atlas-sum-check` Go binary that opens each
`migrations/<dialect>/` directory via Atlas `sqltool.NewGooseDir`,
recomputes the checksum, and compares against the on-disk `atlas.sum`.
Any drift fails the build with a diagnostic pointing at
`go run ./cmd/generate-migrations` as the remediation.

Wires the binary into `nix flake check` via a new `atlas-sum-check`
derivation in `nix/checks/flake-module.nix`. The derivation reuses the
ncps Go module setup but runs the new binary instead of the full build.

Marks task 13.3 complete in the migrate-to-ent-and-atlas change.