### PR TITLE
fix(cache): ignore ErrNotFound in purgeNarInfo store deletes

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4335,17 +4335,16 @@ func (c *Cache) purgeNarInfo(
 		return err
 	}
 
-	if c.narInfoStore.HasNarInfo(ctx, hash) {
-		if err := c.deleteNarInfoFromStore(ctx, hash); err != nil {
-			return fmt.Errorf("error removing narinfo from store: %w", err)
-		}
+	// Ignore ErrNotFound: purge is idempotent. A concurrent goroutine may
+	// have already removed the file between the DB transaction above and
+	// the store delete below (TOCTOU), which is fine — the goal is gone.
+	if err := c.deleteNarInfoFromStore(ctx, hash); err != nil && !errors.Is(err, storage.ErrNotFound) {
+		return fmt.Errorf("error removing narinfo from store: %w", err)
 	}
 
 	if narURL.Hash != "" {
-		if c.HasNarInStore(ctx, *narURL) {
-			if err := c.deleteNarFromStore(ctx, narURL); err != nil {
-				return fmt.Errorf("error removing nar from store: %w", err)
-			}
+		if err := c.deleteNarFromStore(ctx, narURL); err != nil && !errors.Is(err, storage.ErrNotFound) {
+			return fmt.Errorf("error removing nar from store: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- `purgeNarInfo` guarded each store delete with a `Has*` check, but the check and the delete are not atomic. A concurrent goroutine can remove the file between `HasNarInStore` returning `true` and `deleteNarFromStore` being called — which re-checks internally and returns `ErrNotFound`. This surfaced as an intermittent `"error removing nar from store: not found"` test failure in both `ncps-mysql-tests` and `ncps-redis-tests` on aarch64.
- Fix: drop the outer `Has*` guards and treat `ErrNotFound` as success on both the NarInfo and Nar store deletes. Purge is idempotent by intent.

## Test plan

- [ ] `task fmt` / `task lint` / `task test` pass
- [ ] Integration test `TestCacheBackends/.../narinfo_with_transparent_encryption` no longer flakes