### PR TITLE
fix(cache): avoid 25P02 on concurrent narinfo insert

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4441,27 +4441,23 @@ func upsertNarInfoFromParsed(
 
 	switch {
 	case ent.IsNotFound(err):
-		// Insert new
+		// Insert new, ignoring a concurrent insert racing between our
+		// SELECT above and this INSERT. Using DO NOTHING instead of
+		// DO UPDATE keeps the transaction alive on conflict — a
+		// competing INSERT (DO UPDATE) would abort the PostgreSQL
+		// transaction (SQLSTATE 25P02), making the re-fetch below fail.
 		nb := tx.NarInfo.Create().SetHash(hash)
 		applyNarInfoCreate(nb, narInfo)
 
-		nir, err := nb.Save(ctx)
-		if err != nil {
-			// A concurrent writer (e.g. a background migration racing with
-			// PutNarInfo) may have inserted the row between our query and
-			// our insert.  Treat that as success: re-fetch and return the
-			// winner's row so the caller can continue linking references /
-			// signatures / nar_files against the real record.
-			if ent.IsConstraintError(err) {
-				nir, err = tx.NarInfo.Query().Where(entnarinfo.HashEQ(hash)).Only(ctx)
-				if err != nil {
-					return nil, fmt.Errorf("error re-fetching narinfo record after concurrent insert for hash %q: %w", hash, err)
-				}
-
-				return nir, nil
-			}
-
+		if err := nb.OnConflictColumns(entnarinfo.FieldHash).Ignore().Exec(ctx); err != nil {
 			return nil, fmt.Errorf("error inserting the narinfo record for hash %q: %w", hash, err)
+		}
+
+		// Always SELECT after to get the row's ID, whether we inserted
+		// it or a concurrent writer did.
+		nir, err := tx.NarInfo.Query().Where(entnarinfo.HashEQ(hash)).Only(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error fetching narinfo record after insert for hash %q: %w", hash, err)
 		}
 
 		return nir, nil


### PR DESCRIPTION
## Summary

- Replace the narinfo upsert `OnConflictColumns(hash).Update(...)`
  with `OnConflictColumns(hash).Ignore().Exec()` so that a
  concurrent insert of the same hash does not abort the transaction.
- After the `DO NOTHING` insert, query the row by hash to obtain the
  ID for downstream operations.

## Why

The same duplicate-key / aborted-transaction problem that affected
chunk inserts also affects narinfo inserts when two goroutines race
to cache the same hash. Applying `DO NOTHING` here closes that
remaining 25P02 surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)