### PR TITLE
fix(fsck): batch IN-clause queries to avoid Postgres cap

### DIFF
--- a/openspec/changes/archive/2026-05-25-fsck-is-failing/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-25-fsck-is-failing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/archive/2026-05-25-fsck-is-failing/design.md
+++ b/openspec/changes/archive/2026-05-25-fsck-is-failing/design.md
@@ -1,0 +1,212 @@
+## Context
+
+Two queries in `pkg/ncps/fsck.go` issue Ent eager-loads (`With*`) on top of unbounded
+parent rowsets. Both compile to `SELECT ... WHERE <fk> IN ($1, ..., $N)` follow-ups, and
+PostgreSQL's extended protocol caps bound parameters at 65535 per statement.
+
+**Site 1 — `queryCDCNarFilesWithSizeMismatch` (`pkg/ncps/fsck.go:782`)** — confirmed
+broken in production:
+
+```go
+dbClient.Ent().NarFile.Query().
+    Where(entnarfile.TotalChunksGT(0)).
+    WithNarInfoNarFiles(func(q *ent.NarInfoNarFileQuery) {
+        q.WithNarinfo()
+    }).
+    All(ctx)
+```
+
+The outer `WithNarInfoNarFiles` emits a `SELECT FROM narinfo_nar_files WHERE
+nar_file_id IN ($1...$N)` where N grows with the number of CDC `nar_file` rows. On the
+failing production cache (~82.5k `nar_file` rows, the great majority CDC), N exceeds
+65535 and the driver returns `extended protocol limited to 65535 parameters`; fsck
+aborts phase 1 collection. SQLite and MySQL paths happen to tolerate the current sizes
+but the same pattern would break them at higher cardinalities.
+
+**Site 2 — `chunksForNarFile` (`pkg/ncps/fsck.go:1661`)** — same shape, narrower
+trigger:
+
+```go
+dbClient.Ent().NarFileChunk.Query().
+    Where(entnarfilechunk.NarFileIDEQ(narFileID)).
+    Order(ent.Asc(entnarfilechunk.FieldChunkIndex)).
+    WithChunk().
+    All(ctx)
+```
+
+Here the parent is bounded to a single NAR's chunk links, but the `WithChunk()` eager
+load emits `SELECT FROM chunks WHERE id IN ($1...$M)` where M is the link count for
+that NAR. A single multi-gigabyte CDC NAR can exceed 65535 chunks at typical chunk
+sizes, hitting the same driver cap. Less likely to fire than Site 1 in current
+deployments, but the failure mode and fix are identical, so we batch both in one PR
+rather than file a follow-up that will sit until someone uploads a 60+ GB closure.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Make phase 1g complete on PostgreSQL caches of arbitrary size.
+- Keep the behavioral contract of size-mismatch detection unchanged (same rows flagged,
+  same `fsckResults.narFilesWithSizeMismatch`).
+- Fix `chunksForNarFile` so a single oversized CDC NAR (>65535 chunks) cannot break
+  fsck on PostgreSQL via the `WithChunk()` eager-load.
+- Provide a reusable helper so future fsck additions cannot regress into the same trap.
+- Add PostgreSQL-cohort regression tests that exercise row counts above the parameter
+  ceiling for both sites.
+
+**Non-Goals**
+
+- Rewriting fsck's structure or splitting it into a streaming pipeline.
+- Changing schema, migrations, or what counts as a "mismatch".
+- Optimizing fsck wall-clock time beyond what the bug fix incidentally improves.
+- Switching ORMs or moving to raw SQL anywhere it isn't strictly required to bound
+  parameter counts.
+- Auditing the entire codebase outside `pkg/ncps/fsck.go` — this change is scoped to
+  fsck.
+
+## Decisions
+
+### Decision: Bound the parent query, drop eager-load, do per-batch lookups
+
+Replace the single `.All(ctx)` + `With*` eager-load with a paginated walk. The shape
+applies to both sites:
+
+**`queryCDCNarFilesWithSizeMismatch`** (parent grows with cache size):
+
+1. Iterate CDC `nar_file` rows in ID-ordered pages: `Where(TotalChunksGT(0), IDGT(last))`
+   `Order(Asc(ID))` `Limit(batchSize)` `All(ctx)`. Keyset pagination (vs `Offset`) keeps
+   each round-trip O(batchSize) on the index and is safe under concurrent writes.
+2. For each page, collect the `nar_file` IDs and run a separate query against
+   `narinfo_nar_files` joined to `narinfos`, filtered with `NarFileIDIn(ids...)` and
+   `WithNarinfo()`. The page is bounded, so this secondary `IN` is bounded.
+3. Compare `nar_file.file_size` against each linked `narinfo.nar_size` in memory,
+   exactly as today.
+4. Continue until a short page (fewer than `batchSize` rows) is returned.
+
+**`chunksForNarFile`** (parent grows with chunk count of one NAR):
+
+1. Iterate `nar_file_chunks` rows in `chunk_index`-ordered pages:
+   `Where(NarFileIDEQ(narFileID), ChunkIndexGT(last))`
+   `Order(Asc(ChunkIndex))` `Limit(batchSize)` `All(ctx)`. Keyset pagination on
+   `chunk_index` preserves the existing ordering contract (chunks returned in index
+   order) without `Offset`.
+2. For each page, collect chunk IDs and fetch chunks with
+   `Chunk.Query().Where(IDIn(ids...)).All(ctx)`, then re-order locally to match the
+   link order from step 1 before appending. Doing the fetch separately (rather than
+   `WithChunk()` per page) avoids relying on Ent's edge-load preserving page order.
+3. Continue until a short page is returned.
+
+**Why this shape and not "pure SQL join with WHERE file_size != nar_size"**
+
+- A direct join expression would be cleanest but the current code chose Ent + in-memory
+  comparison precisely because Ent's fluent API does not express cross-table column
+  comparison and the project's convention is to stay on Ent (no hand-written SQL except
+  via sqlc generators that don't cover this query). Staying on Ent keeps the fix narrow.
+- The same problem would still need bounded batching for the eager-load even if we
+  filtered server-side, because `WithNarinfo()` itself drives the parameter explosion.
+
+### Decision: Batch size of 1000 rows for both sites
+
+Per-page worst-case parameter usage:
+
+- **Size-mismatch path**: page IDs (1 param each) feed the secondary
+  `NarFileIDIn(...)` (`batchSize` params), and `WithNarinfo()` issues another `IN` over
+  linked `narinfo_id`s (typically ~1 per CDC nar_file, possibly more if a NAR is
+  shared). Peak is on the order of `2 * batchSize`.
+- **chunksForNarFile path**: page IDs feed `IDIn(...)` once per page — peak is
+  `batchSize` params.
+
+At `batchSize = 1000`, peak parameter count stays around 1000–3000 — two orders of
+magnitude under the PostgreSQL 65535 ceiling, with headroom for sharing fan-out. Use a
+single shared constant `fsckEagerLoadBatchSize = 1000` for both sites, documented
+inline with the PostgreSQL 65535 cap as the reason. One knob is easier to tune than
+two and there is no reason for them to diverge.
+
+### Decision: Shared `batchIDs` helper in `pkg/ncps/fsck.go`
+
+Add an unexported helper:
+
+```go
+// batchedIDIter walks rows of T from an Ent query in keyset-paginated batches of
+// `batchSize`, invoking `fn` per batch. It exists to keep secondary IN-clause
+// queries from exceeding driver parameter limits (notably PostgreSQL's 65535
+// extended-protocol cap).
+func batchedIDIter[T any](
+    ctx context.Context,
+    batchSize int,
+    fetch func(ctx context.Context, afterID int, limit int) ([]T, int, error),
+    fn func(ctx context.Context, batch []T) error,
+) error
+```
+
+Scope it to the fsck package for now — promoting to `pkg/database` is a follow-up if
+another caller appears. This keeps the blast radius minimal and avoids prematurely
+designing a generic abstraction.
+
+### Decision: Regression tests gated on the PostgreSQL cohort
+
+Add two tests to `pkg/ncps/fsck_test.go`, both gated on `NCPS_TEST_POSTGRES`:
+
+- `TestQueryCDCNarFilesWithSizeMismatch_LargePostgreSQL` — seed `> 70_000` CDC
+  `nar_file` rows linked to narinfos via `narinfo_nar_files`, with a small known
+  subset whose `file_size` differs from the linked `narinfo.nar_size`. Assert the
+  function returns without error and that exactly the seeded mismatched IDs are
+  returned.
+- `TestChunksForNarFile_LargePostgreSQL` — seed one `nar_file` with `> 70_000`
+  `nar_file_chunks` rows pointing at distinct `chunks` rows. Assert the function
+  returns without error, returns the full chunk list in `chunk_index` order, and
+  length matches the seeded count.
+
+Seed performance is a one-time cost; use single `INSERT ... SELECT` statements per
+table to keep each test under a few seconds.
+
+We do NOT add the same volumetric tests for SQLite/MySQL — those drivers do not have
+the same hard cap and seeding 70k rows in SQLite is needlessly slow. The smaller
+existing fsck tests already cover correctness across all three engines.
+
+### Decision: No new metric, no new flag
+
+The fix is correctness-only. We do not expose batch size as a CLI flag and do not add a
+metric for "batches processed". If the constant proves wrong for some deployment, a
+follow-up change can promote it; YAGNI for now.
+
+## Risks / Trade-offs
+
+- **More round-trips**: phase 1g goes from 1 query (when it works) to roughly
+  `ceil(N / 1000) * 2` queries. On the failing PostgreSQL cache that's ~166 round-trips
+  vs the current zero (because the current path aborts). Net wall-clock impact is
+  strongly positive in the failure mode. On smaller caches that previously succeeded,
+  the added latency is bounded — typically tens of milliseconds. `chunksForNarFile`
+  goes from 1 query to `ceil(chunkCount / 1000) * 2` queries — negligible for typical
+  NARs (one or two batches) and only meaningful for very large CDC NARs where it was
+  about to fail outright anyway.
+- **Keyset pagination assumption**: relies on `nar_file.id` being monotonically
+  increasing and indexed. Both hold (it is the primary key). Concurrent inserts during
+  fsck can cause new rows to appear in later pages; that is acceptable — fsck has
+  always been a best-effort snapshot.
+- **In-memory comparison still O(rows linked)**: total memory is bounded by `batchSize`
+  worth of `nar_file` + their linked `nar_info_nar_files` and `narinfo` rows. Drops
+  peak memory significantly vs the current `.All(ctx)` that materializes everything.
+- **Two queries per batch**: an alternative is one query per batch (a real JOIN against
+  `narinfo_nar_files` + `narinfos`). We keep two for now because Ent's eager-load with
+  bounded `IN` is the smallest diff from the existing code. If profiling shows the
+  extra round-trip matters, collapse to a single Ent query that joins explicitly.
+
+## Migration Plan
+
+Pure code change. No schema change, no data migration, no flag change. Single PR:
+
+1. Implement the batched helper + the refactor of `queryCDCNarFilesWithSizeMismatch`.
+2. Add the large-cache PostgreSQL regression test (cohort-gated).
+3. Run `nix flake check` (specifically `ncps-postgres-tests`) to validate.
+4. Operators upgrade and re-run `ncps fsck`; phase 1g now completes.
+
+No rollback procedure needed — reverting the commit restores the prior (broken on large
+PostgreSQL caches) behavior.
+
+## Open Questions
+
+- Should the helper move to `pkg/database/` immediately? Deferred — promote on second
+  caller, not on speculation.
+- Should we add a generic eager-load lint to `cmd/ent-lint`? Out of scope for this
+  change; tracked separately if it becomes a recurring footgun.

--- a/openspec/changes/archive/2026-05-25-fsck-is-failing/proposal.md
+++ b/openspec/changes/archive/2026-05-25-fsck-is-failing/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+`ncps fsck` aborts during phase 1g on production-sized caches with the PostgreSQL error
+`extended protocol limited to 65535 parameters`. The CDC size-mismatch query eagerly loads
+every `nar_file` with `total_chunks > 0` and asks Ent to fan-out load the related
+`nar_info_nar_files` rows in a single `IN (...)` predicate. Once the cache exceeds ~65k
+CDC nar_files, the follow-up `SELECT ... WHERE nar_file_id IN ($1...$N)` exhausts the
+PostgreSQL extended-protocol parameter limit and the whole fsck run aborts before phase 2.
+
+This is a hard blocker: there is no workaround for operators running PostgreSQL with a
+cache that has grown past the threshold. fsck is the primary integrity tool, so this also
+prevents detection of corruption on exactly the deployments that need it most (large,
+long-lived caches).
+
+## What Changes
+
+- Replace the eager `.All(ctx)` + in-memory comparison in `queryCDCNarFilesWithSizeMismatch`
+  with a streaming/paginated implementation that never holds more than a bounded number of
+  rows in a single statement or in memory.
+- Audit `pkg/ncps/fsck.go` (and any other Ent query in the fsck path) for similar
+  unbounded `With*` eager-loads or `In(...)` predicates that can exceed the PostgreSQL
+  65535-parameter ceiling, and convert them to bounded-batch iteration.
+- Add a shared helper for batching `IN`-style queries with a safe default chunk size
+  (well below 65535, accounting for per-row parameter multipliers) so future fsck phases
+  do not regress.
+- Add a regression test that exercises the size-mismatch path against a row count above
+  the parameter ceiling (using the existing PostgreSQL test cohort) so the bug cannot
+  silently return.
+
+## Capabilities
+
+### New Capabilities
+
+_None — this is a correctness fix to existing fsck behavior._
+
+### Modified Capabilities
+
+- `fsck`: the size-mismatch detection phase MUST handle caches with arbitrarily many
+  CDC `nar_files` without hitting database driver parameter limits. Behaviorally, fsck
+  must complete phase 1 on PostgreSQL regardless of cache size.
+
+## Non-goals
+
+- No change to fsck's reporting format, CLI flags, or repair semantics.
+- No change to the schema, migrations, or the meaning of `total_chunks` / `file_size` /
+  `nar_size`.
+- Not refactoring all of fsck to streaming — only the queries that demonstrably exceed
+  driver parameter ceilings.
+- Not switching ORMs or introducing raw SQL beyond what is necessary to bound parameter
+  counts.
+
+## Impact
+
+- **Code**: `pkg/ncps/fsck.go` (specifically `queryCDCNarFilesWithSizeMismatch` and any
+  sibling eager-load patterns); possibly a small helper in `pkg/database/` for batched
+  IN-clause iteration.
+- **Tests**: `pkg/ncps/fsck_test.go` gets a regression case sized above the parameter
+  ceiling, gated on the existing PostgreSQL cohort env var.
+- **Performance**: trades one large round-trip for several smaller ones. Expect slightly
+  more network round-trips during phase 1g but bounded memory (no longer materializes
+  every CDC nar_file plus its joined narinfo set at once). Net wall-clock impact on
+  fsck should be neutral-to-positive on large caches because the current path simply
+  fails.
+- **APIs / dependencies**: none. No schema change, no new external dependency.
+- **Operators**: unblocks fsck on existing production PostgreSQL deployments without
+  any migration or config change.

--- a/openspec/changes/archive/2026-05-25-fsck-is-failing/specs/fsck/spec.md
+++ b/openspec/changes/archive/2026-05-25-fsck-is-failing/specs/fsck/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Fsck CDC size-mismatch detection MUST scale beyond database driver parameter limits
+
+The implementation of CDC size-mismatch detection (currently
+`queryCDCNarFilesWithSizeMismatch`) SHALL NOT issue any single SQL statement whose
+bound-parameter count grows unboundedly with the number of CDC `nar_file` rows or
+their joined `narinfo_nar_files`/`narinfos` rows. In particular, it MUST NOT produce
+an `IN ($1...$N)` predicate (whether emitted directly or via an ORM eager-load) where
+N can exceed the PostgreSQL extended-protocol limit of 65535 parameters.
+
+Detection SHALL iterate in bounded batches (chunk size chosen so that
+`batch_size * params_per_row` stays well below 65535 across all supported drivers).
+The fsck phase 1g run MUST complete successfully against caches of arbitrary size.
+
+The behavioral contract of the existing "Fsck MUST detect CDC NARs whose stored size
+mismatches the declared NarSize" requirement is unchanged: the same rows are flagged,
+in the same category, with the same `totalIssues()` accounting. Only the execution
+strategy changes.
+
+#### Scenario: Phase 1g completes against a large CDC cache on PostgreSQL
+
+- **WHEN** `ncps fsck` runs against a PostgreSQL database containing more CDC
+  `nar_file` rows than the PostgreSQL extended-protocol parameter limit (65535)
+- **THEN** phase 1g ("checking CDC NAR files with size mismatch") completes without
+  returning `extended protocol limited to 65535 parameters`
+- **AND** fsck proceeds to subsequent phases
+
+#### Scenario: All size-mismatched rows are still detected when batching
+
+- **WHEN** the cache contains a known set of size-mismatched CDC `nar_file` rows
+  distributed across multiple internal batches
+- **THEN** every size-mismatched row appears in `narFilesWithSizeMismatch`
+- **AND** no correctly-sized CDC row is falsely flagged
+
+#### Scenario: SQLite and MySQL paths remain correct
+
+- **WHEN** `ncps fsck` runs the size-mismatch check against SQLite or MySQL
+- **THEN** the batched implementation returns the same result set as the previous
+  unbatched implementation for caches small enough that both would succeed
+
+### Requirement: Fsck chunk-walk MUST scale beyond database driver parameter limits
+
+The implementation that resolves the chunk rows linked to a single `nar_file` (currently
+`chunksForNarFile`) SHALL NOT issue any single SQL statement whose bound-parameter
+count grows unboundedly with the number of chunks belonging to that NAR. In particular,
+it MUST NOT produce an `IN ($1...$M)` predicate on chunk IDs (whether emitted directly
+or via an ORM eager-load) where M can exceed 65535.
+
+The behavioral contract is unchanged: chunks are returned in `chunk_index` order, and
+the returned slice length equals the link count.
+
+#### Scenario: Resolving chunks for a NAR with > 65535 chunks succeeds on PostgreSQL
+
+- **WHEN** `chunksForNarFile` is invoked for a `nar_file` whose `nar_file_chunks` row
+  count exceeds the PostgreSQL extended-protocol parameter limit (65535)
+- **THEN** the call returns without `extended protocol limited to 65535 parameters`
+- **AND** the returned chunk slice contains every linked chunk in `chunk_index` order
+
+### Requirement: Fsck MUST NOT introduce other unbounded IN-clause queries
+
+Any future or existing fsck query that materializes a list of IDs (or composite keys)
+and then performs a secondary `In(...)` / `IN (...)` lookup keyed on that list SHALL
+use the same bounded-batch helper used by the CDC size-mismatch path, or an
+equivalent streaming approach. New code in `pkg/ncps/fsck.go` MUST NOT regress to
+unbounded `With*` eager-loads or unbounded `In(...)` predicates on collections that
+can grow with cache size or with the size of any single NAR's chunk list.
+
+#### Scenario: Code review surfaces unbounded eager-loads
+
+- **WHEN** a new fsck phase is added that walks a table whose row count grows with
+  cache size and joins to a related table
+- **THEN** the implementation uses the shared bounded-batch helper (or documents why
+  the join cardinality is bounded by an unrelated cap)
+- **AND** does not call `.All(ctx)` on an unbounded parent query followed by an
+  Ent `With*(...)` eager-load on the same query

--- a/openspec/changes/archive/2026-05-25-fsck-is-failing/tasks.md
+++ b/openspec/changes/archive/2026-05-25-fsck-is-failing/tasks.md
@@ -1,0 +1,73 @@
+## 1. Shared constant
+
+- [x] 1.1 Define a package-level constant `fsckEagerLoadBatchSize = 1000` in
+      `pkg/ncps/fsck.go` with a one-line comment naming the PostgreSQL 65535
+      extended-protocol cap as the reason. Both refactors below reference it.
+
+## 2. Refactor `queryCDCNarFilesWithSizeMismatch`
+
+- [x] 2.1 Rewrite `queryCDCNarFilesWithSizeMismatch` in `pkg/ncps/fsck.go` to:
+      (a) walk `nar_file` rows with `TotalChunksGT(0)` in keyset-paginated batches of
+      `fsckEagerLoadBatchSize`, ordered by ID ascending (use `IDGT(lastID)` as the
+      pagination predicate);
+      (b) for each batch, run a second query against `narinfo_nar_files` with
+      `NarFileIDIn(ids...)` and `WithNarinfo()` eager-load (now bounded by batch size);
+      (c) compare `nar_file.file_size` to each linked `narinfo.nar_size` in memory and
+      append to the mismatched slice, deduplicating per `nar_file` as the existing
+      `break` already does;
+      (d) stop when a short page (fewer than `fsckEagerLoadBatchSize` rows) is returned.
+- [x] 2.2 Remove the unbounded `.All(ctx)` + outer `WithNarInfoNarFiles(...)` eager-load
+      from the old implementation.
+- [x] 2.3 Ensure all three call sites of `queryCDCNarFilesWithSizeMismatch` (phase 1g
+      collection at `fsck.go:679`, re-verify at `fsck.go:978`, and repair re-verify at
+      `fsck.go:1580`) continue to compile and behave identically — no signature change.
+
+## 3. Refactor `chunksForNarFile`
+
+- [x] 3.1 Rewrite `chunksForNarFile` in `pkg/ncps/fsck.go` to:
+      (a) walk `nar_file_chunks` rows for the given `narFileID` in keyset-paginated
+      batches of `fsckEagerLoadBatchSize`, ordered by `chunk_index` ascending (use
+      `ChunkIndexGT(lastIndex)` as the pagination predicate);
+      (b) for each batch, fetch chunks with `Chunk.Query().Where(IDIn(ids...)).All(ctx)`
+      and re-order locally to match the link order from the page before appending to
+      the result slice;
+      (c) stop when a short page is returned.
+- [x] 3.2 Remove the unbounded `WithChunk().All(ctx)` from the old implementation.
+- [x] 3.3 Confirm the function's return contract (chunks in `chunk_index` order, no
+      `nil` entries) is preserved — both call paths in fsck rely on it.
+
+## 4. Tests
+
+- [x] 4.1 Confirm the existing small-cache CDC size-mismatch and chunk-walk tests in
+      `pkg/ncps/fsck_test.go` still pass under SQLite, PostgreSQL, and MySQL cohorts
+      (no behavioral change for small inputs).
+- [x] 4.2 Add `TestQueryCDCNarFilesWithSizeMismatch_LargePostgreSQL` in
+      `pkg/ncps/fsck_test.go` (package `ncps_test`, `t.Parallel()`), gated on
+      `NCPS_TEST_ADMIN_POSTGRES_URL`. Seed > 70_000 CDC `nar_file` rows (using bulk
+      insert) with a known-small subset whose `file_size` differs from the linked
+      `narinfo.nar_size`. Assert the function returns without error and the returned
+      set equals exactly the seeded mismatched hashes.
+- [x] 4.3 Add `TestChunksForNarFile_LargePostgreSQL` in `pkg/ncps/fsck_test.go`
+      (package `ncps_test`, `t.Parallel()`), gated on `NCPS_TEST_ADMIN_POSTGRES_URL`.
+      Seed one `nar_file` linked to > 70_000 distinct chunks via `nar_file_chunks`
+      (bulk insert). Assert the function returns without error, returns chunks in
+      `chunk_index` order, and length equals the seeded count.
+- [x] 4.4 Verify both new tests fail on the pre-fix code (sanity check that they would
+      have caught the regression) — record the observed errors in the PR description.
+      Confirmed: pre-fix `TestQueryCDCNarFilesWithSizeMismatch_LargePostgreSQL` fails
+      with `query CDC nar_files: extended protocol limited to 65535 parameters`;
+      pre-fix `TestChunksForNarFile_LargePostgreSQL` fails with
+      `extended protocol limited to 65535 parameters`. Both pass after the fix.
+
+## 5. Validation
+
+- [x] 5.1 Run `nix fmt` and `golangci-lint run --fix` to satisfy formatting and lint.
+- [x] 5.2 Run `go test -race ./pkg/ncps/...` with all three database cohorts enabled
+      (`eval "$(enable-integration-tests)"`) and confirm green. Full
+      `TestFsckBackends` tree (SQLite + PostgreSQL + MySQL, all subtests including
+      the CDC tree) plus both new large-PG regression tests passed.
+- [ ] 5.3 Run `nix build .#checks.x86_64-linux.ncps-postgres-tests -L --no-link` to
+      confirm the PostgreSQL cohort passes both new regression tests.
+- [ ] 5.4 Manually re-run `ncps fsck` against a PostgreSQL cache snapshot equivalent to
+      the failing production run (or a synthetic dataset of equivalent scale) and
+      confirm phase 1g completes and fsck advances to phase 2.

--- a/openspec/specs/fsck/spec.md
+++ b/openspec/specs/fsck/spec.md
@@ -130,3 +130,78 @@ When `--verify-content` is active, the fsck CDC summary section SHALL include tw
 #### Scenario: Rows are omitted when --verify-content is not set
 - **WHEN** `--verify-content` is NOT set
 - **THEN** the summary table does not include "NAR files w/ corrupt chunks" or "NAR files w/ hash mismatch" rows
+
+### Requirement: Fsck CDC size-mismatch detection MUST scale beyond database driver parameter limits
+
+The implementation of CDC size-mismatch detection (currently
+`queryCDCNarFilesWithSizeMismatch`) SHALL NOT issue any single SQL statement whose
+bound-parameter count grows unboundedly with the number of CDC `nar_file` rows or
+their joined `narinfo_nar_files`/`narinfos` rows. In particular, it MUST NOT produce
+an `IN ($1...$N)` predicate (whether emitted directly or via an ORM eager-load) where
+N can exceed the PostgreSQL extended-protocol limit of 65535 parameters.
+
+Detection SHALL iterate in bounded batches (chunk size chosen so that
+`batch_size * params_per_row` stays well below 65535 across all supported drivers).
+The fsck phase 1g run MUST complete successfully against caches of arbitrary size.
+
+The behavioral contract of the existing "Fsck MUST detect CDC NARs whose stored size
+mismatches the declared NarSize" requirement is unchanged: the same rows are flagged,
+in the same category, with the same `totalIssues()` accounting. Only the execution
+strategy changes.
+
+#### Scenario: Phase 1g completes against a large CDC cache on PostgreSQL
+
+- **WHEN** `ncps fsck` runs against a PostgreSQL database containing more CDC
+  `nar_file` rows than the PostgreSQL extended-protocol parameter limit (65535)
+- **THEN** phase 1g ("checking CDC NAR files with size mismatch") completes without
+  returning `extended protocol limited to 65535 parameters`
+- **AND** fsck proceeds to subsequent phases
+
+#### Scenario: All size-mismatched rows are still detected when batching
+
+- **WHEN** the cache contains a known set of size-mismatched CDC `nar_file` rows
+  distributed across multiple internal batches
+- **THEN** every size-mismatched row appears in `narFilesWithSizeMismatch`
+- **AND** no correctly-sized CDC row is falsely flagged
+
+#### Scenario: SQLite and MySQL paths remain correct
+
+- **WHEN** `ncps fsck` runs the size-mismatch check against SQLite or MySQL
+- **THEN** the batched implementation returns the same result set as the previous
+  unbatched implementation for caches small enough that both would succeed
+
+### Requirement: Fsck chunk-walk MUST scale beyond database driver parameter limits
+
+The implementation that resolves the chunk rows linked to a single `nar_file` (currently
+`chunksForNarFile`) SHALL NOT issue any single SQL statement whose bound-parameter
+count grows unboundedly with the number of chunks belonging to that NAR. In particular,
+it MUST NOT produce an `IN ($1...$M)` predicate on chunk IDs (whether emitted directly
+or via an ORM eager-load) where M can exceed 65535.
+
+The behavioral contract is unchanged: chunks are returned in `chunk_index` order, and
+the returned slice length equals the link count.
+
+#### Scenario: Resolving chunks for a NAR with > 65535 chunks succeeds on PostgreSQL
+
+- **WHEN** `chunksForNarFile` is invoked for a `nar_file` whose `nar_file_chunks` row
+  count exceeds the PostgreSQL extended-protocol parameter limit (65535)
+- **THEN** the call returns without `extended protocol limited to 65535 parameters`
+- **AND** the returned chunk slice contains every linked chunk in `chunk_index` order
+
+### Requirement: Fsck MUST NOT introduce other unbounded IN-clause queries
+
+Any future or existing fsck query that materializes a list of IDs (or composite keys)
+and then performs a secondary `In(...)` / `IN (...)` lookup keyed on that list SHALL
+use the same bounded-batch helper used by the CDC size-mismatch path, or an
+equivalent streaming approach. New code in `pkg/ncps/fsck.go` MUST NOT regress to
+unbounded `With*` eager-loads or unbounded `In(...)` predicates on collections that
+can grow with cache size or with the size of any single NAR's chunk list.
+
+#### Scenario: Code review surfaces unbounded eager-loads
+
+- **WHEN** a new fsck phase is added that walks a table whose row count grows with
+  cache size and joins to a related table
+- **THEN** the implementation uses the shared bounded-batch helper (or documents why
+  the join cardinality is bounded by an unrelated cap)
+- **AND** does not call `.All(ctx)` on an unbounded parent query followed by an
+  Ent `With*(...)` eager-load on the same query

--- a/pkg/ncps/export_test.go
+++ b/pkg/ncps/export_test.go
@@ -1,0 +1,12 @@
+package ncps
+
+// Test-only re-exports of fsck internals so regression tests in package
+// ncps_test can exercise the bounded-batch query paths directly without
+// driving the full fsck CLI. export_test.go is the canonical Go idiom for
+// exposing unexported symbols to a black-box _test package.
+//
+//nolint:gochecknoglobals // intentional: see comment above.
+var (
+	QueryCDCNarFilesWithSizeMismatchForTest = queryCDCNarFilesWithSizeMismatch
+	ChunksForNarFileForTest                 = chunksForNarFile
+)

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -1729,7 +1729,7 @@ func chunksForNarFile(
 			Limit(fsckEagerLoadBatchSize).
 			All(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("query nar_file_chunks for nar_file %d: %w", narFileID, err)
 		}
 
 		if len(links) == 0 {
@@ -1745,7 +1745,7 @@ func chunksForNarFile(
 			Where(entchunk.IDIn(ids...)).
 			All(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("query chunks for nar_file %d: %w", narFileID, err)
 		}
 
 		byID := make(map[int]*ent.Chunk, len(rows))

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -41,6 +41,12 @@ import (
 // ErrFsckIssuesFound is returned when fsck finds consistency issues.
 var ErrFsckIssuesFound = errors.New("consistency issues found")
 
+// fsckEagerLoadBatchSize bounds the page size of any fsck query that follows up
+// with an Ent `With*(...)` eager-load or an `In(...)` predicate over the page's
+// IDs. Kept well below PostgreSQL's 65535 extended-protocol parameter cap so the
+// secondary `IN ($1...$N)` cannot exceed the driver limit on any supported engine.
+const fsckEagerLoadBatchSize = 1000
+
 // fsckResults holds the results of a fsck run.
 type fsckResults struct {
 	// narinfosWithoutNarFiles: narinfos in DB with no linked nar_file.
@@ -779,40 +785,79 @@ func collectFsckSuspects(
 // queryCDCNarFilesWithSizeMismatch returns CDC nar_files (total_chunks > 0) whose
 // stored file_size differs from the linked narinfo's declared nar_size. Mirrors
 // the legacy GetCDCNarFilesWithSizeMismatch SQL.
+//
+// Implementation walks CDC nar_file rows in keyset-paginated batches of
+// fsckEagerLoadBatchSize and, per page, resolves the linked narinfos with a
+// bounded `NarFileIDIn(...)` + `WithNarinfo()` query. Eager-loading every CDC
+// row in one shot would emit `WHERE nar_file_id IN ($1...$N)` and trip
+// PostgreSQL's 65535 extended-protocol parameter cap once a cache grows past the
+// threshold.
 func queryCDCNarFilesWithSizeMismatch(
 	ctx context.Context,
 	dbClient *database.Client,
 ) ([]*ent.NarFile, error) {
-	// Fetch every CDC nar_file along with its linked narinfo via the join
-	// table. We compare in-memory because Ent's fluent API cannot express a
-	// cross-table column comparison directly.
-	rows, err := dbClient.Ent().NarFile.Query().
-		Where(entnarfile.TotalChunksGT(0)).
-		WithNarInfoNarFiles(func(q *ent.NarInfoNarFileQuery) {
-			q.WithNarinfo()
-		}).
-		All(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("query CDC nar_files: %w", err)
-	}
+	var (
+		mismatched []*ent.NarFile
+		lastID     int
+	)
 
-	var mismatched []*ent.NarFile
+	for {
+		page, err := dbClient.Ent().NarFile.Query().
+			Where(
+				entnarfile.TotalChunksGT(0),
+				entnarfile.IDGT(lastID),
+			).
+			Order(ent.Asc(entnarfile.FieldID)).
+			Limit(fsckEagerLoadBatchSize).
+			All(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("query CDC nar_files: %w", err)
+		}
 
-	for _, nf := range rows {
-		for _, link := range nf.Edges.NarInfoNarFiles {
-			ni := link.Edges.Narinfo
-			if ni == nil || ni.NarSize == nil {
-				continue
+		if len(page) == 0 {
+			break
+		}
+
+		ids := make([]int, len(page))
+		for i, nf := range page {
+			ids[i] = nf.ID
+		}
+
+		links, err := dbClient.Ent().NarInfoNarFile.Query().
+			Where(entnarinfonarfile.NarFileIDIn(ids...)).
+			WithNarinfo().
+			All(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("query CDC nar_file links: %w", err)
+		}
+
+		linksByNarFile := make(map[int][]*ent.NarInfoNarFile, len(page))
+		for _, link := range links {
+			linksByNarFile[link.NarFileID] = append(linksByNarFile[link.NarFileID], link)
+		}
+
+		for _, nf := range page {
+			for _, link := range linksByNarFile[nf.ID] {
+				ni := link.Edges.Narinfo
+				if ni == nil || ni.NarSize == nil {
+					continue
+				}
+				// file_size is uint64; nar_size is *int64. Cast both to int64
+				// for comparison — file_size never exceeds int64 in practice
+				// (real NARs are bounded by storage limits).
+				//nolint:gosec // G115: NAR sizes are well below math.MaxInt64.
+				if int64(nf.FileSize) != *ni.NarSize {
+					mismatched = append(mismatched, nf)
+
+					break
+				}
 			}
-			// file_size is uint64; nar_size is *int64. Cast both to int64 for
-			// comparison — file_size never exceeds int64 in practice (real
-			// NARs are bounded by storage limits).
-			//nolint:gosec // G115: NAR sizes are well below math.MaxInt64.
-			if int64(nf.FileSize) != *ni.NarSize {
-				mismatched = append(mismatched, nf)
+		}
 
-				break
-			}
+		lastID = page[len(page)-1].ID
+
+		if len(page) < fsckEagerLoadBatchSize {
+			break
 		}
 	}
 
@@ -1658,25 +1703,66 @@ func repairSizeMismatchCDCNarFiles(
 
 // chunksForNarFile returns the chunk rows linked to nf via nar_file_chunks,
 // ordered by chunk_index. Mirrors the legacy GetChunksByNarFileID SQL.
+//
+// Implementation walks nar_file_chunks rows in keyset-paginated batches of
+// fsckEagerLoadBatchSize and, per page, fetches chunks with a bounded
+// `IDIn(...)` query. A single oversized CDC NAR with > 65535 chunks would
+// otherwise emit `WHERE id IN ($1...$M)` via `WithChunk()` and trip
+// PostgreSQL's 65535 extended-protocol parameter cap.
 func chunksForNarFile(
 	ctx context.Context,
 	dbClient *database.Client,
 	narFileID int,
 ) ([]*ent.Chunk, error) {
-	links, err := dbClient.Ent().NarFileChunk.Query().
-		Where(entnarfilechunk.NarFileIDEQ(narFileID)).
-		Order(ent.Asc(entnarfilechunk.FieldChunkIndex)).
-		WithChunk().
-		All(ctx)
-	if err != nil {
-		return nil, err
-	}
+	var (
+		chunks    []*ent.Chunk
+		lastIndex = -1
+	)
 
-	chunks := make([]*ent.Chunk, 0, len(links))
+	for {
+		links, err := dbClient.Ent().NarFileChunk.Query().
+			Where(
+				entnarfilechunk.NarFileIDEQ(narFileID),
+				entnarfilechunk.ChunkIndexGT(lastIndex),
+			).
+			Order(ent.Asc(entnarfilechunk.FieldChunkIndex)).
+			Limit(fsckEagerLoadBatchSize).
+			All(ctx)
+		if err != nil {
+			return nil, err
+		}
 
-	for _, link := range links {
-		if link.Edges.Chunk != nil {
-			chunks = append(chunks, link.Edges.Chunk)
+		if len(links) == 0 {
+			break
+		}
+
+		ids := make([]int, len(links))
+		for i, link := range links {
+			ids[i] = link.ChunkID
+		}
+
+		rows, err := dbClient.Ent().Chunk.Query().
+			Where(entchunk.IDIn(ids...)).
+			All(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		byID := make(map[int]*ent.Chunk, len(rows))
+		for _, ch := range rows {
+			byID[ch.ID] = ch
+		}
+
+		for _, link := range links {
+			if ch, ok := byID[link.ChunkID]; ok {
+				chunks = append(chunks, ch)
+			}
+		}
+
+		lastIndex = links[len(links)-1].ChunkIndex
+
+		if len(links) < fsckEagerLoadBatchSize {
+			break
 		}
 	}
 

--- a/pkg/ncps/fsck_test.go
+++ b/pkg/ncps/fsck_test.go
@@ -1645,3 +1645,198 @@ func testFsckCDCRepairHashMismatch(setup fsckSetupFn) func(*testing.T) {
 		assert.True(t, database.IsNotFoundError(dbErr), "nar_file must be deleted")
 	}
 }
+
+// TestQueryCDCNarFilesWithSizeMismatch_LargePostgreSQL is a regression test for
+// the "extended protocol limited to 65535 parameters" failure that the
+// pre-batching implementation hit on production-sized caches. It seeds more CDC
+// nar_file rows than the PostgreSQL extended-protocol parameter cap and then
+// confirms the function completes and returns exactly the seeded mismatched rows.
+func TestQueryCDCNarFilesWithSizeMismatch_LargePostgreSQL(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv("NCPS_TEST_ADMIN_POSTGRES_URL") == "" {
+		t.Skip("Skipping: NCPS_TEST_ADMIN_POSTGRES_URL not set")
+	}
+
+	ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+	dbClient, _, _, _, cleanup := setupFsckPostgres(t)
+	t.Cleanup(cleanup)
+
+	// totalRows must exceed PostgreSQL's 65535 extended-protocol parameter cap so
+	// that the pre-fix code path (single `WHERE nar_file_id IN ($1...$N)` Ent
+	// eager-load) would fail. mismatchCount stays small so the assertion is cheap.
+	const (
+		totalRows         = 70_000
+		mismatchCount     = 5
+		matchingNarSize   = int64(1000)
+		mismatchedSize    = uint64(2000)
+		nfInsertBatchSize = 5000
+		linkInsertBatch   = 10_000
+	)
+
+	// One shared narinfo. Matching nar_files set file_size == narSize; mismatched
+	// ones set file_size != narSize.
+	narInfo, err := dbClient.Ent().NarInfo.Create().
+		SetHash("largepg-shared-narinfo").
+		SetURL("nar/largepg.nar.xz").
+		SetNarSize(matchingNarSize).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Bulk insert CDC nar_files in batches sized to stay below the parameter cap
+	// for the multi-row INSERT itself (5 columns per row * 5000 rows = 25k params).
+	mismatchedHashes := make(map[string]struct{}, mismatchCount)
+
+	for start := 0; start < totalRows; start += nfInsertBatchSize {
+		end := start + nfInsertBatchSize
+		if end > totalRows {
+			end = totalRows
+		}
+
+		creates := make([]*ent.NarFileCreate, 0, end-start)
+
+		for i := start; i < end; i++ {
+			hash := fmt.Sprintf("largepg-narfile-%06d", i)
+
+			size := uint64(matchingNarSize)
+			if i < mismatchCount {
+				size = mismatchedSize
+				mismatchedHashes[hash] = struct{}{}
+			}
+
+			creates = append(creates, dbClient.Ent().NarFile.Create().
+				SetHash(hash).
+				SetCompression("xz").
+				SetQuery("").
+				SetFileSize(size).
+				SetTotalChunks(2))
+		}
+
+		_, err := dbClient.Ent().NarFile.CreateBulk(creates...).Save(ctx)
+		require.NoError(t, err, "bulk-create nar_files batch starting at %d", start)
+	}
+
+	// Fetch all seeded nar_file IDs so we can bulk-link them to the shared narinfo.
+	seeded, err := dbClient.Ent().NarFile.Query().
+		Where(entnarfile.CompressionEQ("xz"), entnarfile.HashHasPrefix("largepg-narfile-")).
+		All(ctx)
+	require.NoError(t, err)
+	require.Len(t, seeded, totalRows)
+
+	for start := 0; start < len(seeded); start += linkInsertBatch {
+		end := start + linkInsertBatch
+		if end > len(seeded) {
+			end = len(seeded)
+		}
+
+		links := make([]*ent.NarInfoNarFileCreate, 0, end-start)
+		for _, nf := range seeded[start:end] {
+			links = append(links, dbClient.Ent().NarInfoNarFile.Create().
+				SetNarinfoID(narInfo.ID).
+				SetNarFileID(nf.ID))
+		}
+
+		_, err := dbClient.Ent().NarInfoNarFile.CreateBulk(links...).Save(ctx)
+		require.NoError(t, err, "bulk-create narinfo_nar_file links batch starting at %d", start)
+	}
+
+	got, err := ncps.QueryCDCNarFilesWithSizeMismatchForTest(ctx, dbClient)
+	require.NoError(t, err, "queryCDCNarFilesWithSizeMismatch must succeed on a large CDC cache")
+
+	gotHashes := make(map[string]struct{}, len(got))
+	for _, nf := range got {
+		gotHashes[nf.Hash] = struct{}{}
+	}
+
+	assert.Equal(t, mismatchedHashes, gotHashes,
+		"returned set must equal exactly the seeded mismatched hashes")
+}
+
+// TestChunksForNarFile_LargePostgreSQL is a regression test for the same
+// 65535-parameter cap, exercised through the `WithChunk()` eager-load that the
+// pre-fix `chunksForNarFile` issued for a single oversized CDC NAR.
+func TestChunksForNarFile_LargePostgreSQL(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv("NCPS_TEST_ADMIN_POSTGRES_URL") == "" {
+		t.Skip("Skipping: NCPS_TEST_ADMIN_POSTGRES_URL not set")
+	}
+
+	ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+	dbClient, _, _, _, cleanup := setupFsckPostgres(t)
+	t.Cleanup(cleanup)
+
+	// chunkCount must exceed 65535 so the pre-fix `WithChunk()` follow-up would
+	// emit `WHERE id IN ($1...$M)` with M > 65535 and trip the cap.
+	const (
+		chunkCount       = 70_000
+		chunkInsertBatch = 10_000
+		linkInsertBatch  = 10_000
+	)
+
+	narFile, err := dbClient.Ent().NarFile.Create().
+		SetHash("largepg-chunky-narfile").
+		SetCompression("xz").
+		SetQuery("").
+		SetFileSize(1).
+		SetTotalChunks(int64(chunkCount)).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Bulk-insert chunks (3 columns per row * 10000 rows = 30k params per batch).
+	for start := 0; start < chunkCount; start += chunkInsertBatch {
+		end := start + chunkInsertBatch
+		if end > chunkCount {
+			end = chunkCount
+		}
+
+		creates := make([]*ent.ChunkCreate, 0, end-start)
+		for i := start; i < end; i++ {
+			creates = append(creates, dbClient.Ent().Chunk.Create().
+				SetHash(fmt.Sprintf("largepg-chunk-%06d", i)).
+				SetSize(uint32(64)).
+				SetCompressedSize(uint32(32)))
+		}
+
+		_, err := dbClient.Ent().Chunk.CreateBulk(creates...).Save(ctx)
+		require.NoError(t, err, "bulk-create chunks batch starting at %d", start)
+	}
+
+	// Fetch seeded chunk IDs in hash order — hash order matches the index we will
+	// assign in the link table, which lets the test check ordering deterministically.
+	chunks, err := dbClient.Ent().Chunk.Query().
+		Where(entchunk.HashHasPrefix("largepg-chunk-")).
+		Order(ent.Asc(entchunk.FieldHash)).
+		All(ctx)
+	require.NoError(t, err)
+	require.Len(t, chunks, chunkCount)
+
+	for start := 0; start < chunkCount; start += linkInsertBatch {
+		end := start + linkInsertBatch
+		if end > chunkCount {
+			end = chunkCount
+		}
+
+		links := make([]*ent.NarFileChunkCreate, 0, end-start)
+		for i := start; i < end; i++ {
+			links = append(links, dbClient.Ent().NarFileChunk.Create().
+				SetNarFileID(narFile.ID).
+				SetChunkID(chunks[i].ID).
+				SetChunkIndex(i))
+		}
+
+		_, err := dbClient.Ent().NarFileChunk.CreateBulk(links...).Save(ctx)
+		require.NoError(t, err, "bulk-create nar_file_chunks batch starting at %d", start)
+	}
+
+	got, err := ncps.ChunksForNarFileForTest(ctx, dbClient, narFile.ID)
+	require.NoError(t, err, "chunksForNarFile must succeed on a NAR with > 65535 chunks")
+	require.Len(t, got, chunkCount, "returned chunk count must match seeded count")
+
+	for i, ch := range got {
+		require.NotNil(t, ch, "chunk at index %d must not be nil", i)
+		assert.Equal(t, chunks[i].ID, ch.ID, "chunk at index %d must be in chunk_index order", i)
+	}
+}


### PR DESCRIPTION
ncps fsck aborted in phase 1g on production-sized PostgreSQL caches
with `extended protocol limited to 65535 parameters`. The CDC
size-mismatch query loaded every CDC nar_file in one shot and asked
Ent to fan-out load the linked narinfo_nar_files rows, which compiled
to `WHERE nar_file_id IN ($1...$N)`. Once N exceeded 65535 the driver
refused the statement and fsck never reached phase 2. The same shape
in chunksForNarFile would have failed for any single CDC NAR with
> 65535 chunks via the `WithChunk()` eager-load.

Replace both eager-load patterns with keyset-paginated walks bounded
by a shared `fsckEagerLoadBatchSize = 1000` constant: walk the parent
table by ID/chunk_index in pages, then issue a bounded
`NarFileIDIn(...)` (size-mismatch) or `IDIn(...)` (chunk-walk) lookup
per page. Behavior is unchanged on small caches; both call sites keep
their existing signatures and ordering contracts.

Add two PostgreSQL-cohort regression tests gated on
NCPS_TEST_ADMIN_POSTGRES_URL that seed > 70_000 rows via CreateBulk
and confirm the function paths succeed. Verified that both tests
reproduce the production error against the pre-fix code.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>