### PR TITLE
docs(readme,changelog): document Ent + Atlas + Goose; add operator upgrade notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All notable changes to ncps are recorded in this file. The format roughly
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
+project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- **Database tooling migrated from sqlc + dbmate to Ent + Atlas + Goose.**
+  Schemas are now authored under `ent/schema/*.go`, migrations are
+  generated from Atlas diffs (used as a Go library) via
+  `go run ./cmd/generate-migrations --name=<descriptive_snake_case>`,
+  and applied at runtime by `ncps migrate up`. The runtime applier is
+  `goose.NewProvider` against the embedded `migrations/<dialect>/` FS.
+
+  See `CLAUDE.md` for the full developer workflow and the
+  expand-contract policy + four-step NOT NULL recipe.
+
+### Removed
+
+- The `dbmate` and `dbmate-wrapper` binaries are no longer shipped in
+  the dev shell or in Docker images.
+- The `sqlc` codegen tooling and the generated `pkg/database/*db/`
+  wrapper packages have been removed; callers now use the Ent client
+  directly via `*database.Client`.
+
+### Migration (operators)
+
+**If you are upgrading an existing dbmate-managed deployment, BACK UP
+YOUR DATABASE first.** The migration is forward-only and rollback
+requires a restore.
+
+The first `ncps migrate up` after upgrading performs a one-shot
+adoption:
+
+1. The new migrator inspects the existing `schema_migrations` table.
+1. If the shape is the legacy dbmate one, it converts the tracking
+   table to the goose shape:
+   - On SQLite and PostgreSQL — inside a single transaction
+     (`BEGIN; CREATE TEMP …; DROP TABLE schema_migrations; CREATE TABLE schema_migrations (goose shape); INSERT sentinel + preserved versions; verify row-count parity; COMMIT;`).
+   - On MySQL — via a RENAME → CREATE → sentinel → copy → verify →
+     DROP backup-table dance that is safe to interrupt and resume.
+1. All previously applied dbmate versions are recorded as
+   goose-applied, so the new migrator picks up only the truly pending
+   migrations.
+1. The normal goose apply path then runs.
+
+Adoption is idempotent — re-running after success is a no-op.
+
+Operators with very large databases should run
+`ncps migrate up --dry-run` first to preview the detected state and
+adoption action without touching the database.
+
+### CI
+
+- New `nix flake check` derivations:
+  - `ent-codegen-drift-check` — regenerates `ent/` and fails on diff.
+  - `ent-lint-check` — runs `cmd/ent-lint --root .`; fails on any
+    `[FAIL]` line.
+  - `atlas-sum-check` — verifies every `migrations/<dialect>/atlas.sum`
+    matches the directory contents.
+  - `schema-equivalence-check` — runs the `TestSchemaEquivalence`
+    golden test across SQLite, PostgreSQL, and MySQL.

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ docker volume create ncps-storage
 docker run --rm -v ncps-storage:/storage alpine /bin/sh -c \
   "mkdir -m 0755 -p /storage/var && mkdir -m 0700 -p /storage/var/ncps && mkdir -m 0700 -p /storage/var/ncps/db"
 
-# Initialize database
+# Initialize database (ncps embeds the migrations and applies them via goose)
 docker run --rm -v ncps-storage:/storage ghcr.io/kalbasit/ncps \
-  /bin/dbmate --url=sqlite:/storage/var/ncps/db/db.sqlite up
+  /bin/ncps migrate up --cache-database-url=sqlite:/storage/var/ncps/db/db.sqlite
 
 # Start the server
 docker run -d --name ncps -p 8501:8501 -v ncps-storage:/storage ghcr.io/kalbasit/ncps \
@@ -86,6 +86,18 @@ Your cache will be available at `http://localhost:8501`. See the [Quick Start Gu
 - **High Availability**: Multiple instances with S3 storage, PostgreSQL/MySQL, and Redis for zero-downtime operation. **Note: Must enable CDC.**
 
 See the [Deployment Guide](https://docs.ncps.dev/user-guide/deployment.html) for detailed setup instructions.
+
+## Architecture
+
+ncps is written in Go. The notable internal dependencies:
+
+- **[Ent](https://entgo.io/)** — type-safe ORM. Schemas under `ent/schema/` are the only source of truth for the database DDL; the generated Ent client lives under `ent/` (committed; produced by `go generate ./ent/...`).
+- **[Atlas](https://atlasgo.io/)** — schema-diff engine, used as a Go library (no `atlas` CLI binary). `cmd/generate-migrations` diffs the Ent schemas against the on-disk migration history and emits one Goose-formatted `.sql` per dialect under `migrations/<dialect>/`, sealed by per-dialect `atlas.sum` integrity files.
+- **[Goose](https://github.com/pressly/goose)** — runtime migration runner. `ncps migrate up` embeds the per-dialect migrations and applies pending ones. Migrations are forward-only; column changes follow an expand-contract policy.
+- **[Chi](https://go-chi.io/)** — HTTP router for the cache server.
+- **Go-based storage backends** — local filesystem and S3 (MinIO-compatible).
+
+See [Architecture](https://docs.ncps.dev/developer-guide/architecture.html) for the full design and [Development](https://docs.ncps.dev/developer-guide.html) for the contributor workflow.
 
 ## Support the Project
 

--- a/openspec/changes/migrate-to-ent-and-atlas/tasks.md
+++ b/openspec/changes/migrate-to-ent-and-atlas/tasks.md
@@ -152,8 +152,8 @@ Per design D6 (Option E), the adoption decision tree has four branches: empty DB
 - [x] 14.4 Rewrite `.agent/skills/migrate-down/SKILL.md` to point at the expand-contract policy instead of describing a down command
 - [x] 14.5 Delete `.agent/skills/sqlc/` and `.agent/skills/generate-db-wrappers/` (also removed `.agent/skills/dbmate/`)
 - [x] 14.6 Add a `.agent/skills/ent-schema/SKILL.md` documenting the five codegen invariants and the snake_case enum-type convention
-- [ ] 14.7 Update the project `README.md` to mention Ent + Atlas + Goose under "Architecture" / "Development"
-- [ ] 14.8 Add a `CHANGELOG.md` entry calling out the upgrade procedure for operators with existing dbmate-managed deployments (backup advised; first `migrate up` performs the one-shot adoption)
+- [x] 14.7 Update the project `README.md` to mention Ent + Atlas + Goose under "Architecture" / "Development"
+- [x] 14.8 Add a `CHANGELOG.md` entry calling out the upgrade procedure for operators with existing dbmate-managed deployments (backup advised; first `migrate up` performs the one-shot adoption)
 - [ ] 14.9 Run `nix fmt` and `golangci-lint run --fix` over the entire tree as a final pass
 
 ## 15. Standardize the `data-model` openspec spec


### PR DESCRIPTION
Two doc-only changes:

- README.md
  - Replace the docker quick-start `dbmate up` invocation with
    `ncps migrate up` (the new migrator embeds the migrations and
    applies them via goose).
  - Add an Architecture section listing the new internal dependencies
    (Ent, Atlas-as-library, Goose, Chi, storage backends) and pointing
    at the docs for the full design.

- CHANGELOG.md (new file)
  - Document the database tooling migration (sqlc + dbmate → Ent +
    Atlas + Goose), the removal of `dbmate`/`dbmate-wrapper` and
    the `pkg/database/*db/` wrapper packages.
  - Operator upgrade procedure: backup first, then the one-shot
    adoption that converts the legacy `schema_migrations` table to
    the goose shape on first `ncps migrate up`. Calls out the
    SQLite/Postgres transactional path and the MySQL backup-table
    dance, plus the `--dry-run` preview for large databases.
  - Lists the four new `nix flake check` derivations.

Marks tasks 14.7 and 14.8 complete in the migrate-to-ent-and-atlas
change.