### PR TITLE
fix: use DO NOTHING for chunk inserts, add 25P02 recovery

### DIFF
--- a/openspec/changes/archive/2026-05-24-fix-postgres-aborted-transaction-500/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-24-fix-postgres-aborted-transaction-500/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-24

--- a/openspec/changes/archive/2026-05-24-fix-postgres-aborted-transaction-500/design.md
+++ b/openspec/changes/archive/2026-05-24-fix-postgres-aborted-transaction-500/design.md
@@ -1,0 +1,125 @@
+## Context
+
+The `chunks` table has an auto-increment integer PK (`id`) and a separate
+`UNIQUE` index on `hash`. `recordChunkBatch` inserts chunks via an upsert:
+`ON CONFLICT (hash) DO UPDATE SET updated_at = now()`. This is intended to
+return the chunk's `id` (via `RETURNING id`) regardless of whether the row
+was newly inserted or already existed.
+
+The bug: when the PostgreSQL sequence for `chunks_id_seq` is desynced with
+the table data (e.g., after a database restore or manual data import), the
+`INSERT` fails on `chunks_pkey` (auto-increment PK) before PostgreSQL can
+evaluate the `ON CONFLICT (hash)` clause. This is a plain unique_violation
+(SQLSTATE 23505) on the PK, which `withEntTransactionRetry` treats as
+retryable — so it retries 5 times, each time consuming a new desynced
+sequence value, each time failing again.
+
+After all 5 retries fail, the transaction is rolled back correctly by
+`WithTransaction`. However, if any intermediate state in the same request
+shares the connection (via an outer transaction or connection reuse in the
+request path), a subsequent query sees PostgreSQL's aborted-transaction state
+(SQLSTATE 25P02) and fails. ncps surfaces this as HTTP 500.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate `chunks_pkey` duplicate key failures during CDC chunk recording
+- Prevent HTTP 500 from 25P02 leaking to narinfo or NAR responses
+- Keep the fix minimal: no schema changes, no sequence-reset migrations
+
+**Non-Goals:**
+- Fixing the underlying sequence desync (operational concern, not a code bug)
+- Changing the retry policy for other operations
+- Altering the `nar_file_chunks` bulk-insert path (already uses `DO NOTHING`)
+
+## Decisions
+
+### Decision 1: Replace per-chunk upsert with DO NOTHING + SELECT
+
+**Chosen**: In `recordChunkBatch`, change each per-chunk upsert from:
+```
+ON CONFLICT (hash) DO UPDATE SET updated_at = now()
+```
+to:
+```
+ON CONFLICT (hash) DO NOTHING
+```
+Then immediately query `WHERE hash = <hash>` to retrieve the chunk's `id`.
+
+**Rationale**: Chunks are content-addressed immutable blobs. There is no
+semantic reason to touch `updated_at` on an existing chunk — it's already
+stored correctly. Using `DO NOTHING` means the INSERT never touches the PK
+path at all if the chunk exists, avoiding the sequence desync problem
+entirely. The extra `SELECT WHERE hash = ...` per unique chunk is a
+lightweight indexed lookup and only fires when the chunk pre-exists.
+
+**Alternative considered**: Fix the sequence desync operationally (ALTER
+SEQUENCE ... RESTART). Rejected as the sole fix: requires manual
+intervention per deployment and doesn't prevent recurrence if the sequence
+drifts again. The code-side DO NOTHING fix is resilient to future drift.
+
+**Alternative considered**: Keep `DO UPDATE` but also handle PK conflict
+separately. Rejected: more complex than needed, still hits the sequence.
+
+**Alternative considered**: Collapse chunk insert + ID retrieval into a
+single `INSERT ... ON CONFLICT (hash) DO NOTHING RETURNING id` and handle
+the case where RETURNING returns 0 rows (i.e., chunk pre-existed). This
+requires raw SQL or a custom Ent hook; the two-step approach (INSERT +
+SELECT) is clearer and fully supported by Ent's query builder.
+
+### Decision 2: Add 25P02 detection and connection rollback
+
+**Chosen**: In `withEntTransactionRetry`, after all retries are exhausted
+(or when a non-retryable error occurs), detect SQLSTATE 25P02
+("in_failed_sql_transaction") and issue an explicit `ROLLBACK` on the
+current database connection before returning the error. This ensures the
+connection is returned to the pool in a clean state.
+
+The detection point is the error returned from `dbClient.WithTransaction`.
+If the error (or its cause) carries SQLSTATE 25P02, call `db.ExecContext`
+with `ROLLBACK` on the raw connection before returning.
+
+**Alternative considered**: Configure `pgxpool` with a `BeforeAcquire` hook
+that checks for 25P02 and rolls back before handing the connection to the
+caller. Rejected: ncps uses `database/sql` (not pgxpool directly), so there
+is no `BeforeAcquire` hook available without significant refactoring.
+
+**Alternative considered**: Set `SetMaxConnLifetime` to a short value so
+dirty connections are recycled quickly. Rejected: this masks the bug rather
+than fixing it, and adds unnecessary connection churn under load.
+
+**Alternative considered**: Wrap every non-transactional DB query with
+25P02 detection and auto-retry on a fresh connection. Rejected: too broad;
+masks the real problem and adds complexity to every query site.
+
+## Risks / Trade-offs
+
+**[Risk] Extra SELECT per pre-existing chunk** → One indexed lookup per
+chunk that already exists in the DB. During normal operation (first-time
+chunking), no extra SELECTs. During retry or duplicate chunking (rare),
+one SELECT per chunk. Acceptable overhead.
+
+**[Risk] DO NOTHING on hash returns no RETURNING row — Ent ID() fails** →
+Addressed by using `Exec(ctx)` (not `ID(ctx)`) for the INSERT, then a
+separate `Query().Where(hash).Only(ctx)` to fetch the ID.
+
+**[Risk] Sequence desync persists** → The sequence will still be desynced
+and WILL affect future first-time inserts (brand new chunks). Those will
+fail the INSERT on `chunks_pkey` too. But with DO NOTHING, this only applies
+to truly new chunks; pre-existing chunks are unaffected. A runbook note
+should explain how to reset the sequence (`SELECT setval('chunks_id_seq',
+MAX(id)) FROM chunks`). The code fix prevents cascading failures; the
+operational fix resolves drift permanently.
+
+**[Risk] 25P02 rollback adds a round-trip on error** → Only triggered on
+failure, not on the hot path. Acceptable.
+
+## Migration Plan
+
+1. Deploy the code change — no DB migrations, no config changes needed.
+2. The sequence desync (if present) can be fixed at any time with:
+   ```sql
+   SELECT setval('chunks_id_seq', (SELECT MAX(id) FROM chunks));
+   ```
+3. Rollback: revert the code change; behavior reverts to pre-fix state
+   (upsert resumes, 25P02 leak may recur if sequence is still desynced).

--- a/openspec/changes/archive/2026-05-24-fix-postgres-aborted-transaction-500/proposal.md
+++ b/openspec/changes/archive/2026-05-24-fix-postgres-aborted-transaction-500/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+CDC chunk recording fails with "duplicate key value violates unique constraint
+`chunks_pkey`" after 5 retries, leaving the PostgreSQL connection in an aborted-
+transaction state (SQLSTATE 25P02). A subsequent narinfo query on that connection
+returns "current transaction is aborted", causing ncps to return HTTP 500.
+
+## What Changes
+
+- Change the `chunks` table insert from `ON CONFLICT (hash) DO UPDATE SET
+  updated_at = ...` to `ON CONFLICT (hash) DO NOTHING`. The upsert pattern
+  fails when a single bulk insert contains two rows with the same chunk hash
+  (PostgreSQL: "ON CONFLICT DO UPDATE command cannot affect row a second time").
+  Since chunks are content-addressed, the existing row is correct; skipping the
+  duplicate is the right behavior — same as `nar_file_chunks` already does.
+- Ensure that after any transaction failure in the CDC chunk recording path, the
+  aborted connection is not returned to the pool with live transaction state. Add
+  explicit rollback verification and/or a connection health check before reuse so
+  that a narinfo query on a pool connection never inherits SQLSTATE 25P02.
+
+## Capabilities
+
+### New Capabilities
+_None._
+
+### Modified Capabilities
+- `cdc-chunking`: chunk insert conflict strategy changes from upsert to ignore;
+  adds a requirement that transaction failures MUST NOT leave pool connections in
+  an aborted state visible to subsequent non-transactional queries.
+
+## Impact
+
+- `pkg/cache/cache.go` — `recordChunkBatch`: change `OnConflictColumns(entchunk.FieldHash).Update(...)` to `.Ignore()`
+- `pkg/database/client.go` — `WithTransaction` or its callers: ensure rollback cleans connection state before returning to pool
+- No API surface changes; no schema migrations needed
+- Performance: negligible — removes redundant `updated_at` writes on duplicate chunks
+- No impact on SQLite or MySQL (both handle the conflict correctly already)

--- a/openspec/changes/archive/2026-05-24-fix-postgres-aborted-transaction-500/specs/cdc-chunking/spec.md
+++ b/openspec/changes/archive/2026-05-24-fix-postgres-aborted-transaction-500/specs/cdc-chunking/spec.md
@@ -1,0 +1,65 @@
+## MODIFIED Requirements
+
+### Requirement: CDC chunk insert MUST use ignore-on-conflict, not upsert
+
+When recording a batch of chunks in `recordChunkBatch`, each chunk insert
+into the `chunks` table SHALL use `ON CONFLICT (hash) DO NOTHING` (not
+`DO UPDATE`). Chunks are content-addressed immutable blobs; an existing
+chunk with the same hash is already correct and MUST NOT be touched.
+
+After the INSERT (whether it inserted or skipped), the system SHALL retrieve
+the chunk's `id` via a `SELECT WHERE hash = <hash>` query and use that ID
+to build the `nar_file_chunks` link. This two-step approach ensures the
+correct ID is obtained regardless of whether the row was newly inserted or
+pre-existed.
+
+#### Scenario: Chunk is new — INSERT succeeds, ID retrieved from SELECT
+
+- **WHEN** a chunk with a given hash does not exist in the `chunks` table
+- **THEN** the INSERT inserts the row and `DO NOTHING` is not triggered
+- **AND** the subsequent SELECT retrieves the newly inserted chunk's `id`
+- **AND** the `nar_file_chunks` link is created with that `id`
+
+#### Scenario: Chunk already exists — INSERT is skipped, ID retrieved from SELECT
+
+- **WHEN** a chunk with a given hash already exists in the `chunks` table
+- **THEN** the INSERT is skipped silently (`DO NOTHING`)
+- **AND** the subsequent SELECT retrieves the pre-existing chunk's `id`
+- **AND** the `nar_file_chunks` link is created with that `id`
+
+#### Scenario: Duplicate hash in same batch — no conflict error
+
+- **WHEN** a chunk batch contains two entries with the same hash (same content)
+- **THEN** the first INSERT inserts the row; the second INSERT is skipped
+- **AND** both `nar_file_chunks` links use the same chunk `id`
+- **AND** no error is returned
+
+## ADDED Requirements
+
+### Requirement: Transaction failure MUST NOT leave connections in aborted state
+
+After any transaction in `withEntTransactionRetry` fails (whether immediately
+or after all retry attempts are exhausted), the system SHALL ensure the
+database connection is returned to the pool in a clean, non-aborted state.
+
+If the final transaction error carries PostgreSQL SQLSTATE 25P02
+(`in_failed_sql_transaction`), the system SHALL issue an explicit `ROLLBACK`
+on the connection before it is returned to the pool. A subsequent query on
+the same connection MUST NOT fail with "current transaction is aborted".
+
+#### Scenario: Transaction exhausts retries — connection is clean on return
+
+- **GIVEN** `withEntTransactionRetry` exhausts all retry attempts
+- **AND** the final error is a PostgreSQL unique_violation (SQLSTATE 23505)
+- **WHEN** the error is returned to the caller
+- **THEN** the connection is returned to the pool in a clean state
+- **AND** a subsequent non-transactional query on any pooled connection
+  succeeds without a 25P02 error
+
+#### Scenario: 25P02 detected — explicit rollback issued
+
+- **GIVEN** a database connection is in PostgreSQL aborted-transaction state
+  (SQLSTATE 25P02 — "in_failed_sql_transaction")
+- **WHEN** `withEntTransactionRetry` detects this condition on the error
+- **THEN** an explicit `ROLLBACK` is issued on that connection
+- **AND** the connection is returned to the pool usable for the next query

--- a/openspec/changes/archive/2026-05-24-fix-postgres-aborted-transaction-500/tasks.md
+++ b/openspec/changes/archive/2026-05-24-fix-postgres-aborted-transaction-500/tasks.md
@@ -1,0 +1,48 @@
+## 1. Write Failing Tests (TDD)
+
+- [x] 1.1 Add `testRecordChunkBatch_PreExistingChunk`: seed a chunk row in DB,
+  call `recordChunkBatch` with a batch containing that hash, assert no error
+  and the `nar_file_chunks` link uses the pre-existing chunk's ID
+- [x] 1.2 Add `testRecordChunkBatch_DuplicateHashInBatch`: build a batch where
+  two entries share the same hash, assert `recordChunkBatch` returns no error
+  and both `nar_file_chunks` links reference the same chunk ID
+- [x] 1.3 Add `testRecordChunkBatch_NewChunk`: assert that a brand-new chunk
+  hash inserts a new `chunks` row and the `nar_file_chunks` link is created
+- [x] 1.4 Verify all new tests fail (RED) before touching production code
+  (Note: tests start GREEN because the sequence-desync bug is environmental
+  and not reproducible in unit tests; tests serve as regression coverage)
+
+## 2. Fix Chunk Insert in recordChunkBatch
+
+- [x] 2.1 In `pkg/cache/cache.go` `recordChunkBatch`, replace the per-chunk
+  UpsertOne (`OnConflictColumns(entchunk.FieldHash).Update(...)`) with
+  `Create().OnConflictColumns(entchunk.FieldHash).Ignore().Exec(ctx)`
+- [x] 2.2 After each INSERT, query the chunk ID via
+  `tx.Chunk.Query().Where(entchunk.Hash(chunkMetadata.Hash)).Only(ctx)`
+  and use `.ID` for the `nar_file_chunks` link
+- [x] 2.3 Run new tests — verify they pass (GREEN)
+
+## 3. Fix 25P02 Connection Leak
+
+- [x] 3.1 Add `database.IsAbortedTransactionError(err)` helper in
+  `pkg/database/errors.go` that detects SQLSTATE 25P02
+- [x] 3.2 In `WithTransaction` (`pkg/database/client.go`), after fn(tx)
+  fails and rollback is called, if the error is 25P02 issue a bare
+  `ROLLBACK` via `c.sdb.ExecContext(context.Background(), "ROLLBACK")`
+  to clean up any aborted connection in the pool (best-effort)
+- [x] 3.3 Skipped: the DO NOTHING fix eliminates the root cause; a meaningful
+  25P02 pool test is non-deterministic without connection-level control over
+  database/sql. IsAbortedTransactionError is exported for future callers.
+
+## 4. Lint and Test
+
+- [x] 4.1 `golangci-lint run --fix ./pkg/cache/... ./pkg/database/...`
+- [x] 4.2 `nix fmt`
+- [x] 4.3 `go test -race -run "TestRecordChunkBatch\|TestCacheBackends" ./pkg/cache/...`
+- [x] 4.4 `go test -race ./pkg/database/...`
+
+## 5. Commit and Update Spec
+
+- [ ] 5.1 Commit with `/git-commit`
+- [ ] 5.2 Update `openspec/specs/cdc-chunking/spec.md` with the delta spec
+  content (sync via `/opsx:archive`)

--- a/openspec/specs/cdc-chunking/spec.md
+++ b/openspec/specs/cdc-chunking/spec.md
@@ -104,6 +104,68 @@ compression would cause Nix to fail with "input compression not recognized".
 - **WHEN** `GetNar` is called with a `.nar.xz` URL
 - **THEN** the whole-file xz content is served from storage
 
+### Requirement: CDC chunk insert MUST use ignore-on-conflict, not upsert
+
+When recording a batch of chunks in `recordChunkBatch`, each chunk insert
+into the `chunks` table SHALL use `ON CONFLICT (hash) DO NOTHING` (not
+`DO UPDATE`). Chunks are content-addressed immutable blobs; an existing
+chunk with the same hash is already correct and MUST NOT be touched.
+
+After the INSERT (whether it inserted or skipped), the system SHALL retrieve
+the chunk's `id` via a `SELECT WHERE hash = <hash>` query and use that ID
+to build the `nar_file_chunks` link. This two-step approach ensures the
+correct ID is obtained regardless of whether the row was newly inserted or
+pre-existed.
+
+#### Scenario: Chunk is new — INSERT succeeds, ID retrieved from SELECT
+
+- **WHEN** a chunk with a given hash does not exist in the `chunks` table
+- **THEN** the INSERT inserts the row and `DO NOTHING` is not triggered
+- **AND** the subsequent SELECT retrieves the newly inserted chunk's `id`
+- **AND** the `nar_file_chunks` link is created with that `id`
+
+#### Scenario: Chunk already exists — INSERT is skipped, ID retrieved from SELECT
+
+- **WHEN** a chunk with a given hash already exists in the `chunks` table
+- **THEN** the INSERT is skipped silently (`DO NOTHING`)
+- **AND** the subsequent SELECT retrieves the pre-existing chunk's `id`
+- **AND** the `nar_file_chunks` link is created with that `id`
+
+#### Scenario: Duplicate hash in same batch — no conflict error
+
+- **WHEN** a chunk batch contains two entries with the same hash (same content)
+- **THEN** the first INSERT inserts the row; the second INSERT is skipped
+- **AND** both `nar_file_chunks` links use the same chunk `id`
+- **AND** no error is returned
+
+### Requirement: Transaction failure MUST NOT leave connections in aborted state
+
+After any transaction in `withEntTransactionRetry` fails (whether immediately
+or after all retry attempts are exhausted), the system SHALL ensure the
+database connection is returned to the pool in a clean, non-aborted state.
+
+If the final transaction error carries PostgreSQL SQLSTATE 25P02
+(`in_failed_sql_transaction`), the system SHALL issue an explicit `ROLLBACK`
+on the connection before it is returned to the pool. A subsequent query on
+the same connection MUST NOT fail with "current transaction is aborted".
+
+#### Scenario: Transaction exhausts retries — connection is clean on return
+
+- **GIVEN** `withEntTransactionRetry` exhausts all retry attempts
+- **AND** the final error is a PostgreSQL unique_violation (SQLSTATE 23505)
+- **WHEN** the error is returned to the caller
+- **THEN** the connection is returned to the pool in a clean state
+- **AND** a subsequent non-transactional query on any pooled connection
+  succeeds without a 25P02 error
+
+#### Scenario: 25P02 detected — explicit rollback issued
+
+- **GIVEN** a database connection is in PostgreSQL aborted-transaction state
+  (SQLSTATE 25P02 — "in_failed_sql_transaction")
+- **WHEN** `withEntTransactionRetry` detects this condition on the error
+- **THEN** an explicit `ROLLBACK` is issued on that connection
+- **AND** the connection is returned to the pool usable for the next query
+
 ### Requirement: CDC goroutine error MUST be logged at error level
 When the background CDC goroutine (started from `pullNarIntoStore`) receives a non-nil
 error from `storeNarWithCDCFromReader`, it SHALL log the error at `error` level (not

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2429,25 +2429,30 @@ func (c *Cache) recordChunkBatch(ctx context.Context, narFileID int64, startInde
 		chunkIDs := make([]int, len(batch))
 
 		for i, chunkMetadata := range batch {
-			// Create-or-touch chunk: ON CONFLICT(hash) DO UPDATE SET
-			// updated_at = CURRENT_TIMESTAMP. Ent's UpsertOne.Update
-			// expresses the touch; .ID(ctx) returns the existing
-			// (or newly-inserted) chunk row's PK regardless of which
-			// branch fired.
-			id, err := tx.Chunk.Create().
+			// Insert the chunk if it doesn't exist yet; skip silently if the
+			// hash is already present. Chunks are content-addressed immutable
+			// blobs — an existing row is always correct and needs no update.
+			// Using DO NOTHING avoids touching the auto-increment PK path at
+			// all when the row pre-exists, which prevents failures when the
+			// PK sequence is desynced with the table data.
+			if err := tx.Chunk.Create().
 				SetHash(chunkMetadata.Hash).
 				SetSize(chunkMetadata.Size).
 				SetCompressedSize(chunkMetadata.CompressedSize).
 				OnConflictColumns(entchunk.FieldHash).
-				Update(func(u *ent.ChunkUpsert) {
-					u.SetUpdatedAt(time.Now())
-				}).
-				ID(ctx)
-			if err != nil {
+				Ignore().
+				Exec(ctx); err != nil {
 				return fmt.Errorf("error creating chunk record: %w", err)
 			}
 
-			chunkIDs[i] = id
+			// SELECT after the INSERT (whether it inserted or was skipped) to
+			// retrieve the chunk's PK for the nar_file_chunks link.
+			ch, err := tx.Chunk.Query().Where(entchunk.HashEQ(chunkMetadata.Hash)).Only(ctx)
+			if err != nil {
+				return fmt.Errorf("error fetching chunk ID after insert: %w", err)
+			}
+
+			chunkIDs[i] = ch.ID
 		}
 
 		// Link to NAR file in bulk; ON CONFLICT (nar_file_id,

--- a/pkg/cache/cache_internal_test.go
+++ b/pkg/cache/cache_internal_test.go
@@ -22,7 +22,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	entchunk "github.com/kalbasit/ncps/ent/chunk"
 	entnarfile "github.com/kalbasit/ncps/ent/narfile"
+	entnarfilechunk "github.com/kalbasit/ncps/ent/narfilechunk"
 	entnarinfo "github.com/kalbasit/ncps/ent/narinfo"
 	entnarinfonarfile "github.com/kalbasit/ncps/ent/narinfonarfile"
 	entnarinforeference "github.com/kalbasit/ncps/ent/narinforeference"
@@ -31,6 +33,7 @@ import (
 
 	"github.com/kalbasit/ncps/ent"
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
+	"github.com/kalbasit/ncps/pkg/chunker"
 	"github.com/kalbasit/ncps/pkg/database"
 	"github.com/kalbasit/ncps/pkg/nar"
 	"github.com/kalbasit/ncps/pkg/storage/chunk"
@@ -2252,5 +2255,177 @@ func TestStoreNarWithCDC_TruncatedStream(t *testing.T) {
 			require.NoError(t, dbErr)
 			assert.Equal(t, int64(0), nf.TotalChunks, "truncated stream must leave total_chunks = 0")
 		})
+	}
+}
+
+// TestRecordChunkBatch tests the recordChunkBatch method across all backends.
+func TestRecordChunkBatch(t *testing.T) {
+	t.Parallel()
+
+	backends := []struct {
+		name   string
+		envVar string
+		setup  cacheFactory
+	}{
+		{name: "SQLite", setup: setupSQLiteFactory},
+		{name: "PostgreSQL", envVar: "NCPS_TEST_ADMIN_POSTGRES_URL", setup: setupPostgresFactory},
+		{name: "MySQL", envVar: "NCPS_TEST_ADMIN_MYSQL_URL", setup: setupMySQLFactory},
+	}
+
+	for _, b := range backends {
+		t.Run(b.name, func(t *testing.T) {
+			t.Parallel()
+
+			if b.envVar != "" && os.Getenv(b.envVar) == "" {
+				t.Skipf("Skipping %s: %s not set", b.name, b.envVar)
+			}
+
+			t.Run("NewChunk", testRecordChunkBatchNewChunk(b.setup))
+			t.Run("PreExistingChunk", testRecordChunkBatchPreExistingChunk(b.setup))
+			t.Run("DuplicateHashInBatch", testRecordChunkBatchDuplicateHashInBatch(b.setup))
+		})
+	}
+}
+
+// testRecordChunkBatch_NewChunk verifies that a brand-new chunk hash inserts
+// a new chunks row and creates the nar_file_chunks link with the correct ID.
+func testRecordChunkBatchNewChunk(factory cacheFactory) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		c, dbClient, _, _, _, cleanup := factory(t)
+		defer cleanup()
+
+		ctx := newContext()
+
+		nf, err := dbClient.Ent().NarFile.Create().
+			SetHash("newchunktestnarfile0000000000000000000000000000000000000").
+			SetCompression("none").
+			SetFileSize(0).
+			Save(ctx)
+		require.NoError(t, err)
+
+		const hash = "newchunkhash0000000000000000000000000000000000000000"
+
+		batch := []*chunker.Chunk{
+			{Hash: hash, Size: 100, CompressedSize: 50},
+		}
+
+		err = c.recordChunkBatch(ctx, int64(nf.ID), 0, batch)
+		require.NoError(t, err)
+
+		ch, err := dbClient.Ent().Chunk.Query().Where(entchunk.HashEQ(hash)).Only(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, hash, ch.Hash)
+
+		links, err := dbClient.Ent().NarFileChunk.Query().
+			Where(entnarfilechunk.NarFileID(nf.ID)).
+			All(ctx)
+		require.NoError(t, err)
+		require.Len(t, links, 1)
+		assert.Equal(t, ch.ID, links[0].ChunkID, "nar_file_chunks must reference the inserted chunk ID")
+		assert.Equal(t, 0, links[0].ChunkIndex)
+	}
+}
+
+// testRecordChunkBatch_PreExistingChunk verifies that when a chunk with the
+// same hash already exists, recordChunkBatch succeeds without error and the
+// nar_file_chunks link uses the pre-existing chunk's ID (not a duplicate row).
+func testRecordChunkBatchPreExistingChunk(factory cacheFactory) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		c, dbClient, _, _, _, cleanup := factory(t)
+		defer cleanup()
+
+		ctx := newContext()
+
+		nf, err := dbClient.Ent().NarFile.Create().
+			SetHash("preexistingchunknarfile000000000000000000000000000000000").
+			SetCompression("none").
+			SetFileSize(0).
+			Save(ctx)
+		require.NoError(t, err)
+
+		const hash = "preexistinghash000000000000000000000000000000000000000"
+
+		// Seed the chunk directly, bypassing recordChunkBatch.
+		existing, err := dbClient.Ent().Chunk.Create().
+			SetHash(hash).
+			SetSize(200).
+			SetCompressedSize(80).
+			Save(ctx)
+		require.NoError(t, err)
+
+		// Now call recordChunkBatch with the same hash — must not error.
+		batch := []*chunker.Chunk{
+			{Hash: hash, Size: 200, CompressedSize: 80},
+		}
+
+		err = c.recordChunkBatch(ctx, int64(nf.ID), 0, batch)
+		require.NoError(t, err)
+
+		// Only one chunk row should exist.
+		count, err := dbClient.Ent().Chunk.Query().Where(entchunk.HashEQ(hash)).Count(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count, "must not duplicate the chunk row")
+
+		// The nar_file_chunks link must reference the pre-existing chunk ID.
+		links, err := dbClient.Ent().NarFileChunk.Query().
+			Where(entnarfilechunk.NarFileID(nf.ID)).
+			All(ctx)
+		require.NoError(t, err)
+		require.Len(t, links, 1)
+		assert.Equal(t, existing.ID, links[0].ChunkID,
+			"link must reference the pre-existing chunk ID, not a new one")
+	}
+}
+
+// testRecordChunkBatch_DuplicateHashInBatch verifies that a batch containing
+// two entries with the same hash succeeds: no duplicate chunk rows are created
+// and both nar_file_chunks links reference the same chunk ID.
+func testRecordChunkBatchDuplicateHashInBatch(factory cacheFactory) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		c, dbClient, _, _, _, cleanup := factory(t)
+		defer cleanup()
+
+		ctx := newContext()
+
+		nf, err := dbClient.Ent().NarFile.Create().
+			SetHash("dupehashbatchnarfile00000000000000000000000000000000000").
+			SetCompression("none").
+			SetFileSize(0).
+			Save(ctx)
+		require.NoError(t, err)
+
+		const hash = "dupehash00000000000000000000000000000000000000000000000"
+
+		// Two entries with identical hash in the same batch.
+		batch := []*chunker.Chunk{
+			{Hash: hash, Size: 100, CompressedSize: 50},
+			{Hash: hash, Size: 100, CompressedSize: 50},
+		}
+
+		err = c.recordChunkBatch(ctx, int64(nf.ID), 0, batch)
+		require.NoError(t, err)
+
+		// Exactly one chunk row.
+		chunks, err := dbClient.Ent().Chunk.Query().Where(entchunk.HashEQ(hash)).All(ctx)
+		require.NoError(t, err)
+		require.Len(t, chunks, 1, "duplicate hash must not create two chunk rows")
+
+		// Two nar_file_chunks links (different indices), both referencing the same chunk.
+		links, err := dbClient.Ent().NarFileChunk.Query().
+			Where(entnarfilechunk.NarFileID(nf.ID)).
+			Order(entnarfilechunk.ByChunkIndex()).
+			All(ctx)
+		require.NoError(t, err)
+		require.Len(t, links, 2)
+		assert.Equal(t, chunks[0].ID, links[0].ChunkID, "index 0 must reference the shared chunk ID")
+		assert.Equal(t, chunks[0].ID, links[1].ChunkID, "index 1 must reference the same chunk ID")
+		assert.Equal(t, 0, links[0].ChunkIndex)
+		assert.Equal(t, 1, links[1].ChunkIndex)
 	}
 }

--- a/pkg/database/client.go
+++ b/pkg/database/client.go
@@ -140,6 +140,17 @@ func (c *Client) WithTransaction(
 			return fmt.Errorf("transaction for %s failed (rollback also failed: %w): %w", name, rbErr, err)
 		}
 
+		// If the error carries SQLSTATE 25P02 (in_failed_sql_transaction),
+		// the pgx driver may have returned the connection to the pool before
+		// the PostgreSQL-side transaction was fully rolled back. Issue an
+		// explicit ROLLBACK via the pool so that any connection in the aborted
+		// state is cleaned up before the next caller acquires it. This is
+		// best-effort: use a fresh context so a cancelled caller ctx does not
+		// prevent the cleanup.
+		if IsAbortedTransactionError(err) {
+			_, _ = c.sdb.ExecContext(context.Background(), "ROLLBACK") //nolint:contextcheck
+		}
+
 		return err
 	}
 

--- a/pkg/database/errors.go
+++ b/pkg/database/errors.go
@@ -82,6 +82,25 @@ func IsDuplicateKeyError(err error) bool {
 	return false
 }
 
+// IsAbortedTransactionError returns true when err carries PostgreSQL SQLSTATE
+// 25P02 ("in_failed_sql_transaction"). This state arises when a prior
+// statement in the same transaction failed, leaving the transaction aborted.
+// Subsequent statements on that connection will also fail until a ROLLBACK is
+// issued. Detecting this lets callers clean up the connection before returning
+// it to the pool.
+func IsAbortedTransactionError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == "25P02"
+	}
+
+	return strings.Contains(err.Error(), "current transaction is aborted")
+}
+
 // IsNotFoundError checks if the error indicates a row was not found.
 // Accepts both the package-level ErrNotFound sentinel and Ent's
 // *NotFoundError wrapper.


### PR DESCRIPTION
## Summary

- Replace per-chunk `UpsertOne(...).Update(...)` with
  `Create().OnConflictColumns(hash).Ignore().Exec()` so that a
  duplicate-hash conflict leaves the transaction alive instead of
  aborting it with SQLSTATE 25P02.
- After each INSERT, query the chunk ID by hash for the
  `nar_file_chunks` link — `DO NOTHING` returns no rows so an
  explicit SELECT is required.
- Add `database.IsAbortedTransactionError` (SQLSTATE 25P02 detector)
  and a best-effort bare `ROLLBACK` in `WithTransaction` to recover
  connections that entered the aborted state before this fix was
  deployed.
- Regression coverage via three new `testRecordChunkBatch_*` subtests.

## Why

A duplicate chunk hash caused the DB engine to abort the whole
transaction. Every subsequent statement on that connection failed
with "current transaction is aborted, commands ignored until end of
transaction block", which surfaced as HTTP 500 to Nix clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)