### PR TITLE
test(cache): fail fast on ConcurrentDownloadCancel hang (refs #1252)

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1972,12 +1972,25 @@ func runWithTimeout(t *testing.T, d time.Duration, what string, fn func()) {
 		fn()
 	}()
 
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
 	select {
 	case <-done:
-	case <-time.After(d):
-		buf := make([]byte, 1<<20)
-		n := runtime.Stack(buf, true)
-		t.Fatalf("%s did not complete within %s; goroutine dump:\n%s", what, d, buf[:n])
+	case <-timer.C:
+		buf := make([]byte, 64<<10)
+		for {
+			n := runtime.Stack(buf, true)
+			if n < len(buf) {
+				buf = buf[:n]
+
+				break
+			}
+
+			buf = make([]byte, 2*len(buf))
+		}
+
+		t.Fatalf("%s did not complete within %s; goroutine dump:\n%s", what, d, buf)
 	}
 }
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -1913,8 +1914,20 @@ func testConcurrentDownloadCancelOneClientOthersContinue(factory cacheFactory) f
 		// Verify client B got the complete data
 		require.NotNil(t, readerB, "client B reader should not be nil")
 
-		bodyB, err := io.ReadAll(readerB)
-		require.NoError(t, err, "should be able to read NAR content from client B")
+		// Bounded io.ReadAll: previously this could hang for the 20 min outer
+		// `go test -timeout` if client A's cancellation left the shared streaming
+		// goroutine in a state where the writer never closed. See ncps #1252.
+		// Fail fast with a goroutine dump so future hangs are actionable.
+		var (
+			bodyB   []byte
+			readErr error
+		)
+
+		runWithTimeout(t, 30*time.Second, "io.ReadAll(readerB)", func() {
+			bodyB, readErr = io.ReadAll(readerB)
+		})
+
+		require.NoError(t, readErr, "should be able to read NAR content from client B")
 		readerB.Close()
 
 		assert.Equal(t, entry.NarText, string(bodyB), "NAR content should match for client B")
@@ -1929,7 +1942,7 @@ func testConcurrentDownloadCancelOneClientOthersContinue(factory cacheFactory) f
 		nu := nar.URL{Hash: entry.NarHash, Compression: entry.NarCompression}
 		assert.True(t, localStore.HasNar(newContext(), nu), "HasNar should return true")
 
-		wg.Wait()
+		runWithTimeout(t, 30*time.Second, "wg.Wait()", wg.Wait)
 
 		t.Log("✅ Client B completed successfully despite client A cancellation - download coordination works!")
 	}
@@ -1939,6 +1952,33 @@ func newContext() context.Context {
 	return zerolog.
 		New(io.Discard).
 		WithContext(context.Background())
+}
+
+// runWithTimeout runs fn in a goroutine and fails the test if it doesn't
+// complete within d. On timeout it dumps all goroutines via runtime.Stack
+// so the next reader can pinpoint where a hang originated, then calls
+// t.Fatalf. Used to convert hangs that would otherwise consume the entire
+// `go test -timeout` budget into fast-failing tests with actionable
+// diagnostics. See ncps #1252 for the originating hang in
+// TestCacheBackends/.../ConcurrentDownloadCancelOneClientOthersContinue.
+func runWithTimeout(t *testing.T, d time.Duration, what string, fn func()) {
+	t.Helper()
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		fn()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(d):
+		buf := make([]byte, 1<<20)
+		n := runtime.Stack(buf, true)
+		t.Fatalf("%s did not complete within %s; goroutine dump:\n%s", what, d, buf[:n])
+	}
 }
 
 func waitForFile(t *testing.T, path string) {


### PR DESCRIPTION
## Summary

testConcurrentDownloadCancelOneClientOthersContinue had two un-timeout-guarded blocking calls after the existing 5–10 s `t.Fatal` guards: `io.ReadAll(readerB)` (line 1916) and `wg.Wait()` (line 1932). When the shared streaming goroutine got stuck in some race with client A's cancellation, `readerB`'s pipe writer never closed and `io.ReadAll` blocked for the full `go test -timeout` budget — observed as **20-minute hangs** on CI under heavy load during the lean-flake-check measurement runs.

This PR wraps both calls in a new test-only helper `runWithTimeout` (30 s budget, dumps all goroutines via `runtime.Stack` on timeout) so the next occurrence of the hang fails the test in 30 s with the exact stuck-goroutine trace instead of consuming 20 minutes of CI.

## What this PR does NOT do

It does not fix the underlying race. The race is non-trivial: not reproducible locally even under 200× `-race -count` stress, code inspection in `c.GetNar`'s shared-reader-fanout path is suggestive but ambiguous (see #1252 for the hypotheses), and a real fix needs goroutine-level diagnostics from an actual CI hang.

Once this PR is merged and the hang fires once more in CI, the failure will print exactly which goroutine is stuck where. That data should let us pinpoint and fix the root cause cheaply.

## Stack

```
main → fix-narinfo-distributed-coordination-race (#1256, the real ds.stored race fix)
     → fail-fast-concurrent-download-cancel-hang (this PR)
```

## Test plan

- [x] `go test -race -count=50 -run "TestCacheBackends/SQLite/ConcurrentDownloadCancelOneClientOthersContinue" ./pkg/cache/` → 50/50 pass (the bug doesn't reproduce locally; this is purely defensive instrumentation).
- [x] `golangci-lint run ./pkg/cache/cache_test.go` → 0 issues after `--fix`.

Refs #1252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)