### PR TITLE
test: shrink integration outliers (s3 bucket, redis TTL, NAR)

### DIFF
--- a/pkg/cache/cache_distributed_test.go
+++ b/pkg/cache/cache_distributed_test.go
@@ -471,7 +471,9 @@ func testDistributedLockFailover(_ distributedDBFactory) func(*testing.T) {
 		require.NoError(t, err)
 
 		testKey := "test-failover-key"
-		shortTTL := 2 * time.Second
+		// Short TTL keeps the "wait for expiry" step under a second; previously this was
+		// 2s + 2s safety = 4s of pure waiting per test, ×3 backends.
+		shortTTL := 500 * time.Millisecond
 
 		// Locker 1 acquires the lock
 		err = locker1.Lock(ctx, testKey, shortTTL)
@@ -481,16 +483,16 @@ func testDistributedLockFailover(_ distributedDBFactory) func(*testing.T) {
 		locker2, err := redis.NewLocker(ctx, redisCfg, retryCfg, false)
 		require.NoError(t, err)
 
-		// Locker 2 should initially fail to acquire (lock held by locker1)
-		ctx2, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		// Locker 2 should initially fail to acquire (lock held by locker1).
+		// Bounded by 200ms — well under shortTTL so it must still be held.
+		ctx2, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
 		defer cancel()
 
 		err = locker2.Lock(ctx2, testKey, shortTTL)
 		require.Error(t, err, "locker2 should fail to acquire lock held by locker1")
 
-		// Simulate locker1 failure (don't unlock, let it expire)
-		// Wait for TTL to expire
-		time.Sleep(shortTTL + 2*time.Second)
+		// Simulate locker1 failure (don't unlock, let it expire). Wait TTL + safety.
+		time.Sleep(shortTTL + 300*time.Millisecond)
 
 		// Now locker2 should be able to acquire the lock
 		err = locker2.Lock(ctx, testKey, shortTTL)
@@ -661,8 +663,10 @@ func testLargeNARConcurrentDownloadScenario(t *testing.T, factory distributedDBF
 	dbClient, sharedDir, cleanup := factory(t)
 	t.Cleanup(cleanup)
 
-	// Generate a large NAR (2MB) - enough for chunking but fast for tests
-	const largeNARSize = 2 * 1024 * 1024
+	// Generate a NAR large enough to exercise chunking but small enough that the
+	// concurrent-download lock dance isn't dominated by raw transfer time. 256KiB is
+	// well above the default CDC min/avg/max and is the actual quantity under test.
+	const largeNARSize = 256 * 1024
 
 	narData := make([]byte, largeNARSize)
 	_, err := rand.Read(narData)
@@ -687,9 +691,10 @@ func testLargeNARConcurrentDownloadScenario(t *testing.T, factory distributedDBF
 
 	handlerID := ts.AddMaybeHandler(func(_ http.ResponseWriter, r *http.Request) bool {
 		if r.URL.Path == narPath && r.Method == http.MethodGet {
-			// Add artificial delay to simulate slow download (like real large NARs)
-			// This ensures concurrent requests arrive while download is in progress
-			time.Sleep(2 * time.Second)
+			// Artificial delay so the other cache instances (spawned in the goroutine
+			// loop below) arrive while the first download is in flight. 300ms is
+			// well above goroutine scheduling latency without dominating wall time.
+			time.Sleep(300 * time.Millisecond)
 		}
 
 		return false // Let default handler process request

--- a/pkg/lock/redis/redis_test.go
+++ b/pkg/lock/redis/redis_test.go
@@ -180,12 +180,14 @@ func TestLocker_LockExpiry(t *testing.T) {
 
 	key := getUniqueKey(t, "expiry")
 
-	// Acquire lock with short TTL
-	err = locker1.Lock(ctx, key, 1*time.Second)
+	// Acquire lock with short TTL. 200ms keeps the "wait for expiry" step well under
+	// a second; Redis lock-release semantics are millisecond-granular on a quiet
+	// machine and 400ms is comfortable safety margin.
+	err = locker1.Lock(ctx, key, 200*time.Millisecond)
 	require.NoError(t, err)
 
 	// Wait for lock to expire
-	time.Sleep(2 * time.Second)
+	time.Sleep(400 * time.Millisecond)
 
 	// Second locker should be able to acquire (lock expired)
 	err = locker2.Lock(ctx, key, 5*time.Second)
@@ -271,14 +273,17 @@ func TestLocker_DegradedModeDisabled(t *testing.T) {
 	t.Parallel()
 	skipIfRedisNotAvailable(t)
 
-	ctx := context.Background()
-
-	// Configure with invalid Redis address
+	// Configure with invalid Redis address.
 	cfg := redis.Config{
 		Addrs:     []string{"localhost:9999"}, // Invalid port
 		KeyPrefix: "test:ncps:lock:",
 	}
 	retryCfg := getTestRetryConfig()
+
+	// Bound the context so we don't pay the go-redis default DialTimeout (5s) for
+	// each ping attempt; 500ms is well above "connection refused" latency.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
 
 	// With degraded mode disabled, should fail to create locker
 	_, err := redis.NewLocker(ctx, cfg, retryCfg, false)

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -36,9 +36,8 @@ const (
 )
 
 var (
-	errConnectionFailed    = errors.New("connection failed")
-	errTestingBucketAccess = errors.New("error testing bucket access")
-	errCallbackFailed      = errors.New("callback error")
+	errConnectionFailed = errors.New("connection failed")
+	errCallbackFailed   = errors.New("callback error")
 
 	//nolint:gochecknoglobals
 	s3ListObjectsResponse = `<?xml version="1.0" encoding="UTF-8"?>
@@ -1801,10 +1800,12 @@ func TestNew_BucketAccessError(t *testing.T) {
 
 	cfg := getTestConfig(t)
 
-	// Use mock transport to trigger error
-	expectedErr := errTestingBucketAccess
+	// Return a non-retryable 403 instead of a RoundTripper error so the minio SDK
+	// gives up immediately (would otherwise retry with exponential backoff for ~5s).
+	// The production wrapper at s3.go:95 wraps any non-nil error as
+	// "error testing bucket access", so the assertion still holds.
 	cfg.Transport = roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
-		return nil, expectedErr
+		return s3ErrorResponse("error testing bucket access")
 	})
 
 	_, err := storage_s3.New(newContext(), *cfg)


### PR DESCRIPTION
Continuation of the integration-test wall-time work. Builds on the
fix(ncps): close dbClient on shutdown commit, which already removed
~16s of DROP DATABASE wait. This commit picks off the remaining
named integration outliers:

pkg/storage/s3 TestNew_BucketAccessError (5.22s -> ~0s):
- The RoundTripper mock returned a Go error, triggering minio-go's
  exponential-backoff retry loop (~5s before giving up). Replace
  with s3ErrorResponse() so the SDK gives up immediately on the
  non-retryable 403. The production wrapper at s3.go:95 already
  wraps any non-nil err with "error testing bucket access", so the
  Contains() assertion still passes. The now-unused
  errTestingBucketAccess sentinel is removed.

pkg/cache TestDistributedBackends/.../LockFailover (4.51s -> ~1s
each, x3 backends):
- shortTTL: 2s -> 500ms (sleep matched at 800ms).
- ctx2 timeout: 500ms -> 200ms — still well under shortTTL so the
  "second locker fails while first holds the lock" check is sound.
- Total saving across the three backend variants: ~10s of test
  wall time.

pkg/cache TestDistributedBackends/.../LargeNARConcurrentDownload
(5.4s -> ~1s each, x3 backends):
- NAR payload 2 MiB -> 256 KiB. The test exercises concurrent
  download coordination, not raw throughput; 256 KiB still trips
  CDC chunking and keeps the lock dance honest.
- Server-side artificial delay 2s -> 300ms. The only requirement is
  that follower goroutines arrive while the first download is in
  flight, and goroutine scheduling latency is sub-millisecond on a
  quiet machine.

pkg/lock/redis TestLocker_LockExpiry (2.01s -> ~0.6s):
- Lock TTL 1s -> 200ms, post-expiry sleep 2s -> 400ms. Redis lock
  expiry is millisecond-granular; 400ms is plenty of safety.

pkg/lock/redis TestLocker_DegradedModeDisabled (1.72s -> ~0.5s):
- The "unreachable Redis port" call previously waited on the
  go-redis default DialTimeout (5s) per attempt. Wrap ctx in a
  500ms WithTimeout so the failure surfaces fast — matches the
  same fix already applied to TestNewLocker_ReturnType.

Skipped intentionally:
- TestDistributedBackends/.../PutNarInfoConcurrentSharedNar (50
  iterations to catch a concurrency race) — same policy as the
  chunker race test; reducing iterations weakens the safety net.

Cumulative integration-test wall time (full suite, all deps live):
~64.40s -> ~58.99s after this commit. Combined with the previous
dbClient fix, integration baseline 80.09s -> 58.99s (~26% lower).

Captures the post-batch profile under
openspec/changes/less-tests/integration-after-batch5-timings.txt.

Verified: \`go test -race\` on every touched package passes;
\`golangci-lint run\` is clean.