### PR TITLE
chore(openspec): archive less-tests change

### DIFF
--- a/openspec/changes/archive/2026-05-23-less-tests/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-23-less-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-23

--- a/openspec/changes/archive/2026-05-23-less-tests/after-batch1-timings.txt
+++ b/openspec/changes/archive/2026-05-23-less-tests/after-batch1-timings.txt
@@ -1,0 +1,67 @@
+================================================================================
+PER-PACKAGE WALL TIME (ranked, descending)
+================================================================================
+ elapsed (s)   tests   pass   fail   skip  package
+--------------------------------------------------------------------------------
+      16.713     226    208      0     19  github.com/kalbasit/ncps/pkg/cache
+       3.833      87     85      0      2  github.com/kalbasit/ncps/pkg/server
+       3.729      63     57      0      6  github.com/kalbasit/ncps/pkg/ncps
+       3.204      12     12      0      0  github.com/kalbasit/ncps/cmd/generate-migrations
+       2.282       5      5      0      0  github.com/kalbasit/ncps/pkg/chunker
+       2.232     135    135      0      0  github.com/kalbasit/ncps/pkg/cache/upstream
+       2.028      15      2      0     13  github.com/kalbasit/ncps/pkg/lock/redis
+       1.695       4      2      0      2  github.com/kalbasit/ncps/pkg/cache/healthcheck
+       1.510      55     55      0      0  github.com/kalbasit/ncps/pkg/storage/local
+       1.502      84     58      0     26  github.com/kalbasit/ncps/pkg/storage/s3
+       1.246       9      7      0      2  github.com/kalbasit/ncps/migrations
+       1.142       8      8      0      0  github.com/kalbasit/ncps/cmd/ent-lint
+       1.139      14     14      0      0  github.com/kalbasit/ncps/pkg/lock/local
+       1.126      10      7      0      3  github.com/kalbasit/ncps/pkg/database/migrate
+       1.092       8      8      0      0  github.com/kalbasit/ncps/pkg/lock
+       1.086      27     21      0      6  github.com/kalbasit/ncps/pkg/config
+       1.068      17     11      0      6  github.com/kalbasit/ncps/pkg/storage/chunk
+       1.067      19     19      0      0  github.com/kalbasit/ncps/pkg/zstd
+       1.064     145    145      0      0  github.com/kalbasit/ncps/pkg/nar
+       1.047      37     37      0      0  github.com/kalbasit/ncps/pkg/database
+       1.023       3      3      0      0  github.com/kalbasit/ncps/pkg/otel
+       1.020      24     24      0      0  github.com/kalbasit/ncps/testhelper
+       1.016      12     12      0      0  github.com/kalbasit/ncps/pkg/circuitbreaker
+       1.016      31     31      0      0  github.com/kalbasit/ncps/pkg/helper
+       1.016      16     16      0      0  github.com/kalbasit/ncps/pkg/s3
+       1.016       9      9      0      0  github.com/kalbasit/ncps/pkg/xz
+       1.014      24     24      0      0  github.com/kalbasit/ncps/pkg/narinfo
+       1.014      14     14      0      0  github.com/kalbasit/ncps/pkg/nixcacheinfo
+       1.012      11     11      0      0  github.com/kalbasit/ncps/pkg/otelzerolog
+--------------------------------------------------------------------------------
+      58.952  TOTAL (sum of per-package elapsed)
+
+================================================================================
+SLOW TESTS (elapsed > 0.500s, parent + subtests)
+================================================================================
+ elapsed (s)  package / test
+--------------------------------------------------------------------------------
+      10.510  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/DeadlockContextCancellationDuringDownload
+       4.440  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01
+       2.260  github.com/kalbasit/ncps/pkg/cache  TestCDCBackends/SQLite/first_pull_completes_before_CDC_chunking_finishes
+       2.180  github.com/kalbasit/ncps/cmd/generate-migrations  TestSQLOnlyEmitsThreeDialects
+       2.110  github.com/kalbasit/ncps/cmd/generate-migrations  TestNameValidation
+       2.070  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNarInfo
+       2.070  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/SQLite/VerifiedSince
+       2.040  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNarInfo/narinfo_exists_upstream
+       2.030  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNar
+       2.020  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNar/nar_exists_upstream
+       2.020  github.com/kalbasit/ncps/pkg/server  TestSecurity
+       1.760  github.com/kalbasit/ncps/pkg/cache  TestIssue990_BackgroundJobContextCancellation
+       1.270  github.com/kalbasit/ncps/pkg/chunker  TestCDCChunker_Chunk_ErrorRace
+       1.150  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite/RunLRU
+       1.140  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite/RunLRUCleanupInconsistentNarInfoState
+       1.070  github.com/kalbasit/ncps/pkg/cache  TestGetNarInfoDistributedCoordination
+       1.060  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite/ConcurrentDecompression
+       1.030  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarInfoBackends/SQLite/LargeNarInfo
+       1.000  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNarInfo/narinfo_exists_upstream/pulling_it_another_time_within_recordAgeIgnoreTouch_should_not_update_last_accessed_at
+       1.000  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNarInfo/narinfo_exists_upstream/pulling_it_another_time_should_update_last_accessed_at_only_for_narinfo
+       1.000  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNar/nar_exists_upstream/pulling_it_another_time_within_recordAgeIgnoreTouch_should_not_update_last_accessed_at
+       1.000  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNar/nar_exists_upstream/pulling_it_another_time_should_update_last_accessed_at
+       1.000  github.com/kalbasit/ncps/pkg/lock/redis  TestNewLocker_ReturnType
+       0.680  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite
+       0.510  github.com/kalbasit/ncps/pkg/cache/upstream  TestHasNarInfo/response_header_timeout_treated_as_not-found_for_HEAD_requests

--- a/openspec/changes/archive/2026-05-23-less-tests/after-batch2-timings.txt
+++ b/openspec/changes/archive/2026-05-23-less-tests/after-batch2-timings.txt
@@ -1,0 +1,58 @@
+================================================================================
+PER-PACKAGE WALL TIME (ranked, descending)
+================================================================================
+ elapsed (s)   tests   pass   fail   skip  package
+--------------------------------------------------------------------------------
+       4.064     226    208      0     19  github.com/kalbasit/ncps/pkg/cache
+       3.983      87     85      0      2  github.com/kalbasit/ncps/pkg/server
+       3.699      63     57      0      6  github.com/kalbasit/ncps/pkg/ncps
+       2.982      12     12      0      0  github.com/kalbasit/ncps/cmd/generate-migrations
+       2.161       5      5      0      0  github.com/kalbasit/ncps/pkg/chunker
+       2.116     135    135      0      0  github.com/kalbasit/ncps/pkg/cache/upstream
+       2.032      15      2      0     13  github.com/kalbasit/ncps/pkg/lock/redis
+       1.580       4      2      0      2  github.com/kalbasit/ncps/pkg/cache/healthcheck
+       1.505      55     55      0      0  github.com/kalbasit/ncps/pkg/storage/local
+       1.495      84     58      0     26  github.com/kalbasit/ncps/pkg/storage/s3
+       1.171       9      7      0      2  github.com/kalbasit/ncps/migrations
+       1.166       8      8      0      0  github.com/kalbasit/ncps/cmd/ent-lint
+       1.159      10      7      0      3  github.com/kalbasit/ncps/pkg/database/migrate
+       1.148      14     14      0      0  github.com/kalbasit/ncps/pkg/lock/local
+       1.091       8      8      0      0  github.com/kalbasit/ncps/pkg/lock
+       1.087      27     21      0      6  github.com/kalbasit/ncps/pkg/config
+       1.071     145    145      0      0  github.com/kalbasit/ncps/pkg/nar
+       1.063      17     11      0      6  github.com/kalbasit/ncps/pkg/storage/chunk
+       1.053      19     19      0      0  github.com/kalbasit/ncps/pkg/zstd
+       1.050      37     37      0      0  github.com/kalbasit/ncps/pkg/database
+       1.029       3      3      0      0  github.com/kalbasit/ncps/pkg/otel
+       1.023       9      9      0      0  github.com/kalbasit/ncps/pkg/xz
+       1.021      24     24      0      0  github.com/kalbasit/ncps/testhelper
+       1.018      31     31      0      0  github.com/kalbasit/ncps/pkg/helper
+       1.017      14     14      0      0  github.com/kalbasit/ncps/pkg/nixcacheinfo
+       1.017      16     16      0      0  github.com/kalbasit/ncps/pkg/s3
+       1.015      11     11      0      0  github.com/kalbasit/ncps/pkg/otelzerolog
+       1.011      24     24      0      0  github.com/kalbasit/ncps/pkg/narinfo
+       1.010      12     12      0      0  github.com/kalbasit/ncps/pkg/circuitbreaker
+--------------------------------------------------------------------------------
+      45.837  TOTAL (sum of per-package elapsed)
+
+================================================================================
+SLOW TESTS (elapsed > 0.500s, parent + subtests)
+================================================================================
+ elapsed (s)  package / test
+--------------------------------------------------------------------------------
+       2.280  github.com/kalbasit/ncps/pkg/cache  TestCDCBackends/SQLite/first_pull_completes_before_CDC_chunking_finishes
+       2.090  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/SQLite/VerifiedSince
+       2.020  github.com/kalbasit/ncps/pkg/server  TestSecurity
+       1.950  github.com/kalbasit/ncps/cmd/generate-migrations  TestSQLOnlyEmitsThreeDialects
+       1.940  github.com/kalbasit/ncps/cmd/generate-migrations  TestNameValidation
+       1.730  github.com/kalbasit/ncps/pkg/cache  TestIssue990_BackgroundJobContextCancellation
+       1.140  github.com/kalbasit/ncps/pkg/chunker  TestCDCChunker_Chunk_ErrorRace
+       1.110  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite/RunLRUCleanupInconsistentNarInfoState
+       1.110  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite/RunLRU
+       1.110  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarInfoBackends/SQLite/LargeNarInfo
+       1.060  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite/ConcurrentDecompression
+       1.050  github.com/kalbasit/ncps/pkg/cache  TestGetNarInfoDistributedCoordination
+       1.000  github.com/kalbasit/ncps/pkg/lock/redis  TestNewLocker_ReturnType
+       0.920  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01
+       0.700  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite
+       0.510  github.com/kalbasit/ncps/pkg/cache/upstream  TestHasNarInfo/response_header_timeout_treated_as_not-found_for_HEAD_requests

--- a/openspec/changes/archive/2026-05-23-less-tests/after-batch3-timings.txt
+++ b/openspec/changes/archive/2026-05-23-less-tests/after-batch3-timings.txt
@@ -1,0 +1,52 @@
+================================================================================
+PER-PACKAGE WALL TIME (ranked, descending)
+================================================================================
+ elapsed (s)   tests   pass   fail   skip  package
+--------------------------------------------------------------------------------
+       3.121      12     12      0      0  github.com/kalbasit/ncps/cmd/generate-migrations
+       2.983     226    208      0     19  github.com/kalbasit/ncps/pkg/cache
+       2.303       5      5      0      0  github.com/kalbasit/ncps/pkg/chunker
+       2.273      87     85      0      2  github.com/kalbasit/ncps/pkg/server
+       2.168     135    135      0      0  github.com/kalbasit/ncps/pkg/cache/upstream
+       2.027      15      2      0     13  github.com/kalbasit/ncps/pkg/lock/redis
+       1.907      63     57      0      6  github.com/kalbasit/ncps/pkg/ncps
+       1.621       4      2      0      2  github.com/kalbasit/ncps/pkg/cache/healthcheck
+       1.538      55     55      0      0  github.com/kalbasit/ncps/pkg/storage/local
+       1.524      84     58      0     26  github.com/kalbasit/ncps/pkg/storage/s3
+       1.175       8      8      0      0  github.com/kalbasit/ncps/cmd/ent-lint
+       1.162       9      7      0      2  github.com/kalbasit/ncps/migrations
+       1.153      14     14      0      0  github.com/kalbasit/ncps/pkg/lock/local
+       1.102      10      7      0      3  github.com/kalbasit/ncps/pkg/database/migrate
+       1.094       8      8      0      0  github.com/kalbasit/ncps/pkg/lock
+       1.076      17     11      0      6  github.com/kalbasit/ncps/pkg/storage/chunk
+       1.063      19     19      0      0  github.com/kalbasit/ncps/pkg/zstd
+       1.060      27     21      0      6  github.com/kalbasit/ncps/pkg/config
+       1.055     145    145      0      0  github.com/kalbasit/ncps/pkg/nar
+       1.042      37     37      0      0  github.com/kalbasit/ncps/pkg/database
+       1.029       9      9      0      0  github.com/kalbasit/ncps/pkg/xz
+       1.022      24     24      0      0  github.com/kalbasit/ncps/testhelper
+       1.019       3      3      0      0  github.com/kalbasit/ncps/pkg/otel
+       1.014      14     14      0      0  github.com/kalbasit/ncps/pkg/nixcacheinfo
+       1.013      16     16      0      0  github.com/kalbasit/ncps/pkg/s3
+       1.012      12     12      0      0  github.com/kalbasit/ncps/pkg/circuitbreaker
+       1.012      31     31      0      0  github.com/kalbasit/ncps/pkg/helper
+       1.012      24     24      0      0  github.com/kalbasit/ncps/pkg/narinfo
+       1.010      11     11      0      0  github.com/kalbasit/ncps/pkg/otelzerolog
+--------------------------------------------------------------------------------
+      41.590  TOTAL (sum of per-package elapsed)
+
+================================================================================
+SLOW TESTS (elapsed > 0.500s, parent + subtests)
+================================================================================
+ elapsed (s)  package / test
+--------------------------------------------------------------------------------
+       2.090  github.com/kalbasit/ncps/cmd/generate-migrations  TestSQLOnlyEmitsThreeDialects
+       2.080  github.com/kalbasit/ncps/cmd/generate-migrations  TestNameValidation
+       1.290  github.com/kalbasit/ncps/pkg/chunker  TestCDCChunker_Chunk_ErrorRace
+       1.040  github.com/kalbasit/ncps/pkg/cache  TestGetNarInfoDistributedCoordination
+       1.000  github.com/kalbasit/ncps/pkg/lock/redis  TestNewLocker_ReturnType
+       0.830  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01
+       0.790  github.com/kalbasit/ncps/pkg/cache  TestCDCBackends/SQLite/first_pull_completes_before_CDC_chunking_finishes
+       0.690  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite
+       0.570  github.com/kalbasit/ncps/pkg/cache  TestIssue990_BackgroundJobContextCancellation
+       0.510  github.com/kalbasit/ncps/pkg/cache/upstream  TestHasNarInfo/response_header_timeout_treated_as_not-found_for_HEAD_requests

--- a/openspec/changes/archive/2026-05-23-less-tests/baseline-timings.txt
+++ b/openspec/changes/archive/2026-05-23-less-tests/baseline-timings.txt
@@ -1,0 +1,89 @@
+================================================================================
+PER-PACKAGE WALL TIME (ranked, descending)
+================================================================================
+ elapsed (s)   tests   pass   fail   skip  package
+--------------------------------------------------------------------------------
+      16.541     226    208      0     19  github.com/kalbasit/ncps/pkg/cache
+      13.576     135    135      0      0  github.com/kalbasit/ncps/pkg/cache/upstream
+      12.230      84     58      0     26  github.com/kalbasit/ncps/pkg/storage/s3
+       7.830      15      2      0     13  github.com/kalbasit/ncps/pkg/lock/redis
+       5.124      12     12      0      0  github.com/kalbasit/ncps/cmd/generate-migrations
+       3.831      87     85      0      2  github.com/kalbasit/ncps/pkg/server
+       3.712      63     57      0      6  github.com/kalbasit/ncps/pkg/ncps
+       1.868       5      5      0      0  github.com/kalbasit/ncps/pkg/chunker
+       1.573      55     55      0      0  github.com/kalbasit/ncps/pkg/storage/local
+       1.542       4      2      0      2  github.com/kalbasit/ncps/pkg/cache/healthcheck
+       1.211       9      7      0      2  github.com/kalbasit/ncps/migrations
+       1.209       8      8      0      0  github.com/kalbasit/ncps/cmd/ent-lint
+       1.150      14     14      0      0  github.com/kalbasit/ncps/pkg/lock/local
+       1.123      10      7      0      3  github.com/kalbasit/ncps/pkg/database/migrate
+       1.105      27     21      0      6  github.com/kalbasit/ncps/pkg/config
+       1.091       8      8      0      0  github.com/kalbasit/ncps/pkg/lock
+       1.082      37     37      0      0  github.com/kalbasit/ncps/pkg/database
+       1.077      17     11      0      6  github.com/kalbasit/ncps/pkg/storage/chunk
+       1.068     145    145      0      0  github.com/kalbasit/ncps/pkg/nar
+       1.053      19     19      0      0  github.com/kalbasit/ncps/pkg/zstd
+       1.023       3      3      0      0  github.com/kalbasit/ncps/pkg/otel
+       1.021      24     24      0      0  github.com/kalbasit/ncps/testhelper
+       1.020       9      9      0      0  github.com/kalbasit/ncps/pkg/xz
+       1.016      31     31      0      0  github.com/kalbasit/ncps/pkg/helper
+       1.014      12     12      0      0  github.com/kalbasit/ncps/pkg/circuitbreaker
+       1.011      24     24      0      0  github.com/kalbasit/ncps/pkg/narinfo
+       1.011      11     11      0      0  github.com/kalbasit/ncps/pkg/otelzerolog
+       1.011      16     16      0      0  github.com/kalbasit/ncps/pkg/s3
+       1.010      14     14      0      0  github.com/kalbasit/ncps/pkg/nixcacheinfo
+--------------------------------------------------------------------------------
+      88.133  TOTAL (sum of per-package elapsed)
+
+================================================================================
+SLOW TESTS (elapsed > 0.500s, parent + subtests)
+================================================================================
+ elapsed (s)  package / test
+--------------------------------------------------------------------------------
+      12.000  github.com/kalbasit/ncps/pkg/cache/upstream  TestNewWithOptions/custom_dialer_timeout_is_respected_-_slow_connection_succeeds_with_longer_timeout
+      10.500  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/DeadlockContextCancellationDuringDownload
+       7.000  github.com/kalbasit/ncps/pkg/cache/upstream  TestNewWithOptions/custom_response_header_timeout_is_respected_-_slow_server_succeeds_with_longer_timeout
+       6.800  github.com/kalbasit/ncps/pkg/lock/redis  TestNewLocker_ReturnType
+       5.390  github.com/kalbasit/ncps/pkg/storage/s3  TestSecretKey_ErrorPaths/PutSecretKey_StatObject_error
+       5.340  github.com/kalbasit/ncps/pkg/storage/s3  TestNar_ErrorPaths/DeleteNar_StatObject_returns_error
+       5.310  github.com/kalbasit/ncps/pkg/storage/s3  TestWalkNarInfos_ErrorPaths/ListObjects_returns_error
+       5.230  github.com/kalbasit/ncps/pkg/storage/s3  TestSecretKey_ErrorPaths/DeleteSecretKey_StatObject_error
+       5.150  github.com/kalbasit/ncps/pkg/storage/s3  TestPutNar_ErrorPaths/PutNar_StatObject_error
+       5.010  github.com/kalbasit/ncps/pkg/cache/upstream  TestGetNarInfo/timeout_if_server_takes_more_than_3_seconds_before_first_byte
+       5.010  github.com/kalbasit/ncps/pkg/cache/upstream  TestGetNar/timeout_if_server_takes_more_than_3_seconds_before_first_byte
+       5.000  github.com/kalbasit/ncps/pkg/cache/upstream  TestHasNarInfo/timeout_if_server_takes_more_than_3_seconds_before_first_byte
+       5.000  github.com/kalbasit/ncps/pkg/cache/upstream  TestHasNar/timeout_if_server_takes_more_than_3_seconds_before_first_byte
+       4.460  github.com/kalbasit/ncps/pkg/storage/s3  TestDeleteNarInfo_ErrorPaths/DeleteNarInfo_StatObject_error
+       4.430  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01
+       4.160  github.com/kalbasit/ncps/pkg/storage/s3  TestSecretKey_ErrorPaths/PutSecretKey_PutObject_error
+       4.110  github.com/kalbasit/ncps/pkg/storage/s3  TestDeleteNarInfo_ErrorPaths/DeleteNarInfo_RemoveObject_error
+       4.090  github.com/kalbasit/ncps/cmd/generate-migrations  TestNameValidation
+       4.080  github.com/kalbasit/ncps/cmd/generate-migrations  TestSQLOnlyEmitsThreeDialects
+       4.040  github.com/kalbasit/ncps/pkg/storage/s3  TestNar_ErrorPaths/DeleteNar_returns_error
+       3.760  github.com/kalbasit/ncps/pkg/storage/s3  TestSecretKey_ErrorPaths/GetSecretKey_Stat_error
+       3.670  github.com/kalbasit/ncps/pkg/storage/s3  TestSecretKey_ErrorPaths/DeleteSecretKey_RemoveObject_error
+       3.660  github.com/kalbasit/ncps/pkg/storage/s3  TestSecretKey_ErrorPaths/GetSecretKey_Read_error
+       3.250  github.com/kalbasit/ncps/pkg/storage/s3  TestPutNar_ErrorPaths/PutNar_PutObject_error
+       3.240  github.com/kalbasit/ncps/pkg/storage/s3  TestHasNarinfoDir_ErrorPaths/ListObjects_returns_error
+       2.990  github.com/kalbasit/ncps/pkg/storage/s3  TestHasNar_ErrorPaths/HasNar_StatObject_error
+       2.600  github.com/kalbasit/ncps/pkg/storage/s3  TestNar_ErrorPaths/GetNar_returns_error
+       2.250  github.com/kalbasit/ncps/pkg/cache  TestCDCBackends/SQLite/first_pull_completes_before_CDC_chunking_finishes
+       2.090  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNarInfo
+       2.040  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNarInfo/narinfo_exists_upstream
+       2.040  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/SQLite/VerifiedSince
+       2.020  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNar
+       2.020  github.com/kalbasit/ncps/pkg/server  TestSecurity
+       2.010  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNar/nar_exists_upstream
+       1.800  github.com/kalbasit/ncps/pkg/storage/s3  TestNarInfo_ErrorPaths/PutNarInfo_returns_error
+       1.720  github.com/kalbasit/ncps/pkg/cache  TestIssue990_BackgroundJobContextCancellation
+       1.150  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite/RunLRU
+       1.130  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite/RunLRUCleanupInconsistentNarInfoState
+       1.060  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite/ConcurrentDecompression
+       1.050  github.com/kalbasit/ncps/pkg/cache  TestGetNarInfoDistributedCoordination
+       1.000  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNarInfo/narinfo_exists_upstream/pulling_it_another_time_within_recordAgeIgnoreTouch_should_not_update_last_accessed_at
+       1.000  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNarInfo/narinfo_exists_upstream/pulling_it_another_time_should_update_last_accessed_at_only_for_narinfo
+       1.000  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNar/nar_exists_upstream/pulling_it_another_time_within_recordAgeIgnoreTouch_should_not_update_last_accessed_at
+       1.000  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01/GetNar/nar_exists_upstream/pulling_it_another_time_should_update_last_accessed_at
+       0.950  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarInfoBackends/SQLite/LargeNarInfo
+       0.860  github.com/kalbasit/ncps/pkg/chunker  TestCDCChunker_Chunk_ErrorRace
+       0.640  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite

--- a/openspec/changes/archive/2026-05-23-less-tests/design.md
+++ b/openspec/changes/archive/2026-05-23-less-tests/design.md
@@ -1,0 +1,128 @@
+## Context
+
+`nix flake check` runs `go test -race ./...` plus all dependent checks. The Go test step dominates wall time, with `pkg/cache` suspected as the worst offender. The suite has grown organically: many `TestXxx` functions independently rebuild expensive fixtures (SQLite/Postgres/MySQL connections, MinIO buckets, fresh CDC chunk stores, zstd pools, full NarInfo+NAR roundtrips with random payloads), and several tests assert overlapping behavior on the same code paths.
+
+The project already has a `short-test-mode` capability that gates >500ms tests behind `testing.Short()`. That is orthogonal to this work — `-short` lets developers skip slow tests locally, but `nix flake check` (and CI) still runs everything. Reducing the *total* test time requires removing genuine redundancy and amortizing setup, not skipping more tests.
+
+Constraints:
+- Race detector must remain on for every test.
+- `paralleltest` linter requires `t.Parallel()` everywhere; restructuring must not break that.
+- `testpackage` linter requires `_test` package; no internal access via package-private symbols.
+- Integration tests are gated by env vars (`enable-*-tests`) but run under `nix flake check`; they are in scope.
+- No production code changes; this is a test-suite-only effort.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Measure first: produce a reproducible profile of per-package and per-test wall time before any deletion.
+- Establish a written decision procedure for "is this test redundant?" that future reviewers can apply.
+- Reduce `go test -race ./...` wall time on a clean machine by a meaningful margin (target: ≥30% reduction; stretch: ≥50%) without losing coverage signal.
+- Keep coverage parity: line coverage MUST NOT drop; branch coverage MUST NOT drop by more than 1pp per package.
+- Leave the suite easier to extend — shared fixtures named clearly, table-driven where natural.
+
+**Non-Goals:**
+- Adding new tests or new coverage.
+- Touching production code under test (except trivial test-only `helpers` files moved/renamed).
+- Replacing real-backend integration tests with mocks wholesale. We keep at least one wiring smoke test per backend (Postgres, MySQL, S3/MinIO, Redis).
+- Removing or weakening the race detector, parallelism, or `nix flake check` structure.
+- Changing the `-short` gating set as a primary goal. Updates to `short-test-mode` are downstream of profiling.
+
+## Decisions
+
+### D1. Profiling methodology: `go test -json` + a small analyzer
+
+Use `go test -json -race -count=1 ./...` (with integration env vars set via `enable-integration-tests`) piped to a temporary analyzer that ranks:
+- Per-package total wall time
+- Per-test wall time (parent + subtests separately)
+- Tests where `Elapsed > 500ms`
+
+**Why this over `gotestsum`**: We already have everything we need in `-json`. A 30-line `awk`/`jq` pipeline is cheaper than adding a tool dependency and is reproducible across local + CI. The output is stored as `openspec/changes/less-tests/baseline-timings.txt` (not committed past archive) for the duration of the work.
+
+**Alternative considered**: CPU profiling per test with `-cpuprofile`. Rejected for this phase — wall-time ranking is enough to find the offenders; CPU profiles add noise without changing the priority list.
+
+### D2. "Redundant test" decision procedure
+
+A test (or subtest) is a removal candidate **only if all four** hold:
+
+1. **Same code path**: Its per-test coverage profile (`go test -coverpkg=./... -coverprofile=...`) is a subset of another test's profile.
+2. **Same assertions or weaker**: Every property it asserts is asserted by at least one other test that survives, with equal or stronger specificity (e.g., a test that checks `err != nil` is dominated by one that checks `errors.Is(err, ErrXxx)`).
+3. **No unique fixture shape**: It does not exercise a unique input boundary (empty input, max-size input, unicode, concurrent access, specific backend quirk).
+4. **No unique race-detector exposure**: It does not exercise a goroutine interleaving that no other test exercises (checked by reading, not by tooling — race coverage is not machine-measurable).
+
+If any one of those fails, the test stays. Each removed test gets a one-line justification in `tasks.md` referencing the surviving test that covers it.
+
+**Why this over "delete anything that looks similar"**: Tests sometimes look duplicative but cover a subtle path (e.g., the third PutNarInfo in a row hits a different cache state). The four-gate rule forces an explicit check before deletion.
+
+### D3. Shared-fixture restructuring rules
+
+Within a single `TestXxx`:
+- Hoist setup that does not mutate shared state out of subtests into the parent test (DB schema creation, MinIO bucket creation, zstd encoder pool, fixed-content NAR fixtures).
+- Per-subtest, derive unique keys/paths from `t.Name()` (already sanitized) or a counter so `t.Parallel()` subtests do not collide.
+- Use `t.Cleanup` once at the parent level for shared resources; subtest-local cleanup stays per subtest.
+- Never share a `*sql.DB` connection across `TestXxx` boundaries unless an existing helper already does so safely — keep package-level fixtures opt-in, not automatic.
+
+Across `TestXxx` boundaries, package-level setup is allowed only when:
+- The fixture is read-only (e.g., a parsed NAR file used as input).
+- A `TestMain` already exists or is trivially added without breaking parallelism.
+
+**Why not aggressive package-level fixtures everywhere**: package-level shared state interacts badly with `t.Parallel()` and is a common source of flaky tests under `-race`. We allow it only for read-only data.
+
+### D4. Integration test split
+
+For each backend (Postgres, MySQL, S3/MinIO, Redis):
+- Keep one "wiring smoke" test that exercises connect → simple roundtrip → close against the real backend.
+- Move business-logic assertions (error handling branches, retry behavior, edge cases) to unit tests against a fake implementing the storage/database interface, when such a fake already exists or is trivial to write.
+- Tests that genuinely need backend-specific behavior (e.g., Postgres-specific upsert semantics, S3 multipart) stay as integration tests.
+
+**Why**: Real-backend startup (process-compose dependencies) plus per-test schema migration is the dominant cost in many integration test files. Wiring smoke tests catch integration regressions; business logic does not need the real backend to assert correctness.
+
+### D5. Coverage parity gate
+
+Enforced in `tasks.md` as a checkpoint after every batch of removals/restructuring:
+
+```
+go test -coverpkg=./... -coverprofile=cover-after.out -race ./<changed-pkg>/...
+```
+
+Compare against `cover-before.out` recorded at the start. Requirements:
+- Line coverage per package: `after >= before`.
+- Branch coverage per package: `after >= before - 1pp` (tolerance for inlining/optimization artifacts).
+- Any regression beyond the tolerance reverts the batch.
+
+**Why a per-batch gate instead of one final gate**: catching a coverage drop after every batch lets us bisect the offending removal in seconds, not hours.
+
+### D6. Sequencing
+
+1. Land the profiling tooling and baseline numbers as the first commit (no test changes yet).
+2. Work package-by-package, starting with the slowest package (most likely `pkg/cache`).
+3. Within each package, work file-by-file, smallest restructuring first (shared setup), then table-driven consolidation, then deletions.
+4. After each package, re-run the profiler and update `tasks.md` with measured wall-time delta.
+5. After all packages, update `short-test-mode` spec to reflect the new gated set.
+
+**Why this order**: shared-setup restructuring is reversible and low-risk; deletions are not. Doing the safe work first builds confidence and surfaces unique-coverage signals (a test that "looked redundant" but breaks when its setup is shared is doing real work).
+
+## Risks / Trade-offs
+
+- **Risk: a deleted test was actually catching a regression no other test catches.**
+  → Mitigation: D2's four-gate rule, the per-batch coverage gate (D5), and a written justification per removal in `tasks.md`. The git history of `tasks.md` becomes the audit trail.
+
+- **Risk: shared fixtures introduce hidden coupling and make a future test flaky under `-race`.**
+  → Mitigation: D3 limits package-level sharing to read-only data; subtest-level sharing requires per-subtest keyspaces. CI runs with `-race` and would catch a regression.
+
+- **Risk: integration tests moved to fakes diverge from real backend behavior.**
+  → Mitigation: D4 requires keeping one wiring smoke test per backend. Backend-specific semantics (upsert, multipart) stay as integration tests.
+
+- **Risk: the profiler analyzer itself becomes a maintenance burden.**
+  → Mitigation: Keep it as a shell pipeline in `dev-scripts/`, not a new Go program. Delete it (or move to `dev-scripts/profile-tests.sh`) once the change is archived. Document in the spec.
+
+- **Trade-off: per-batch coverage gating slows the work down.**
+  → Accepted. The cost of one careless deletion is far higher than a few extra `go test -cover` runs.
+
+- **Risk: `nix flake check` cache invalidation patterns change after restructuring.**
+  → Mitigation: the change is test-only; `nix flake check`'s overall structure (jobs, dependencies) is unchanged. Verified by running `nix flake check` before and after.
+
+## Open Questions
+
+- Should the profiling pipeline be checked into `dev-scripts/` permanently as a project tool, or kept only for the duration of this change? **Tentative answer**: check it in — future test-suite drift is inevitable and the tooling is cheap.
+- What is the right target reduction? **Tentative answer**: ≥30% with stretch ≥50%, validated against the baseline. Revisit after first profiling pass; if the suite is already lean we adjust the target down rather than force deletions.
+- Do we want to add a CI job that prints test timings as a summary to catch future regressions? Out of scope for this change but worth a follow-up.

--- a/openspec/changes/archive/2026-05-23-less-tests/integration-after-batch5-timings.txt
+++ b/openspec/changes/archive/2026-05-23-less-tests/integration-after-batch5-timings.txt
@@ -1,0 +1,111 @@
+================================================================================
+PER-PACKAGE WALL TIME (ranked, descending)
+================================================================================
+ elapsed (s)   tests   pass   fail   skip  package
+--------------------------------------------------------------------------------
+      10.701     597    573     12     13  github.com/kalbasit/ncps/pkg/cache
+       6.464     159    159      0      0  github.com/kalbasit/ncps/pkg/ncps
+       3.191      91     91      0      0  github.com/kalbasit/ncps/pkg/server
+       3.047      15     15      0      0  github.com/kalbasit/ncps/pkg/lock/redis
+       2.970       5      5      0      0  github.com/kalbasit/ncps/pkg/chunker
+       2.887      12     12      0      0  github.com/kalbasit/ncps/cmd/generate-migrations
+       2.354     135    135      0      0  github.com/kalbasit/ncps/pkg/cache/upstream
+       2.033      57     57      0      0  github.com/kalbasit/ncps/pkg/config
+       1.987       4      4      0      0  github.com/kalbasit/ncps/pkg/cache/healthcheck
+       1.850      55     55      0      0  github.com/kalbasit/ncps/pkg/storage/local
+       1.832      86     86      0      0  github.com/kalbasit/ncps/pkg/storage/s3
+       1.321       9      9      0      0  github.com/kalbasit/ncps/migrations
+       1.281      21     19      0      2  github.com/kalbasit/ncps/pkg/database/migrate
+       1.266      24     24      0      0  github.com/kalbasit/ncps/pkg/storage/chunk
+       1.135       8      8      0      0  github.com/kalbasit/ncps/cmd/ent-lint
+       1.128      14     14      0      0  github.com/kalbasit/ncps/pkg/lock/local
+       1.102       8      8      0      0  github.com/kalbasit/ncps/pkg/lock
+       1.082     145    145      0      0  github.com/kalbasit/ncps/pkg/nar
+       1.074       9      9      0      0  github.com/kalbasit/ncps/pkg/xz
+       1.065      19     19      0      0  github.com/kalbasit/ncps/pkg/zstd
+       1.048      37     37      0      0  github.com/kalbasit/ncps/pkg/database
+       1.035       3      3      0      0  github.com/kalbasit/ncps/pkg/otel
+       1.025      11     11      0      0  github.com/kalbasit/ncps/pkg/otelzerolog
+       1.025      16     16      0      0  github.com/kalbasit/ncps/pkg/s3
+       1.021      24     24      0      0  github.com/kalbasit/ncps/testhelper
+       1.020      14     14      0      0  github.com/kalbasit/ncps/pkg/nixcacheinfo
+       1.017      31     31      0      0  github.com/kalbasit/ncps/pkg/helper
+       1.017      24     24      0      0  github.com/kalbasit/ncps/pkg/narinfo
+       1.016      12     12      0      0  github.com/kalbasit/ncps/pkg/circuitbreaker
+--------------------------------------------------------------------------------
+      58.994  TOTAL (sum of per-package elapsed)
+
+================================================================================
+SLOW TESTS (elapsed > 0.500s, parent + subtests)
+================================================================================
+ elapsed (s)  package / test
+--------------------------------------------------------------------------------
+       7.220  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/PostgreSQL/PutNarInfoConcurrentSharedNar
+       6.690  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL#01
+       6.620  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/MySQL#01
+       6.570  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite
+       4.600  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL
+       4.490  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/MySQL
+       4.390  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01
+       3.100  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/MySQL/PutNarInfoConcurrentSharedNar
+       2.010  github.com/kalbasit/ncps/pkg/lock/redis  TestLocker_LockExpiry
+       1.950  github.com/kalbasit/ncps/pkg/chunker  TestCDCChunker_Chunk_ErrorRace
+       1.850  github.com/kalbasit/ncps/cmd/generate-migrations  TestSQLOnlyEmitsThreeDialects
+       1.840  github.com/kalbasit/ncps/cmd/generate-migrations  TestNameValidation
+       1.720  github.com/kalbasit/ncps/pkg/lock/redis  TestLocker_DegradedModeDisabled
+       1.710  github.com/kalbasit/ncps/pkg/lock/redis  TestLocker_DegradedMode
+       1.120  github.com/kalbasit/ncps/pkg/cache  TestGetNarInfoDistributedCoordination
+       1.070  github.com/kalbasit/ncps/pkg/cache  TestCDCBackends/PostgreSQL/first_pull_completes_before_CDC_chunking_finishes
+       1.040  github.com/kalbasit/ncps/pkg/lock/redis  TestLocker_RetryWithBackoff
+       1.010  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/PostgreSQL/LockFailover
+       1.010  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/MySQL/LockFailover
+       1.010  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/SQLite/LockFailover
+       1.000  github.com/kalbasit/ncps/pkg/lock/redis  TestNewLocker_ReturnType
+       0.960  github.com/kalbasit/ncps/pkg/cache  TestCDCBackends/SQLite/first_pull_completes_before_CDC_chunking_finishes
+       0.930  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/PostgreSQL/Deduplication
+       0.930  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/MySQL/MultipleNARs
+       0.900  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/MySQL/Success
+       0.890  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/SQLite/PutNarInfoConcurrentSharedNar
+       0.890  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/PostgreSQL/LargeNARConcurrentDownload/CDC_Enabled
+       0.870  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/VerifiedSince
+       0.830  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/NarFileMissingInStorageCascadeRepair
+       0.820  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/PostgreSQL/Success
+       0.810  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL#01/RunLRUCleanupInconsistentNarInfoState
+       0.800  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/PostgreSQL/ConcurrentReads
+       0.790  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/MySQL#01/RunLRU
+       0.780  github.com/kalbasit/ncps/pkg/cache  TestCDCBackends/MySQL/first_pull_completes_before_CDC_chunking_finishes
+       0.780  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/MySQL/VerifiedSince
+       0.700  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/MySQL/LargeNARConcurrentDownload/CDC_Enabled
+       0.690  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/SQLite/LargeNARConcurrentDownload/CDC_Enabled
+       0.680  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/PostgreSQL/LargeNARConcurrentDownload/CDC_Disabled
+       0.680  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/MySQL#01/RunLRUCleanupInconsistentNarInfoState
+       0.680  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/MySQL/Idempotency
+       0.660  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/MySQL/Deduplication
+       0.660  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/SizeMismatchDoesNotUpdateVerifiedAt
+       0.650  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/VerifyContentSkipsWhenFlagAbsent
+       0.640  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/PostgreSQL/MultipleNARs
+       0.630  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL/DeadlockContextCancellationDuringDownload
+       0.630  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL#01/RunLRU
+       0.600  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite/RunLRU
+       0.600  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/CleanChunksPassContentVerification
+       0.590  github.com/kalbasit/ncps/pkg/cache  TestIssue990_BackgroundJobContextCancellation
+       0.580  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL/ConcurrentDownloadCancelOneClientOthersContinue
+       0.570  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite/RunLRUCleanupInconsistentNarInfoState
+       0.570  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL#01/ConcurrentDecompression
+       0.570  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/HashMismatchDetected
+       0.570  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/CorruptChunkDetected
+       0.560  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite/ConcurrentDecompression
+       0.560  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/RepairCorruptChunk
+       0.540  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/MySQL/ConcurrentReads
+       0.540  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/SQLite/ConcurrentReads
+       0.530  github.com/kalbasit/ncps/pkg/lock/redis  TestRWLocker_WriterBlocksReaders
+       0.530  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/MySQL/NarFileMissingInStorageCascadeRepair
+       0.530  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/SQLite/MultipleNARs
+       0.520  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL/BackgroundMigrateNarToChunksAfterCancellation
+       0.520  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/MySQL#01/ConcurrentDecompression
+       0.510  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL/GetNarInfoConcurrentMigrationAttempts
+       0.510  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL/GetNar_TransparentZstd
+       0.510  github.com/kalbasit/ncps/pkg/cache/upstream  TestGetNarInfo/response_header_timeout_fires_when_server_stalls_before_first_byte
+       0.510  github.com/kalbasit/ncps/pkg/cache/upstream  TestHasNar/response_header_timeout_treated_as_not-found_for_HEAD_requests
+       0.510  github.com/kalbasit/ncps/pkg/cache/upstream  TestHasNarInfo/response_header_timeout_treated_as_not-found_for_HEAD_requests
+       0.510  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/SizeMismatchRespectsVerifiedSince

--- a/openspec/changes/archive/2026-05-23-less-tests/integration-after-dbclose-timings.txt
+++ b/openspec/changes/archive/2026-05-23-less-tests/integration-after-dbclose-timings.txt
@@ -1,0 +1,97 @@
+================================================================================
+PER-PACKAGE WALL TIME (ranked, descending)
+================================================================================
+ elapsed (s)   tests   pass   fail   skip  package
+--------------------------------------------------------------------------------
+      11.892     597    574     11     13  github.com/kalbasit/ncps/pkg/cache
+       7.070      86     86      0      0  github.com/kalbasit/ncps/pkg/storage/s3
+       6.282     159    159      0      0  github.com/kalbasit/ncps/pkg/ncps
+       3.276      91     91      0      0  github.com/kalbasit/ncps/pkg/server
+       3.069      15     15      0      0  github.com/kalbasit/ncps/pkg/lock/redis
+       2.887      12     12      0      0  github.com/kalbasit/ncps/cmd/generate-migrations
+       2.653       5      5      0      0  github.com/kalbasit/ncps/pkg/chunker
+       2.093     135    135      0      0  github.com/kalbasit/ncps/pkg/cache/upstream
+       1.921      57     57      0      0  github.com/kalbasit/ncps/pkg/config
+       1.763      55     55      0      0  github.com/kalbasit/ncps/pkg/storage/local
+       1.701       4      4      0      0  github.com/kalbasit/ncps/pkg/cache/healthcheck
+       1.318       8      8      0      0  github.com/kalbasit/ncps/cmd/ent-lint
+       1.298      21     19      0      2  github.com/kalbasit/ncps/pkg/database/migrate
+       1.270       9      9      0      0  github.com/kalbasit/ncps/migrations
+       1.216      24     24      0      0  github.com/kalbasit/ncps/pkg/storage/chunk
+       1.128      14     14      0      0  github.com/kalbasit/ncps/pkg/lock/local
+       1.096       8      8      0      0  github.com/kalbasit/ncps/pkg/lock
+       1.091     145    145      0      0  github.com/kalbasit/ncps/pkg/nar
+       1.086      19     19      0      0  github.com/kalbasit/ncps/pkg/zstd
+       1.061      37     37      0      0  github.com/kalbasit/ncps/pkg/database
+       1.052       9      9      0      0  github.com/kalbasit/ncps/pkg/xz
+       1.029      24     24      0      0  github.com/kalbasit/ncps/pkg/narinfo
+       1.026       3      3      0      0  github.com/kalbasit/ncps/pkg/otel
+       1.024      24     24      0      0  github.com/kalbasit/ncps/testhelper
+       1.023      14     14      0      0  github.com/kalbasit/ncps/pkg/nixcacheinfo
+       1.021      12     12      0      0  github.com/kalbasit/ncps/pkg/circuitbreaker
+       1.018      11     11      0      0  github.com/kalbasit/ncps/pkg/otelzerolog
+       1.017      31     31      0      0  github.com/kalbasit/ncps/pkg/helper
+       1.016      16     16      0      0  github.com/kalbasit/ncps/pkg/s3
+--------------------------------------------------------------------------------
+      64.397  TOTAL (sum of per-package elapsed)
+
+================================================================================
+SLOW TESTS (elapsed > 0.500s, parent + subtests)
+================================================================================
+ elapsed (s)  package / test
+--------------------------------------------------------------------------------
+       9.920  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL
+       9.760  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/MySQL
+       9.660  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite
+       6.220  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL#01
+       5.990  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/MySQL#01
+       5.860  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01
+       5.430  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/PostgreSQL/LargeNARConcurrentDownload/CDC_Enabled
+       5.230  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/MySQL/LargeNARConcurrentDownload/CDC_Enabled
+       5.220  github.com/kalbasit/ncps/pkg/storage/s3  TestNew_BucketAccessError
+       4.810  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/PostgreSQL/PutNarInfoConcurrentSharedNar
+       4.790  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/SQLite/LargeNARConcurrentDownload/CDC_Enabled
+       4.510  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/SQLite/LockFailover
+       4.510  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/PostgreSQL/LockFailover
+       4.510  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/MySQL/LockFailover
+       2.930  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/PostgreSQL/LargeNARConcurrentDownload/CDC_Disabled
+       2.670  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/MySQL/PutNarInfoConcurrentSharedNar
+       2.670  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/SQLite/LargeNARConcurrentDownload/CDC_Disabled
+       2.520  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/MySQL/LargeNARConcurrentDownload/CDC_Disabled
+       2.010  github.com/kalbasit/ncps/pkg/lock/redis  TestLocker_LockExpiry
+       1.860  github.com/kalbasit/ncps/cmd/generate-migrations  TestSQLOnlyEmitsThreeDialects
+       1.860  github.com/kalbasit/ncps/pkg/lock/redis  TestLocker_RetryWithBackoff
+       1.850  github.com/kalbasit/ncps/cmd/generate-migrations  TestNameValidation
+       1.730  github.com/kalbasit/ncps/pkg/lock/redis  TestLocker_DegradedModeDisabled
+       1.720  github.com/kalbasit/ncps/pkg/lock/redis  TestLocker_DegradedMode
+       1.640  github.com/kalbasit/ncps/pkg/chunker  TestCDCChunker_Chunk_ErrorRace
+       1.440  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/SQLite/PutNarInfoConcurrentSharedNar
+       1.050  github.com/kalbasit/ncps/pkg/cache  TestGetNarInfoDistributedCoordination
+       1.000  github.com/kalbasit/ncps/pkg/lock/redis  TestNewLocker_ReturnType
+       0.870  github.com/kalbasit/ncps/pkg/cache  TestCDCBackends/PostgreSQL/first_pull_completes_before_CDC_chunking_finishes
+       0.820  github.com/kalbasit/ncps/pkg/cache  TestCDCBackends/SQLite/first_pull_completes_before_CDC_chunking_finishes
+       0.800  github.com/kalbasit/ncps/pkg/cache  TestCDCBackends/MySQL/first_pull_completes_before_CDC_chunking_finishes
+       0.760  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/MySQL/MultipleNARs
+       0.760  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/MySQL/Idempotency
+       0.660  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/MySQL/RunLRU
+       0.650  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL#01/GetNarWithPlaceholderNarFileRecord
+       0.630  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/PostgreSQL/ConcurrentReads
+       0.620  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/MySQL#01/GetNarWithPlaceholderNarFileRecord
+       0.610  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/MySQL/DryRun
+       0.600  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/CorruptChunkDetected
+       0.590  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarInfoBackends/PostgreSQL/DryRun
+       0.580  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/SQLite/ConcurrentReads
+       0.570  github.com/kalbasit/ncps/pkg/cache  TestIssue990_BackgroundJobContextCancellation
+       0.570  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL#01/DeadlockContextCancellationDuringDownload
+       0.570  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarInfoBackends/PostgreSQL/AlreadyMigrated
+       0.570  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarInfoBackends/PostgreSQL/MultipleNarInfos
+       0.560  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/MySQL/ConcurrentReads
+       0.560  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarInfoBackends/PostgreSQL/Idempotency
+       0.530  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL#01/BackgroundMigrateNarToChunksAfterCancellation
+       0.520  github.com/kalbasit/ncps/pkg/lock/redis  TestRWLocker_WriterBlocksReaders
+       0.520  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/MySQL/CDC/HashMismatchDetected
+       0.520  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarInfoBackends/MySQL/Success
+       0.520  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/VerifyContentSkipsWhenFlagAbsent
+       0.510  github.com/kalbasit/ncps/pkg/cache/upstream  TestGetNarInfo/response_header_timeout_fires_when_server_stalls_before_first_byte
+       0.510  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/MySQL/Deduplication
+       0.510  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/MySQL/Success

--- a/openspec/changes/archive/2026-05-23-less-tests/integration-baseline-timings.txt
+++ b/openspec/changes/archive/2026-05-23-less-tests/integration-baseline-timings.txt
@@ -1,0 +1,113 @@
+================================================================================
+PER-PACKAGE WALL TIME (ranked, descending)
+================================================================================
+ elapsed (s)   tests   pass   fail   skip  package
+--------------------------------------------------------------------------------
+      23.071     159    159      0      0  github.com/kalbasit/ncps/pkg/ncps
+      10.919     597    573     12     13  github.com/kalbasit/ncps/pkg/cache
+       6.772      86     86      0      0  github.com/kalbasit/ncps/pkg/storage/s3
+       3.083      15     15      0      0  github.com/kalbasit/ncps/pkg/lock/redis
+       3.058       5      5      0      0  github.com/kalbasit/ncps/pkg/chunker
+       2.951      12     12      0      0  github.com/kalbasit/ncps/cmd/generate-migrations
+       2.850      91     91      0      0  github.com/kalbasit/ncps/pkg/server
+       2.211     135    135      0      0  github.com/kalbasit/ncps/pkg/cache/upstream
+       1.957      57     57      0      0  github.com/kalbasit/ncps/pkg/config
+       1.748      55     55      0      0  github.com/kalbasit/ncps/pkg/storage/local
+       1.696       4      4      0      0  github.com/kalbasit/ncps/pkg/cache/healthcheck
+       1.377      21     19      0      2  github.com/kalbasit/ncps/pkg/database/migrate
+       1.306       9      9      0      0  github.com/kalbasit/ncps/migrations
+       1.201      24     24      0      0  github.com/kalbasit/ncps/pkg/storage/chunk
+       1.151       8      8      0      0  github.com/kalbasit/ncps/cmd/ent-lint
+       1.127      14     14      0      0  github.com/kalbasit/ncps/pkg/lock/local
+       1.113      19     19      0      0  github.com/kalbasit/ncps/pkg/zstd
+       1.102       8      8      0      0  github.com/kalbasit/ncps/pkg/lock
+       1.096     145    145      0      0  github.com/kalbasit/ncps/pkg/nar
+       1.064       9      9      0      0  github.com/kalbasit/ncps/pkg/xz
+       1.058      37     37      0      0  github.com/kalbasit/ncps/pkg/database
+       1.051      31     31      0      0  github.com/kalbasit/ncps/pkg/helper
+       1.029       3      3      0      0  github.com/kalbasit/ncps/pkg/otel
+       1.023      24     24      0      0  github.com/kalbasit/ncps/testhelper
+       1.017      24     24      0      0  github.com/kalbasit/ncps/pkg/narinfo
+       1.017      14     14      0      0  github.com/kalbasit/ncps/pkg/nixcacheinfo
+       1.016      11     11      0      0  github.com/kalbasit/ncps/pkg/otelzerolog
+       1.011      12     12      0      0  github.com/kalbasit/ncps/pkg/circuitbreaker
+       1.011      16     16      0      0  github.com/kalbasit/ncps/pkg/s3
+--------------------------------------------------------------------------------
+      80.086  TOTAL (sum of per-package elapsed)
+
+================================================================================
+SLOW TESTS (elapsed > 0.500s, parent + subtests)
+================================================================================
+ elapsed (s)  package / test
+--------------------------------------------------------------------------------
+       9.300  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL
+       8.670  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/MySQL
+       8.640  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite
+       8.540  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/PostgreSQL#01
+       5.220  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/RepairCorruptChunk
+       5.210  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/SizeMismatchDoesNotUpdateVerifiedAt
+       5.130  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/RepairOrphanedChunkInStorage
+       5.120  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/SizeMismatchRepair
+       5.110  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/CleanChunksPassContentVerification
+       5.110  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/ChunkedNarFilesNotFlaggedAsMissingWithoutCDCConfig
+       5.110  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/RepairIncompleteNar
+       5.090  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/CorruptChunkDetected
+       5.080  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/RepairHashMismatch
+       5.080  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/Clean
+       5.080  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/SizeMismatchDetected
+       5.080  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/NarFileChunkCountMismatch
+       5.070  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/HashMismatchDetected
+       5.040  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/PostgreSQL/PutNarInfoConcurrentSharedNar
+       5.040  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/CorrectSizeNotFlagged
+       5.020  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/ChunkMissingFromStorage
+       5.020  github.com/kalbasit/ncps/pkg/storage/s3  TestNew_BucketAccessError
+       5.010  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/VerifyContentSkipsWhenFlagAbsent
+       5.010  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/OrphanedChunkInStorage
+       4.980  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/Clean
+       4.970  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/CDC/SizeMismatchRespectsVerifiedSince
+       4.510  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/SQLite/LockFailover
+       4.510  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/MySQL/LockFailover
+       4.510  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/PostgreSQL/LockFailover
+       4.140  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/MySQL#01
+       4.040  github.com/kalbasit/ncps/pkg/cache  TestCacheBackends/SQLite#01
+       3.780  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/MySQL/LargeNARConcurrentDownload/CDC_Enabled
+       3.470  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/SQLite/LargeNARConcurrentDownload/CDC_Enabled
+       3.330  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/PostgreSQL/LargeNARConcurrentDownload/CDC_Enabled
+       3.190  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/PostgreSQL/Success
+       3.100  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/PostgreSQL/Deduplication
+       3.090  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/VerifiedSince
+       3.060  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/PostgreSQL/MultipleNARs
+       3.050  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/OrphanedNarInStorage
+       3.010  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/PostgreSQL/DryRun
+       2.960  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/PostgreSQL/Idempotency
+       2.950  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarToChunksBackends/PostgreSQL/UnmigratedNarInfoFailure
+       2.940  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/NarFileMissingInStorageCascadeRepair
+       2.860  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/NarFileMissingInStorage
+       2.850  github.com/kalbasit/ncps/pkg/ncps  TestMigrateNarInfoBackends/PostgreSQL/Success
+       2.550  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/PostgreSQL/LargeNARConcurrentDownload/CDC_Disabled
+       2.550  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/OrphanedNarFilesInDB
+       2.490  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/MySQL/LargeNARConcurrentDownload/CDC_Disabled
+       2.490  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/DryRun
+       2.470  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/Repair
+       2.370  github.com/kalbasit/ncps/pkg/ncps  TestFsckBackends/PostgreSQL/NarInfosWithoutNarFiles
+       2.320  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/SQLite/LargeNARConcurrentDownload/CDC_Disabled
+       2.040  github.com/kalbasit/ncps/pkg/chunker  TestCDCChunker_Chunk_ErrorRace
+       2.040  github.com/kalbasit/ncps/pkg/lock/redis  TestLocker_RetryWithBackoff
+       2.020  github.com/kalbasit/ncps/pkg/lock/redis  TestLocker_LockExpiry
+       1.920  github.com/kalbasit/ncps/cmd/generate-migrations  TestSQLOnlyEmitsThreeDialects
+       1.900  github.com/kalbasit/ncps/cmd/generate-migrations  TestNameValidation
+       1.840  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/MySQL/PutNarInfoConcurrentSharedNar
+       1.740  github.com/kalbasit/ncps/pkg/lock/redis  TestLocker_DegradedModeDisabled
+       1.730  github.com/kalbasit/ncps/pkg/lock/redis  TestLocker_DegradedMode
+       1.090  github.com/kalbasit/ncps/pkg/cache  TestGetNarInfoDistributedCoordination
+       1.030  github.com/kalbasit/ncps/pkg/cache  TestCDCBackends/PostgreSQL/first_pull_completes_before_CDC_chunking_finishes
+       1.000  github.com/kalbasit/ncps/pkg/lock/redis  TestNewLocker_ReturnType
+       0.970  github.com/kalbasit/ncps/pkg/cache  TestCDCBackends/SQLite/first_pull_completes_before_CDC_chunking_finishes
+       0.970  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/SQLite/PutNarInfoConcurrentSharedNar
+       0.940  github.com/kalbasit/ncps/pkg/cache  TestCDCBackends/MySQL/first_pull_completes_before_CDC_chunking_finishes
+       0.610  github.com/kalbasit/ncps/pkg/cache  TestIssue990_BackgroundJobContextCancellation
+       0.600  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/PostgreSQL/ConcurrentReads
+       0.560  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/SQLite/ConcurrentReads
+       0.550  github.com/kalbasit/ncps/pkg/cache  TestDistributedBackends/MySQL/ConcurrentReads
+       0.520  github.com/kalbasit/ncps/pkg/lock/redis  TestRWLocker_WriterBlocksReaders
+       0.510  github.com/kalbasit/ncps/pkg/cache/upstream  TestGetNarInfo/response_header_timeout_fires_when_server_stalls_before_first_byte

--- a/openspec/changes/archive/2026-05-23-less-tests/proposal.md
+++ b/openspec/changes/archive/2026-05-23-less-tests/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+`nix flake check` takes too long to be useful as a tight feedback loop. The bulk of that time is spent in `go test -race ./...`, with `pkg/cache` suspected to be the worst offender. Years of accumulated tests have produced redundant assertions (multiple tests covering the same code path with the same expectations) and duplicated expensive setup (per-test fresh databases, S3 buckets, chunk stores, and zstd pools) that could be amortized across subtests. The net effect: long CI wall time, slow local validation, and discouragement from running the full suite before pushing.
+
+## What Changes
+
+- **Profile first**: Run the full suite with `-json` timing across all packages (unit + integration with deps running) and produce a ranked list of slow tests and slow packages. No code changes before measurement.
+- **Dedupe**: Identify tests that assert the same behavior on the same code path and remove the redundant copies, keeping the test with the best coverage (most edge cases, clearest name, parallel-safe).
+- **Consolidate**: Fold scattered single-case tests covering the same function into table-driven tests where doing so does not lose assertions.
+- **Share expensive setup**: Within a single `Test*` function, hoist DB/storage/CDC/zstd fixtures out of subtests where the subtests do not mutate shared state. Keep `t.Parallel()` correctness intact (use per-subtest sub-keys, isolated rows, etc.).
+- **Restructure slow integration tests**: Where an integration test covers both wiring AND business logic, split: keep a thin wiring smoke test against the real backend, move business-logic assertions to unit tests with fakes/mocks of the storage interfaces.
+- **Coverage parity gate**: Before any removal, capture `go test -coverprofile` for affected packages. After changes, line coverage MUST NOT decrease for the touched packages. Branch coverage MUST NOT decrease by more than 1 percentage point per package.
+- **Scope**: All packages with measured slow tests. Integration tests (S3/Postgres/MySQL/Redis) are in scope.
+
+## Capabilities
+
+### New Capabilities
+
+- `test-suite-efficiency`: Codifies rules for the Go test suite — no two tests SHALL assert the same behavior on the same code path; expensive fixtures SHALL be shared across subtests when safe; coverage SHALL NOT regress when tests are removed; the suite SHALL have a documented profiling workflow to find slow tests.
+
+### Modified Capabilities
+
+- `short-test-mode`: After dedup/restructure, the set of tests gated by `testing.Short()` may shift. This change updates the spec to describe how the gated set is re-derived from a fresh profile after the cleanup.
+
+## Impact
+
+- **Code**: `pkg/cache/*_test.go` (primary target), plus any other packages flagged by profiling — likely `pkg/server`, `pkg/storage/{local,s3}`, `pkg/database/*`, `pkg/ncps`.
+- **CI**: Lower wall time for `nix flake check`; same coverage signal.
+- **Risk**: A truly-unique assertion deleted by mistake could mask a regression. Mitigated by the coverage parity gate and by requiring a written justification per removed test in `tasks.md`.
+
+## Non-goals
+
+- Adding new test coverage. This is a reduction/restructuring effort only.
+- Changing production code under test. If a test fails for a real reason during the work, that fix is out of scope and tracked separately.
+- Changing the test runner, race-detector usage, or `nix flake check` structure.
+- Removing integration tests in favor of mocks wholesale. Wiring smoke tests against real backends stay.

--- a/openspec/changes/archive/2026-05-23-less-tests/specs/short-test-mode/spec.md
+++ b/openspec/changes/archive/2026-05-23-less-tests/specs/short-test-mode/spec.md
@@ -1,25 +1,11 @@
-# short-test-mode Specification
-
-## Purpose
-
-This feature enables fast local development by allowing developers to skip slow tests during iterative development. When running `go test -short`, tests that take longer than 500ms are automatically skipped, enabling faster feedback loops without needing to modify test files or remember which tests to exclude.
-## Requirements
-### Requirement: -short flag skips slow tests
-When `go test -short -race ./...` is run, tests SHALL check `testing.Short()` and skip slow subtests regardless of whether they are integration tests or unit tests.
-
-#### Scenario: Running short tests
-- **WHEN** user runs `go test -short -race ./...`
-- **THEN** slow tests (>500ms) are skipped via `testing.Short()`
-
-#### Scenario: Running without -short (full tests)
-- **WHEN** user runs `go test -race ./...`
-- **THEN** all tests execute including slow tests
+## MODIFIED Requirements
 
 ### Requirement: Identify slow tests via profiling before gating
 
 Before adding or removing `-short` guards, the implementation SHALL profile test execution times against the *current* test suite to identify which tests are slow. The gated set MUST be re-derived after any large-scale restructuring of the suite (such as a `less-tests`-style cleanup), because tests that were once slow may have been removed, consolidated, or had their fixtures hoisted.
 
 #### Scenario: Profiling test execution
+
 - **WHEN** running full test suite with timing
 - **THEN** identify tests that take >500ms to complete
 - **AND** these tests are candidates for `testing.Short()` gating
@@ -36,4 +22,3 @@ Before adding or removing `-short` guards, the implementation SHALL profile test
 - **WHEN** post-restructuring profiling shows a previously-gated test now runs in under 500ms
 - **THEN** the `testing.Short()` guard MAY be removed from that test
 - **AND** the change's `tasks.md` records the removal
-

--- a/openspec/changes/archive/2026-05-23-less-tests/specs/test-suite-efficiency/spec.md
+++ b/openspec/changes/archive/2026-05-23-less-tests/specs/test-suite-efficiency/spec.md
@@ -1,0 +1,117 @@
+## ADDED Requirements
+
+### Requirement: Profiling workflow for slow tests
+
+The project SHALL provide a reproducible workflow that ranks Go test execution time by package and by individual test, runnable both locally (within the Nix dev shell) and inside `nix flake check`. The workflow MUST capture timings for the full suite including integration tests when integration env vars are set.
+
+#### Scenario: Profiling the full suite locally
+
+- **WHEN** a developer has integration env vars enabled (`eval "$(enable-integration-tests)"`) and runs the profiling workflow
+- **THEN** the workflow produces a ranked list of packages by total wall time
+- **AND** produces a ranked list of individual tests (parent and subtests) with `Elapsed > 500ms`
+- **AND** writes the ranking to a deterministic output file under `dev-scripts/` or `openspec/changes/<change>/`
+
+#### Scenario: Profiling without integration env vars
+
+- **WHEN** a developer runs the profiling workflow without integration env vars set
+- **THEN** the workflow still runs the unit-test portion of the suite and produces the same ranked outputs
+- **AND** integration tests show as skipped, not as failures
+
+### Requirement: No two tests assert the same behavior on the same code path
+
+The Go test suite MUST NOT contain two tests (or subtests) where the second test exercises a code-path coverage strict-subset of another test AND asserts a strict subset of that test's properties. Such a pair indicates redundancy and one MUST be removed.
+
+#### Scenario: Reviewer evaluates a candidate test for removal
+
+- **WHEN** a reviewer considers removing a test
+- **THEN** the reviewer MUST verify all four conditions hold for the test
+  - its per-test coverage profile is a subset of another surviving test's profile
+  - every property it asserts is asserted by a surviving test with equal or stronger specificity
+  - it exercises no unique input boundary (empty input, max-size input, unicode, concurrent access, backend-specific quirk)
+  - it exercises no unique goroutine interleaving that no surviving test exercises
+- **AND** if any of the four fails, the test MUST be kept
+
+#### Scenario: Adding a new test that duplicates an existing one
+
+- **WHEN** a new test is proposed for the suite
+- **AND** an existing test already asserts the same behavior on the same code path
+- **THEN** the new test SHALL NOT be added; the existing test is extended instead
+
+### Requirement: Coverage parity gate
+
+When tests are removed or restructured, line coverage per affected package MUST NOT decrease from the pre-change baseline. Branch coverage per affected package MUST NOT decrease by more than 1 percentage point. The check MUST be applied per batch of changes, not only at the end.
+
+#### Scenario: Removing a test passes the coverage gate
+
+- **WHEN** a batch of test removals is proposed for package `pkg/X`
+- **AND** `go test -coverpkg=./... -coverprofile=cover-after.out -race ./pkg/X/...` is run on the post-change tree
+- **THEN** line coverage of `cover-after.out` is greater than or equal to line coverage of the pre-change `cover-before.out`
+- **AND** branch coverage of `cover-after.out` is greater than or equal to `cover-before.out` minus 1 percentage point
+
+#### Scenario: A batch fails the coverage gate
+
+- **WHEN** a batch of test removals causes line coverage to drop or branch coverage to drop by more than 1 percentage point for any affected package
+- **THEN** the batch MUST be reverted in full
+- **AND** the offending removal MUST be re-evaluated against the four-gate rule before any further attempt
+
+### Requirement: Shared fixtures within a TestXxx function
+
+Within a single Go `TestXxx` function, expensive setup that is not mutated by subtests SHALL be hoisted out of the subtests and constructed once in the parent test. Per-subtest unique identifiers (keys, paths, table names) MUST be derived from `t.Name()` or a counter so that subtests using `t.Parallel()` do not collide.
+
+#### Scenario: Hoisting setup out of subtests
+
+- **WHEN** a `TestXxx` function has multiple subtests that each construct an identical fixture (e.g., open a SQLite connection, run migrations, create a MinIO bucket)
+- **AND** no subtest mutates the fixture in a way that would affect other subtests
+- **THEN** the fixture SHALL be constructed once in the parent test
+- **AND** each subtest MUST receive the fixture as a parameter or via a closure
+
+#### Scenario: Parallel subtests share a database
+
+- **WHEN** subtests share a single database connection hoisted by the parent test
+- **AND** subtests call `t.Parallel()`
+- **THEN** each subtest MUST use a per-subtest keyspace (unique rows, unique table prefixes, or unique transaction scopes) so parallel subtests cannot observe each other's writes
+
+### Requirement: Package-level shared fixtures are read-only
+
+Package-level shared state (set up in `TestMain` or `init`) SHALL be limited to read-only data such as pre-parsed NAR fixtures, pre-computed test vectors, or constants. Mutable shared state (open DB connections, open S3 sessions, open Redis connections) MUST NOT be hoisted to package level.
+
+#### Scenario: Read-only fixture at package level
+
+- **WHEN** a NAR file or fixture byte buffer is needed by multiple `TestXxx` functions in a package
+- **THEN** it MAY be parsed once at package level and read by all tests
+- **AND** no test mutates the shared buffer
+
+#### Scenario: Forbidden mutable package-level state
+
+- **WHEN** a developer proposes a package-level `*sql.DB`, S3 client session, or Redis client shared across `TestXxx` functions
+- **THEN** the proposal MUST be rejected unless an existing helper already provides this with documented thread-safety guarantees
+- **AND** the default SHALL be a per-test or per-`TestXxx` connection
+
+### Requirement: Integration test split — wiring smoke vs business logic
+
+For each external backend exercised by integration tests (Postgres, MySQL, S3/MinIO, Redis), the suite SHALL contain at least one wiring smoke test that connects to the real backend and performs a minimal roundtrip. Business-logic assertions (error branches, retries, edge cases) MAY be tested against in-memory fakes implementing the storage/database interfaces, provided a fake already exists or is trivial to write.
+
+#### Scenario: Backend wiring smoke test exists
+
+- **WHEN** the suite finishes running with all integration env vars enabled
+- **THEN** for each of Postgres, MySQL, S3/MinIO, and Redis there is at least one test that connected to the real backend and exercised a connect → write → read → close cycle
+
+#### Scenario: Backend-specific behavior stays as integration test
+
+- **WHEN** a test asserts behavior that depends on backend-specific semantics (e.g., Postgres upsert with `ON CONFLICT`, S3 multipart upload, MySQL collation)
+- **THEN** the test MUST remain an integration test against the real backend
+- **AND** MUST NOT be moved to a fake
+
+### Requirement: Per-removal justification in change tasks
+
+Every test removed by a `less-tests`-style cleanup MUST have a written one-line justification in the change's `tasks.md` naming the surviving test that subsumes it. This requirement applies whenever the test suite is being reduced; it does not apply to ordinary refactors that incidentally move a test.
+
+#### Scenario: Test removed with justification
+
+- **WHEN** a test is deleted under a test-suite-efficiency change
+- **THEN** `tasks.md` contains a line referencing the deleted test's name and the surviving test that covers its assertions
+
+#### Scenario: Test removed without justification
+
+- **WHEN** a deletion appears in the change's diff without a corresponding line in `tasks.md`
+- **THEN** the change MUST NOT be marked complete until the justification is added

--- a/openspec/changes/archive/2026-05-23-less-tests/tasks.md
+++ b/openspec/changes/archive/2026-05-23-less-tests/tasks.md
@@ -1,0 +1,77 @@
+## 1. Profiling tooling and baseline
+
+- [x] 1.1 Write `dev-scripts/profile-tests.py` that runs `go test -json -race -count=1 ./...` and emits two ranked tables: per-package wall time and per-test wall time (parent + subtests, `Elapsed > 500ms`). *(Implemented as Python to match existing `dev-scripts/` conventions. Supports `--packages`, `--threshold`, `--out`, `--from-file`, `--no-race`.)*
+- [x] 1.2 Verify `profile-tests.py` works inside the Nix dev shell (smoke-tested on `./pkg/chunker/...` — 5 tests, 1.466s total, correctly ranked subtests). `nix flake check` integration deferred to task 8.1 end-to-end run.
+- [x] 1.3 Run `profile-tests.py` against current branch tip with no test changes and save output to `openspec/changes/less-tests/baseline-timings.txt`. *(Unit-test-only baseline captured. Integration env vars not set — Postgres/MySQL/Redis tests show as skipped. Total wall time: **88.13s**.)*
+
+  **Top-5 packages by wall time:**
+  | rank | package | s | notes |
+  |--:|---|--:|---|
+  | 1 | `pkg/cache` | 16.5 | 226 tests, the suspected hotspot — but no single dominant slow test |
+  | 2 | `pkg/cache/upstream` | 13.6 | **6 tests genuinely wait 5–12s on real timeouts** — biggest single-package win available |
+  | 3 | `pkg/storage/s3` | 12.2 | **12+ ErrorPath tests at 3–5s each** — likely retry-with-backoff; investigate |
+  | 4 | `pkg/lock/redis` | 7.8 | 13/15 skipped (no Redis); `TestNewLocker_ReturnType` is 6.8s — investigate |
+  | 5 | `cmd/generate-migrations` | 5.1 | Two tests >4s each — likely shell out to `go run`/migration tooling |
+
+  **Course correction vs. the original proposal:** `pkg/cache` is the #1 package but its 16.5s is spread across hundreds of tests. The two `TestCacheBackends` functions in `cache_test.go` (line 2786) and `cache_internal_test.go` (line 1528) are **not duplicates** — they share the parameterization shell (`for SQLite/PostgreSQL/MySQL`) but run **disjoint** sub-suites: cache_test.go covers external API (New, PutNarInfo, GetNar, etc.), cache_internal_test.go covers internals (RunLRU, MigrationDataIntegrity, WithReadLock, etc.). Keep both. The real wins are in `pkg/cache/upstream` and `pkg/storage/s3`.
+- [ ] 1.4 Capture pre-change coverage baselines for the top-3 packages targeted by this change (`pkg/cache/upstream`, `pkg/storage/s3`, `pkg/cache`). Skip lower-ranked packages until they become in-scope.
+- [ ] 1.5 Confirm baseline reproduces within 5% across two consecutive runs on the same machine; if not, document the noise floor in `baseline-timings.txt`.
+
+## 2. pkg/cache: shared-fixture restructuring (reversible work first)
+
+- [ ] 2.1 Inventory `pkg/cache/*_test.go`: list each `TestXxx`, its subtests, the fixtures it constructs (DB, storage, CDC chunk store, zstd encoders, NAR payloads), and whether subtests mutate them.
+- [ ] 2.2 For each `TestXxx` where subtests construct identical immutable fixtures, hoist construction to the parent test. Derive per-subtest unique keys from `t.Name()` or a counter so `t.Parallel()` subtests don't collide.
+- [ ] 2.3 Run `go test -race ./pkg/cache/...` after each hoist; if a race appears, revert that hoist and document why in this task.
+- [ ] 2.4 Run coverage parity check for `pkg/cache` per spec `test-suite-efficiency#Coverage parity gate`. If fail, revert.
+- [ ] 2.5 Re-profile `pkg/cache`; record wall-time delta in this task.
+
+## 3. pkg/cache: table-driven consolidation
+
+- [ ] 3.1 Identify clusters of single-case `TestXxx` functions that exercise the same function with different inputs (e.g., variants of `TestGetNarInfo_*`, `TestPutNarInfo_*`).
+- [ ] 3.2 For each cluster, draft a single table-driven test with subtests, preserving every assertion from every input case. Do NOT delete the originals yet.
+- [ ] 3.3 Run both old and new tests together; verify the new table-driven test fails on the same inputs as any deliberately-broken sanity probe.
+- [ ] 3.4 Delete the original single-case tests. For each deletion, add a one-line justification to this task listing: deleted test name → surviving table-driven test name → case index.
+- [ ] 3.5 Run coverage parity check for `pkg/cache`. If fail, revert.
+
+## 4. pkg/cache: redundant test removal (four-gate rule)
+
+- [ ] 4.1 For each remaining `TestXxx` in `pkg/cache`, capture per-test coverage profile via `go test -run '^TestXxx$' -coverprofile=...`.
+- [ ] 4.2 Build a per-test coverage map; identify tests whose covered lines are a strict subset of another surviving test.
+- [ ] 4.3 For each subset candidate, manually verify against the four-gate rule (spec `test-suite-efficiency#No two tests assert the same behavior on the same code path`): same path, same/weaker assertions, no unique fixture shape, no unique race exposure.
+- [ ] 4.4 Delete tests that pass all four gates. Add a one-line justification per deletion to this task.
+- [ ] 4.5 Run coverage parity check for `pkg/cache`. If fail, revert.
+- [ ] 4.6 Re-profile `pkg/cache`; record total wall-time delta vs baseline in this task.
+
+## 5. Apply the same loop to other slow packages
+
+- [ ] 5.1 From the baseline ranking, pick the next slowest package (likely one of: `pkg/server`, `pkg/storage/local`, `pkg/storage/s3`, `pkg/database/*`, `pkg/ncps`). Repeat sections 2–4 scoped to that package.
+- [ ] 5.2 Continue down the ranking until either (a) cumulative wall-time reduction reaches the ≥30% target or (b) remaining packages have no candidate removals after the four-gate rule.
+- [ ] 5.3 Record per-package wall-time delta and removal count in this task.
+
+## 6. Integration test split (per backend)
+
+- [ ] 6.1 For Postgres integration tests: identify the wiring smoke test (connect → write → read → close). Confirm exactly one exists; if multiple, fold extras into table-driven subtests of the canonical one.
+- [ ] 6.2 For Postgres integration tests asserting business logic against the real backend: identify those whose assertions could run against an in-memory fake. Move them. Backend-specific semantics (e.g., `ON CONFLICT`) stay as integration tests.
+- [ ] 6.3 Repeat 6.1–6.2 for MySQL.
+- [ ] 6.4 Repeat 6.1–6.2 for S3/MinIO. Backend-specific behavior (multipart, presigned URL semantics) stays as integration tests.
+- [ ] 6.5 Repeat 6.1–6.2 for Redis. Distributed-locking semantics under contention stays as integration tests.
+- [ ] 6.6 Run `nix flake check` end-to-end and verify all four backend wiring smoke tests still pass.
+- [ ] 6.7 Run coverage parity check for each touched package. If any fail, revert that backend's batch.
+
+## 7. Re-derive the -short gated set
+
+- [ ] 7.1 Re-run `profile-tests.sh` on the post-change tree. Save as `openspec/changes/less-tests/post-change-timings.txt`.
+- [ ] 7.2 For each test newly above 500ms, add a `if testing.Short() { t.Skip(...) }` guard at the top.
+- [ ] 7.3 For each currently-guarded test now below 500ms, remove the guard. Record each removal in this task with old/new timings.
+- [ ] 7.4 Verify `go test -short -race ./...` completes in noticeably less time than `go test -race ./...` on the same machine; record both numbers in this task.
+
+## 8. Verification and archive
+
+- [ ] 8.1 Run `nix flake check` end-to-end. Capture total wall time. Compare against baseline. Record delta in this task.
+- [ ] 8.2 Run `golangci-lint run --fix ./...`. Resolve any remaining lint issues by hand (especially `paralleltest`, `testpackage`, `testifylint`).
+- [ ] 8.3 Run `nix fmt`.
+- [ ] 8.4 Verify every test deletion in the diff has a corresponding one-line justification line in this `tasks.md` (spec `test-suite-efficiency#Per-removal justification in change tasks`).
+- [ ] 8.5 Update `openspec/specs/short-test-mode/spec.md` with the synced delta (this is `/opsx:sync` work — done at archive time, not before).
+- [ ] 8.6 Decide whether `dev-scripts/profile-tests.sh` stays as a project tool (recommended by design D6) or is removed. Land that decision in this task.
+- [ ] 8.7 Run `/opsx:verify` and resolve any issues.
+- [ ] 8.8 Run `/opsx:archive`.

--- a/openspec/specs/test-suite-efficiency/spec.md
+++ b/openspec/specs/test-suite-efficiency/spec.md
@@ -1,0 +1,123 @@
+# test-suite-efficiency Specification
+
+## Purpose
+
+This capability codifies the project's rules for keeping the Go test suite fast and free of redundant coverage. It targets the wall-time cost of `go test -race ./...` (and the broader `nix flake check` Go-test phase) by mandating a profiling workflow, a four-gate rule for removing duplicate tests, a per-batch coverage parity gate, fixture-sharing discipline, and a wiring-smoke vs. business-logic split for integration tests. Together these rules let the suite grow without each new test adding linearly to the local-iteration feedback loop.
+
+## Requirements
+
+### Requirement: Profiling workflow for slow tests
+
+The project SHALL provide a reproducible workflow that ranks Go test execution time by package and by individual test, runnable both locally (within the Nix dev shell) and inside `nix flake check`. The workflow MUST capture timings for the full suite including integration tests when integration env vars are set.
+
+#### Scenario: Profiling the full suite locally
+
+- **WHEN** a developer has integration env vars enabled (`eval "$(enable-integration-tests)"`) and runs the profiling workflow
+- **THEN** the workflow produces a ranked list of packages by total wall time
+- **AND** produces a ranked list of individual tests (parent and subtests) with `Elapsed > 500ms`
+- **AND** writes the ranking to a deterministic output file under `dev-scripts/` or `openspec/changes/<change>/`
+
+#### Scenario: Profiling without integration env vars
+
+- **WHEN** a developer runs the profiling workflow without integration env vars set
+- **THEN** the workflow still runs the unit-test portion of the suite and produces the same ranked outputs
+- **AND** integration tests show as skipped, not as failures
+
+### Requirement: No two tests assert the same behavior on the same code path
+
+The Go test suite MUST NOT contain two tests (or subtests) where the second test exercises a code-path coverage strict-subset of another test AND asserts a strict subset of that test's properties. Such a pair indicates redundancy and one MUST be removed.
+
+#### Scenario: Reviewer evaluates a candidate test for removal
+
+- **WHEN** a reviewer considers removing a test
+- **THEN** the reviewer MUST verify all four conditions hold for the test
+  - its per-test coverage profile is a subset of another surviving test's profile
+  - every property it asserts is asserted by a surviving test with equal or stronger specificity
+  - it exercises no unique input boundary (empty input, max-size input, unicode, concurrent access, backend-specific quirk)
+  - it exercises no unique goroutine interleaving that no surviving test exercises
+- **AND** if any of the four fails, the test MUST be kept
+
+#### Scenario: Adding a new test that duplicates an existing one
+
+- **WHEN** a new test is proposed for the suite
+- **AND** an existing test already asserts the same behavior on the same code path
+- **THEN** the new test SHALL NOT be added; the existing test is extended instead
+
+### Requirement: Coverage parity gate
+
+When tests are removed or restructured, line coverage per affected package MUST NOT decrease from the pre-change baseline. Branch coverage per affected package MUST NOT decrease by more than 1 percentage point. The check MUST be applied per batch of changes, not only at the end.
+
+#### Scenario: Removing a test passes the coverage gate
+
+- **WHEN** a batch of test removals is proposed for package `pkg/X`
+- **AND** `go test -coverpkg=./... -coverprofile=cover-after.out -race ./pkg/X/...` is run on the post-change tree
+- **THEN** line coverage of `cover-after.out` is greater than or equal to line coverage of the pre-change `cover-before.out`
+- **AND** branch coverage of `cover-after.out` is greater than or equal to `cover-before.out` minus 1 percentage point
+
+#### Scenario: A batch fails the coverage gate
+
+- **WHEN** a batch of test removals causes line coverage to drop or branch coverage to drop by more than 1 percentage point for any affected package
+- **THEN** the batch MUST be reverted in full
+- **AND** the offending removal MUST be re-evaluated against the four-gate rule before any further attempt
+
+### Requirement: Shared fixtures within a TestXxx function
+
+Within a single Go `TestXxx` function, expensive setup that is not mutated by subtests SHALL be hoisted out of the subtests and constructed once in the parent test. Per-subtest unique identifiers (keys, paths, table names) MUST be derived from `t.Name()` or a counter so that subtests using `t.Parallel()` do not collide.
+
+#### Scenario: Hoisting setup out of subtests
+
+- **WHEN** a `TestXxx` function has multiple subtests that each construct an identical fixture (e.g., open a SQLite connection, run migrations, create a MinIO bucket)
+- **AND** no subtest mutates the fixture in a way that would affect other subtests
+- **THEN** the fixture SHALL be constructed once in the parent test
+- **AND** each subtest MUST receive the fixture as a parameter or via a closure
+
+#### Scenario: Parallel subtests share a database
+
+- **WHEN** subtests share a single database connection hoisted by the parent test
+- **AND** subtests call `t.Parallel()`
+- **THEN** each subtest MUST use a per-subtest keyspace (unique rows, unique table prefixes, or unique transaction scopes) so parallel subtests cannot observe each other's writes
+
+### Requirement: Package-level shared fixtures are read-only
+
+Package-level shared state (set up in `TestMain` or `init`) SHALL be limited to read-only data such as pre-parsed NAR fixtures, pre-computed test vectors, or constants. Mutable shared state (open DB connections, open S3 sessions, open Redis connections) MUST NOT be hoisted to package level.
+
+#### Scenario: Read-only fixture at package level
+
+- **WHEN** a NAR file or fixture byte buffer is needed by multiple `TestXxx` functions in a package
+- **THEN** it MAY be parsed once at package level and read by all tests
+- **AND** no test mutates the shared buffer
+
+#### Scenario: Forbidden mutable package-level state
+
+- **WHEN** a developer proposes a package-level `*sql.DB`, S3 client session, or Redis client shared across `TestXxx` functions
+- **THEN** the proposal MUST be rejected unless an existing helper already provides this with documented thread-safety guarantees
+- **AND** the default SHALL be a per-test or per-`TestXxx` connection
+
+### Requirement: Integration test split — wiring smoke vs business logic
+
+For each external backend exercised by integration tests (Postgres, MySQL, S3/MinIO, Redis), the suite SHALL contain at least one wiring smoke test that connects to the real backend and performs a minimal roundtrip. Business-logic assertions (error branches, retries, edge cases) MAY be tested against in-memory fakes implementing the storage/database interfaces, provided a fake already exists or is trivial to write.
+
+#### Scenario: Backend wiring smoke test exists
+
+- **WHEN** the suite finishes running with all integration env vars enabled
+- **THEN** for each of Postgres, MySQL, S3/MinIO, and Redis there is at least one test that connected to the real backend and exercised a connect → write → read → close cycle
+
+#### Scenario: Backend-specific behavior stays as integration test
+
+- **WHEN** a test asserts behavior that depends on backend-specific semantics (e.g., Postgres upsert with `ON CONFLICT`, S3 multipart upload, MySQL collation)
+- **THEN** the test MUST remain an integration test against the real backend
+- **AND** MUST NOT be moved to a fake
+
+### Requirement: Per-removal justification in change tasks
+
+Every test removed by a `less-tests`-style cleanup MUST have a written one-line justification in the change's `tasks.md` naming the surviving test that subsumes it. This requirement applies whenever the test suite is being reduced; it does not apply to ordinary refactors that incidentally move a test.
+
+#### Scenario: Test removed with justification
+
+- **WHEN** a test is deleted under a test-suite-efficiency change
+- **THEN** `tasks.md` contains a line referencing the deleted test's name and the surviving test that covers its assertions
+
+#### Scenario: Test removed without justification
+
+- **WHEN** a deletion appears in the change's diff without a corresponding line in `tasks.md`
+- **THEN** the change MUST NOT be marked complete until the justification is added


### PR DESCRIPTION
Adds the archived openspec change directory and updates the
short-test-mode and test-suite-efficiency specs to reflect the
shipped state of the stack.