### PR TITLE
fix(helm): migration job must not mount storage or tmp for non-SQLite databases

### DIFF
--- a/charts/ncps/templates/migration-job.yaml
+++ b/charts/ncps/templates/migration-job.yaml
@@ -98,6 +98,6 @@ spec:
       volumes:
         - name: storage
           persistentVolumeClaim:
-            claimName: {{ include "ncps.fullname" . }}
+            claimName: {{ .Values.config.storage.local.persistence.existingClaim | default (include "ncps.fullname" .) }}
       {{- end }}
 {{- end }}

--- a/charts/ncps/templates/migration-job.yaml
+++ b/charts/ncps/templates/migration-job.yaml
@@ -60,12 +60,8 @@ spec:
             - |
               mkdir -p $(dirname {{ .Values.config.database.sqlite.path }})
           volumeMounts:
-            {{- if or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite") }}
             - name: storage
               mountPath: /storage
-            {{- end }}
-            - name: tmp
-              mountPath: {{ .Values.config.cache.tempPath }}
           resources:
             {{- toYaml .Values.initImage.resources | nindent 12 }}
           securityContext:
@@ -93,22 +89,15 @@ spec:
             {{- include "ncps.migrationDatabaseURLEnv" . | nindent 12 }}
           resources:
             {{- toYaml .Values.migration.resources | nindent 12 }}
+          {{- if eq .Values.config.database.type "sqlite" }}
           volumeMounts:
-            {{- if or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite") }}
             - name: storage
               mountPath: /storage
-            {{- end }}
-            - name: tmp
-              mountPath: {{ .Values.config.cache.tempPath }}
+          {{- end }}
+      {{- if eq .Values.config.database.type "sqlite" }}
       volumes:
-        {{- if or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite") }}
         - name: storage
-          {{- if or .Values.config.storage.local.persistence.enabled (eq .Values.config.database.type "sqlite") }}
           persistentVolumeClaim:
             claimName: {{ include "ncps.fullname" . }}
-          {{- else }}
-          emptyDir: {}
-          {{- end }}
-        {{- end }}
-        {{- include "ncps.tempVolume" . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/ncps/tests/migration_test.yaml
+++ b/charts/ncps/tests/migration_test.yaml
@@ -70,6 +70,66 @@ tests:
                 name: RELEASE-NAME-ncps
                 key: database-url
 
+  # ---- migration-job volume assertions ----
+  - it: migration-job has no volumes for postgresql + local storage
+    template: migration-job.yaml
+    set:
+      mode: deployment
+      config.hostname: test.example.com
+      config.database.type: postgresql
+      config.database.postgresql.host: pg
+      config.database.postgresql.password: pw
+      config.storage.type: local
+      config.storage.local.path: /storage
+      migration.enabled: true
+      migration.mode: job
+    asserts:
+      - isNull:
+          path: spec.template.spec.volumes
+      - isNull:
+          path: spec.template.spec.containers[0].volumeMounts
+
+  - it: migration-job has no volumes for mysql + local storage
+    template: migration-job.yaml
+    set:
+      mode: deployment
+      config.hostname: test.example.com
+      config.database.type: mysql
+      config.database.mysql.host: mysql
+      config.database.mysql.password: pw
+      config.storage.type: local
+      config.storage.local.path: /storage
+      migration.enabled: true
+      migration.mode: job
+    asserts:
+      - isNull:
+          path: spec.template.spec.volumes
+      - isNull:
+          path: spec.template.spec.containers[0].volumeMounts
+
+  - it: migration-job retains storage volume for sqlite + local storage
+    template: migration-job.yaml
+    set:
+      mode: deployment
+      config.hostname: test.example.com
+      config.database.type: sqlite
+      config.storage.type: local
+      config.storage.local.path: /storage
+      migration.enabled: true
+      migration.mode: job
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: storage
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-ncps
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: storage
+            mountPath: /storage
+
   # ---- deployment initContainer ----
   - it: deployment migration initContainer invokes ncps migrate up
     template: deployment.yaml

--- a/charts/ncps/tests/migration_test.yaml
+++ b/charts/ncps/tests/migration_test.yaml
@@ -130,6 +130,25 @@ tests:
             name: storage
             mountPath: /storage
 
+  - it: migration-job uses existingClaim for sqlite + existingClaim
+    template: migration-job.yaml
+    set:
+      mode: deployment
+      config.hostname: test.example.com
+      config.database.type: sqlite
+      config.storage.type: local
+      config.storage.local.path: /storage
+      config.storage.local.persistence.existingClaim: my-existing-pvc
+      migration.enabled: true
+      migration.mode: job
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: storage
+            persistentVolumeClaim:
+              claimName: my-existing-pvc
+
   # ---- deployment initContainer ----
   - it: deployment migration initContainer invokes ncps migrate up
     template: deployment.yaml

--- a/openspec/changes/archive/2026-05-24-migration-job-needs-no-storage/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-24-migration-job-needs-no-storage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/archive/2026-05-24-migration-job-needs-no-storage/design.md
+++ b/openspec/changes/archive/2026-05-24-migration-job-needs-no-storage/design.md
@@ -1,0 +1,74 @@
+# Design: migration-job-needs-no-storage
+
+## Context
+
+`migration-job.yaml` constructs volumes and volumeMounts using the condition:
+
+```
+or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite")
+```
+
+This makes the storage PVC present whenever local storage is configured, even
+when the database is PostgreSQL or MySQL. The `tmp` emptyDir is always present.
+Neither volume is needed by `ncps migrate up`: the command opens a database
+connection (from `CACHE_DATABASE_URL`) and runs Goose migrations — it performs
+no filesystem I/O outside the database driver.
+
+Stakeholders: users running ArgoCD PreSync migration jobs with non-SQLite
+databases and local storage.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove the `tmp` volume and volumeMount from the migration Job unconditionally.
+- Scope the `storage` volume and volumeMount to `database.type == "sqlite"` only.
+- Apply the same narrow condition inside the `create-db-dir` initContainer's
+  inner volumeMount (currently also guarded by the broader `or local sqlite`).
+- Add/update helm-unittest tests to assert the corrected rendering.
+
+**Non-Goals:**
+- Changes to Go application code — `ncps migrate up` already works without storage.
+- Changes to the main Deployment/StatefulSet volumes.
+- Changes to the fsck CronJob or any other workload.
+
+## Decisions
+
+### Decision 1: Remove `tmp` volume entirely from migration Job
+
+The `tmp` volume exists so the main server can write temporary NAR files during
+download. The migration command has no download path and will never write to
+`/tmp/ncps`. Keeping it adds an 8 GiB memory reservation for zero benefit.
+
+**Alternative considered**: conditionally mount tmp when some future migration
+needs scratch space. Rejected: YAGNI. If a future migration needs scratch, it
+can re-add the volume at that time.
+
+### Decision 2: Gate `storage` on `database.type == "sqlite"` only
+
+SQLite stores its database file inside the storage path, so the PVC is needed
+for the initContainer to create the parent directory. PostgreSQL and MySQL
+databases have their own network endpoint — no filesystem path needed.
+
+The current condition also includes `storage.type == "local"`, which is the
+trigger for the user-reported bug: a local-storage + postgresql deployment
+unnecessarily pulls in the PVC.
+
+**Alternative considered**: add a separate `migration.mountStorage` bool values
+override. Rejected: the correct behavior is deterministic from the database
+type; an override would just be a footgun.
+
+### Decision 3: No Go code changes
+
+The `migrate up` command is already storage-agnostic. The bug is purely in
+how the Helm chart assembles the Pod spec.
+
+## Risks / Trade-offs
+
+[Risk: SQLite + non-local storage] — The `storage` volume condition
+`eq .Values.config.database.type "sqlite"` always evaluates to true for SQLite,
+regardless of the storage backend, which is correct — SQLite needs a PVC to
+persist. No regression.
+
+[Risk: initContainer storage mount] — The `create-db-dir` initContainer is
+already inside `{{- if eq .Values.config.database.type "sqlite" }}`, so the
+inner mount condition change is redundant but explicit for consistency.

--- a/openspec/changes/archive/2026-05-24-migration-job-needs-no-storage/proposal.md
+++ b/openspec/changes/archive/2026-05-24-migration-job-needs-no-storage/proposal.md
@@ -1,0 +1,36 @@
+# Proposal: migration-job-needs-no-storage
+
+## Why
+
+The migration Job unconditionally mounts the storage PVC and a large in-memory
+`tmp` emptyDir, but `ncps migrate up` only connects to the database — it never
+reads or writes to either volume. This couples the PreSync hook to storage
+availability and wastes 8 GiB of memory reservation for a job that needs
+neither.
+
+## What Changes
+
+- **Helm chart `migration-job.yaml`**: Remove the `tmp` volume and volumeMount
+  from the migration container entirely.
+- **Helm chart `migration-job.yaml`**: Scope the `storage` volume and
+  volumeMount to `database.type == "sqlite"` only (SQLite needs the storage
+  path for its database file; non-SQLite databases do not).
+- **Helm chart `migration-job.yaml`**: Same narrower condition for the
+  `create-db-dir` initContainer's storage volumeMount (already sqlite-gated at
+  the container level, but the mount condition inside it uses the broader
+  `or local sqlite` check).
+- **Helm chart tests**: Update or add unit tests to assert the migration Job
+  produced for a non-SQLite backend has no storage or tmp volumes.
+
+## Capabilities
+
+No capability-level (spec) changes — this is a pure Helm chart rendering fix.
+No new or modified behavioral specs are needed.
+
+## Impact
+
+- `charts/ncps/templates/migration-job.yaml` — primary change.
+- `charts/ncps/tests/migration_test.yaml` — test updates.
+- Deployed migration Jobs for PostgreSQL/MySQL users will no longer mount the
+  storage PVC or the memory-backed emptyDir, reducing resource reservations and
+  removing an unnecessary dependency on PVC availability at sync time.

--- a/openspec/changes/archive/2026-05-24-migration-job-needs-no-storage/specs/helm-migration-job-volumes/spec.md
+++ b/openspec/changes/archive/2026-05-24-migration-job-needs-no-storage/specs/helm-migration-job-volumes/spec.md
@@ -1,0 +1,41 @@
+# Spec: helm-migration-job-volumes
+
+## ADDED Requirements
+
+### Requirement: Migration Job omits tmp volume
+
+The migration Job MUST NOT include a `tmp` volume or volumeMount regardless of
+storage backend or database type, because `ncps migrate up` performs no
+filesystem I/O that requires a scratch directory.
+
+#### Scenario: PostgreSQL database with local storage
+
+- **WHEN** `config.database.type` is `postgresql` and `config.storage.type` is `local`
+- **THEN** the migration Job spec SHALL contain no volume named `tmp` and no volumeMount with `mountPath` matching the cache temp path
+
+#### Scenario: SQLite database with local storage
+
+- **WHEN** `config.database.type` is `sqlite` and `config.storage.type` is `local`
+- **THEN** the migration Job spec SHALL contain no volume named `tmp` and no volumeMount with `mountPath` matching the cache temp path
+
+### Requirement: Migration Job mounts storage only for SQLite
+
+The migration Job MUST mount the storage volume only when `config.database.type`
+is `sqlite`, because SQLite persists its database file on the storage path.
+Non-SQLite databases (PostgreSQL, MySQL) access their data over the network and
+require no storage mount.
+
+#### Scenario: PostgreSQL database — no storage volume
+
+- **WHEN** `config.database.type` is `postgresql`
+- **THEN** the migration Job spec SHALL contain no volume named `storage` and no volumeMount at `/storage`
+
+#### Scenario: MySQL database — no storage volume
+
+- **WHEN** `config.database.type` is `mysql`
+- **THEN** the migration Job spec SHALL contain no volume named `storage` and no volumeMount at `/storage`
+
+#### Scenario: SQLite database — storage volume present
+
+- **WHEN** `config.database.type` is `sqlite`
+- **THEN** the migration Job spec SHALL include a volume named `storage` bound to the configured PVC, and the initContainer SHALL mount it at `/storage` to create the database directory

--- a/openspec/changes/archive/2026-05-24-migration-job-needs-no-storage/tasks.md
+++ b/openspec/changes/archive/2026-05-24-migration-job-needs-no-storage/tasks.md
@@ -1,0 +1,19 @@
+## 1. Fix migration-job.yaml template
+
+- [x] 1.1 Remove the `tmp` volumeMount from the migration container (unconditional removal)
+- [x] 1.2 Remove the `tmp` volume from the Job's volumes list (unconditional removal)
+- [x] 1.3 Change the `storage` volumeMount condition in the migration container from `or (eq .Values.config.storage.type "local") (eq .Values.config.database.type "sqlite")` to `eq .Values.config.database.type "sqlite"` only
+- [x] 1.4 Apply the same narrowed condition to the `storage` volume definition in the Job's volumes list
+- [x] 1.5 Apply the same narrowed condition to the storage volumeMount inside the `create-db-dir` initContainer
+
+## 2. Update Helm unit tests
+
+- [x] 2.1 Add or update a test case in `charts/ncps/tests/migration_test.yaml` asserting that, for a PostgreSQL + local-storage configuration, the migration Job has no volume named `tmp`
+- [x] 2.2 Add or update a test case asserting that, for a PostgreSQL + local-storage configuration, the migration container has no volumeMount at the cache temp path
+- [x] 2.3 Add or update a test case asserting that, for a PostgreSQL + local-storage configuration, the migration Job has no volume named `storage` and no volumeMount at `/storage`
+- [x] 2.4 Add a test case asserting that, for an SQLite + local-storage configuration, the migration Job still includes the `storage` volume and volumeMount (regression guard)
+- [x] 2.5 Run `helm unittest charts/ncps` and confirm all tests pass
+
+## 3. Verify
+
+- [x] 3.1 Run `nix flake check` (includes helm-unittest-check) and confirm it passes

--- a/openspec/specs/helm-migration-job-volumes/spec.md
+++ b/openspec/specs/helm-migration-job-volumes/spec.md
@@ -1,0 +1,49 @@
+# Spec: helm-migration-job-volumes
+
+## Purpose
+
+Defines which volumes and volumeMounts the Helm-rendered migration Job includes
+depending on storage backend and database type. The migration Job (`ncps migrate
+up`) performs no filesystem I/O that requires a scratch directory, and only
+needs storage access when using SQLite (which persists its database file on the
+storage path).
+
+## Requirements
+
+### Requirement: Migration Job omits tmp volume
+
+The migration Job MUST NOT include a `tmp` volume or volumeMount regardless of
+storage backend or database type, because `ncps migrate up` performs no
+filesystem I/O that requires a scratch directory.
+
+#### Scenario: PostgreSQL database with local storage
+
+- **WHEN** `config.database.type` is `postgresql` and `config.storage.type` is `local`
+- **THEN** the migration Job spec SHALL contain no volume named `tmp` and no volumeMount with `mountPath` matching the cache temp path
+
+#### Scenario: SQLite database with local storage
+
+- **WHEN** `config.database.type` is `sqlite` and `config.storage.type` is `local`
+- **THEN** the migration Job spec SHALL contain no volume named `tmp` and no volumeMount with `mountPath` matching the cache temp path
+
+### Requirement: Migration Job mounts storage only for SQLite
+
+The migration Job MUST mount the storage volume only when `config.database.type`
+is `sqlite`, because SQLite persists its database file on the storage path.
+Non-SQLite databases (PostgreSQL, MySQL) access their data over the network and
+require no storage mount.
+
+#### Scenario: PostgreSQL database — no storage volume
+
+- **WHEN** `config.database.type` is `postgresql`
+- **THEN** the migration Job spec SHALL contain no volume named `storage` and no volumeMount at `/storage`
+
+#### Scenario: MySQL database — no storage volume
+
+- **WHEN** `config.database.type` is `mysql`
+- **THEN** the migration Job spec SHALL contain no volume named `storage` and no volumeMount at `/storage`
+
+#### Scenario: SQLite database — storage volume present
+
+- **WHEN** `config.database.type` is `sqlite`
+- **THEN** the migration Job spec SHALL include a volume named `storage` bound to the configured PVC, and the initContainer SHALL mount it at `/storage` to create the database directory


### PR DESCRIPTION
## Summary

- The migration Job was mounting the storage PVC and an 8 GiB in-memory `tmp` emptyDir whenever local storage was configured, even for PostgreSQL/MySQL deployments. `ncps migrate up` only opens a database connection — it never reads or writes to either volume.
- Remove `tmp` volume and volumeMount from the migration Job unconditionally.
- Scope the `storage` volume and volumeMount to `database.type == sqlite` only; non-SQLite databases need no filesystem path.
- Gate the `volumes:` block itself so non-SQLite Jobs render no `volumes:` key in the Pod spec.

## Test plan

- [x] New helm-unittest cases assert no volumes for PostgreSQL + local-storage and MySQL + local-storage migration Jobs
- [x] Regression guard asserts SQLite still gets the storage PVC and volumeMount
- [x] `helm unittest charts/ncps` — 138 tests pass
- [x] `nix flake check --no-build` evaluates cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)