### PR TITLE
test(migrate): use timestamp cutoff in filterDbmateEra

### DIFF
--- a/pkg/database/migrate/migrate_test.go
+++ b/pkg/database/migrate/migrate_test.go
@@ -516,20 +516,27 @@ func seedDbmateFullState(t *testing.T, db *sql.DB, dx dialectFixture) {
 	seedDbmateSchemaMigrations(t, db, dx.dialect, fileVersions(pre))
 }
 
+// bridgeEraStart is the timestamp of the first §8 bridge migration
+// (20260520000000). Any migration with a version >= this value is
+// post-bridge and must be excluded from the dbmate-era seed.
+const bridgeEraStart int64 = 20260520000000
+
 func filterDbmateEra(files []string) []string {
 	out := make([]string, 0, len(files))
 
 	for _, f := range files {
-		// The translated dbmate-era files cover 2024-01 through
-		// 2026-03-18. The §8 bridge files start at 2026-05-20.
-		// Filter by name pattern: anything containing "ent_baseline"
-		// or "serial_to_identity" is post-bridge.
 		base := f
 		if idx := strings.LastIndex(base, "/"); idx >= 0 {
 			base = base[idx+1:]
 		}
 
-		if strings.Contains(base, "ent_baseline") || strings.Contains(base, "serial_to_identity") {
+		var v int64
+
+		for i := 0; i < 14 && i < len(base); i++ {
+			v = v*10 + int64(base[i]-'0')
+		}
+
+		if v >= bridgeEraStart {
 			continue
 		}
 

--- a/pkg/database/migrate/migrate_test.go
+++ b/pkg/database/migrate/migrate_test.go
@@ -530,17 +530,32 @@ func filterDbmateEra(files []string) []string {
 			base = base[idx+1:]
 		}
 
-		var v int64
+		// Require exactly 14 leading digits; anything else can't be a
+		// migration version and is included unchanged.
+		if len(base) < 14 {
+			out = append(out, f)
 
-		for i := 0; i < 14 && i < len(base); i++ {
-			v = v*10 + int64(base[i]-'0')
-		}
-
-		if v >= bridgeEraStart {
 			continue
 		}
 
-		out = append(out, f)
+		var v int64
+
+		valid := true
+
+		for i := range 14 {
+			c := base[i]
+			if c < '0' || c > '9' {
+				valid = false
+
+				break
+			}
+
+			v = v*10 + int64(c-'0')
+		}
+
+		if !valid || v < bridgeEraStart {
+			out = append(out, f)
+		}
 	}
 
 	return out


### PR DESCRIPTION
The previous implementation filtered bridge-era migrations by name
pattern ("ent_baseline", "serial_to_identity"). Adding any new
post-bridge migration caused the dbmate-era seed test to break with
a "missing out-of-order migration" error from goose.

Switch to a timestamp-based cutoff (bridgeEraStart = 20260520000000).
Any migration with a version >= that constant is post-bridge and is
excluded from the dbmate-era seed, regardless of its name. This
matches the existing fileVersions() parsing approach and will
correctly exclude all future incremental migrations without requiring
a name-list update.