### PR TITLE
fix: remove non-deterministic 25P02 pool ROLLBACK

### DIFF
--- a/pkg/database/client.go
+++ b/pkg/database/client.go
@@ -140,17 +140,6 @@ func (c *Client) WithTransaction(
 			return fmt.Errorf("transaction for %s failed (rollback also failed: %w): %w", name, rbErr, err)
 		}
 
-		// If the error carries SQLSTATE 25P02 (in_failed_sql_transaction),
-		// the pgx driver may have returned the connection to the pool before
-		// the PostgreSQL-side transaction was fully rolled back. Issue an
-		// explicit ROLLBACK via the pool so that any connection in the aborted
-		// state is cleaned up before the next caller acquires it. This is
-		// best-effort: use a fresh context so a cancelled caller ctx does not
-		// prevent the cleanup.
-		if IsAbortedTransactionError(err) {
-			_, _ = c.sdb.ExecContext(context.Background(), "ROLLBACK") //nolint:contextcheck
-		}
-
 		return err
 	}
 


### PR DESCRIPTION
## Summary

- Remove the best-effort bare `ROLLBACK` that was added in the
  previous commit to recover aborted-transaction connections.
- The root cause (duplicate chunk conflicts) is eliminated by the
  `DO NOTHING` fix, so the ROLLBACK is no longer needed.
- A meaningful integration test for this behaviour is non-deterministic
  without connection-level control over `database/sql`, so the code
  was removed rather than left in with a misleading comment.

## Why

The bare `ROLLBACK` was a defensive measure for connections already
in the aborted state. Now that no statement ever aborts the transaction,
the fallback is dead code that adds complexity without benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)