### PR TITLE
fix(ncps): close dbClient on shutdown; use FORCE drop in tests

### DIFF
--- a/nix/process-compose/postgres-dblink-create-drop-functions.sql
+++ b/nix/process-compose/postgres-dblink-create-drop-functions.sql
@@ -34,13 +34,17 @@ END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
 -- 4. Function to DROP database
+-- Uses WITH (FORCE) (PostgreSQL 13+) so leaked connections from the test process
+-- (e.g. the inner dbClient pool used by ncps subcommands) don't make DROP DATABASE
+-- block for the connection idle timeout. Without FORCE, every per-test cleanup paid
+-- a ~5s wait for connections to drain.
 CREATE OR REPLACE FUNCTION drop_test_db(dbname text) RETURNS void AS $$
 BEGIN
     IF left(dbname, 5) != 'test-' THEN
         RAISE EXCEPTION 'Access Denied: Database name must start with "test-"';
     END IF;
 
-    PERFORM dblink_exec('local_admin_server', 'DROP DATABASE ' || quote_ident(dbname));
+    PERFORM dblink_exec('local_admin_server', 'DROP DATABASE ' || quote_ident(dbname) || ' WITH (FORCE)');
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -302,6 +302,8 @@ Use --repair to automatically fix detected issues, or --dry-run to preview what 
 				return err
 			}
 
+			registerShutdown("database client", func(_ context.Context) error { return dbClient.Close() })
+
 			// 2. Setup Lockers
 			locker, rwLocker, err := getLockers(ctx, cmd)
 			if err != nil {

--- a/pkg/ncps/migrate_nar_to_chunks.go
+++ b/pkg/ncps/migrate_nar_to_chunks.go
@@ -211,6 +211,8 @@ Once a NAR is successfully migrated to chunks and verified, it is deleted from t
 				return fmt.Errorf("error creating database client: %w", err)
 			}
 
+			registerShutdown("database client", func(_ context.Context) error { return dbClient.Close() })
+
 			// 2a. Load CDC configuration from database (must happen after DB creation)
 			// CDC is required for migrate-nar-to-chunks command
 			locker, rwLocker, err := getLockers(ctx, cmd)

--- a/pkg/ncps/migrate_narinfo.go
+++ b/pkg/ncps/migrate_narinfo.go
@@ -209,6 +209,8 @@ requests. Without Redis, the command uses in-memory locking (no coordination wit
 				return err
 			}
 
+			registerShutdown("database client", func(_ context.Context) error { return dbClient.Close() })
+
 			// 2. Setup Lockers
 			locker, rwLocker, err := getLockers(ctx, cmd)
 			if err != nil {

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -509,6 +509,8 @@ func serveAction(registerShutdown registerShutdownFn) cli.ActionFunc {
 			return err
 		}
 
+		registerShutdown("database client", func(_ context.Context) error { return dbClient.Close() })
+
 		locker, rwLocker, err := getLockers(ctx, cmd)
 		if err != nil {
 			zerolog.Ctx(ctx).


### PR DESCRIPTION
Found while shrinking the integration-test wall time. Every ncps
subcommand (serve, fsck, migrate-narinfo, migrate-nar-to-chunks)
opens a *database.Client via createDatabaseClient but never registers
its Close in the cli After-hook. In production the process just
exits so it's invisible; in tests the connection pool lingers, and
every integration-test cleanup paid a flat ~5s waiting for
DROP DATABASE to drain the leaked connections.

Quantified impact (full integration run, all deps live):
- pkg/ncps total: 23.07s -> 6.28s
- 18 TestFsckBackends/PostgreSQL/CDC/* tests all dropped off the
  "elapsed > 500ms" list (was uniformly ~5s each).
- Cumulative `go test -race ./...` with integration backends:
  80.09s -> 64.40s (~20% reduction in this commit alone).

Changes:
- pkg/ncps/{fsck,serve,migrate_narinfo,migrate_nar_to_chunks}.go:
  register `dbClient.Close` as a shutdown function right after
  createDatabaseClient. Captured by closure so the body of the
  Action continues to use the same client; After-hook calls Close
  in parallel with otelShutdown via wg.Go.
- nix/process-compose/postgres-dblink-create-drop-functions.sql:
  drop_test_db now issues `DROP DATABASE ... WITH (FORCE)` (PG 13+)
  as a belt-and-braces measure in case any future test still leaks
  a connection past Close. The Go-side fix above is the actual
  reason the per-test wait disappeared.

Also captures the integration timings before and after this commit
under openspec/changes/less-tests/integration-*-timings.txt.

Verified: `go test -race` on every touched package passes;
\`golangci-lint run\` is clean. The applied SQL function update was
also run against the live PG instance by hand so subsequent local
runs immediately benefit.