### PR TITLE
fix(cache): fill stub narinfo from concurrent race

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4460,6 +4460,18 @@ func upsertNarInfoFromParsed(
 			return nil, fmt.Errorf("error fetching narinfo record after insert for hash %q: %w", hash, err)
 		}
 
+		// If the concurrent writer inserted a stub (URL=NULL), fill it
+		// in now — otherwise the caller links an incomplete narinfo row.
+		if nir.URL == nil || *nir.URL == "" {
+			ub := tx.NarInfo.UpdateOneID(nir.ID)
+			applyNarInfoUpdate(ub, narInfo)
+
+			nir, err = ub.Save(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("error updating raced stub narinfo record for hash %q: %w", hash, err)
+			}
+		}
+
 		return nir, nil
 	case err != nil:
 		return nil, fmt.Errorf("error fetching the narinfo record for hash %q: %w", hash, err)


### PR DESCRIPTION
## Summary

- After the `DO NOTHING` + re-fetch pattern, detect whether the
  fetched row is a stub (URL is NULL or empty) written by a
  concurrent goroutine mid-flight.
- If so, issue an `UpdateOneID` to fill in the caller's narinfo data
  before returning the row.

## Why

`DO NOTHING` returns the pre-existing row as-is. If another goroutine
inserted a stub row (URL=NULL) just before us and hasn't filled it
yet, callers would operate on an incomplete narinfo record. Detecting
and updating the stub ensures the row is always fully populated after
`upsertNarInfoFromParsed` returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)