### PR TITLE
chore(nix): restore dbmate to the dev shell only

### DIFF
--- a/nix/devshells/flake-module.nix
+++ b/nix/devshells/flake-module.nix
@@ -11,6 +11,14 @@
         buildInputs =
           (import ../dev-packages.nix pkgs)
           ++ [
+            # dbmate is kept available for local dev only (used by
+            # dev-scripts/run.py's perform_clean() to drop dev
+            # databases between scenarios). NOT included in
+            # dev-packages.nix because that set is shared with the
+            # docker-dev image, and dbmate is no longer part of the
+            # runtime — `ncps migrate up` is the supported path.
+            pkgs.dbmate
+
             # python environment for dev-scripts.
             (pkgs.python3.withPackages (
               ps: with ps; [


### PR DESCRIPTION
dev-scripts/run.py's perform_clean() uses `dbmate drop` to reset
dev databases between scenarios. dbmate was removed in 80c4a15
along with sqlc; restore it to the dev shell only — keep it out
of nix/dev-packages.nix (shared with the docker-dev image) and
nix/packages/ncps/default.nix. Runtime migration is still
`ncps migrate up` (embedded goose).