### PR TITLE
docs: fix awk/jq→Python and Nix sandbox spec

### DIFF
--- a/openspec/changes/archive/2026-05-23-less-tests/design.md
+++ b/openspec/changes/archive/2026-05-23-less-tests/design.md
@@ -36,7 +36,7 @@ Use `go test -json -race -count=1 ./...` (with integration env vars set via `ena
 - Per-test wall time (parent + subtests separately)
 - Tests where `Elapsed > 500ms`
 
-**Why this over `gotestsum`**: We already have everything we need in `-json`. A 30-line `awk`/`jq` pipeline is cheaper than adding a tool dependency and is reproducible across local + CI. The output is stored as `openspec/changes/less-tests/baseline-timings.txt` (not committed past archive) for the duration of the work.
+**Why this over `gotestsum`**: We already have everything we need in `-json`. A small Python script is cheaper than adding a tool dependency and is reproducible across local + CI. The output is stored as `openspec/changes/less-tests/baseline-timings.txt` (not committed past archive) for the duration of the work.
 
 **Alternative considered**: CPU profiling per test with `-cpuprofile`. Rejected for this phase — wall-time ranking is enough to find the offenders; CPU profiles add noise without changing the priority list.
 

--- a/openspec/specs/test-suite-efficiency/spec.md
+++ b/openspec/specs/test-suite-efficiency/spec.md
@@ -15,7 +15,7 @@ The project SHALL provide a reproducible workflow that ranks Go test execution t
 - **WHEN** a developer has integration env vars enabled (`eval "$(enable-integration-tests)"`) and runs the profiling workflow
 - **THEN** the workflow produces a ranked list of packages by total wall time
 - **AND** produces a ranked list of individual tests (parent and subtests) with `Elapsed > 500ms`
-- **AND** writes the ranking to a deterministic output file under `dev-scripts/` or `openspec/changes/<change>/`
+- **AND** when run locally, writes the ranking to a deterministic output file under `dev-scripts/` or `openspec/changes/<change>/`
 
 #### Scenario: Profiling without integration env vars
 


### PR DESCRIPTION
Address two review comments from PR #1245:

- design.md: The profiling tool was implemented as Python
  (dev-scripts/profile-tests.py), not an awk/jq pipeline.
  Update the D1 rationale to reflect the actual implementation.

- spec.md: The "writes the ranking to a file" step contradicts
  running inside nix flake check, where the source tree is
  read-only (Nix sandbox). Qualify the requirement as local
  execution only so the spec no longer contradicts itself.