### PR TITLE
refactor(cache): scope stale-lock orphan query to known candidate IDs

### DIFF
--- a/.agent/skills/ent-schema/SKILL.md
+++ b/.agent/skills/ent-schema/SKILL.md
@@ -32,16 +32,30 @@ func (Chunk) Annotations() []schema.Annotation {
 }
 ```
 
-### A2 — snake_case enum-type naming
+### A2 — `entsql.OnDelete(...)` lives on `edge.To`, never on `edge.From`
 
-Ent uses snake_case enum-type names by convention. Every `field.Enum(...)`
-needs a matching `entsql.Annotation{Type: "<table>_<column>_enum"}` so
-the generated DDL emits a stable, predictable type name across dialects.
+Ent silently ignores `entsql.OnDelete(...)` annotations attached to
+`edge.From(...)` declarations. CASCADE / RESTRICT / SET NULL semantics
+MUST be declared on the owning `edge.To(...)` side, otherwise the
+generated DDL falls back to the default ON DELETE rule and the intended
+behaviour disappears without warning.
 
 ```go
-field.Enum("compression").
-    Values("none", "xz", "zstd").
-    Annotations(entsql.Annotation{Type: "nar_files_compression_enum"})
+// Correct — OnDelete on edge.To (the FK owner).
+func (Parent) Edges() []ent.Edge {
+    return []ent.Edge{
+        edge.To("children", Child.Type).
+            Annotations(entsql.Annotation{OnDelete: entsql.Cascade}),
+    }
+}
+
+// Wrong — OnDelete on edge.From is silently dropped.
+func (Child) Edges() []ent.Edge {
+    return []ent.Edge{
+        edge.From("parent", Parent.Type).Ref("children").Unique().
+            Annotations(entsql.Annotation{OnDelete: entsql.Cascade}),
+    }
+}
 ```
 
 ### A3 — UNIQUE + edge.From().Field() pairing
@@ -81,6 +95,20 @@ func (Child) Edges() []ent.Edge {
 Every `field.Bytes("*_ciphertext")` field MUST chain `.Sensitive()` so
 the ciphertext never leaks into error messages, log lines, or the
 generated `String()` methods.
+
+### Snake_case enum-type naming (convention; not yet linted)
+
+Ent uses snake_case enum-type names by convention. Every `field.Enum(...)`
+needs a matching `entsql.Annotation{Type: "<table>_<column>_enum"}` so
+the generated DDL emits a stable, predictable type name across dialects.
+This is enforced by code review until ncps's schema tree gains its first
+`field.Enum(...)` declaration and the check is wired into `cmd/ent-lint`.
+
+```go
+field.Enum("compression").
+    Values("none", "xz", "zstd").
+    Annotations(entsql.Annotation{Type: "nar_files_compression_enum"})
+```
 
 ```go
 field.Bytes("password_ciphertext").Sensitive()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Database tooling migrated from sqlc + dbmate to Ent + Atlas + Goose.**
   Schemas are now authored under `ent/schema/*.go`, migrations are
   generated from Atlas diffs (used as a Go library) via
-  `go run ./cmd/generate-migrations --name=<descriptive_snake_case>`,
-  and applied at runtime by `ncps migrate up`. The runtime applier is
-  `goose.NewProvider` against the embedded `migrations/<dialect>/` FS.
+  `task migrations:gen NAME=<descriptive_snake_case>` (which regenerates
+  the Ent client via its dependency on `ent:generate`, then calls
+  `go run ./cmd/generate-migrations --name=...`), and applied at runtime
+  by `ncps migrate up`. The runtime applier is `goose.NewProvider`
+  against the embedded `migrations/<dialect>/` FS.
 
   See `CLAUDE.md` for the full developer workflow and the
   expand-contract policy + four-step NOT NULL recipe.
@@ -39,7 +41,7 @@ adoption:
 1. If the shape is the legacy dbmate one, it converts the tracking
    table to the goose shape:
    - On SQLite and PostgreSQL — inside a single transaction
-     (`BEGIN; CREATE TEMP …; DROP TABLE schema_migrations; CREATE TABLE schema_migrations (goose shape); INSERT sentinel + preserved versions; verify row-count parity; COMMIT;`).
+     (`BEGIN; CREATE TEMP …; DROP TABLE schema_migrations; CREATE TABLE schema_migrations (goose shape); INSERT sentinel + preserved versions; verify row-count consistency (including the sentinel row); COMMIT;`).
    - On MySQL — via a RENAME → CREATE → sentinel → copy → verify →
      DROP backup-table dance that is safe to interrupt and resume.
 1. All previously applied dbmate versions are recorded as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -733,8 +733,9 @@ constraint to an existing nullable column):
 
 - **A1** — Field-level `entsql.Check(...)` annotations are silently
   dropped by Ent. CHECKs MUST live on table-level `Annotations()`.
-- **A2** — Ent uses snake_case enum-type names. Every `field.Enum(...)`
-  needs a matching `entsql.Annotation{Type: "<table>_<column>_enum"}`.
+- **A2** — `entsql.OnDelete(...)` annotations on `edge.From(...)` are
+  silently ignored by Ent. CASCADE/RESTRICT/SET NULL MUST live on the
+  owning `edge.To(...)` side.
 - **A3** — UNIQUE columns also bound by `edge.From().Field()` must carry
   duplicate index annotations so Ent doesn't fabricate phantom indexes.
 - **A4** — Every `edge.To(name, T.Type)` needs a reciprocal
@@ -743,10 +744,14 @@ constraint to an existing nullable column):
 - **A5** — Every `field.Bytes("*_ciphertext")` field MUST chain
   `.Sensitive()` so the ciphertext never appears in error messages, logs,
   or generated `String()` methods.
+- **Snake_case enum-type naming** (convention; not yet linted). Every
+  `field.Enum(...)` needs a matching
+  `entsql.Annotation{Type: "<table>_<column>_enum"}` so the generated
+  DDL emits a stable, predictable type name across dialects.
 
 See `cmd/ent-lint/main.go` for the live AST enforcement of A1, A2, and
-A4; A3 and A5 are tracked in the ent-schema-lint spec and currently
-enforced by code review.
+A4; A3, A5, and the snake_case enum-type convention are tracked in the
+ent-schema-lint spec and currently enforced by code review.
 
 **IMPORTANT:** Never hand-edit a committed migration file. The
 `atlas.sum` integrity file under each `migrations/<dialect>/` seals the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,8 @@ go run ./cmd/generate-migrations --sql-only --name=descriptive_snake_case
 
 # Apply migrations (embedded; runs goose against the right dialect)
 ncps migrate up --cache-database-url=sqlite:/path/to/db.sqlite
-ncps migrate up --cache-database-url=postgresql://user:pass@host/db
-ncps migrate up --cache-database-url=mysql://user:pass@host/db
+ncps migrate up --cache-database-url=postgresql://user:password@host:port/database
+ncps migrate up --cache-database-url=mysql://user:password@host:port/database
 
 # Preview pending migrations without touching the database
 ncps migrate up --dry-run --cache-database-url=sqlite:/path/to/db.sqlite
@@ -706,7 +706,9 @@ For ANY database changes, follow this workflow:
 
 Use the **/migrate-new** skill for the schema-edit + generate flow,
 **/migrate-up** for applying, and **/migrate-down** for the expand-contract
-recipe (migrations are forward-only; there is no `migrate down` command).
+recipe (migrations are forward-only; the `migrate down` command is
+implemented but unsupported — it returns an error pointing at the
+expand-contract policy).
 
 **Expand-contract policy (never alter columns in place):**
 

--- a/cmd/atlas-sum-check/main.go
+++ b/cmd/atlas-sum-check/main.go
@@ -11,8 +11,9 @@
 //
 //	atlas-sum-check --root .
 //
-// The binary exits non-zero on the first mismatch and prints a diagnostic
-// pointing at the offending directory.
+// The binary checks every dialect and exits non-zero at the end if any
+// dialect's directory mismatched, printing a diagnostic for each
+// offending directory.
 package main
 
 import (

--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -142,13 +142,13 @@
             preCheck = ''
               # Set up cleanup trap to ensure background processes are killed even if tests fail.
               cleanup() {
-                source $src/nix/packages/ncps/post-check-mysql.sh
-                source $src/nix/packages/ncps/post-check-postgres.sh
+                source "$src/nix/packages/ncps/post-check-mysql.sh"
+                source "$src/nix/packages/ncps/post-check-postgres.sh"
               }
               trap cleanup EXIT
 
-              source $src/nix/packages/ncps/pre-check-mysql.sh
-              source $src/nix/packages/ncps/pre-check-postgres.sh
+              source "$src/nix/packages/ncps/pre-check-mysql.sh"
+              source "$src/nix/packages/ncps/pre-check-postgres.sh"
             '';
             checkPhase = ''
               runHook preCheck

--- a/nix/formatter/flake-module.nix
+++ b/nix/formatter/flake-module.nix
@@ -19,8 +19,11 @@
         # loop against the codegen drift check (see
         # nix/checks/flake-module.nix → ent-codegen-drift-check). The
         # schemas under ent/schema/ remain formattable (they are inputs to
-        # the generator); only the generated tree is excluded.
+        # the generator); only the generated tree is excluded. The
+        # hand-written ent/generate.go (which carries the //go:generate
+        # directive) is explicitly re-included so it stays formattable.
         "ent/*.go"
+        "!ent/generate.go"
         "ent/chunk/**/*.go"
         "ent/configentry/**/*.go"
         "ent/enttest/**/*.go"

--- a/openspec/specs/database-migrations/spec.md
+++ b/openspec/specs/database-migrations/spec.md
@@ -108,13 +108,13 @@ The bridge SHALL include, at minimum:
 
 ### Requirement: Fresh installs skip the dbmate-era history via `Schema.Create`
 
-The system SHALL detect an empty database at `migrate up` and SHALL produce the Ent-expected schema by invoking Ent's runtime `entSchema.NewMigrate(drv).Create(ctx, migrate.Tables...)` — not by replaying the translated dbmate-era migrations. After `Schema.Create` succeeds, the system SHALL seed `schema_migrations` with every version stamp present in the embedded `migrations/<dialect>/` directory, each row recorded as `is_applied=true` and `tstamp` set to the current time (the dialect-appropriate function, or a Go-side `time.Now()` value).
+The system SHALL detect an empty database at `migrate up` and SHALL produce the Ent-expected schema by invoking Ent's runtime `entSchema.NewMigrate(drv).Create(ctx, migrate.Tables...)` — not by replaying the translated dbmate-era migrations. After `Schema.Create` succeeds, the system SHALL seed `schema_migrations` with every version stamp present in the embedded `migrations/<dialect>/` directory, each row recorded as `is_applied=true`. The `tstamp` column is populated by the database's default timestamp function (Goose's `InsertRequest` exposes only `Version`, so the Go side does not pass a `time.Now()` value).
 
 #### Scenario: Empty database first-boot
 
 - **WHEN** `migrate up` runs against an empty database (no `schema_migrations`, no application tables)
 - **THEN** the system SHALL call `Schema.Create` to produce the entire Ent-expected schema in one operation
-- **AND** the system SHALL enumerate every `.sql` file under `migrations/<dialect>/` from `migrations.FS`, parse its timestamp prefix, and insert one row per version into `schema_migrations` with `is_applied=true` and `tstamp` set to the current time
+- **AND** the system SHALL enumerate every `.sql` file under `migrations/<dialect>/` from `migrations.FS`, parse its timestamp prefix, and insert one row per version into `schema_migrations` with `is_applied=true` (the `tstamp` column is populated by the database's default timestamp function)
 - **AND** the subsequent Goose invocation SHALL report zero pending migrations
 
 #### Scenario: Fresh install at v1.1 (after a new incremental migration has been added)
@@ -181,7 +181,7 @@ The system SHALL produce migrations that are safe to apply while the immediately
 #### Scenario: Forbidden DDL in the newest migration
 
 - **WHEN** the newest file in any `migrations/<dialect>/` directory contains a forbidden DDL statement
-- **THEN** `cmd/ent-lint` SHALL fail with a non-zero exit and a checklist-formatted message naming the file and the forbidden statement
+- **THEN** the change SHALL be rejected in code review against the expand-contract policy documented in `CLAUDE.md`, until a future change wires this check into `cmd/ent-lint` to fail with a non-zero exit and a checklist-formatted message naming the file and the forbidden statement
 
 #### Scenario: Promoting a column to NOT NULL safely
 

--- a/openspec/specs/ent-schema-lint/spec.md
+++ b/openspec/specs/ent-schema-lint/spec.md
@@ -55,5 +55,5 @@ The system SHALL emit one line per check with a leading `[PASS]` or `[FAIL]` tok
 #### Scenario: Output shape
 
 - **WHEN** `cmd/ent-lint --root .` is invoked
-- **THEN** stdout SHALL contain lines like `[PASS] A1 ent/schema/narinfo.go: no field-level entsql.Check` and (on failure) `[FAIL] A4 ent/schema/narinfo.go: edge.To("references") has no reciprocal edge.From().Ref()`
+- **THEN** stdout SHALL contain lines like `[PASS] A1 ent/schema/narinfo.go: no field-level entsql.Check` and (on failure) `[FAIL] A4 ent/schema/narinfo.go:<line> edge.To("references", Target.Type) has no reciprocal edge.From(NarInfo.Type).Ref("references") on Target — Ent will fabricate a phantom FK column`
 - **AND** the exit code SHALL be non-zero if and only if at least one `[FAIL]` line is emitted

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -265,13 +265,13 @@ func (r *reporter) registerMeterTotalSizeGaugeCallback(meter metric.Meter) error
 	}
 
 	_, err = meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
-		var sums []struct {
-			Sum sql.NullInt64 `sql:"sum"`
-		}
-
+		// Scan positionally into a single sql.NullInt64 so we don't depend
+		// on Ent aliasing the SUM(...) column to "sum"; this also handles
+		// the NULL result from SUM on an empty table.
+		var sum sql.NullInt64
 		if err := r.dbClient.Ent().NarFile.Query().
 			Aggregate(ent.Sum(entnarfile.FieldFileSize)).
-			Scan(ctx, &sums); err != nil {
+			Scan(ctx, &sum); err != nil {
 			zerolog.Ctx(ctx).
 				Error().
 				Err(err).
@@ -283,8 +283,8 @@ func (r *reporter) registerMeterTotalSizeGaugeCallback(meter metric.Meter) error
 		}
 
 		var size int64
-		if len(sums) > 0 && sums[0].Sum.Valid {
-			size = sums[0].Sum.Int64
+		if sum.Valid {
+			size = sum.Int64
 		}
 
 		o.ObserveInt64(totalSizeGauge, size)

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -265,13 +265,19 @@ func (r *reporter) registerMeterTotalSizeGaugeCallback(meter metric.Meter) error
 	}
 
 	_, err = meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
-		// Scan positionally into a single sql.NullInt64 so we don't depend
-		// on Ent aliasing the SUM(...) column to "sum"; this also handles
-		// the NULL result from SUM on an empty table.
-		var sum sql.NullInt64
+		// Ent's Select.Scan calls sql.ScanSlice, which requires a slice
+		// destination AND uses tag-based field matching for struct
+		// elements. The sql:"sum" tag matches the normalized column
+		// name Ent emits from ent.Sum(...) — scanStruct splits the
+		// column at "(" and lowercases the leading token, so
+		// "SUM(file_size)" → "sum". sql.NullInt64 then captures the
+		// SUM NULL for an empty table without panicking.
+		var sums []struct {
+			Sum sql.NullInt64 `sql:"sum"`
+		}
 		if err := r.dbClient.Ent().NarFile.Query().
 			Aggregate(ent.Sum(entnarfile.FieldFileSize)).
-			Scan(ctx, &sum); err != nil {
+			Scan(ctx, &sums); err != nil {
 			zerolog.Ctx(ctx).
 				Error().
 				Err(err).
@@ -283,8 +289,8 @@ func (r *reporter) registerMeterTotalSizeGaugeCallback(meter metric.Meter) error
 		}
 
 		var size int64
-		if sum.Valid {
-			size = sum.Int64
+		if len(sums) > 0 && sums[0].Sum.Valid {
+			size = sums[0].Sum.Int64
 		}
 
 		o.ObserveInt64(totalSizeGauge, size)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4847,12 +4847,24 @@ func MigrateNarInfo(
 	nir, err := dbClient.Ent().NarInfo.Query().
 		Where(entnarinfo.HashEQ(hash)).
 		Only(ctx)
-	if err == nil && nir.URL != nil && *nir.URL != "" {
-		zerolog.Ctx(ctx).Debug().
-			Str("narinfo_hash", hash).
-			Msg("migration completed by another instance while waiting for lock")
 
-		return nil
+	switch {
+	case err == nil:
+		if nir.URL != nil && *nir.URL != "" {
+			zerolog.Ctx(ctx).Debug().
+				Str("narinfo_hash", hash).
+				Msg("migration completed by another instance while waiting for lock")
+
+			return nil
+		}
+	case ent.IsNotFound(err):
+		// Expected: narinfo not yet in DB; fall through to migrate.
+	default:
+		// Unexpected DB error — log but still attempt migration; if the
+		// DB is genuinely broken the upsert below will surface the error.
+		zerolog.Ctx(ctx).Warn().Err(err).
+			Str("narinfo_hash", hash).
+			Msg("double-check NarInfo lookup failed; proceeding with migration")
 	}
 
 	log := zerolog.Ctx(ctx).With().Str("narinfo_hash", hash).Logger()

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2304,16 +2304,33 @@ func (c *Cache) cleanupStaleLockChunks(ctx context.Context, cs chunk.Store, stal
 	// see the committed deletion. Ent equivalent of the legacy LEFT
 	// JOIN nar_file_chunks WHERE chunk_id IS NULL: chunks that have no
 	// NarFileLinks edge.
-	orphanedChunks, err := c.dbClient.Ent().Chunk.Query().
-		Where(
-			entchunk.IDIn(ids...),
-			entchunk.Not(entchunk.HasNarFileLinks()),
-		).
-		All(ctx)
-	if err != nil {
-		log.Warn().Err(err).Msg("failed to get orphaned chunks during stale lock cleanup; will rely on GC")
+	//
+	// IDIn is batched (cdcCleanupHashBatchSize) to stay below driver
+	// parameter limits: a very large NAR file split into small CDC
+	// chunks can produce many thousands of partial-chunk IDs after a
+	// stale-lock cleanup, which would otherwise exceed SQLite's ≤ 999
+	// placeholder ceiling on older builds.
+	var orphanedChunks []*ent.Chunk
 
-		return
+	for start := 0; start < len(ids); start += cdcCleanupHashBatchSize {
+		end := start + cdcCleanupHashBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+
+		batch, err := c.dbClient.Ent().Chunk.Query().
+			Where(
+				entchunk.IDIn(ids[start:end]...),
+				entchunk.Not(entchunk.HasNarFileLinks()),
+			).
+			All(ctx)
+		if err != nil {
+			log.Warn().Err(err).Msg("failed to get orphaned chunks during stale lock cleanup; will rely on GC")
+
+			return
+		}
+
+		orphanedChunks = append(orphanedChunks, batch...)
 	}
 
 	for _, oc := range orphanedChunks {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2291,16 +2291,24 @@ func (c *Cache) cleanupStaleLockChunks(ctx context.Context, cs chunk.Store, stal
 	// GetOrphanedChunks is on Ent (§11.5), the chunk PK type is
 	// plain int on both sides — no conversion needed.
 	staleByID := make(map[int]string, len(staleLockChunks))
+
+	ids := make([]int, 0, len(staleLockChunks))
 	for _, ch := range staleLockChunks {
 		staleByID[ch.ID] = ch.Hash
+		ids = append(ids, ch.ID)
 	}
 
-	// Find all currently orphaned chunks (no nar_file_chunks references).
-	// Run this outside the previous transaction so we see the committed deletion.
-	// Ent equivalent of the legacy LEFT JOIN nar_file_chunks WHERE chunk_id IS NULL:
-	// chunks that have no NarFileLinks edge.
+	// Restrict the orphan-check query to the candidate IDs we already
+	// know about, so we don't pull (and filter in memory) every orphan
+	// in the database. Run this outside the previous transaction so we
+	// see the committed deletion. Ent equivalent of the legacy LEFT
+	// JOIN nar_file_chunks WHERE chunk_id IS NULL: chunks that have no
+	// NarFileLinks edge.
 	orphanedChunks, err := c.dbClient.Ent().Chunk.Query().
-		Where(entchunk.Not(entchunk.HasNarFileLinks())).
+		Where(
+			entchunk.IDIn(ids...),
+			entchunk.Not(entchunk.HasNarFileLinks()),
+		).
 		All(ctx)
 	if err != nil {
 		log.Warn().Err(err).Msg("failed to get orphaned chunks during stale lock cleanup; will rely on GC")
@@ -2309,10 +2317,7 @@ func (c *Cache) cleanupStaleLockChunks(ctx context.Context, cs chunk.Store, stal
 	}
 
 	for _, oc := range orphanedChunks {
-		hash, ok := staleByID[oc.ID]
-		if !ok {
-			continue // Not one of our stale lock chunks.
-		}
+		hash := staleByID[oc.ID]
 
 		chunkLog := log.With().Str("chunk_hash", hash).Int("chunk_id", oc.ID).Logger()
 		chunkLog.Debug().Msg("immediately cleaning up chunk from stale CDC lock")

--- a/pkg/database/client_test.go
+++ b/pkg/database/client_test.go
@@ -1,7 +1,6 @@
 package database_test
 
 import (
-	"context"
 	"database/sql"
 	"errors"
 	"path/filepath"
@@ -239,7 +238,7 @@ func freshSchemaSQLite(t *testing.T) (*sql.DB, func()) {
 		t.Fatalf("NewMigrate: %v", err)
 	}
 
-	if createErr := m.Create(context.Background(), entmigrate.Tables...); createErr != nil {
+	if createErr := m.Create(t.Context(), entmigrate.Tables...); createErr != nil {
 		database.SchemaCreateMu.Unlock()
 
 		t.Fatalf("Schema.Create: %v", createErr)

--- a/pkg/database/errors.go
+++ b/pkg/database/errors.go
@@ -94,9 +94,9 @@ func IsNotFoundError(err error) bool {
 		return true
 	}
 
-	// ent.IsNotFound matches Ent's *NotFoundError type. We avoid the
-	// direct import dependency by checking the error message structure
-	// via the well-known Ent sentinel below.
+	// ent.IsNotFound matches Ent's *NotFoundError type. We delegate to
+	// isEntNotFound (defined in ent_errors.go) so the ent import stays
+	// isolated to a single file.
 	return isEntNotFound(err)
 }
 

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -794,15 +794,9 @@ func queryCDCNarFilesWithSizeMismatch(
 		return nil, fmt.Errorf("query CDC nar_files: %w", err)
 	}
 
-	seen := make(map[int]struct{}, len(rows))
-
 	var mismatched []*ent.NarFile
 
 	for _, nf := range rows {
-		if _, ok := seen[nf.ID]; ok {
-			continue
-		}
-
 		for _, link := range nf.Edges.NarInfoNarFiles {
 			ni := link.Edges.Narinfo
 			if ni == nil || ni.NarSize == nil {
@@ -814,7 +808,6 @@ func queryCDCNarFilesWithSizeMismatch(
 			//nolint:gosec // G115: NAR sizes are well below math.MaxInt64.
 			if int64(nf.FileSize) != *ni.NarSize {
 				mismatched = append(mismatched, nf)
-				seen[nf.ID] = struct{}{}
 
 				break
 			}


### PR DESCRIPTION
refactor(cache): scope stale-lock orphan query to known candidate IDs

Restrict the orphan-check query inside cleanupStaleLockChunks to the chunk
IDs we already know about from staleLockChunks, instead of pulling every
orphan in the database and filtering them in memory. The post-filter
`if _, ok := staleByID[oc.ID]; !ok` is no longer needed since the query
already returns only candidates.

Addresses gemini-code-assist comment on PR #1209 (PRRT_kwDONV6tZs6D3VF-).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

refactor(fsck): drop redundant seen map in CDC size-mismatch check

queryCDCNarFilesWithSizeMismatch's `seen` map was redundant: Ent's
All(ctx) returns one row per NarFile, and the inner loop already breaks
after recording the first mismatch, so each NarFile can only be appended
to mismatched once.

Addresses gemini-code-assist comment on PR #1212 (PRRT_kwDONV6tZs6D3P8r).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

test(database): use t.Context() in freshSchemaSQLite helper

Replace context.Background() with t.Context() so the schema-create call
is bound to the test lifetime. Drops the now-unused context import.

Addresses gemini-code-assist comment from PR #1214
(PRRT_kwDONV6tZs6D3PyX); the original test_schema_parity file was folded
into client_test.go but the same pattern lives in freshSchemaSQLite.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

refactor(cache): explicit not-found vs error split in migration double-check

After acquiring the migration lock, distinguish ent.IsNotFound (the
expected "not yet migrated" case, fall through to migrate) from other DB
errors (log at warn level instead of silently swallowing). The migration
still attempts on any error so a transient lookup glitch doesn't block
progress; if the DB is genuinely broken the upsert below will surface
the failure.

Addresses gemini-code-assist comment on PR #1216 (PRRT_kwDONV6tZs6D3YoD).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

refactor(analytics): scan SUM(file_size) into a single sql.NullInt64

Ent's Aggregate(ent.Sum(...)) emits a raw SUM(...) expression without an
alias; scanning into []struct{ Sum sql.NullInt64 \`sql:"sum"\` } relied
on tag-name resolution that may not match the column header. Scan
positionally into a single sql.NullInt64 instead, which is more robust
and also correctly handles the NULL result that SUM returns on an empty
table.

Addresses gemini-code-assist comments on PR #1217
(PRRT_kwDONV6tZs6D3Um1, PRRT_kwDONV6tZs6D3Um6).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

docs(database): correct IsNotFoundError comment about delegation

The previous wording referenced a "well-known Ent sentinel below" that
doesn't exist in this file — IsNotFoundError simply delegates to
isEntNotFound (declared in ent_errors.go) which keeps the ent import
isolated to a single file.

Addresses gemini-code-assist comment on PR #1218 (PRRT_kwDONV6tZs6D3WsX).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

build(formatter): re-include ent/generate.go in the formatter glob

ent/generate.go is hand-written (carries the //go:generate directive)
but the broad ent/*.go exclusion swept it into the codegen-only group.
Add an explicit !ent/generate.go negation so it stays formattable
without re-introducing diff loops against the codegen drift check.

Addresses gemini-code-assist comment on PR #1221 (PRRT_kwDONV6tZs6D3zlq).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

docs(atlas-sum-check): correct doc comment about exit behavior

The package doc claimed the binary exits non-zero on the first mismatch.
The implementation actually iterates every dialect and only exits at the
end, reporting all offending directories at once. Update the doc to
match.

Addresses gemini-code-assist comment on PR #1222 (PRRT_kwDONV6tZs6D31Je).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

build(checks): quote \$src paths in schema-equivalence preCheck

Quote the path expansions when sourcing the pre/post-check helper
scripts in schema-equivalence-check. Nix store paths don't contain
spaces in practice, but quoting is shell best practice and silences
shellcheck-style nitpicks on the inherited shell content.

Addresses gemini-code-assist comment on PR #1223 (PRRT_kwDONV6tZs6D32tm).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

docs(claude): use host:port/database in URL examples + clarify migrate down

- Bring the Common Commands DSN examples in line with the Database section
  by using the full host:port/database placeholder for postgresql/mysql.
- Replace "there is no migrate down command" with the accurate phrasing:
  the command is implemented (pkg/ncps/migrate.go:107) but returns an
  error pointing at the expand-contract policy.

Addresses gemini-code-assist comments on PR #1224 (PRRT_kwDONV6tZs6D37b-,
PRRT_kwDONV6tZs6D37cD). The third sqlfluff suggestion is intentionally
skipped — migrations/ is sealed by atlas.sum so sqlfluff isn't run
against it, and the only SQL outside migrations/ is already covered by
nix fmt.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

docs(ent-schema): A2 is the OnDelete invariant, not enum naming

Both .agent/skills/ent-schema/SKILL.md and CLAUDE.md described A2 as the
snake_case enum-type convention, which contradicted cmd/ent-lint/main.go
(line 286+) and openspec/specs/ent-schema-lint/spec.md — both of which
treat A2 as the "OnDelete on edge.From is forbidden" check.

Reword A2 in both docs to match the actual linter invariant, and move
the snake_case enum-type rule into its own section labelled as a
convention enforced by code review until the schema tree gains its
first field.Enum(...) declaration.

Addresses gemini-code-assist comment on PR #1225 (PRRT_kwDONV6tZs6D34eU).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

docs(changelog): mention task migrations:gen and clarify row-count check

- Lead with the Taskfile entrypoint (task migrations:gen NAME=...) for
  generating new migrations, since it regenerates the Ent client first
  via task ent:generate. Mention the underlying go run invocation in
  parentheses for users who want the raw command.
- The schema_migrations adoption verifies row-count consistency, not
  parity — the new table intentionally adds a sentinel row, so the
  expected post-count is preCount + 1. Reword to make that explicit.

Addresses gemini-code-assist comments on PR #1226
(PRRT_kwDONV6tZs6D3756, PRRT_kwDONV6tZs6D376E).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

docs(openspec): align migration + lint specs with actual implementation

Four wording corrections so the OpenSpec specs match what the code does:

- Fresh-install seeding text claimed the Go side passes a time.Now()
  to schema_migrations.tstamp. Goose's database.InsertRequest exposes
  only Version, so the tstamp column relies on the database's default
  timestamp function. Reword the Requirement and Scenario lines to
  match.
- The "Forbidden DDL" scenario claimed cmd/ent-lint SHALL fail on a
  forbidden DDL statement. The linter has not yet been wired up for
  that check (see cmd/ent-lint/main.go:21 deferral comment and the
  scope note already documented in ent-schema-lint/spec.md). Update
  the THEN clause to describe the current manual-review enforcement,
  retaining the future-cmd/ent-lint intent.
- The example output in ent-schema-lint/spec.md no longer matches
  cmd/ent-lint/main.go:511-515 — the real output includes the source
  line number and a fuller "Ent will fabricate a phantom FK column"
  trailer. Update the example accordingly.

Addresses gemini-code-assist comments on PR #1228
(PRRT_kwDONV6tZs6D4drm, PRRT_kwDONV6tZs6D4dr2, PRRT_kwDONV6tZs6D4dsA,
PRRT_kwDONV6tZs6D4dsG).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>