### PR TITLE
fix: address unresolved review comments from merged PRs #1179-#1246

### DIFF
--- a/.agent/skills/migrate-down/SKILL.md
+++ b/.agent/skills/migrate-down/SKILL.md
@@ -23,7 +23,9 @@ new binaries can coexist against the same schema.
 1. **Backfill** the new column in migration N+1 (use `--sql-only` —
    `go run ./cmd/generate-migrations --sql-only --name=backfill_x`).
 1. **Switch reads** to the new column in the application code; deploy.
-1. **Drop** the old column in migration N+2.
+1. **Remove** the old column in migration N+2. `DROP COLUMN` is flagged
+   as sensitive DDL by the migration spec and is only permissible at
+   this final step, once no deployed binary references the old column.
 
 Each migration ships in its own release; the application gracefully
 handles the dual-column state in between.
@@ -34,7 +36,9 @@ The specific case of adding a NOT NULL constraint to an existing
 nullable column:
 
 1. **Migration A**: ADD COLUMN nullable, default-able.
-1. **Migration B** (`--sql-only` stub): BACKFILL existing rows.
+1. **Deploy** application code that always writes a non-null value for
+   the new column (so all rows written after this deploy have a value).
+1. **Migration B** (`--sql-only` stub): BACKFILL existing null rows.
 1. **Migration C**: ADD CONSTRAINT NOT NULL (or
    `ALTER COLUMN ... SET NOT NULL`).
 1. **Deploy each step independently**; never combine into a single

--- a/.agent/skills/migrate-new/SKILL.md
+++ b/.agent/skills/migrate-new/SKILL.md
@@ -90,8 +90,9 @@ backfills and the four-step NOT NULL recipe.
 
 - `task ent:check` (or `go generate ./ent/... && git diff --exit-code ./ent/`)
   confirms the Ent client is up to date.
-- `go run ./cmd/ent-lint --root .` checks every schema against the five
-  codegen invariants.
+- `go run ./cmd/ent-lint --root .` checks schemas against the
+  implemented invariants (A1, A2, A4); A3 and A5 are enforced by code
+  review until wired into the linter.
 - `go run ./cmd/atlas-sum-check --root .` confirms every `atlas.sum`
   matches the directory contents.
 - `go test -race -run TestSchemaEquivalence ./migrations/...` runs the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
       ent: ${{ steps.filter.outputs.ent }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
@@ -92,6 +94,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: cachix/install-nix-action@b97f05dcb019ddea06450a50ef6203d2fdc19fee # v31
       - uses: cachix/cachix-action@02b16339eddcf6ea27126a830c7f1992855cae13 # v17
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,9 @@ on:
   pull_request:
     branches:
       - main
-      - "release-*"
   push:
     branches:
       - main
-      - "release-*"
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.run_id }}
@@ -57,6 +55,8 @@ jobs:
             ent:
               - "ent/schema/**"
               - "ent/generate.go"
+              - "go.mod"
+              - "go.sum"
             docs:
               - "docs/**"
   generate-database:
@@ -80,7 +80,7 @@ jobs:
         run: nix develop --command go generate ./ent/...
       - name: Format Code
         run: nix fmt
-      - uses: stefanzweifel/git-auto-commit-action@v7
+      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: "Auto Regenerate Ent Code"
   deploy-docs-pages:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,8 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       ent: ${{ steps.filter.outputs.ent }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
           filters: |
@@ -66,13 +66,13 @@ jobs:
     if: (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)) && needs.filter.outputs.ent == 'true'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ secrets.GHA_PAT_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
-      - uses: cachix/install-nix-action@v31
-      - uses: cachix/cachix-action@v17
+      - uses: cachix/install-nix-action@b97f05dcb019ddea06450a50ef6203d2fdc19fee # v31
+      - uses: cachix/cachix-action@02b16339eddcf6ea27126a830c7f1992855cae13 # v17
         with:
           name: ncps
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -91,9 +91,9 @@ jobs:
     if: (github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)) && needs.filter.outputs.docs == 'true'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@v31
-      - uses: cachix/cachix-action@v17
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: cachix/install-nix-action@b97f05dcb019ddea06450a50ef6203d2fdc19fee # v31
+      - uses: cachix/cachix-action@02b16339eddcf6ea27126a830c7f1992855cae13 # v17
         with:
           name: ncps
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -101,14 +101,14 @@ jobs:
         run: nix develop --command bash -c trilium-build-docs
       - name: Deploy docs
         id: deploy-docs-pages
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
         with:
           apiToken: ${{ secrets.CF_NCPS_DEV_EDIT_WORKERS_TOKEN }}
           accountId: ${{ secrets.CF_NCPS_DEV_ACCOUNT_ID }}
           command: pages deploy public/docs --project-name=ncps-docs --commit-dirty=true
       - name: Post Pages Deployment URL on the Pull Request
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -29,9 +29,9 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Release with Notes
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           generate_release_notes: true
           draft: true

--- a/cmd/generate-migrations/main.go
+++ b/cmd/generate-migrations/main.go
@@ -98,6 +98,8 @@ func main() {
 		log.Fatalf("generate-migrations: invalid --skip: %v", err)
 	}
 
+	var generatedStamps []string
+
 	for _, d := range []dialectSpec{
 		{name: "sqlite", goDialect: dialect.SQLite, driver: "sqlite3", openDSN: "file::memory:?_fk=1&cache=shared"},
 		{name: "postgres", goDialect: dialect.Postgres, driver: "pgx", openDSN: pgURL},
@@ -109,8 +111,24 @@ func main() {
 			continue
 		}
 
-		if err := runDialect(ctx, *root, d, fname, *name, *sqlOnly); err != nil {
+		generated, err := runDialect(ctx, *root, d, fname, *name, *sqlOnly)
+		if err != nil {
 			log.Fatalf("generate-migrations: %s: %v", d.name, err)
+		}
+
+		// Collect the 14-char timestamp prefix for consistency check.
+		if base := filepath.Base(generated); len(base) >= 14 {
+			generatedStamps = append(generatedStamps, base[:14])
+		}
+	}
+
+	// Warn when a second boundary fell between dialect runs; callers can
+	// re-run to produce a consistent set.
+	for i := 1; i < len(generatedStamps); i++ {
+		if generatedStamps[i] != generatedStamps[0] {
+			log.Printf("generate-migrations: WARNING: timestamp prefix %q for dialect %d "+
+				"differs from %q; re-run if a shared prefix is required",
+				generatedStamps[i], i+1, generatedStamps[0])
 		}
 	}
 }
@@ -144,10 +162,10 @@ type dialectSpec struct {
 	openDSN   string
 }
 
-func runDialect(ctx context.Context, root string, d dialectSpec, fname, migName string, sqlOnly bool) error {
+func runDialect(ctx context.Context, root string, d dialectSpec, fname, migName string, sqlOnly bool) (string, error) {
 	dir := filepath.Join(root, "migrations", d.name)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return fmt.Errorf("mkdir %s: %w", dir, err)
+		return "", fmt.Errorf("mkdir %s: %w", dir, err)
 	}
 
 	if sqlOnly {
@@ -155,36 +173,36 @@ func runDialect(ctx context.Context, root string, d dialectSpec, fname, migName 
 		stub := "-- +goose Up\n\n-- +goose Down\n"
 
 		if err := os.WriteFile(path, []byte(stub), 0o600); err != nil {
-			return fmt.Errorf("write stub: %w", err)
+			return "", fmt.Errorf("write stub: %w", err)
 		}
 
 		gdir, err := sqltool.NewGooseDir(dir)
 		if err != nil {
-			return fmt.Errorf("NewGooseDir(%s): %w", dir, err)
+			return "", fmt.Errorf("NewGooseDir(%s): %w", dir, err)
 		}
 
 		if err := ensureAtlasSum(gdir); err != nil {
-			return fmt.Errorf("ensureAtlasSum: %w", err)
+			return "", fmt.Errorf("ensureAtlasSum: %w", err)
 		}
 
 		fmt.Println(path)
 
-		return nil
+		return path, nil
 	}
 
 	db, err := openDevDB(d)
 	if err != nil {
-		return fmt.Errorf("open dev db: %w", err)
+		return "", fmt.Errorf("open dev db: %w", err)
 	}
 	defer db.Close()
 
 	if err := resetDevDB(ctx, db, d); err != nil {
-		return fmt.Errorf("reset dev db: %w", err)
+		return "", fmt.Errorf("reset dev db: %w", err)
 	}
 
 	gdir, err := sqltool.NewGooseDir(dir)
 	if err != nil {
-		return fmt.Errorf("NewGooseDir(%s): %w", dir, err)
+		return "", fmt.Errorf("NewGooseDir(%s): %w", dir, err)
 	}
 
 	// Ensure atlas.sum exists and is current before Atlas validates the
@@ -192,7 +210,18 @@ func runDialect(ctx context.Context, root string, d dialectSpec, fname, migName 
 	// first run after a migration tree is hand-edited (notably the §7
 	// translation) and refreshes it on every subsequent generation.
 	if err := ensureAtlasSum(gdir); err != nil {
-		return fmt.Errorf("ensureAtlasSum: %w", err)
+		return "", fmt.Errorf("ensureAtlasSum: %w", err)
+	}
+
+	// Snapshot existing SQL files so we can identify the newly created one.
+	beforeFiles, err := filepath.Glob(filepath.Join(dir, "*.sql"))
+	if err != nil {
+		return "", fmt.Errorf("glob before: %w", err)
+	}
+
+	beforeSet := make(map[string]struct{}, len(beforeFiles))
+	for _, f := range beforeFiles {
+		beforeSet[f] = struct{}{}
 	}
 
 	drv := entsql.OpenDB(d.goDialect, db)
@@ -204,14 +233,29 @@ func runDialect(ctx context.Context, root string, d dialectSpec, fname, migName 
 		schema.WithFormatter(sqltool.GooseFormatter),
 	)
 	if err != nil {
-		return fmt.Errorf("NewMigrate: %w", err)
+		return "", fmt.Errorf("NewMigrate: %w", err)
 	}
 
 	if err := m.NamedDiff(ctx, migName, migrate.Tables...); err != nil {
-		return fmt.Errorf("NamedDiff: %w", err)
+		return "", fmt.Errorf("NamedDiff: %w", err)
 	}
 
-	return nil
+	// Find the newly created file.
+	afterFiles, err := filepath.Glob(filepath.Join(dir, "*.sql"))
+	if err != nil {
+		return "", fmt.Errorf("glob after: %w", err)
+	}
+
+	for _, f := range afterFiles {
+		if _, exists := beforeSet[f]; !exists {
+			fmt.Println(f)
+
+			return f, nil
+		}
+	}
+
+	// No new file — schema was already up to date (no-op diff).
+	return "", nil
 }
 
 func openDevDB(d dialectSpec) (*sql.DB, error) {
@@ -308,7 +352,7 @@ func validateName(name string) error {
 	}
 
 	switch strings.ToLower(s) {
-	case "auto", "wip", "tmp", "todo", "temp", "test":
+	case "auto", "wip", "tmp", "todo", "temp", "test", "empty":
 		return fmt.Errorf("%w: %q", errPlaceholderName, s)
 	}
 

--- a/cmd/generate-migrations/main.go
+++ b/cmd/generate-migrations/main.go
@@ -59,8 +59,11 @@ const (
 	defaultMySQLURL    = "test-user:test-password@tcp(127.0.0.1:3306)/test-db?parseTime=true&loc=UTC"
 )
 
-var errPlaceholderName = errors.New(
-	"placeholder migration name is forbidden — provide a descriptive snake_case identifier")
+var (
+	errPlaceholderName = errors.New(
+		"placeholder migration name is forbidden — provide a descriptive snake_case identifier")
+	errInvalidDialect = errors.New("unknown dialect in --skip (allowed: sqlite,postgres,mysql)")
+)
 
 func main() {
 	var (
@@ -90,7 +93,10 @@ func main() {
 	stamp := time.Now().UTC().Format("20060102150405")
 	fname := fmt.Sprintf("%s_%s.sql", stamp, *name)
 
-	skipSet := parseSkip(*skip)
+	skipSet, err := parseSkip(*skip)
+	if err != nil {
+		log.Fatalf("generate-migrations: invalid --skip: %v", err)
+	}
 
 	for _, d := range []dialectSpec{
 		{name: "sqlite", goDialect: dialect.SQLite, driver: "sqlite3", openDSN: "file::memory:?_fk=1&cache=shared"},
@@ -109,17 +115,26 @@ func main() {
 	}
 }
 
-func parseSkip(s string) map[string]struct{} {
+func parseSkip(s string) (map[string]struct{}, error) {
 	out := map[string]struct{}{}
+	allowed := map[string]struct{}{
+		"sqlite":   {},
+		"postgres": {},
+		"mysql":    {},
+	}
 
 	for _, part := range strings.Split(s, ",") {
-		part = strings.TrimSpace(part)
+		part = strings.ToLower(strings.TrimSpace(part))
 		if part != "" {
+			if _, ok := allowed[part]; !ok {
+				return nil, fmt.Errorf("%w: %q", errInvalidDialect, part)
+			}
+
 			out[part] = struct{}{}
 		}
 	}
 
-	return out
+	return out, nil
 }
 
 type dialectSpec struct {
@@ -141,6 +156,15 @@ func runDialect(ctx context.Context, root string, d dialectSpec, fname, migName 
 
 		if err := os.WriteFile(path, []byte(stub), 0o600); err != nil {
 			return fmt.Errorf("write stub: %w", err)
+		}
+
+		gdir, err := sqltool.NewGooseDir(dir)
+		if err != nil {
+			return fmt.Errorf("NewGooseDir(%s): %w", dir, err)
+		}
+
+		if err := ensureAtlasSum(gdir); err != nil {
+			return fmt.Errorf("ensureAtlasSum: %w", err)
 		}
 
 		fmt.Println(path)

--- a/cmd/generate-migrations/main_test.go
+++ b/cmd/generate-migrations/main_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,7 +40,7 @@ func TestSQLOnlyEmitsThreeDialects(t *testing.T) {
 
 	matches, err := filepath.Glob(filepath.Join(root, "migrations", "*", "*.sql"))
 	require.NoError(t, err)
-	assert.Len(t, matches, 3, "expected exactly 3 .sql files (one per dialect); got %v", matches)
+	require.Len(t, matches, 3, "expected exactly 3 .sql files (one per dialect); got %v", matches)
 
 	// All three files should share the same timestamp prefix.
 	stamps := make([]string, 0, len(matches))
@@ -107,7 +108,11 @@ func buildGenerateMigrations(t *testing.T) string {
 
 		sharedBinaryDir = dir
 		sharedBinary = filepath.Join(dir, "generate-migrations")
-		cmd := exec.CommandContext(context.Background(), "go", "build", "-o", sharedBinary, ".")
+
+		buildCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		cmd := exec.CommandContext(buildCtx, "go", "build", "-o", sharedBinary, ".")
 		cmd.Dir = "."
 
 		out, err := cmd.CombinedOutput()

--- a/dev-scripts/run.py
+++ b/dev-scripts/run.py
@@ -369,6 +369,9 @@ def run_db_migration(db_url):
         path = db_url.replace("sqlite:", "")
         os.makedirs(os.path.dirname(path), exist_ok=True)
     else:
+        if not shutil.which("dbmate"):
+            log("'dbmate' is required for PostgreSQL/MySQL. Run inside the Nix dev shell.", RED)
+            raise FileNotFoundError("dbmate not found in PATH")
         subprocess.run(
             ["dbmate", "--url", db_url, "create"],
             check=False,

--- a/dev-scripts/test-migration-e2e.py
+++ b/dev-scripts/test-migration-e2e.py
@@ -22,7 +22,7 @@ For each (db, cdc, storage) scenario:
  14. Build a *new* package — proves the write path works on the new schema.
  15. Stop ncps cleanly.
 
-Results are written to var/ncps/e2e-results/<timestamp>/.
+Results are written to .e2e-results/<timestamp>/.
 """
 
 import argparse
@@ -167,18 +167,14 @@ def reset_everything():
     subprocess.run(
         ["mc", "mb", f"e2e/{S3['bucket']}"],
         env=mc_env,
-        check=False,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        check=True,
         timeout=15,
     )
 
     log("reset: flushing Redis", Y)
     subprocess.run(
         ["redis-cli", "-h", "127.0.0.1", "-p", "6379", "flushall"],
-        check=False,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        check=True,
         timeout=10,
     )
 

--- a/dev-scripts/test-migration-e2e.py
+++ b/dev-scripts/test-migration-e2e.py
@@ -239,13 +239,20 @@ def stop_ncps(p, f):
                 pass
             p.wait(timeout=5)
     f.close()
-    wait_port_close(PORT, timeout=15)
+    if not wait_port_close(PORT, timeout=15):
+        raise RuntimeError(f"stop_ncps: port {PORT} still in use after 15s")
 
 
-def wait_ready(timeout=120):
+def wait_ready(proc, timeout=120):
+    """Poll until ncps answers HTTP, or proc dies, or timeout expires."""
     deadline = time.time() + timeout
     url = f"http://127.0.0.1:{PORT}/nix-cache-info"
     while time.time() < deadline:
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"wait_ready: ncps exited with code {proc.returncode} "
+                "before becoming ready"
+            )
         try:
             with urllib.request.urlopen(url, timeout=2) as r:
                 if r.status == 200:
@@ -454,7 +461,7 @@ def run_scenario(scenario, fix_branch, results_dir):
         # Stage 2: main
         git_checkout(MAIN_BRANCH)
         srv, f = start_ncps(scenario, os.path.join(sdir, "main-server.log"))
-        if not wait_ready():
+        if not wait_ready(srv):
             raise RuntimeError("ncps did not become ready on main")
 
         result["stages"]["main_pubkey"] = get_pubkey()
@@ -489,8 +496,11 @@ def run_scenario(scenario, fix_branch, results_dir):
         import re
         m = re.search(r"pending versions:\s*(\d+)", dry2)
         if m is None:
-            log(f"WARN: dry-run output did not contain 'pending versions: N': {dry2!r}", Y)
-        elif int(m.group(1)) != 0:
+            raise RuntimeError(
+                f"idempotency check: dry-run output did not contain "
+                f"'pending versions: N': {dry2!r}"
+            )
+        if int(m.group(1)) != 0:
             raise RuntimeError(
                 f"idempotency check failed: {m.group(1)} migration(s) still "
                 f"pending after migrate up"
@@ -513,7 +523,7 @@ def run_scenario(scenario, fix_branch, results_dir):
 
         # Stage 6: restart on fix branch (no --clean)
         srv, f = start_ncps(scenario, os.path.join(sdir, "fix-server.log"))
-        if not wait_ready():
+        if not wait_ready(srv):
             raise RuntimeError("ncps did not become ready on fix branch")
 
         new_pubkey = get_pubkey()

--- a/docs/docs/User Guide/Configuration/Database/PostgreSQL Configuration.md
+++ b/docs/docs/User Guide/Configuration/Database/PostgreSQL Configuration.md
@@ -112,7 +112,7 @@ cache:
 
 ```
 # Run migrations
-ncps migrate up --cache-database-url=postgresql://ncps:password@localhost:5432/ncps?sslmode=disable
+ncps migrate up --cache-database-url="postgresql://ncps:password@localhost:5432/ncps?sslmode=disable"
 ```
 
 ### Performance Tuning

--- a/docs/docs/User Guide/Installation/Docker Compose.md
+++ b/docs/docs/User Guide/Installation/Docker Compose.md
@@ -142,7 +142,7 @@ services:
       - "3900:3900"   # S3 API
       - "3903:3903"   # admin API
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3903/health"]
+      test: ["CMD", "/garage", "-c", "/etc/garage.toml", "status"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/docs/User Guide/Installation/Docker Compose.md
+++ b/docs/docs/User Guide/Installation/Docker Compose.md
@@ -174,7 +174,7 @@ services:
       postgres:
         condition: service_healthy
     command: >
-      /bin/ncps migrate up --cache-database-url=postgresql://ncps:changeme@postgres:5432/ncps?sslmode=disable
+      /bin/ncps migrate up --cache-database-url="postgresql://ncps:changeme@postgres:5432/ncps?sslmode=disable"
     restart: "no"
 
   # ncps instance 1

--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -105,10 +105,13 @@
             src = ../../.;
             outputs = [ "out" ];
             buildPhase = ''
+              set -o pipefail
               HOME=$TMPDIR
 
               # Build the lint binary, then run it against the schema tree.
               # Capture output so we can both display it and grep for FAIL.
+              # set -o pipefail ensures a non-zero exit from ent-lint fails
+              # the pipeline even though tee always exits 0.
               go build -o ./ent-lint ./cmd/ent-lint
               ./ent-lint --root . | tee ent-lint.out
 

--- a/nix/process-compose/flake-module.nix
+++ b/nix/process-compose/flake-module.nix
@@ -84,8 +84,6 @@
                   };
                 in
                 ''
-                  # Ensure the data + metadata dirs exist before garage starts.
-                  mkdir -p "$GARAGE_DATA_DIR" "$GARAGE_META_DIR"
                   exec ${startGarage}/bin/start-garage
                 '';
               environment = garageEnvironment;

--- a/nix/process-compose/init-garage.sh
+++ b/nix/process-compose/init-garage.sh
@@ -132,7 +132,7 @@ echo "  Endpoint:     $NCPS_TEST_S3_ENDPOINT"
 echo "  Region:       $NCPS_TEST_S3_REGION"
 echo "  Bucket:       $NCPS_TEST_S3_BUCKET"
 echo "  Access Key:   $NCPS_TEST_S3_ACCESS_KEY_ID"
-echo "  Secret Key:   $NCPS_TEST_S3_SECRET_ACCESS_KEY"
+echo "  Secret Key:   [redacted]"
 echo
 echo "  Garage CLI:   garage -c \$GARAGE_CONFIG_FILE <cmd>"
 echo "                (e.g. garage status, garage bucket list)"

--- a/openspec/changes/archive/2026-05-21-migrate-to-ent-and-atlas/design.md
+++ b/openspec/changes/archive/2026-05-21-migrate-to-ent-and-atlas/design.md
@@ -105,7 +105,7 @@ No `migrations/<shard>/<dialect>/` layer — ncps has one logical database. The 
 
 #### Adoption decision tree at `ncps migrate up`
 
-```
+```text
 probe dialect-specific catalog →
 
   empty DB
@@ -151,7 +151,7 @@ Once no operator is on a pre-v1 install, the 14/8/8 translated dbmate-era files 
 
 - **Translate + bridge alone (option A)**: new installs would run 14/8/8 dbmate-era migrations then the bridge, wasting first-boot time on a sequence of intermediate schemas they never need. Eliminated by (3): Schema.Create skips straight to the end state.
 
-- **Schema overrides to match dbmate exactly (option D)**: would require `SchemaType` overrides on every `id` column (to force Postgres `BIGSERIAL`), `StorageKey` overrides on every index name, and creative workarounds for dbmate's anonymous CHECK constraints (Ent's invariant A1 requires named CHECKs). Maintains the existing schema forever, but locks ncps into legacy Postgres patterns. Rejected: v1 is the right moment to modernize.
+- **Schema overrides to match dbmate exactly (option D)**: would require `SchemaType` overrides on every `id` column (to force Postgres `BIGSERIAL`), `StorageKey` overrides on every index name, and creative workarounds for dbmate's anonymous CHECK constraints (Ent's invariant A1 requires CHECK constraints to be named). Maintains the existing schema forever, but locks ncps into legacy Postgres patterns. Rejected: v1 is the right moment to modernize.
 
 - **Rebaseline (option C)**: drop the dbmate-era files and create one fresh "initial_baseline" — but this breaks the upgrade path for existing v0.x installs, which is unacceptable per the rule the user set out at the start of this change ("users could be on older versions of ncps, like v0.4").
 

--- a/openspec/changes/archive/2026-05-21-migrate-to-ent-and-atlas/tasks.md
+++ b/openspec/changes/archive/2026-05-21-migrate-to-ent-and-atlas/tasks.md
@@ -139,7 +139,7 @@ Per design D6 (Option E), the adoption decision tree has four branches: empty DB
 - [x] 13.3 Add an `atlas-sum-check` derivation that verifies every `migrations/<dialect>/atlas.sum` matches the directory contents
 - [x] 13.4 Add a `schema-equivalence-check` derivation that runs the §8 golden test for all three engines (uses process-compose deps)
 - [x] 13.5 Verify `nix flake check` passes end-to-end with all four new derivations contributing
-- [x] 13.6 Confirm the existing `.github/workflows/ci.yml` still passes (no edits expected — the new checks plug into `nix flake check`)
+- [x] 13.6 Confirm `.github/workflows/ci.yml` still passes after adding the `generate-database` and `deploy-docs-pages` jobs
 
 ## 14. Docs and skills
 

--- a/openspec/changes/archive/2026-05-21-migrate-to-ent-and-atlas/tasks.md
+++ b/openspec/changes/archive/2026-05-21-migrate-to-ent-and-atlas/tasks.md
@@ -104,13 +104,13 @@ Per design D6 (Option E), the adoption decision tree has four branches: empty DB
 
 ## 10. `pkg/database/` rewrite
 
-- [x] 10.1 Replace `database.Querier` return type with `*database.Client` (wraps `*ent.Client` + driver metadata) in `database.Open(url, poolCfg)` (introduced parallel surface in §10; signature swap deferred to §11 to keep build green)
+- [x] 10.1 Introduce `*database.Client` (wraps `*ent.Client` + driver metadata) alongside the existing `database.Querier` surface in `database.Open(url, poolCfg)` (parallel surface added here; caller migration to use `*database.Client` completed in §11)
 - [x] 10.2 Implement `(*database.Client).WithTransaction(ctx, name, fn func(*ent.Tx) error) error` preserving the OTel span/error wrapping the legacy helper provided
 - [x] 10.3 Keep `database.DetectFromDatabaseURL` and `database.PoolConfig` as-is; verify their tests still pass
 
 ## 11. Caller migration
 
-- [x] 11.1 Rewrite `pkg/cache/cache.go` storage of `database.Querier` to `*database.Client`; convert call sites one method at a time (added `*Client` field + `dbClient` param threaded through `cache.New`, testhelpers, and all call sites; call-site method conversions in §11.2-§11.8)
+- [x] 11.1 Thread `*database.Client` in parallel through `cache.New`, testhelpers, and all call sites alongside existing `database.Querier` (actual removal of `Querier` storage completed as part of this §11 caller migration; method conversions in §11.2-§11.8)
 - [x] 11.2 Convert `GetNarInfo*` paths in `pkg/cache/` to Ent fluent API; run package tests
 - [x] 11.3 Convert `PutNarInfo*` paths; run package tests
 - [x] 11.4 Convert `GetNarFile*` / `PutNarFile*` paths (including CDC chunk insertion); run package tests

--- a/openspec/changes/archive/2026-05-22-swap-minio-with-garage/design.md
+++ b/openspec/changes/archive/2026-05-22-swap-minio-with-garage/design.md
@@ -67,9 +67,9 @@ Garage has no web console. We free up port 9001 and remove the `MINIO_CONSOLE*` 
 
 Garage publishes an official container image (`dxflrs/garage`). For k8s-tests we keep the same shape as today's MinIO deployment: a single-replica Deployment + Service + initContainer that runs `garage layout assign` and bucket/key bootstrap. We do *not* introduce a Helm chart dependency — a small templated YAML in `nix/k8s-tests/` matches the existing pattern.
 
-### D6: Keep test credentials stable (`test-access-key` / `test-secret-key`, `test-bucket`)
+### D6: Keep test credentials stable (`GK1234567890abcdef12345678` / 64-char hex secret, `test-bucket`)
 
-Garage allows specifying access key IDs and secrets explicitly at key-creation time. We pin them to the same values MinIO used so no Go test code needs updating beyond the env var rename.
+Garage requires key IDs that follow its `GK<hex>` format and secrets that are 64-character hex strings. The implementation pins `NCPS_TEST_S3_ACCESS_KEY_ID=GK1234567890abcdef12345678` and `NCPS_TEST_S3_SECRET_ACCESS_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef`, with bucket name `test-bucket`. These stable values mean no Go test code needs updating beyond the env var rename from the MinIO names.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/archive/2026-05-23-less-tests/design.md
+++ b/openspec/changes/archive/2026-05-23-less-tests/design.md
@@ -17,7 +17,7 @@ Constraints:
 - Measure first: produce a reproducible profile of per-package and per-test wall time before any deletion.
 - Establish a written decision procedure for "is this test redundant?" that future reviewers can apply.
 - Reduce `go test -race ./...` wall time on a clean machine by a meaningful margin (target: ≥30% reduction; stretch: ≥50%) without losing coverage signal.
-- Keep coverage parity: line coverage MUST NOT drop; branch coverage MUST NOT drop by more than 1pp per package.
+- Keep coverage parity: line coverage MUST NOT drop; statement/block coverage MUST NOT drop by more than 1pp per package.
 - Leave the suite easier to extend — shared fixtures named clearly, table-driven where natural.
 
 **Non-Goals:**
@@ -36,7 +36,7 @@ Use `go test -json -race -count=1 ./...` (with integration env vars set via `ena
 - Per-test wall time (parent + subtests separately)
 - Tests where `Elapsed > 500ms`
 
-**Why this over `gotestsum`**: We already have everything we need in `-json`. A small Python script is cheaper than adding a tool dependency and is reproducible across local + CI. The output is stored as `openspec/changes/less-tests/baseline-timings.txt` (not committed past archive) for the duration of the work.
+**Why this over `gotestsum`**: We already have everything we need in `-json`. A small Python script is cheaper than adding a tool dependency and is reproducible across local + CI. The output is stored as `openspec/changes/archive/2026-05-23-less-tests/baseline-timings.txt` (not committed past archive) for the duration of the work.
 
 **Alternative considered**: CPU profiling per test with `-cpuprofile`. Rejected for this phase — wall-time ranking is enough to find the offenders; CPU profiles add noise without changing the priority list.
 
@@ -80,7 +80,7 @@ For each backend (Postgres, MySQL, S3/MinIO, Redis):
 
 Enforced in `tasks.md` as a checkpoint after every batch of removals/restructuring:
 
-```
+```bash
 go test -coverpkg=./... -coverprofile=cover-after.out -race ./<changed-pkg>/...
 ```
 

--- a/openspec/changes/archive/2026-05-23-less-tests/design.md
+++ b/openspec/changes/archive/2026-05-23-less-tests/design.md
@@ -113,7 +113,7 @@ Compare against `cover-before.out` recorded at the start. Requirements:
   → Mitigation: D4 requires keeping one wiring smoke test per backend. Backend-specific semantics (upsert, multipart) stay as integration tests.
 
 - **Risk: the profiler analyzer itself becomes a maintenance burden.**
-  → Mitigation: Keep it as a shell pipeline in `dev-scripts/`, not a new Go program. Delete it (or move to `dev-scripts/profile-tests.sh`) once the change is archived. Document in the spec.
+  → Mitigation: Keep it as a Python script in `dev-scripts/`, not a new Go program. Delete it (or keep as `dev-scripts/profile-tests.py`) once the change is archived. Document in the spec.
 
 - **Trade-off: per-batch coverage gating slows the work down.**
   → Accepted. The cost of one careless deletion is far higher than a few extra `go test -cover` runs.

--- a/openspec/changes/archive/2026-05-23-less-tests/design.md
+++ b/openspec/changes/archive/2026-05-23-less-tests/design.md
@@ -86,7 +86,7 @@ go test -coverpkg=./... -coverprofile=cover-after.out -race ./<changed-pkg>/...
 
 Compare against `cover-before.out` recorded at the start. Requirements:
 - Line coverage per package: `after >= before`.
-- Branch coverage per package: `after >= before - 1pp` (tolerance for inlining/optimization artifacts).
+- Statement/instrumented-block coverage per package: `after >= before - 1pp` (tolerance for inlining/optimization artifacts).
 - Any regression beyond the tolerance reverts the batch.
 
 **Why a per-batch gate instead of one final gate**: catching a coverage drop after every batch lets us bisect the offending removal in seconds, not hours.

--- a/openspec/changes/archive/2026-05-23-less-tests/tasks.md
+++ b/openspec/changes/archive/2026-05-23-less-tests/tasks.md
@@ -2,9 +2,10 @@
 
 - [x] 1.1 Write `dev-scripts/profile-tests.py` that runs `go test -json -race -count=1 ./...` and emits two ranked tables: per-package wall time and per-test wall time (parent + subtests, `Elapsed > 500ms`). *(Implemented as Python to match existing `dev-scripts/` conventions. Supports `--packages`, `--threshold`, `--out`, `--from-file`, `--no-race`.)*
 - [x] 1.2 Verify `profile-tests.py` works inside the Nix dev shell (smoke-tested on `./pkg/chunker/...` — 5 tests, 1.466s total, correctly ranked subtests). `nix flake check` integration deferred to task 8.1 end-to-end run.
-- [x] 1.3 Run `profile-tests.py` against current branch tip with no test changes and save output to `openspec/changes/less-tests/baseline-timings.txt`. *(Unit-test-only baseline captured. Integration env vars not set — Postgres/MySQL/Redis tests show as skipped. Total wall time: **88.13s**.)*
+- [x] 1.3 Run `profile-tests.py` against current branch tip with no test changes and save output to `openspec/changes/archive/2026-05-23-less-tests/baseline-timings.txt`. *(Unit-test-only baseline captured. Integration env vars not set — Postgres/MySQL/Redis tests show as skipped. Total wall time: **88.13s**.)*
 
   **Top-5 packages by wall time:**
+
   | rank | package | s | notes |
   |--:|---|--:|---|
   | 1 | `pkg/cache` | 16.5 | 226 tests, the suspected hotspot — but no single dominant slow test |
@@ -60,7 +61,7 @@
 
 ## 7. Re-derive the -short gated set
 
-- [ ] 7.1 Re-run `profile-tests.sh` on the post-change tree. Save as `openspec/changes/less-tests/post-change-timings.txt`.
+- [ ] 7.1 Re-run `profile-tests.py` on the post-change tree. Save as `openspec/changes/archive/2026-05-23-less-tests/post-change-timings.txt`.
 - [ ] 7.2 For each test newly above 500ms, add a `if testing.Short() { t.Skip(...) }` guard at the top.
 - [ ] 7.3 For each currently-guarded test now below 500ms, remove the guard. Record each removal in this task with old/new timings.
 - [ ] 7.4 Verify `go test -short -race ./...` completes in noticeably less time than `go test -race ./...` on the same machine; record both numbers in this task.

--- a/openspec/specs/test-suite-efficiency/spec.md
+++ b/openspec/specs/test-suite-efficiency/spec.md
@@ -15,7 +15,7 @@ The project SHALL provide a reproducible workflow that ranks Go test execution t
 - **WHEN** a developer has integration env vars enabled (`eval "$(enable-integration-tests)"`) and runs the profiling workflow
 - **THEN** the workflow produces a ranked list of packages by total wall time
 - **AND** produces a ranked list of individual tests (parent and subtests) with `Elapsed > 500ms`
-- **AND** when run locally, writes the ranking to a deterministic output file under `dev-scripts/` or `openspec/changes/<change>/`
+- **AND** writes the ranking to a deterministic output file under `dev-scripts/` or `openspec/changes/<change>/`
 
 #### Scenario: Profiling without integration env vars
 

--- a/openspec/specs/test-suite-efficiency/spec.md
+++ b/openspec/specs/test-suite-efficiency/spec.md
@@ -45,7 +45,7 @@ The Go test suite MUST NOT contain two tests (or subtests) where the second test
 
 ### Requirement: Coverage parity gate
 
-When tests are removed or restructured, line coverage per affected package MUST NOT decrease from the pre-change baseline. Branch coverage per affected package MUST NOT decrease by more than 1 percentage point. The check MUST be applied per batch of changes, not only at the end.
+When tests are removed or restructured, line coverage per affected package MUST NOT decrease from the pre-change baseline. Statement/instrumented-block coverage per affected package MUST NOT decrease by more than 1 percentage point. The check MUST be applied per batch of changes, not only at the end.
 
 #### Scenario: Removing a test passes the coverage gate
 

--- a/openspec/specs/test-suite-efficiency/spec.md
+++ b/openspec/specs/test-suite-efficiency/spec.md
@@ -52,11 +52,11 @@ When tests are removed or restructured, line coverage per affected package MUST 
 - **WHEN** a batch of test removals is proposed for package `pkg/X`
 - **AND** `go test -coverpkg=./... -coverprofile=cover-after.out -race ./pkg/X/...` is run on the post-change tree
 - **THEN** line coverage of `cover-after.out` is greater than or equal to line coverage of the pre-change `cover-before.out`
-- **AND** branch coverage of `cover-after.out` is greater than or equal to `cover-before.out` minus 1 percentage point
+- **AND** statement/instrumented-block coverage of `cover-after.out` is greater than or equal to `cover-before.out` minus 1 percentage point
 
 #### Scenario: A batch fails the coverage gate
 
-- **WHEN** a batch of test removals causes line coverage to drop or branch coverage to drop by more than 1 percentage point for any affected package
+- **WHEN** a batch of test removals causes line coverage to drop or statement/instrumented-block coverage to drop by more than 1 percentage point for any affected package
 - **THEN** the batch MUST be reverted in full
 - **AND** the offending removal MUST be re-evaluated against the four-gate rule before any further attempt
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2385,13 +2385,13 @@ func (c *Cache) relinkNarInfosToNarFileWithEntTx(
 
 	// Chunk the CreateBulk to stay below driver placeholder limits.
 	// Each row sends 2 parameters (narinfo_id, nar_file_id); 500 rows
-	// per batch = 1000 placeholders, well under Postgres 65535,
-	// modern SQLite 32766, and older SQLite 999. Closures with
-	// thousands of narinfos sharing a NAR URL (large multi-output
-	// derivations, deep dependency trees) are uncommon but real, and
-	// without chunking the bulk insert would silently fail on
-	// older sqlite.
-	const relinkBatchSize = 500
+	// The upsert binds 2 values per row (narinfoID + narFileID), so
+	// 499 rows = 998 placeholders — safely under older SQLite's hard
+	// limit of 999. Closures with thousands of narinfos sharing a
+	// NAR URL (large multi-output derivations, deep dependency trees)
+	// are uncommon but real; without chunking the bulk insert would
+	// silently fail on older SQLite.
+	const relinkBatchSize = 499
 
 	for start := 0; start < len(narInfoIDs); start += relinkBatchSize {
 		end := start + relinkBatchSize

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -5677,6 +5677,13 @@ func (c *Cache) deleteLRURecordsFromDB(
 		return nil, nil, nil, nil
 	}
 
+	if len(candidates) == maxFetchRows {
+		log.Warn().Int("limit", maxFetchRows).Msg(
+			"LRU candidate fetch hit the row cap; narinfos beyond this " +
+				"window are not considered for eviction in this pass",
+		)
+	}
+
 	// Apply the legacy cumulative-byte filter: keep the LRU prefix whose
 	// cumulative file_size is <= max(2*cleanupSize, smallest-single-row).
 	// For cleanupSize == 0 ("delete all") keep every candidate.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -6773,8 +6773,11 @@ func (c *Cache) streamProgressiveChunks(ctx context.Context, w io.Writer, narFil
 				// Feed all available chunks from the batch into the pipeline.
 				for _, link := range batch {
 					if link.Edges.Chunk == nil {
-						chunkChan <- &prefetchedChunk{
+						select {
+						case chunkChan <- &prefetchedChunk{
 							err: fmt.Errorf("nar_file_chunk %d: %w", link.ID, errMissingChunkEdge),
+						}:
+						case <-ctx.Done():
 						}
 
 						return
@@ -6876,8 +6879,11 @@ func (c *Cache) streamProgressiveChunks(ctx context.Context, w io.Writer, narFil
 					// Feed the newly-available chunks and break out of the wait loop.
 					for _, link := range batch2 {
 						if link.Edges.Chunk == nil {
-							chunkChan <- &prefetchedChunk{
+							select {
+							case chunkChan <- &prefetchedChunk{
 								err: fmt.Errorf("nar_file_chunk %d: %w", link.ID, errMissingChunkEdge),
+							}:
+							case <-ctx.Done():
 							}
 
 							return

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -145,6 +145,8 @@ var (
 	// ErrNarAlreadyChunked is returned when the nar is already chunked.
 	ErrNarAlreadyChunked = errors.New("nar is already chunked")
 
+	errMissingChunkEdge = errors.New("nar_file_chunk is missing eager-loaded chunk edge")
+
 	//nolint:gochecknoglobals
 	meter metric.Meter
 
@@ -5994,7 +5996,9 @@ func (c *Cache) runLRU(ctx context.Context) func() {
 				return err
 			}
 
-			if len(narInfoHashesToRemove) == 0 && len(chunkHashesToRemove) == 0 {
+			if len(narInfoHashesToRemove) == 0 &&
+				len(narURLsToRemove) == 0 &&
+				len(chunkHashesToRemove) == 0 {
 				return nil
 			}
 
@@ -6535,16 +6539,14 @@ func (c *Cache) getNarFromChunks(ctx context.Context, narURL *nar.URL) (int64, i
 		totalSize = int64(nr.FileSize)
 		totalChunks = nr.TotalChunks
 
-		// Touch the NAR file
+		// Touch the NAR file by the fetched row's ID. getNarFileFromDB may
+		// return a compression=none fallback row whose key differs from
+		// narURL, so filtering on narURL fields can silently miss it.
 		if nr.LastAccessedAt == nil || time.Since(*nr.LastAccessedAt) > c.recordAgeIgnoreTouch {
-			if _, err := tx.NarFile.Update().
-				Where(
-					entnarfile.HashEQ(narURL.Hash),
-					entnarfile.CompressionEQ(narURL.Compression.String()),
-					entnarfile.QueryEQ(narURL.Query.Encode()),
-				).
-				SetLastAccessedAt(time.Now()).
-				SetUpdatedAt(time.Now()).
+			now := time.Now()
+			if _, err := tx.NarFile.UpdateOneID(nr.ID).
+				SetLastAccessedAt(now).
+				SetUpdatedAt(now).
 				Save(ctx); err != nil {
 				return fmt.Errorf("error touching the nar record: %w", err)
 			}
@@ -6614,9 +6616,11 @@ func (c *Cache) streamCompleteChunks(
 	}
 
 	for _, link := range links {
-		if link.Edges.Chunk != nil {
-			chunkHashes = append(chunkHashes, link.Edges.Chunk.Hash)
+		if link.Edges.Chunk == nil {
+			return fmt.Errorf("nar_file_chunk %d: %w", link.ID, errMissingChunkEdge)
 		}
+
+		chunkHashes = append(chunkHashes, link.Edges.Chunk.Hash)
 	}
 
 	if len(chunkHashes) != int(totalChunks) {
@@ -6762,7 +6766,11 @@ func (c *Cache) streamProgressiveChunks(ctx context.Context, w io.Writer, narFil
 				// Feed all available chunks from the batch into the pipeline.
 				for _, link := range batch {
 					if link.Edges.Chunk == nil {
-						continue
+						chunkChan <- &prefetchedChunk{
+							err: fmt.Errorf("nar_file_chunk %d: %w", link.ID, errMissingChunkEdge),
+						}
+
+						return
 					}
 
 					ch := link.Edges.Chunk
@@ -6861,7 +6869,11 @@ func (c *Cache) streamProgressiveChunks(ctx context.Context, w io.Writer, narFil
 					// Feed the newly-available chunks and break out of the wait loop.
 					for _, link := range batch2 {
 						if link.Edges.Chunk == nil {
-							continue
+							chunkChan <- &prefetchedChunk{
+								err: fmt.Errorf("nar_file_chunk %d: %w", link.ID, errMissingChunkEdge),
+							}
+
+							return
 						}
 
 						ch := link.Edges.Chunk

--- a/pkg/cache/cache_distributed_test.go
+++ b/pkg/cache/cache_distributed_test.go
@@ -484,12 +484,11 @@ func testDistributedLockFailover(_ distributedDBFactory) func(*testing.T) {
 		require.NoError(t, err)
 
 		// Locker 2 should initially fail to acquire (lock held by locker1).
-		// Bounded by 200ms — well under shortTTL so it must still be held.
-		ctx2, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
-		defer cancel()
-
-		err = locker2.Lock(ctx2, testKey, shortTTL)
-		require.Error(t, err, "locker2 should fail to acquire lock held by locker1")
+		// Use TryLock (non-blocking) so the check is instant and deterministic
+		// even under race-detector scheduling pressure.
+		acquired, err := locker2.TryLock(ctx, testKey, shortTTL)
+		require.NoError(t, err, "TryLock should not error when lock is already held")
+		require.False(t, acquired, "locker2 should not acquire lock held by locker1")
 
 		// Simulate locker1 failure (don't unlock, let it expire). Wait TTL + safety.
 		time.Sleep(shortTTL + 300*time.Millisecond)

--- a/pkg/cache/cache_prefetch_test.go
+++ b/pkg/cache/cache_prefetch_test.go
@@ -176,17 +176,28 @@ func TestPrefetchErrorPropagation(t *testing.T) {
 	err = c.PutNar(ctx, nu, io.NopCloser(strings.NewReader(content)))
 	require.NoError(t, err)
 
+	// Resolve the NarFile row by (hash, compression, query) so the test
+	// is not sensitive to insertion order when other tests run in parallel.
+	narFileRec, err := dbClient.Ent().NarFile.Query().
+		Where(
+			entnarfile.Hash(nu.Hash),
+			entnarfile.Compression(nu.Compression.String()),
+			entnarfile.Query(nu.Query.Encode()),
+		).
+		Only(ctx)
+	require.NoError(t, err)
+
 	// Get the chunks and delete one from storage (but not from DB)
 	chunkLinks, err := dbClient.Ent().NarFileChunk.Query().
-		Where(entnarfilechunk.NarFileIDEQ(1)).
+		Where(entnarfilechunk.NarFileIDEQ(narFileRec.ID)).
 		Order(ent.Asc(entnarfilechunk.FieldChunkIndex)).
 		WithChunk().
 		All(ctx)
 	require.NoError(t, err)
-	require.NotEmpty(t, chunkLinks)
+	require.GreaterOrEqual(t, len(chunkLinks), 2, "need at least 2 chunks to exercise the missing-chunk path")
 
 	// Delete the second chunk from storage to simulate a missing chunk
-	if len(chunkLinks) > 1 {
+	{
 		// Find the chunk file
 		chunkHash := chunkLinks[1].Edges.Chunk.Hash
 		chunkPath := filepath.Join(chunkStoreDir, chunkHash[:2], chunkHash)

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -68,7 +68,14 @@ func Open(dbURL string, poolCfg *PoolConfig) (*Client, error) {
 		return nil, fmt.Errorf("error opening the database at %q: %w", dbURL, err)
 	}
 
-	return NewClient(sdb, dbType)
+	client, err := NewClient(sdb, dbType)
+	if err != nil {
+		_ = sdb.Close()
+
+		return nil, err
+	}
+
+	return client, nil
 }
 
 // applyPoolSettings applies connection pool settings to the database connection.

--- a/pkg/database/migrate/adopt.go
+++ b/pkg/database/migrate/adopt.go
@@ -52,7 +52,7 @@ func adopt(ctx context.Context, db *sql.DB, d database.Type, st State) error {
 	case StateUnknown:
 		fallthrough
 	default:
-		return fmt.Errorf("adopt: %w %v", ErrUnknownDialect, st)
+		return fmt.Errorf("adopt: %w %v", ErrUnknownState, st)
 	}
 }
 

--- a/pkg/database/migrate/state.go
+++ b/pkg/database/migrate/state.go
@@ -21,6 +21,11 @@ var (
 	// migrate operation encounters an unrecognised database.Type value.
 	ErrUnknownDialect = errors.New("migrate: unknown dialect")
 
+	// ErrUnknownState is returned when adopt encounters an unrecognised
+	// State value. Distinct from ErrUnknownDialect, which is for
+	// database.Type values.
+	ErrUnknownState = errors.New("migrate: unknown state")
+
 	// ErrCorruptState is returned when probe detects ncps application
 	// tables but no schema_migrations tracking table. This should never
 	// happen during normal operation and requires manual intervention.

--- a/testhelper/sqlite.go
+++ b/testhelper/sqlite.go
@@ -161,8 +161,15 @@ func RegisterNarInfoAsUnmigrated(
 		builder = builder.SetFileHash(ni.FileHash.String())
 	}
 
+	// Mirror narFileSize(): compression=none narinfos omit FileSize (0);
+	// NarSize is the correct fallback so nar_files.file_size is always non-zero.
+	fileSize := ni.FileSize
+	if fileSize == 0 {
+		fileSize = ni.NarSize
+	}
+
 	//nolint:gosec
-	builder = builder.SetFileSize(int64(ni.FileSize))
+	builder = builder.SetFileSize(int64(fileSize))
 
 	if ni.NarHash != nil {
 		builder = builder.SetNarHash(ni.NarHash.String())
@@ -224,8 +231,15 @@ func getOrCreateNarInfo(
 		builder = builder.SetFileHash(ni.FileHash.String())
 	}
 
+	// Mirror narFileSize(): compression=none narinfos omit FileSize (0);
+	// NarSize is the correct fallback so nar_files.file_size is always non-zero.
+	fileSize := ni.FileSize
+	if fileSize == 0 {
+		fileSize = ni.NarSize
+	}
+
 	//nolint:gosec
-	builder = builder.SetFileSize(int64(ni.FileSize))
+	builder = builder.SetFileSize(int64(fileSize))
 
 	if ni.NarHash != nil {
 		builder = builder.SetNarHash(ni.NarHash.String())

--- a/testhelper/sqlite.go
+++ b/testhelper/sqlite.go
@@ -117,7 +117,14 @@ func MigrateNarInfoToDatabase(
 		}
 
 		// Get or Create NarFile
-		narFile, err := getOrCreateNarFile(ctx, tx, &narURL, ni.FileSize)
+		// Mirror narFileSize(): compression=none narinfos omit FileSize (0);
+		// NarSize is the correct fallback so nar_files.file_size is always non-zero.
+		narFileSize := ni.FileSize
+		if narFileSize == 0 {
+			narFileSize = ni.NarSize
+		}
+
+		narFile, err := getOrCreateNarFile(ctx, tx, &narURL, narFileSize)
 		if err != nil {
 			return err
 		}
@@ -205,6 +212,12 @@ func getOrCreateNarInfo(
 	// First, try to get the record.
 	existing, err := tx.NarInfo.Query().Where(entnarinfo.HashEQ(hash)).Only(ctx)
 	if err == nil {
+		// If the existing record is a placeholder (no URL), update it with the
+		// full narinfo so MigrateNarInfoToDatabase fills in migrated fields.
+		if existing.URL == nil || *existing.URL == "" {
+			return updatePlaceholderNarInfo(ctx, tx, existing.ID, ni)
+		}
+
 		return existing, nil
 	}
 
@@ -326,6 +339,62 @@ func getOrCreateNarFile(
 	}
 
 	return narFile, nil
+}
+
+// updatePlaceholderNarInfo fills in a placeholder (URL-less) narinfo row
+// with the full narinfo fields so MigrateNarInfoToDatabase correctly
+// transitions RegisterNarInfoAsUnmigrated rows to fully-migrated state.
+func updatePlaceholderNarInfo(
+	ctx context.Context,
+	tx *ent.Tx,
+	id int,
+	ni *narinfo.NarInfo,
+) (*ent.NarInfo, error) {
+	upd := tx.NarInfo.UpdateOneID(id)
+
+	if ni.URL != "" {
+		upd = upd.SetURL(ni.URL)
+	}
+
+	if ni.StorePath != "" {
+		upd = upd.SetStorePath(ni.StorePath)
+	}
+
+	if ni.Compression != "" {
+		upd = upd.SetCompression(ni.Compression)
+	}
+
+	if ni.FileHash != nil {
+		upd = upd.SetFileHash(ni.FileHash.String())
+	}
+
+	if ni.NarHash != nil {
+		upd = upd.SetNarHash(ni.NarHash.String())
+	}
+
+	fileSize := ni.FileSize
+	if fileSize == 0 {
+		fileSize = ni.NarSize
+	}
+
+	//nolint:gosec
+	upd = upd.SetFileSize(int64(fileSize))
+	//nolint:gosec
+	upd = upd.SetNarSize(int64(ni.NarSize))
+
+	if ni.Deriver != "" {
+		upd = upd.SetDeriver(ni.Deriver)
+	}
+
+	if ni.System != "" {
+		upd = upd.SetSystem(ni.System)
+	}
+
+	if ni.CA != "" {
+		upd = upd.SetCa(ni.CA)
+	}
+
+	return upd.Save(ctx)
 }
 
 // isDuplicateKey returns true if the error appears to be a unique-key


### PR DESCRIPTION
## Summary

Consolidation branch addressing unresolved reviewer threads left open across
merged PRs #1179–#1246. Each fix has its own atomic commit referencing the
source PR and thread ID; all threads are resolved on GitHub after each change.

### Bug fixes

- **cache:** touch `nar_file` by fetched row ID, not by narURL fields —
  `getNarFileFromDB` can return a `compression=none` fallback whose key differs
  from `narURL`, causing stale `last_accessed_at` and LRU regressions (#1206)
- **cache:** fail fast on `nil` eager-loaded chunk edges in `streamCompleteChunks`
  and `streamProgressiveChunks` instead of silently `continue`-ing, which caused
  count mismatches or infinite re-streaming (#1207)
- **cache:** include `narURLsToRemove` in the LRU early-return guard so orphaned
  `NarFile` blobs are passed to `parallelDeleteFromStores` instead of being
  silently leaked in storage (#1215)
- **cache:** log a warning when LRU candidate fetch hits the `maxFetchRows` cap
  so operators know eviction scanned only a partial window (#1206)
- **cache/relink:** lower `relinkBatchSize` from 500 → 499 to stay under
  SQLite's 999-placeholder limit (500 rows × 2 binds = 1000 > 999) (#1208)
- **database:** close `*sql.DB` in `Open()` when `NewClient` fails (#1208)
- **migrate/adopt:** use `ErrUnknownState` (not `ErrUnknownDialect`) for
  unrecognised `State` values — fixes false-positive `errors.Is` checks (#1188)
- **generate-migrations:** `parseSkip` validates dialect names, returning an error
  on unknown values like `"myslq"` instead of silently skipping them (#1187)
- **generate-migrations:** `--sql-only` path now calls `ensureAtlasSum` after
  writing the stub so `atlas.sum` stays in sync (#1187)
- **generate-migrations:** `runDialect` now returns the generated file path and
  prints it to stdout; `main()` warns when a second boundary falls between
  dialect runs so callers know to re-run for a consistent timestamp set (#1215)
- **generate-migrations:** add `"empty"` to `validateName` reject list (#1185)
- **nix/ent-lint-check:** add `set -o pipefail` so `ent-lint | tee` propagates
  a non-zero exit through the pipeline (#1221)
- **e2e:** fix docstring path (`var/ncps/e2e-results/` → `.e2e-results/`);
  `mc mb` and `redis-cli flushall` now use `check=True` so reset failures
  abort the test immediately (#1233)
- **e2e:** `stop_ncps` now verifies the port closes within timeout; `wait_ready`
  exits early if the child process dies before becoming ready (#1233)
- **run.py:** guard `dbmate` usage with a `shutil.which` check so a missing
  binary fails fast with a clear message instead of an obscure error (#1234)
- **CI:** pin all external GitHub Action refs to immutable commit SHAs to
  prevent supply-chain mutation (#1223)
- **CI:** remove `release-*` from pull_request/push triggers; add `go.mod` and
  `go.sum` to the ent paths-filter (#1235)
- **docs:** replace distroless-incompatible `wget` healthcheck in Docker Compose
  example with `garage status` (#1223)

### Test fixes

- Replace non-fatal `assert.Len` → `require.Len` before indexing `stamps[0..2]`
  in `generate-migrations` tests (#1185)
- Add 60 s timeout to the one-time `go build` in the test setup (#1241)
- Fix `cache_prefetch_test.go` to look up `nar_file` by `(hash, compression,
  query)` instead of hard-coded `id=1` (#1218)
- Apply `NarSize` fallback when `FileSize == 0` in `testhelper/sqlite.go` to
  avoid impossible `file_size=0` fixture rows for `compression=none` narinfos (#1218)
- Increase `chunkingDelay` from 500 ms → 1 s in `cdc_test.go` to reduce
  flakiness on slow CI machines (#1217)
- Replace `Lock`-with-timeout with `TryLock` in `cache_distributed_test.go` to
  avoid spurious failures when the lock-hold window is tight (#1217)

### Docs / skills

- Quote PostgreSQL DSNs in shell-command examples to prevent `?`-glob expansion
  by shells (#1234)
- `migrate-new/SKILL.md`: ent-lint checks A1, A2, A4 — not all five invariants
  as previously stated (#1225)
- `migrate-down/SKILL.md`: clarify that `DROP COLUMN` is sensitive/forbidden DDL
  per the migration spec and is only permissible as the terminal expand-contract
  step; add the missing "deploy code that always writes non-null" step to the
  NOT NULL recipe (#1225)
- `openspec/changes/archive/2026-05-23-less-tests/`: fix stale paths, add `bash`
  fence tag, replace "branch coverage" with "statement/block coverage" (#1245)
- `openspec/specs/test-suite-efficiency/spec.md`: same coverage terminology
  fix (#1245)
- `openspec/changes/archive/2026-05-21-migrate-to-ent-and-atlas/design.md`:
  add language tag to decision-tree fence block; fix grammar (#1186)
- `openspec/changes/archive/2026-05-21-migrate-to-ent-and-atlas/tasks.md`:
  update §10.1/§11.1 notes to reflect that `*database.Client` threading was
  completed in §11, not deferred (#1191, #1192)

## Test plan

- [x] `nix flake check` (includes all unit + integration tests, lint, ent-lint,
  atlas-sum, helm-unittest, schema-equivalence)
- [x] `go test -race ./...` locally with `eval "$(enable-integration-tests)"`
- [x] Verify all referenced GitHub threads are marked resolved

🤖 Generated with [Claude Code](https://claude.ai/claude-code)