### PR TITLE
fix(cache): close ds.stored after storeInDatabase, not before

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -3455,10 +3455,6 @@ func (c *Cache) pullNarInfo(
 	// The storage backend (S3/filesystem) is used only for NAR files.
 	// Legacy narinfos in storage are handled by background migration during GetNarInfo.
 
-	// Signal that the asset is now in final storage and the distributed lock can be released
-	// This prevents the race condition where other instances check hasAsset() before storage completes
-	ds.storedOnce.Do(func() { close(ds.stored) })
-
 	if err := c.storeInDatabase(ctx, hash, narInfo); err != nil {
 		zerolog.Ctx(ctx).
 			Error().
@@ -3469,6 +3465,16 @@ func (c *Cache) pullNarInfo(
 
 		return
 	}
+
+	// Signal that the asset is now in final storage and the distributed lock
+	// can be released. MUST be after storeInDatabase succeeds: the coordinator
+	// at coordinateDownload waits on ds.stored and then releases the download
+	// lock; if we signaled before the DB write, another instance polling
+	// hasAsset() (which checks the database) would acquire the lock, find the
+	// DB empty, and start a redundant upstream download — surfacing as
+	// TestGetNarInfoDistributedCoordination failures with two upstream calls
+	// instead of one.
+	ds.storedOnce.Do(func() { close(ds.stored) })
 
 	zerolog.Ctx(ctx).
 		Info().


### PR DESCRIPTION
## Summary

`pullNarInfo` signaled `ds.stored` **before** calling `storeInDatabase`. The coordinator at `coordinateDownload` waits on `ds.stored` and then releases the distributed download lock, so the order made the lock release race against the actual database write:

1. c1 calls upstream, gets narinfo
2. c1 signals `ds.stored`
3. c1's coordinator releases the download lock
4. c2 (which was blocked on `Lock`) acquires the lock
5. c2's "double-check" `hasAsset()` reads the database — still empty, because c1 hasn't called `storeInDatabase` yet
6. c2 starts its own upstream download — duplicate work
7. c1 finally calls `storeInDatabase`

Surfaced as a 10% flake on `TestGetNarInfoDistributedCoordination` (reproducible locally with `go test -count=10`; also observed once on the lean-flake-check PR's CI run 26353355126). The fix is a straight swap: signal `ds.stored` AFTER `storeInDatabase` succeeds — which is exactly what the existing comment claims ("the asset is now in final storage") but the code wasn't doing.

## Why this slipped through

The comment at the original `ds.storedOnce.Do` site said:
> Signal that the asset is now in final storage and the distributed lock can be released. This prevents the race condition where other instances check hasAsset() before storage completes.

That was the *intent*. The code was doing the opposite. The new comment now matches what the code actually does and names the specific failure mode to make the ordering load-bearing for anyone who refactors this path later.

## Error path

Unchanged behavior. If `storeInDatabase` fails, `pullNarInfo` returns without signaling `ds.stored`, but the `defer done()` closes `ds.done`. The coordinator's `case <-ds.done` arm fires and the lock is still released — same as before, just no spurious "stored" signal.

## Test plan

- [x] `go test -race -count=30 -run "^TestGetNarInfoDistributedCoordination$" ./pkg/cache/` → 30/30 pass (was failing ~10% before).
- [x] Adjacent test sanity: `go test -race -run "TestGetNarInfo|TestCacheBackends/SQLite/(GetNarInfo|PutNarInfo)" ./pkg/cache/` → all pass.

Refs #1247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)