### PR TITLE
fix(cache): fix compression mismatch in CDC lazy-chunking

### DIFF
--- a/openspec/changes/archive/2026-05-24-fix-compression-not-recognized/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-24-fix-compression-not-recognized/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-24

--- a/openspec/changes/archive/2026-05-24-fix-compression-not-recognized/design.md
+++ b/openspec/changes/archive/2026-05-24-fix-compression-not-recognized/design.md
@@ -1,0 +1,97 @@
+## Context
+
+ncps supports two NAR storage modes:
+
+1. **Whole-file**: NARs stored as compressed files (e.g., `.nar.xz`) in the storage
+   backend. Narinfos reference the original compression.
+2. **CDC (content-defined chunking)**: NARs are split into content-addressed chunks,
+   always stored **uncompressed**. Narinfos should reference `Compression: none`.
+
+When **lazy CDC chunking** is enabled, narinfos fetched from upstream are initially
+stored with the upstream's compression (e.g., `Compression: xz`). This allows the NAR
+to be served from the original compressed file while chunking happens in the background.
+
+After chunking completes, `migrateNarToChunksCleanup` updates the narinfo in the DB to
+`Compression: none`. However, `GetNarInfo` returns the stale narinfo immediately and
+asynchronously triggers the cleanup — creating a race window.
+
+During this window, `GetNar` for the `.nar.xz` URL detects the NAR is in chunks
+(`HasNarInChunks` returns true via `getNarFileFromDB`'s `Compression=none` fallback) and
+serves uncompressed data from chunks. The Nix client expects xz data and fails with
+"input compression not recognized".
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate "input compression not recognized" errors in lazy-chunking CDC deployments
+- Fix the race between narinfo DB update and NAR serving
+- Maintain backward compatibility with non-CDC and non-lazy-chunking deployments
+
+**Non-Goals:**
+- Fix the secondary "expected N chunks but got 0" data inconsistency (separate issue)
+- Change the async narinfo DB update mechanism
+- Add new configuration options
+
+## Decisions
+
+### Decision 1: Normalize narinfo in-memory in `GetNarInfo` when NAR is chunked
+
+**Chosen**: In `GetNarInfo`, after triggering background migration for a narinfo with
+non-none compression in CDC mode, call `HasNarInChunks`. If the NAR is already chunked,
+normalize the narinfo URL and Compression field in memory before returning.
+
+**Rationale**:
+- Fixes the race window without changing the async DB update mechanism
+- The in-memory normalization is cheap (one DB query) and only runs during the
+  transition window (while narinfo URL hasn't been updated in DB yet)
+- Once the DB is updated by `migrateNarToChunksCleanup`, `GetNarInfo` returns the
+  correct narinfo directly without the extra `HasNarInChunks` query
+
+**Alternative considered**: Return 404 from `GetNar` when compression mismatch is
+detected (CDC chunks exist but narinfo says xz). Rejected: this would cascade to Nix
+falling back to building, which is far worse than a transient normalization query.
+
+**Alternative considered**: Re-compress from chunks to xz before serving. Rejected:
+extremely expensive for large NARs; defeats the purpose of CDC chunking.
+
+**Alternative considered**: Always normalize narinfo URL in `GetNarInfo` when CDC is
+enabled (regardless of whether NAR is chunked). Rejected: if the NAR is NOT yet chunked
+(still in whole-file xz storage), normalizing the URL would make `GetNar` unable to find
+the NAR in `HasNarInStore` (which only checks `.nar` and `.nar.zst`, not `.nar.xz`),
+forcing a wasteful re-download from upstream.
+
+### Decision 2: No re-signing after in-memory normalization
+
+The narinfo fingerprint used for signing covers: StorePath, NarHash, NarSize, References
+— NOT URL or Compression. Therefore, modifying URL and Compression in memory does not
+invalidate existing signatures. No re-signing is needed.
+
+### Decision 3: FileHash and FileSize set to nil/0 when normalizing
+
+`Compression: none` narinfos in ncps don't carry FileHash or FileSize (set in
+`PutNarInfo` and `pullNarInfo` when normalizing). The in-memory normalization follows
+the same convention for consistency.
+
+## Risks / Trade-offs
+
+**[Risk] Extra DB query during transition window** → Acceptable: `HasNarInChunks` is a
+lightweight indexed query. The transition window (narinfo with xz URL in DB, NAR already
+chunked) is transient and ends once `migrateNarToChunksCleanup` runs.
+
+**[Risk] HasNarInChunks returns true for TotalChunks=1 but no NarFileChunk records** →
+In this case, `GetNar` would still fail with "expected N chunks but got 0". This is the
+pre-existing bug 2 (separate issue). Our fix changes the error path (Nix gets HTTP 404
+instead of "input compression not recognized"), which is less confusing.
+
+**[Risk] Narinfo served from storage (not DB) path** → If a narinfo is read from the
+old storage backend (legacy path, not from DB), it won't go through the normalization
+fix. However, these legacy narinfos have their NAR in whole-file storage too, so
+`GetNar` would serve the xz file correctly — no bug in this path.
+
+## Migration Plan
+
+1. Deploy the code change — no DB migrations or config changes needed
+2. In-flight requests during deployment may briefly see the old behavior; subsequent
+   requests will normalize correctly
+3. Rollback: revert the code change; behavior reverts to the pre-fix state (the race
+   window returns, but no worse than before)

--- a/openspec/changes/archive/2026-05-24-fix-compression-not-recognized/proposal.md
+++ b/openspec/changes/archive/2026-05-24-fix-compression-not-recognized/proposal.md
@@ -1,0 +1,47 @@
+## Problem
+
+When lazy CDC chunking is enabled, ncps stores narinfos with their upstream compression
+(e.g., `Compression: xz`, URL `nar/hash.nar.xz`). After the NAR is migrated to CDC
+chunks (which are always stored uncompressed), `GetNarInfo` still returns the stale
+narinfo with `Compression: xz`.
+
+When Nix subsequently downloads the `.nar.xz` URL, ncps serves **uncompressed** data
+from CDC chunks, while Nix expects xz-compressed data. Nix fails with:
+
+```
+error: input compression not recognized
+```
+
+## Root Cause
+
+In `GetNarInfo` (`pkg/cache/cache.go`), when a narinfo with `Compression: xz` is
+fetched from the database, the code triggers a background migration
+(`maybeBackgroundMigrateNarToChunks`) to update the narinfo URL asynchronously. However,
+it returns the **stale** narinfo to the caller immediately — before the background
+migration has a chance to update the DB.
+
+The background cleanup (`migrateNarToChunksCleanup`) correctly updates the narinfo URL
+in the DB, but there is a race window between:
+1. `GetNarInfo` returning `Compression: xz` to Nix
+2. `migrateNarToChunksCleanup` updating the DB to `Compression: none`
+
+During this window, `GetNar` for the `.nar.xz` URL finds the NAR in chunks
+(`HasNarInChunks` returns true via the `Compression=none` nar_file fallback) and serves
+uncompressed data — causing the mismatch.
+
+## Proposed Fix
+
+In `GetNarInfo`, after triggering the background migration for a narinfo with non-none
+compression in CDC mode, synchronously check if the NAR is already in chunks
+(`HasNarInChunks`). If yes, normalize the narinfo URL in memory to `Compression: none`
+before returning — eliminating the race window.
+
+The DB update continues to happen asynchronously (reducing future query overhead once
+the narinfo URL is fixed in the DB).
+
+## Impact
+
+- Fixes "input compression not recognized" errors in lazy-chunking CDC deployments
+- Adds one extra DB query per `GetNarInfo` call for narinfos with non-none compression
+  in CDC mode (only during the migration transition window)
+- No schema changes, no migrations needed

--- a/openspec/changes/archive/2026-05-24-fix-compression-not-recognized/specs.md
+++ b/openspec/changes/archive/2026-05-24-fix-compression-not-recognized/specs.md
@@ -1,0 +1,27 @@
+## Specifications
+
+### Spec 1: GetNarInfo normalizes narinfo URL when NAR is already chunked in CDC mode
+
+**Given** CDC is enabled
+**And** a narinfo exists in the DB with `Compression: xz` / URL `nar/hash.nar.xz`
+**And** the NAR has been migrated to CDC chunks (`HasNarInChunks` returns true)
+**When** `GetNarInfo` is called for that hash
+**Then** the returned narinfo has `Compression: none` and URL `nar/hash.nar`
+**And** FileHash is nil and FileSize is 0
+**And** the narinfo DB record is NOT modified synchronously (update is async)
+
+### Spec 2: GetNarInfo does NOT normalize when NAR is not yet chunked
+
+**Given** CDC is enabled
+**And** a narinfo exists in the DB with `Compression: xz` / URL `nar/hash.nar.xz`
+**And** the NAR is NOT in CDC chunks (`HasNarInChunks` returns false)
+**When** `GetNarInfo` is called for that hash
+**Then** the returned narinfo retains `Compression: xz` and the original URL
+**And** background migration is triggered
+
+### Spec 3: No normalization when CDC is disabled
+
+**Given** CDC is disabled
+**And** a narinfo exists in the DB with `Compression: xz`
+**When** `GetNarInfo` is called
+**Then** the returned narinfo retains the original `Compression: xz`

--- a/openspec/changes/archive/2026-05-24-fix-compression-not-recognized/tasks.md
+++ b/openspec/changes/archive/2026-05-24-fix-compression-not-recognized/tasks.md
@@ -1,0 +1,27 @@
+## Tasks
+
+### Task 1: Write failing tests for GetNarInfo normalization
+
+File: `pkg/cache/cache_test.go`
+
+Add tests:
+- `TestGetNarInfo_CDCMode_NormalizesCompressionWhenChunked`: narinfo with xz in DB,
+  NAR in chunks → returned narinfo has Compression=none
+- `TestGetNarInfo_CDCMode_NoNormalizationWhenNotChunked`: narinfo with xz in DB, NAR
+  NOT in chunks → returned narinfo retains xz
+- `TestGetNarInfo_CDCDisabled_NoNormalization`: CDC disabled, narinfo with xz → retains xz
+
+### Task 2: Implement the fix in GetNarInfo
+
+File: `pkg/cache/cache.go`
+
+In the block at lines ~3175-3195 where `narURL.Compression != nar.CompressionTypeNone`:
+- After calling `maybeBackgroundMigrateNarToChunks`
+- Add: if `c.isCDCEnabled()` and `c.HasNarInChunks(ctx, narURL)` returns true,
+  normalize `narInfo.URL`, `narInfo.Compression`, `narInfo.FileHash`, `narInfo.FileSize`
+
+### Task 3: Run tests and lint
+
+- `go test -race -run TestGetNarInfo ./pkg/cache/...`
+- `golangci-lint run --fix ./pkg/cache/...`
+- `go test -race ./...` (full suite)

--- a/openspec/specs/cdc-chunking/spec.md
+++ b/openspec/specs/cdc-chunking/spec.md
@@ -37,6 +37,73 @@ If `fileSize == 0`, the validation MUST be skipped (narinfo with unknown declare
 - **THEN** the size validation step is skipped entirely
 - **AND** `UpdateNarFileTotalChunks` is called regardless of how many bytes were chunked
 
+### Requirement: GetNarInfo MUST normalize compression in-memory during lazy-chunking transition
+
+When lazy CDC chunking is enabled, narinfos are initially stored in the DB with the
+upstream compression (e.g., `Compression: xz`) while the NAR is chunked in the
+background. After chunking completes, the DB update is asynchronous. During this window,
+`GetNarInfo` MUST normalize the narinfo in-memory before returning so that clients
+receive consistent `Compression: none` / `.nar` URL without waiting for the DB update.
+
+The normalization SHALL:
+- Call `HasNarInChunks` (a lightweight indexed query checking `total_chunks > 0`)
+- If the NAR is already chunked: rewrite `Compression`, `URL`, `FileHash`, and `FileSize`
+  in memory only — the DB record is NOT modified synchronously
+- Normalize the URL hash before the `HasNarInChunks` lookup to handle nix-serve-style
+  prefixed hashes (e.g., `abc-hash` → `hash`) matching nar_file rows correctly
+- Skip normalization entirely when CDC is disabled
+
+#### Scenario: GetNarInfo normalizes when NAR is already chunked
+
+- **GIVEN** CDC is enabled
+- **AND** a narinfo exists in the DB with `Compression: xz` and URL `nar/hash.nar.xz`
+- **AND** the NAR has been migrated to CDC chunks (`HasNarInChunks` returns true)
+- **WHEN** `GetNarInfo` is called for that hash
+- **THEN** the returned narinfo has `Compression: none` and URL `nar/hash.nar`
+- **AND** `FileHash` is nil and `FileSize` is 0
+- **AND** the narinfo DB record is NOT modified synchronously
+
+#### Scenario: GetNarInfo does NOT normalize when NAR is not yet chunked
+
+- **GIVEN** CDC is enabled
+- **AND** a narinfo exists in the DB with `Compression: xz` and URL `nar/hash.nar.xz`
+- **AND** the NAR is NOT in CDC chunks (`HasNarInChunks` returns false)
+- **WHEN** `GetNarInfo` is called for that hash
+- **THEN** the returned narinfo retains `Compression: xz` and the original URL
+- **AND** background migration is triggered
+
+#### Scenario: No normalization when CDC is disabled
+
+- **GIVEN** CDC is disabled
+- **AND** a narinfo exists in the DB with `Compression: xz`
+- **WHEN** `GetNarInfo` is called
+- **THEN** the returned narinfo retains the original `Compression: xz`
+
+### Requirement: GetNar MUST return 404 for compressed URL when NAR exists only as chunks
+
+When CDC is enabled and a client requests a NAR by its compressed URL (e.g.,
+`nar/hash.nar.xz`), but the NAR exists only as CDC chunks (no whole-file in storage),
+the system SHALL return `storage.ErrNotFound` rather than attempting to serve
+uncompressed chunk data as compressed content. Serving chunk data with mismatched
+compression would cause Nix to fail with "input compression not recognized".
+
+#### Scenario: xz NAR request returns 404 when only chunks exist
+
+- **GIVEN** CDC is enabled
+- **AND** `nar_file.total_chunks > 0` (NAR is chunked)
+- **AND** no whole-file `.nar.xz` exists in storage
+- **WHEN** `GetNar` is called with a `.nar.xz` URL
+- **THEN** the response is `storage.ErrNotFound`
+- **AND** chunk data is NOT served
+
+#### Scenario: xz NAR request succeeds when whole-file is still in storage
+
+- **GIVEN** CDC is enabled with lazy chunking
+- **AND** `nar_file.total_chunks > 0` (NAR is chunked)
+- **AND** the whole-file `.nar.xz` still exists in storage (lazy chunking preserves it)
+- **WHEN** `GetNar` is called with a `.nar.xz` URL
+- **THEN** the whole-file xz content is served from storage
+
 ### Requirement: CDC goroutine error MUST be logged at error level
 When the background CDC goroutine (started from `pullNarIntoStore`) receives a non-nil
 error from `storeNarWithCDCFromReader`, it SHALL log the error at `error` level (not

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2880,11 +2880,26 @@ func (c *Cache) serveNarFromStorageViaPipe(
 	if hasInStore && c.isCDCEnabled() {
 		// Check if the nar is chunked by looking at the nar_file record
 		nr, nrErr := c.getNarFileFromDB(ctx, c.dbClient.Ent().NarFile, *narURL)
-		if nrErr == nil && nr.TotalChunks > 0 {
+		// Only upgrade to chunks when the request is for the uncompressed NAR.
+		// Chunks are always stored uncompressed; serving them for a compressed
+		// request (e.g. .nar.xz) would send raw bytes the client cannot decode.
+		if nrErr == nil && nr.TotalChunks > 0 && narURL.Compression == nar.CompressionTypeNone {
 			// Nar is chunked, serve from chunks for better performance
 			serveFromChunks = true
 		}
-		// If nrErr (not found) or total_chunks=0, serve from store (raw or legacy)
+		// If nrErr (not found), total_chunks=0, or request wants compressed data,
+		// serve from store (raw or legacy).
+	}
+
+	// Chunks are always uncompressed. If the client requested a compressed NAR
+	// (e.g. .nar.xz) but the whole-file is no longer in storage (only chunks
+	// remain), we cannot reconstruct the compressed stream. Return not-found so
+	// the client falls back to an upstream cache that still has the original
+	// compressed file. This prevents "input compression not recognized" errors
+	// caused by serving raw chunk bytes to a client expecting xz data.
+	if serveFromChunks && narURL.Compression != nar.CompressionTypeNone {
+		return 0, nil, fmt.Errorf("NAR %s is only available as chunks, cannot serve as %s: %w",
+			narURL.Hash, narURL.Compression, storage.ErrNotFound)
 	}
 
 	if serveFromChunks {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -6512,12 +6512,19 @@ func (c *Cache) maybeCDCNormalizeNarInfoURL(ctx context.Context, narURL nar.URL,
 		return
 	}
 
-	hasChunks, err := c.HasNarInChunks(ctx, narURL)
+	// Normalize the URL before querying so nix-serve-style prefixed hashes
+	// (e.g. "abc-hash") match the normalized hashes stored in nar_file rows.
+	normalizedURL, err := narURL.Normalize()
+	if err != nil {
+		return
+	}
+
+	hasChunks, err := c.HasNarInChunks(ctx, normalizedURL)
 	if err != nil || !hasChunks {
 		return
 	}
 
-	noneURL := nar.URL{Hash: narURL.Hash, Compression: nar.CompressionTypeNone, Query: narURL.Query}
+	noneURL := nar.URL{Hash: normalizedURL.Hash, Compression: nar.CompressionTypeNone, Query: normalizedURL.Query}
 	narInfo.URL = noneURL.String()
 	narInfo.Compression = nar.CompressionTypeNone.String()
 	narInfo.FileHash = nil

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -3182,6 +3182,9 @@ func (c *Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, 
 			// CDC) will still be migrated when they are served via GetNar.
 			if narURL.Compression != nar.CompressionTypeNone {
 				c.maybeBackgroundMigrateNarToChunks(ctx, narURL)
+				// If the NAR is already in CDC chunks, normalize in-memory before
+				// returning (see maybeCDCNormalizeNarInfoURL for rationale).
+				c.maybeCDCNormalizeNarInfoURL(ctx, narURL, narInfo)
 			}
 
 			zerolog.Ctx(ctx).
@@ -6481,6 +6484,29 @@ func derefInt64Ptr(p *int64) int64 {
 	}
 
 	return *p
+}
+
+// maybeCDCNormalizeNarInfoURL normalizes the narinfo URL and Compression in-memory
+// when CDC is enabled and the NAR has already been migrated to chunks. Without this,
+// there is a race window where GetNarInfo returns "Compression: xz" but GetNar serves
+// uncompressed data from chunks — causing Nix to fail with "input compression not
+// recognized". The DB update happens asynchronously via migrateNarToChunksCleanup;
+// this call makes the in-flight response correct immediately.
+func (c *Cache) maybeCDCNormalizeNarInfoURL(ctx context.Context, narURL nar.URL, narInfo *narinfo.NarInfo) {
+	if !c.isCDCEnabled() {
+		return
+	}
+
+	hasChunks, err := c.HasNarInChunks(ctx, narURL)
+	if err != nil || !hasChunks {
+		return
+	}
+
+	noneURL := nar.URL{Hash: narURL.Hash, Compression: nar.CompressionTypeNone, Query: narURL.Query}
+	narInfo.URL = noneURL.String()
+	narInfo.Compression = nar.CompressionTypeNone.String()
+	narInfo.FileHash = nil
+	narInfo.FileSize = 0
 }
 
 // HasNarInChunks returns true if the NAR is already in chunks and chunking is complete.

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -2960,6 +2960,8 @@ func runCacheTestSuite(t *testing.T, factory cacheFactory) {
 	t.Run("GetNarInfo_CDCNormalizesCompressionWhenChunked", testGetNarInfoCDCNormalizesCompressionWhenChunked(factory))
 	t.Run("GetNarInfo_CDCNoNormalizationWhenNotChunked", testGetNarInfoCDCNoNormalizationWhenNotChunked(factory))
 	t.Run("GetNarInfo_CDCDisabledNoNormalization", testGetNarInfoCDCDisabledNoNormalization(factory))
+	t.Run("GetNar_CDCXzRequestReturnsErrWhenChunked", testGetNarCDCXzRequestReturnsErrWhenChunked(factory))
+	t.Run("GetNar_CDCXzServesFromStoreWhenBothExist", testGetNarCDCXzServesFromStoreWhenBothExist(factory))
 }
 
 func testCheckAndFixNarInfo(factory cacheFactory) func(*testing.T) {
@@ -4000,5 +4002,94 @@ func testGetNarInfoCDCDisabledNoNormalization(factory cacheFactory) func(*testin
 			"GetNarInfo should NOT normalize Compression when CDC is disabled")
 		assert.Equal(t, xzURL.String(), ni.URL,
 			"GetNarInfo should NOT normalize URL when CDC is disabled")
+	}
+}
+
+// testGetNarCDCXzRequestReturnsErrWhenChunked verifies that GetNar returns an error
+// when the NAR is only available as CDC chunks and the client requests the xz form.
+// Without the fix in serveNarFromStorageViaPipe, this served raw uncompressed chunk
+// bytes for a .nar.xz request, causing "input compression not recognized" on the
+// Nix client side.
+func testGetNarCDCXzRequestReturnsErrWhenChunked(factory cacheFactory) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		c, dbClient, _, dir, _, cleanup := factory(t)
+		t.Cleanup(cleanup)
+
+		cs, err := chunk.NewLocalStore(dir)
+		require.NoError(t, err)
+		c.SetChunkStore(cs)
+		require.NoError(t, c.SetCDCConfiguration(true, 1024, 2048, 4096))
+
+		// Insert a nar_file record with Compression=none and TotalChunks=1, simulating a
+		// fully-chunked NAR. No xz file exists on disk (deleted after chunking completed).
+		noneURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeNone}
+		_, err = dbClient.Ent().NarFile.Create().
+			SetHash(noneURL.Hash).
+			SetCompression(noneURL.Compression.String()).
+			SetQuery(noneURL.Query.Encode()).
+			SetFileSize(0).
+			SetTotalChunks(1).
+			Save(ctx)
+		require.NoError(t, err)
+
+		// Confirm the xz file is absent from local storage.
+		assert.NoFileExists(t, filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath))
+
+		// GetNar for the xz URL must return an error, not serve raw chunk bytes.
+		xzURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
+		_, _, _, err = c.GetNar(ctx, xzURL)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, storage.ErrNotFound)
+	}
+}
+
+// testGetNarCDCXzServesFromStoreWhenBothExist verifies that GetNar still serves
+// the xz file from whole-file storage when both the xz file and CDC chunks exist.
+// This guards the transition period (chunking complete but xz file not yet deleted).
+func testGetNarCDCXzServesFromStoreWhenBothExist(factory cacheFactory) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		c, dbClient, _, dir, _, cleanup := factory(t)
+		t.Cleanup(cleanup)
+
+		cs, err := chunk.NewLocalStore(dir)
+		require.NoError(t, err)
+		c.SetChunkStore(cs)
+		require.NoError(t, c.SetCDCConfiguration(true, 1024, 2048, 4096))
+
+		// Insert a nar_file record with Compression=none and TotalChunks=1.
+		noneURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeNone}
+		_, err = dbClient.Ent().NarFile.Create().
+			SetHash(noneURL.Hash).
+			SetCompression(noneURL.Compression.String()).
+			SetQuery(noneURL.Query.Encode()).
+			SetFileSize(0).
+			SetTotalChunks(1).
+			Save(ctx)
+		require.NoError(t, err)
+
+		// Also place the xz file in local storage, simulating the transition period
+		// where both the original xz file and CDC chunks exist simultaneously.
+		narPath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(narPath), 0o755))
+		require.NoError(t, os.WriteFile(narPath, []byte(testdata.Nar1.NarText), 0o600))
+
+		// GetNar for the xz URL must succeed by serving from the xz file, not from chunks.
+		xzURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
+		_, _, r, err := c.GetNar(ctx, xzURL)
+		require.NoError(t, err)
+
+		t.Cleanup(func() { _ = r.Close() })
+
+		body, err := io.ReadAll(r)
+		require.NoError(t, err)
+		assert.Equal(t, testdata.Nar1.NarText, string(body))
 	}
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -3887,6 +3887,9 @@ func testGetNarInfoCDCNormalizesCompressionWhenChunked(factory cacheFactory) fun
 			SetNarHash(parsed.NarHash.String()).
 			//nolint:gosec // G115: NarSize is non-negative by spec
 			SetNarSize(int64(parsed.NarSize)).
+			SetFileHash(parsed.FileHash.String()).
+			//nolint:gosec // G115: FileSize is non-negative by spec
+			SetFileSize(int64(parsed.FileSize)).
 			Save(ctx)
 		require.NoError(t, err)
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -2957,6 +2957,9 @@ func runCacheTestSuite(t *testing.T, factory cacheFactory) {
 	t.Run("PinUnpinNonExistentClosure", testPinUnpinNonExistentClosure(factory))
 	t.Run("GetPinnedClosureHashesSimple", testGetPinnedClosureHashesSimple(factory))
 	t.Run("LRUEvictionSkipsPinnedClosures", testLRUEvictionSkipsPinnedClosures(factory))
+	t.Run("GetNarInfo_CDCNormalizesCompressionWhenChunked", testGetNarInfoCDCNormalizesCompressionWhenChunked(factory))
+	t.Run("GetNarInfo_CDCNoNormalizationWhenNotChunked", testGetNarInfoCDCNoNormalizationWhenNotChunked(factory))
+	t.Run("GetNarInfo_CDCDisabledNoNormalization", testGetNarInfoCDCDisabledNoNormalization(factory))
 }
 
 func testCheckAndFixNarInfo(factory cacheFactory) func(*testing.T) {
@@ -3844,4 +3847,158 @@ func TestGetNarInfoDistributedCoordination(t *testing.T) {
 
 	// 6. Verify only one upstream call was made
 	assert.Equal(t, int32(1), atomic.LoadInt32(&upstreamCallCount), "Only one upstream call should have been made")
+}
+
+// testGetNarInfoCDCNormalizesCompressionWhenChunked verifies that GetNarInfo normalizes
+// the narinfo URL in-memory when CDC is enabled and the NAR has already been migrated
+// to chunks. This prevents "input compression not recognized" errors that occur when Nix
+// receives a stale "Compression: xz" narinfo but ncps serves uncompressed data from chunks.
+func testGetNarInfoCDCNormalizesCompressionWhenChunked(factory cacheFactory) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		c, dbClient, _, dir, _, cleanup := factory(t)
+		t.Cleanup(cleanup)
+
+		cs, err := chunk.NewLocalStore(dir)
+		require.NoError(t, err)
+
+		c.SetChunkStore(cs)
+		require.NoError(t, c.SetCDCConfiguration(true, 1024, 2048, 4096))
+
+		// Parse the narinfo to get required fields (NarHash, NarSize) for a valid DB record.
+		parsed, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
+		require.NoError(t, err)
+
+		// Insert a narinfo into the DB with xz compression, bypassing PutNarInfo
+		// normalization to simulate the race window: chunking completed but the
+		// DB narinfo URL hasn't been updated yet by migrateNarToChunksCleanup.
+		xzURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
+
+		_, err = dbClient.Ent().NarInfo.Create().
+			SetHash(testdata.Nar1.NarInfoHash).
+			SetURL(xzURL.String()).
+			SetCompression(xzURL.Compression.String()).
+			SetStorePath(parsed.StorePath).
+			SetNarHash(parsed.NarHash.String()).
+			//nolint:gosec // G115: NarSize is non-negative by spec
+			SetNarSize(int64(parsed.NarSize)).
+			Save(ctx)
+		require.NoError(t, err)
+
+		// Insert a nar_file record with TotalChunks > 0 to simulate a fully chunked NAR.
+		// CDC stores NARs with Compression=none regardless of the original compression.
+		noneURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeNone}
+
+		_, err = dbClient.Ent().NarFile.Create().
+			SetHash(noneURL.Hash).
+			SetCompression(noneURL.Compression.String()).
+			SetQuery(noneURL.Query.Encode()).
+			SetFileSize(0).
+			SetTotalChunks(1).
+			Save(ctx)
+		require.NoError(t, err)
+
+		ni, err := c.GetNarInfo(ctx, testdata.Nar1.NarInfoHash)
+		require.NoError(t, err)
+
+		assert.Equal(t, noneURL.Compression.String(), ni.Compression,
+			"GetNarInfo should normalize Compression to none when NAR is already in CDC chunks")
+		assert.Equal(t, noneURL.String(), ni.URL,
+			"GetNarInfo should normalize URL to .nar when NAR is already in CDC chunks")
+		assert.Nil(t, ni.FileHash, "FileHash should be nil for in-memory normalized narinfo")
+		assert.Equal(t, uint64(0), ni.FileSize, "FileSize should be 0 for in-memory normalized narinfo")
+	}
+}
+
+// testGetNarInfoCDCNoNormalizationWhenNotChunked verifies that GetNarInfo does NOT
+// normalize when CDC is enabled but the NAR has not yet been migrated to chunks.
+// The xz narinfo must be returned as-is so Nix can fetch the xz NAR file.
+func testGetNarInfoCDCNoNormalizationWhenNotChunked(factory cacheFactory) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		c, dbClient, _, dir, _, cleanup := factory(t)
+		t.Cleanup(cleanup)
+
+		cs, err := chunk.NewLocalStore(dir)
+		require.NoError(t, err)
+
+		c.SetChunkStore(cs)
+		require.NoError(t, c.SetCDCConfiguration(true, 1024, 2048, 4096))
+
+		parsed, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
+		require.NoError(t, err)
+
+		xzURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
+
+		_, err = dbClient.Ent().NarInfo.Create().
+			SetHash(testdata.Nar1.NarInfoHash).
+			SetURL(xzURL.String()).
+			SetCompression(xzURL.Compression.String()).
+			SetStorePath(parsed.StorePath).
+			SetNarHash(parsed.NarHash.String()).
+			//nolint:gosec // G115: NarSize is non-negative by spec
+			SetNarSize(int64(parsed.NarSize)).
+			Save(ctx)
+		require.NoError(t, err)
+
+		// TotalChunks=0 simulates a placeholder nar_file record created when chunking
+		// starts but before chunks have been written (chunking in progress).
+		noneURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeNone}
+
+		_, err = dbClient.Ent().NarFile.Create().
+			SetHash(noneURL.Hash).
+			SetCompression(noneURL.Compression.String()).
+			SetQuery(noneURL.Query.Encode()).
+			SetFileSize(0).
+			SetTotalChunks(0).
+			Save(ctx)
+		require.NoError(t, err)
+
+		ni, err := c.GetNarInfo(ctx, testdata.Nar1.NarInfoHash)
+		require.NoError(t, err)
+
+		assert.Equal(t, xzURL.Compression.String(), ni.Compression,
+			"GetNarInfo should NOT normalize Compression when NAR is not yet fully chunked")
+		assert.Equal(t, xzURL.String(), ni.URL,
+			"GetNarInfo should NOT normalize URL when NAR is not yet fully chunked")
+	}
+}
+
+// testGetNarInfoCDCDisabledNoNormalization verifies that GetNarInfo does NOT normalize
+// when CDC is disabled, even for narinfos with non-none compression.
+func testGetNarInfoCDCDisabledNoNormalization(factory cacheFactory) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		c, _, _, dir, _, cleanup := factory(t)
+		t.Cleanup(cleanup)
+
+		// PutNarInfo with CDC disabled stores the narinfo as-is (no URL normalization).
+		r := io.NopCloser(strings.NewReader(testdata.Nar1.NarInfoText))
+		require.NoError(t, c.PutNarInfo(ctx, testdata.Nar1.NarInfoHash, r))
+
+		// Create the xz NAR file in local storage so HasNarInStore returns true,
+		// preventing the narinfo from being purged by getNarInfoFromDatabase.
+		narPath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(narPath), 0o755))
+		require.NoError(t, os.WriteFile(narPath, []byte("fake_xz_data"), 0o600))
+
+		ni, err := c.GetNarInfo(ctx, testdata.Nar1.NarInfoHash)
+		require.NoError(t, err)
+
+		xzURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
+
+		assert.Equal(t, xzURL.Compression.String(), ni.Compression,
+			"GetNarInfo should NOT normalize Compression when CDC is disabled")
+		assert.Equal(t, xzURL.String(), ni.URL,
+			"GetNarInfo should NOT normalize URL when CDC is disabled")
+	}
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -4049,7 +4049,9 @@ func testGetNarCDCXzRequestReturnsErrWhenChunked(factory cacheFactory) func(*tes
 
 // testGetNarCDCXzServesFromStoreWhenBothExist verifies that GetNar still serves
 // the xz file from whole-file storage when both the xz file and CDC chunks exist.
-// This guards the transition period (chunking complete but xz file not yet deleted).
+// This guards the transition period (chunking complete but xz file not yet deleted),
+// which only occurs when lazy chunking is enabled — the xz file is kept until the
+// background cleanup job removes it.
 func testGetNarCDCXzServesFromStoreWhenBothExist(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
@@ -4063,6 +4065,10 @@ func testGetNarCDCXzServesFromStoreWhenBothExist(factory cacheFactory) func(*tes
 		require.NoError(t, err)
 		c.SetChunkStore(cs)
 		require.NoError(t, c.SetCDCConfiguration(true, 1024, 2048, 4096))
+		// Enable lazy chunking: this is the only mode where the xz whole-file coexists
+		// with chunks (immediate deletion is skipped). It also prevents the background
+		// migration goroutine from deleting the xz file during the test assertion.
+		c.SetCDCLazyChunking(true, 1)
 
 		// Insert a nar_file record with Compression=none and TotalChunks=1.
 		noneURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeNone}


### PR DESCRIPTION
## Root cause

In lazy CDC deployments, narinfos are initially stored with upstream
compression (e.g. `Compression: xz`). Chunking happens in the
background; `migrateNarToChunksCleanup` updates the narinfo in the DB
to `Compression: none` asynchronously. Two races cause "input
compression not recognized" on the Nix client:

**Race 1 — GetNarInfo returns stale xz narinfo while NAR is already
chunked.** During the window between chunking completing and the DB
update, `GetNarInfo` returns a narinfo with `Compression: xz`. When Nix
downloads the NAR, `GetNar` detects it is in chunks (via the
`Compression=none` CDC fallback in `getNarFileFromDB`) and serves raw
uncompressed bytes — which Nix cannot decode as xz.

**Race 2 — Nix client has locally cached the old xz narinfo.** Even
after the DB is updated, Nix clients that cached the old `.nar.xz`
narinfo request the `.nar.xz` URL directly without re-fetching the
narinfo. `serveNarFromStorageViaPipe` was routing these requests to
chunks anyway (via the CDC fallback), again serving raw bytes to a
client expecting xz data.

## Fixes

**Fix 1 (`GetNarInfo`):** After triggering background migration for a
narinfo with non-none compression in CDC mode, call `HasNarInChunks`.
If the NAR is already chunked, normalize URL and Compression to `none`
in-memory before returning. Extracted into `maybeCDCNormalizeNarInfoURL`
to keep nesting within lint limits. Narinfo fingerprints cover
StorePath/NarHash/NarSize/References — not URL or Compression — so no
re-signing is needed.

**Fix 2 (`serveNarFromStorageViaPipe`):** Only promote `hasInStore` to
`serveFromChunks` when the request itself is for `Compression=none`.
For xz requests where only chunks remain (whole-file deleted), return
`storage.ErrNotFound` so Nix falls back to an upstream cache that still
has the original compressed file. This handles stale client-side
narinfo caches regardless of what the DB says.

## Test plan

- `TestCacheBackends/*/GetNarInfo_CDCNormalizesCompressionWhenChunked` — Fix 1: narinfo normalized when chunks exist
- `TestCacheBackends/*/GetNarInfo_CDCNoNormalizationWhenNotChunked` — Fix 1: no normalization before chunking
- `TestCacheBackends/*/GetNarInfo_CDCDisabledNoNormalization` — Fix 1: no normalization without CDC
- `TestCacheBackends/*/GetNar_CDCXzRequestReturnsErrWhenChunked` — Fix 2: ErrNotFound for xz request when only chunks exist
- `TestCacheBackends/*/GetNar_CDCXzServesFromStoreWhenBothExist` — Fix 2: xz served from whole-file during lazy-chunking transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)