### PR TITLE
fix(cache): prevent hang when client cancels concurrent NAR download

### DIFF
--- a/openspec/changes/archive/2026-05-28-fix-concurrent-download-cancel-hang/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-28-fix-concurrent-download-cancel-hang/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-28

--- a/openspec/changes/archive/2026-05-28-fix-concurrent-download-cancel-hang/design.md
+++ b/openspec/changes/archive/2026-05-28-fix-concurrent-download-cancel-hang/design.md
@@ -1,0 +1,135 @@
+## Context
+
+`GetNar` deduplicates in-flight downloads via a shared `downloadState` (`ds`). Each caller
+gets its own `io.Pipe` and a per-client SafeGo streaming goroutine that tails the temp file and
+forwards bytes. The goroutine has two blocking points:
+
+1. **`cond.Wait()` loop** (`cache.go:~1240`): sleeps until `ds.bytesWritten` advances or
+   `ds.finalSize` is set. Exits on `downloadError` but **not** on the client's own context
+   cancellation.
+2. **Storage-wait `select`** (`cache.go:~1301`): `select { case <-ds.stored: case <-ds.done: }`.
+   Neither channel is closed until `pullNarIntoStore` completes storage and returns. If storage
+   stalls (e.g., I/O pressure on a busy CI runner), neither channel fires and the goroutine
+   blocks indefinitely — leaving `defer writer.Close()` un-run, so `io.ReadAll(readerB)` hangs.
+
+PR #1257 added a 30-second `runWithTimeout` guard with goroutine dump around the two
+previously un-guarded blocking calls in the test. The test now fails fast with diagnostics
+instead of consuming the full 20-minute `go test` timeout.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Ensure the streaming goroutine for any client always terminates within a bounded time,
+  regardless of whether a sibling client cancels or storage stalls.
+- Make context cancellation an explicit exit condition in the `cond.Wait()` loop so cancelled
+  clients clean up promptly without depending on downstream broadcasts.
+- Preserve the correctness invariant: `HasNar` returns true before the streaming goroutine
+  closes the pipe (needed because the test — and HTTP handlers — may check storage immediately
+  after reading).
+
+**Non-Goals:**
+- Removing or redesigning the `downloadState` fanout model.
+- Changing storage backends or adding retry logic for failed storage writes.
+- Fixing unrelated flaky tests.
+
+## Decisions
+
+### Decision 1: Make `cond.Wait()` context-aware via a watcher goroutine
+
+**Choice**: Launch a single short-lived goroutine per streaming goroutine that calls
+`ds.cond.Broadcast()` when the client's context is cancelled.
+
+```go
+// Inside the streaming SafeGo, before the loop:
+watcherDone := make(chan struct{})
+defer close(watcherDone)
+go func() {
+    select {
+    case <-ctx.Done():
+        ds.cond.Broadcast()
+    case <-watcherDone:
+    }
+}()
+```
+
+Then add `ctx.Err() != nil` to the `downloadError` check inside the loop:
+```go
+if ds.downloadError != nil || ctx.Err() != nil {
+    ds.mu.Unlock()
+    return
+}
+```
+
+**Why not `sync.Cond` with a deadline?** Go's `sync.Cond` has no timeout/context API. The
+watcher-goroutine pattern is the idiomatic alternative; it adds exactly one goroutine per
+active streaming client, which exits immediately when either the client context cancels or the
+streaming goroutine itself finishes.
+
+**Why not poll `ctx.Err()` inside the loop?** Polling would only catch the cancellation after
+the next broadcast. The watcher guarantees cancellation is noticed within microseconds by
+forcing a broadcast.
+
+### Decision 2: Add `ctx.Done()` to the storage-wait `select`
+
+**Choice**: Extend the storage-wait select to include the client's context:
+
+```go
+select {
+case <-ds.stored:
+    // storage complete — normal path
+case <-ds.done:
+    // download done (may include error)
+    if err := ds.getError(); err != nil { ... }
+case <-ctx.Done():
+    // client cancelled — exit cleanly without waiting for storage
+    zerolog.Ctx(ctx).Debug().Msg("client context cancelled while waiting for NAR storage")
+}
+```
+
+**Why this is safe**: The client has already received all bytes at this point (the loop ran to
+`bytesSent >= ds.finalSize`). The only reason to wait for `ds.stored` is to satisfy the
+invariant that `HasNar` returns true before the HTTP response ends. For a cancelled client,
+the HTTP connection is already torn down, so the invariant doesn't apply. For a normal client,
+`ds.stored` fires first (before `ds.done`, which is deferred), so behaviour is unchanged.
+
+**Risk**: If a future caller relies on `GetNar` completing only after storage is guaranteed,
+this change subtly relaxes that guarantee for cancelled contexts. Accepted: cancelled HTTP
+clients don't receive a response anyway, so a HasNar race for them is inconsequential.
+
+### Decision 3: Use TDD — write a stress reproduction harness before fixing
+
+**Choice**: Before touching production code, write a subtest loop that runs
+`ConcurrentDownloadCancelOneClientOthersContinue` 50× in a tight loop under `-race`, to get a
+reproducible failure on the existing code and confirm the fix eliminates it.
+
+**Why**: The bug has been observed only once in CI. Without a reproducible failure, we cannot
+confirm the fix works. The 30-second `runWithTimeout` guard means each failed iteration fails
+fast, so 50 iterations at most cost 25 minutes if all hang — acceptable for a targeted run.
+
+## Risks / Trade-offs
+
+- **Watcher goroutine leak**: If the watcher goroutine and the streaming goroutine both exit
+  at nearly the same time, the `close(watcherDone)` in the defer ensures the watcher exits.
+  No leak possible.
+- **Spurious broadcast on normal exit**: When `watcherDone` closes (streaming goroutine done),
+  the watcher exits via the `<-watcherDone` case — no spurious `Broadcast()` is emitted.
+  Goroutines already past `cond.Wait()` are unaffected.
+- **`ctx.Done()` path returns without confirming storage**: For cancelled clients only. The
+  test's `HasNar` assertion runs with `ctxB` (never cancelled), so the test-level invariant
+  is preserved.
+- **Stress loop may not reproduce**: The bug is environment-sensitive. If the stress loop
+  doesn't reproduce, fall back to shipping the defensive fixes (Decisions 1 & 2) anyway, since
+  they are strictly safer than the status quo.
+
+## Migration Plan
+
+1. Write the stress sub-loop test (red phase — should hang on current code, then fail fast via `runWithTimeout`).
+2. Apply Decision 1 (context watcher in `cond.Wait()` loop) and Decision 2 (`ctx.Done()` in storage-wait select).
+3. Re-run the stress loop to confirm no hangs.
+4. Run `task test` and `task lint` to confirm no regressions.
+5. Ship. No migration, no schema change, no config change needed.
+
+## Open Questions
+
+- **Is the storage-wait `select` actually the hang site?** Without a goroutine dump from a live hang, we are reasoning from code. The `runWithTimeout` guards in the test will capture a dump the next time it fires in CI — if the fix in this PR doesn't prevent the hang, the dump will tell us exactly where to look.
+- **Should the `cond.Wait()` loop also check `ds.done` directly?** If `ds.done` is closed (download goroutine exited) while the streaming goroutine is in `cond.Wait()`, the goroutine is woken by the final `Broadcast()` at line 2569. No separate check needed.

--- a/openspec/changes/archive/2026-05-28-fix-concurrent-download-cancel-hang/proposal.md
+++ b/openspec/changes/archive/2026-05-28-fix-concurrent-download-cancel-hang/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`GetNar`'s per-client streaming goroutine contains at least one blocking point that does not have a cancellation escape: the `select { case <-ds.stored: case <-ds.done: }` wait and, more subtly, the `cond.Wait()` loop that only checks `downloadError` — not client context cancellation. When client A cancels mid-download, its pipe reader is closed, but the shared `downloadState` may be left in a state where the signals client B's goroutine depends on (`ds.stored`, `ds.done`) arrive in a pathological order relative to the goroutine's execution point, causing `io.ReadAll(readerB)` to block indefinitely. PR #1257 added a 30-second timeout guard with goroutine dump to convert this from a 20-minute outer-timeout hang into a fast-failing diagnostic; the root cause in production code is still present.
+
+## What Changes
+
+- Harden the streaming goroutine in `pkg/cache/cache.go` (`GetNar`, lines ~1175–1317) so that no blocking point can stall indefinitely when a sibling client has cancelled its context:
+  - Propagate the client's own context into the `cond.Wait()` loop by waking the goroutine on `ctx.Done()` (via a side goroutine that broadcasts when the client context is cancelled).
+  - Add `case <-ctx.Done():` to the `select { case <-ds.stored: case <-ds.done: }` wait so a cancelled client's goroutine does not block cleanup.
+- If TDD reproduction surfaces a deeper shared-state bug in the download-coordination path (the pipe-fanout or `bytesWritten`/`finalSize` visibility), fix that too.
+- Close GitHub issue #1252 once the root cause is confirmed fixed by a reliably passing stress run.
+
+## Capabilities
+
+### New Capabilities
+
+_(none — this is a correctness fix to an existing streaming path)_
+
+### Modified Capabilities
+
+- `narinfo-concurrent-fetch`: The concurrent-fetch coordination model is adjacent; this change tightens the NAR streaming analogue but does not alter narinfo requirements.
+
+> **Note:** No dedicated spec exists for concurrent NAR streaming today. If the investigation reveals a spec-level invariant (e.g. "when client A cancels, client B must still receive all bytes and observe `HasNar → true`"), a new `nar-concurrent-streaming` spec should be created to capture it.
+
+## Impact
+
+- **`pkg/cache/cache.go`**: streaming SafeGo goroutine, `cond.Wait()` loop, and the `ds.stored`/`ds.done` select (lines ~1235–1316).
+- **`pkg/cache/cache_test.go`**: `testConcurrentDownloadCancelOneClientOthersContinue` — no test logic changes needed (defensive guards from #1257 stay); may add a stress harness sub-loop if repro is needed.
+- **No API surface changes**, no migration, no schema changes.
+- **I/O / memory**: negligible — one extra goroutine per active streaming client to watch `ctx.Done()` and broadcast; this goroutine exits immediately on broadcast.

--- a/openspec/changes/archive/2026-05-28-fix-concurrent-download-cancel-hang/specs/nar-concurrent-streaming/spec.md
+++ b/openspec/changes/archive/2026-05-28-fix-concurrent-download-cancel-hang/specs/nar-concurrent-streaming/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Concurrent NAR streaming goroutines MUST terminate within a bounded time
+
+When multiple clients concurrently request the same NAR hash and one client's context is
+cancelled mid-download, the streaming goroutine for the cancelled client SHALL exit promptly
+(without waiting for the next `cond.Broadcast()`) and the streaming goroutines for all
+remaining clients SHALL continue to completion unaffected.
+
+#### Scenario: Cancelled client's streaming goroutine exits on context cancellation
+
+- **WHEN** client A and client B both have active streaming goroutines for the same NAR hash
+- **AND** client A's context is cancelled while its goroutine is blocked in the `cond.Wait()` loop
+- **THEN** client A's streaming goroutine MUST exit within a bounded time (≤ a few milliseconds after cancellation), without requiring a broadcast from the download goroutine
+- **AND** the per-client `io.Pipe` writer for client A MUST be closed so the caller's reader unblocks
+
+#### Scenario: Non-cancelled client receives all bytes after sibling cancellation
+
+- **WHEN** client A and client B concurrently call `GetNar` for the same NAR hash
+- **AND** client A cancels its context mid-download
+- **AND** client B's context is never cancelled
+- **THEN** client B's reader SHALL receive all bytes of the NAR content
+- **AND** `io.ReadAll` on client B's reader SHALL complete without hanging
+- **AND** `HasNar` SHALL return true after client B's read completes
+
+#### Scenario: Streaming goroutine exits cleanly when storage stalls for a cancelled client
+
+- **WHEN** a client's context is cancelled
+- **AND** the streaming goroutine has finished forwarding all bytes to the client pipe
+- **AND** the storage goroutine (`storeNarFromTempFile`) has not yet completed
+- **THEN** the streaming goroutine for the cancelled client SHALL exit via the `ctx.Done()` case
+- **AND** `defer writer.Close()` SHALL run, unblocking the caller
+- **AND** the storage goroutine SHALL continue to completion independently
+
+### Requirement: Streaming goroutine `cond.Wait()` loop MUST check client context cancellation
+
+The `cond.Wait()` loop in the per-client streaming goroutine SHALL treat client context
+cancellation as an exit condition equivalent to `downloadError`, so that a cancelled client
+does not hold a streaming goroutine open indefinitely waiting for a `Broadcast()` that may
+arrive infrequently.
+
+#### Scenario: Context-cancelled client exits loop without broadcast
+
+- **WHEN** the streaming goroutine is blocked in `cond.Wait()` (no new bytes available, download not complete)
+- **AND** the client's context is cancelled
+- **THEN** the goroutine SHALL wake within microseconds (via a watcher goroutine that calls `ds.cond.Broadcast()` on `ctx.Done()`)
+- **AND** the goroutine SHALL check `ctx.Err() != nil` and return, closing the pipe writer
+
+### Requirement: Storage-wait `select` MUST include a client context escape
+
+After the streaming goroutine has forwarded all bytes, it waits for `ds.stored` or `ds.done`
+before closing the pipe. This `select` SHALL also include `ctx.Done()` so that a cancelled
+client does not remain blocked if the storage operation stalls.
+
+#### Scenario: Cancelled client does not block at storage-wait select
+
+- **WHEN** the streaming goroutine has sent all bytes (`bytesSent >= ds.finalSize`)
+- **AND** neither `ds.stored` nor `ds.done` has fired yet (storage is in progress)
+- **AND** the client's context is cancelled
+- **THEN** the goroutine SHALL exit via `<-ctx.Done()`
+- **AND** the pipe writer SHALL be closed, allowing the caller's `io.ReadAll` to return
+
+#### Scenario: Non-cancelled client still waits for storage confirmation
+
+- **WHEN** the streaming goroutine has sent all bytes
+- **AND** the client's context is active (not cancelled)
+- **THEN** the goroutine SHALL wait for `ds.stored` or `ds.done` before closing the pipe
+- **AND** `HasNar` SHALL return true when observed by the caller after reading completes

--- a/openspec/changes/archive/2026-05-28-fix-concurrent-download-cancel-hang/tasks.md
+++ b/openspec/changes/archive/2026-05-28-fix-concurrent-download-cancel-hang/tasks.md
@@ -1,0 +1,24 @@
+## 1. Stress Reproduction (Red Phase)
+
+- [x] 1.1 In `pkg/cache/cache_test.go`, add a sub-loop that runs `testConcurrentDownloadCancelOneClientOthersContinue` 50× in a tight inner loop under `-race` to surface the hang reliably
+- [x] 1.2 Confirm the stress loop fails (hangs for 30 s then prints goroutine dump) on unmodified code, establishing a red baseline
+
+## 2. Context-Aware `cond.Wait()` Loop
+
+- [x] 2.1 In `pkg/cache/cache.go`, inside the per-client streaming SafeGo (regular path, ~line 1235), add a watcher goroutine before the loop that broadcasts on `ctx.Done()` and exits via a `defer close(watcherDone)` channel
+- [x] 2.2 Add `ctx.Err() != nil` as an additional exit condition inside the `cond.Wait()` loop (alongside the existing `ds.downloadError != nil` check), and `return` when true
+- [x] 2.3 Apply the same watcher + ctx-check to the decompression path (`cond.Wait()` inside `fileAvailableReader.Read` at ~line 494) if it is reachable from the test scenario
+- [x] 2.4 Run the stress loop — confirm hang frequency decreases or disappears
+
+## 3. Context-Aware Storage-Wait `select`
+
+- [x] 3.1 In the regular streaming path (~line 1301), extend `select { case <-ds.stored: case <-ds.done: }` to also include `case <-ctx.Done():` with a debug-level log message
+- [x] 3.2 In the decompression path (~line 1219), apply the same `ctx.Done()` extension
+- [x] 3.3 Run the stress loop — confirm no remaining hangs
+
+## 4. Verification
+
+- [x] 4.1 Run `task test` with `-race` and confirm `TestCacheBackends/.../ConcurrentDownloadCancelOneClientOthersContinue` passes across all backends
+- [x] 4.2 Run `task fmt` and `task lint` and fix any issues
+- [x] 4.3 Remove or keep the 50× stress sub-loop depending on CI time budget (if kept, guard behind a build tag or short-test skip)
+- [x] 4.4 Confirm the stress loop passes 50/50 iterations with the fix in place

--- a/openspec/specs/nar-concurrent-streaming/spec.md
+++ b/openspec/specs/nar-concurrent-streaming/spec.md
@@ -1,0 +1,77 @@
+# NAR Concurrent Streaming
+
+## Purpose
+
+Defines correctness and termination requirements for the per-client streaming goroutines that
+serve NAR content to multiple concurrent clients requesting the same NAR hash. In particular,
+governs how client context cancellation propagates so that cancelled clients exit promptly
+without blocking non-cancelled peers.
+
+## Requirements
+
+### Requirement: Concurrent NAR streaming goroutines MUST terminate within a bounded time
+
+When multiple clients concurrently request the same NAR hash and one client's context is
+cancelled mid-download, the streaming goroutine for the cancelled client SHALL exit promptly
+(without waiting for the next `cond.Broadcast()`) and the streaming goroutines for all
+remaining clients SHALL continue to completion unaffected.
+
+#### Scenario: Cancelled client's streaming goroutine exits on context cancellation
+
+- **WHEN** client A and client B both have active streaming goroutines for the same NAR hash
+- **AND** client A's context is cancelled while its goroutine is blocked in the `cond.Wait()` loop
+- **THEN** client A's streaming goroutine MUST exit within a bounded time (≤ a few milliseconds after cancellation), without requiring a broadcast from the download goroutine
+- **AND** the per-client `io.Pipe` writer for client A MUST be closed so the caller's reader unblocks
+
+#### Scenario: Non-cancelled client receives all bytes after sibling cancellation
+
+- **WHEN** client A and client B concurrently call `GetNar` for the same NAR hash
+- **AND** client A cancels its context mid-download
+- **AND** client B's context is never cancelled
+- **THEN** client B's reader SHALL receive all bytes of the NAR content
+- **AND** `io.ReadAll` on client B's reader SHALL complete without hanging
+- **AND** `HasNar` SHALL return true after client B's read completes
+
+#### Scenario: Streaming goroutine exits cleanly when storage stalls for a cancelled client
+
+- **WHEN** a client's context is cancelled
+- **AND** the streaming goroutine has finished forwarding all bytes to the client pipe
+- **AND** the storage goroutine (`storeNarFromTempFile`) has not yet completed
+- **THEN** the streaming goroutine for the cancelled client SHALL exit via the `ctx.Done()` case
+- **AND** `defer writer.Close()` SHALL run, unblocking the caller
+- **AND** the storage goroutine SHALL continue to completion independently
+
+### Requirement: Streaming goroutine `cond.Wait()` loop MUST check client context cancellation
+
+The `cond.Wait()` loop in the per-client streaming goroutine SHALL treat client context
+cancellation as an exit condition equivalent to `downloadError`, so that a cancelled client
+does not hold a streaming goroutine open indefinitely waiting for a `Broadcast()` that may
+arrive infrequently.
+
+#### Scenario: Context-cancelled client exits loop without broadcast
+
+- **WHEN** the streaming goroutine is blocked in `cond.Wait()` (no new bytes available, download not complete)
+- **AND** the client's context is cancelled
+- **THEN** the goroutine SHALL wake within microseconds (via a watcher goroutine that calls `ds.cond.Broadcast()` on `ctx.Done()`)
+- **AND** the goroutine SHALL check `ctx.Err() != nil` and return, closing the pipe writer
+
+### Requirement: Storage-wait `select` MUST include a client context escape
+
+After the streaming goroutine has forwarded all bytes, it waits for `ds.stored` or `ds.done`
+before closing the pipe. This `select` SHALL also include `ctx.Done()` so that a cancelled
+client does not remain blocked if the storage operation stalls.
+
+#### Scenario: Cancelled client does not block at storage-wait select
+
+- **WHEN** the streaming goroutine has sent all bytes (`bytesSent >= ds.finalSize`)
+- **AND** neither `ds.stored` nor `ds.done` has fired yet (storage is in progress)
+- **AND** the client's context is cancelled
+- **THEN** the goroutine SHALL exit via `<-ctx.Done()`
+- **AND** the pipe writer SHALL be closed, allowing the caller's `io.ReadAll` to return
+
+#### Scenario: Non-cancelled client still waits for storage confirmation
+
+- **WHEN** the streaming goroutine has sent all bytes
+- **AND** the client's context is active (not cancelled)
+- **THEN** the goroutine SHALL wait for `ds.stored` or `ds.done` before closing the pipe
+- **AND** `HasNar` SHALL return true when observed by the caller after reading completes

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -495,13 +495,15 @@ func (r *fileAvailableReader) Read(p []byte) (int, error) {
 	r.ds.mu.Lock()
 
 	for r.offset >= r.ds.bytesWritten && r.ds.finalSize == 0 && r.ds.downloadError == nil {
-		r.ds.cond.Wait()
-
-		if r.ctx.Err() != nil {
+		// Check before Wait so a broadcast that already fired is not missed.
+		// sync.Cond has no memory: a Broadcast that arrives before Wait() is lost.
+		if r.ctx != nil && r.ctx.Err() != nil {
 			r.ds.mu.Unlock()
 
 			return 0, r.ctx.Err()
 		}
+
+		r.ds.cond.Wait()
 	}
 
 	if r.ds.downloadError != nil {
@@ -2771,7 +2773,7 @@ func (c *Cache) pullNarIntoStore(
 
 			// fileAvailableReader blocks until bytes are available and returns
 			// EOF when ds.finalSize is set (download goroutine finished writing).
-			cdcReader := &fileAvailableReader{f: fForCDC, ds: ds}
+			cdcReader := &fileAvailableReader{f: fForCDC, ds: ds, ctx: ctx}
 
 			// onNarFileReady fires right after the nar_file DB record is created
 			// (before chunking starts). Concurrent GetNar clients waiting for

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -488,6 +488,7 @@ type fileAvailableReader struct {
 	f      *os.File
 	ds     *downloadState
 	offset int64
+	ctx    context.Context
 }
 
 func (r *fileAvailableReader) Read(p []byte) (int, error) {
@@ -495,6 +496,12 @@ func (r *fileAvailableReader) Read(p []byte) (int, error) {
 
 	for r.offset >= r.ds.bytesWritten && r.ds.finalSize == 0 && r.ds.downloadError == nil {
 		r.ds.cond.Wait()
+
+		if r.ctx.Err() != nil {
+			r.ds.mu.Unlock()
+
+			return 0, r.ctx.Err()
+		}
 	}
 
 	if r.ds.downloadError != nil {
@@ -1180,6 +1187,21 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (nar.URL, int64, io.
 			// before ds.start is closed, and this goroutine runs after <-ds.start.
 			tempFileCompression := ds.tempFileCompression
 
+			// If the client's context is cancelled while this goroutine is blocked
+			// in cond.Wait, the watcher below broadcasts to wake it immediately.
+			// Without this, a cancelled client can hold the goroutine open until
+			// the next data broadcast from the download goroutine. See ncps #1252.
+			watcherDone := make(chan struct{})
+			defer close(watcherDone)
+
+			go func() {
+				select {
+				case <-ctx.Done():
+					ds.cond.Broadcast()
+				case <-watcherDone:
+				}
+			}()
+
 			// When the temp file holds compressed data but the client expects
 			// uncompressed bytes (CDC-normalized URL), decompress on-the-fly.
 			// This happens when GetNar piggybacks on a download started by
@@ -1196,7 +1218,7 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (nar.URL, int64, io.
 
 				defer f.Close()
 
-				fileReader := &fileAvailableReader{f: f, ds: ds}
+				fileReader := &fileAvailableReader{f: f, ds: ds, ctx: ctx}
 
 				decompReader, err := nar.DecompressReader(ctx, fileReader, tempFileCompression)
 				if err != nil {
@@ -1227,6 +1249,10 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (nar.URL, int64, io.
 							Str("nar_url", narURL.String()).
 							Msg("download completed with error during decompressed streaming")
 					}
+				case <-ctx.Done():
+					zerolog.Ctx(ctx).Debug().
+						Str("nar_url", narURL.String()).
+						Msg("client context cancelled while waiting for NAR storage (decompress path)")
 				}
 
 				return
@@ -1242,10 +1268,11 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (nar.URL, int64, io.
 				for bytesSent >= ds.bytesWritten && ds.finalSize == 0 {
 					ds.cond.Wait() // Put this goroutine to sleep until a broadcast is received from the downloader
 
-					// check for error just in case otherwise we'd end up sleeping forever
-					// in case an error happened and the downloader bailed after its last
-					// broadcast in the defered function.
-					if ds.downloadError != nil {
+					// Exit on download error or client context cancellation so the
+					// goroutine does not block indefinitely. The watcher goroutine above
+					// calls cond.Broadcast when ctx is cancelled, ensuring this loop
+					// wakes promptly rather than waiting for the next data broadcast.
+					if ds.downloadError != nil || ctx.Err() != nil {
 						ds.mu.Unlock()
 
 						return
@@ -1309,6 +1336,12 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (nar.URL, int64, io.
 								Str("nar_url", narURL.String()).
 								Msg("download completed with error during streaming")
 						}
+					case <-ctx.Done():
+						// Client cancelled — all bytes were already delivered; skip
+						// waiting for storage so this goroutine does not block cleanup.
+						zerolog.Ctx(ctx).Debug().
+							Str("nar_url", narURL.String()).
+							Msg("client context cancelled while waiting for NAR storage")
 					}
 
 					return

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -4169,3 +4169,18 @@ func testGetNarCDCXzServesFromStoreWhenBothExist(factory cacheFactory) func(*tes
 		assert.Equal(t, testdata.Nar1.NarText, string(body))
 	}
 }
+
+// TestConcurrentDownloadCancelStress runs testConcurrentDownloadCancelOneClientOthersContinue
+// 50 times in sequence to surface the once-in-CI hang described in ncps #1252.
+// Skipped in short mode (-short) to avoid adding wall time to the normal test suite.
+func TestConcurrentDownloadCancelStress(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping stress test in short mode")
+	}
+
+	for i := range 50 { //nolint:paralleltest // t.Parallel() is called inside the returned func
+		t.Run(fmt.Sprintf("iter%02d", i), testConcurrentDownloadCancelOneClientOthersContinue(setupSQLiteFactory))
+	}
+}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1754,198 +1754,206 @@ func testBackgroundDownloadCompletionAfterCancellation(factory cacheFactory) fun
 func testConcurrentDownloadCancelOneClientOthersContinue(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
+		runConcurrentDownloadCancelOneClientOthersContinue(t, factory)
+	}
+}
 
-		c, _, localStore, dir, _, cleanup := factory(t)
-		t.Cleanup(cleanup)
+// runConcurrentDownloadCancelOneClientOthersContinue is the shared body used by both
+// testConcurrentDownloadCancelOneClientOthersContinue (parallel) and the stress loop
+// (sequential). Callers control whether t.Parallel() is invoked before this.
+func runConcurrentDownloadCancelOneClientOthersContinue(t *testing.T, factory cacheFactory) {
+	t.Helper()
 
-		// Use an existing test entry (Nar5 to avoid conflict with other tests)
-		entry := testdata.Nar5
+	c, _, localStore, dir, _, cleanup := factory(t)
+	t.Cleanup(cleanup)
 
-		// Setup a test server with the entry
-		ts := testdata.NewTestServer(t, 1)
-		t.Cleanup(ts.Close)
+	// Use an existing test entry (Nar5 to avoid conflict with other tests)
+	entry := testdata.Nar5
 
-		// Add a handler that serves the NAR slowly to allow cancellation mid-download
-		slowNarServed := make(chan struct{})
+	// Setup a test server with the entry
+	ts := testdata.NewTestServer(t, 1)
+	t.Cleanup(ts.Close)
 
-		var slowNarServedOnce sync.Once
+	// Add a handler that serves the NAR slowly to allow cancellation mid-download
+	slowNarServed := make(chan struct{})
 
-		downloadComplete := make(chan struct{})
+	var slowNarServedOnce sync.Once
 
-		var downloadCompleteOnce sync.Once
+	downloadComplete := make(chan struct{})
 
-		ts.AddMaybeHandler(func(w http.ResponseWriter, r *http.Request) bool {
-			if r.URL.Path == "/nar/"+entry.NarHash+".nar.xz" {
-				// Signal that we started serving
-				slowNarServedOnce.Do(func() { close(slowNarServed) })
+	var downloadCompleteOnce sync.Once
 
-				// Write data slowly in chunks
-				data := []byte(entry.NarText)
+	ts.AddMaybeHandler(func(w http.ResponseWriter, r *http.Request) bool {
+		if r.URL.Path == "/nar/"+entry.NarHash+".nar.xz" {
+			// Signal that we started serving
+			slowNarServedOnce.Do(func() { close(slowNarServed) })
 
-				chunkSize := 1024
-				for i := 0; i < len(data); i += chunkSize {
-					end := min(i+chunkSize, len(data))
+			// Write data slowly in chunks
+			data := []byte(entry.NarText)
 
-					_, err := w.Write(data[i:end])
-					if err != nil {
-						return true
-					}
+			chunkSize := 1024
+			for i := 0; i < len(data); i += chunkSize {
+				end := min(i+chunkSize, len(data))
 
-					// Flush to ensure data is sent
-					if f, ok := w.(http.Flusher); ok {
-						f.Flush()
-					}
-
-					// Sleep to make download slow
-					time.Sleep(2 * time.Millisecond)
+				_, err := w.Write(data[i:end])
+				if err != nil {
+					return true
 				}
 
-				// Signal download is complete
-				downloadCompleteOnce.Do(func() { close(downloadComplete) })
+				// Flush to ensure data is sent
+				if f, ok := w.(http.Flusher); ok {
+					f.Flush()
+				}
 
-				return true
+				// Sleep to make download slow
+				time.Sleep(2 * time.Millisecond)
 			}
 
-			return false
-		})
+			// Signal download is complete
+			downloadCompleteOnce.Do(func() { close(downloadComplete) })
 
-		uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), nil)
-		require.NoError(t, err)
-
-		c.AddUpstreamCaches(newContext(), uc)
-
-		// Wait for health check
-		select {
-		case <-c.GetHealthChecker().Trigger():
-		case <-time.After(5 * time.Second):
-			t.Fatal("timeout waiting for upstream health check")
+			return true
 		}
 
-		// Verify NAR does not exist yet
-		narPath := filepath.Join(dir, "store", "nar", entry.NarPath)
-		assert.NoFileExists(t, narPath, "NAR should not exist in cache yet")
+		return false
+	})
 
-		// Start both clients at the same time
-		var wg sync.WaitGroup
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), nil)
+	require.NoError(t, err)
 
-		ctxA, cancelA := context.WithCancel(newContext())
-		ctxB := newContext()
+	c.AddUpstreamCaches(newContext(), uc)
 
-		doneA := make(chan struct{})
-		doneB := make(chan struct{})
+	// Wait for health check
+	select {
+	case <-c.GetHealthChecker().Trigger():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for upstream health check")
+	}
 
-		var (
-			getNarErrA, getNarErrB error
-			sizeB                  int64
-			readerB                io.ReadCloser
-		)
+	// Verify NAR does not exist yet
+	narPath := filepath.Join(dir, "store", "nar", entry.NarPath)
+	assert.NoFileExists(t, narPath, "NAR should not exist in cache yet")
 
-		// Client A - will be cancelled mid-download
+	// Start both clients at the same time
+	var wg sync.WaitGroup
 
-		wg.Go(func() {
-			defer close(doneA)
+	ctxA, cancelA := context.WithCancel(newContext())
+	ctxB := newContext()
 
-			nu := nar.URL{Hash: entry.NarHash, Compression: entry.NarCompression}
-			_, _, r, err := c.GetNar(ctxA, nu)
-			getNarErrA = err
+	doneA := make(chan struct{})
+	doneB := make(chan struct{})
 
-			if r != nil {
-				// Try to read some data
-				buf := make([]byte, 1024)
-				_, _ = r.Read(buf)
-				r.Close()
-			}
-		})
+	var (
+		getNarErrA, getNarErrB error
+		sizeB                  int64
+		readerB                io.ReadCloser
+	)
 
-		// Client B - should complete successfully despite A's cancellation
+	// Client A - will be cancelled mid-download
 
-		wg.Go(func() {
-			defer close(doneB)
-
-			nu := nar.URL{Hash: entry.NarHash, Compression: entry.NarCompression}
-
-			var err error
-
-			_, sizeB, readerB, err = c.GetNar(ctxB, nu)
-			getNarErrB = err
-		})
-
-		// Wait for the download to start
-		select {
-		case <-slowNarServed:
-			// Good, download started
-		case <-time.After(5 * time.Second):
-			t.Fatal("timeout waiting for NAR download to start")
-		}
-
-		// Give it a moment to ensure both clients are waiting on the same download
-		time.Sleep(50 * time.Millisecond)
-
-		// Cancel client A mid-download
-		t.Log("Canceling client A mid-download")
-		cancelA()
-
-		// Wait for client A to return (should return quickly after cancellation)
-		select {
-		case <-doneA:
-			t.Logf("Client A returned with error: %v", getNarErrA)
-			// Client A may or may not have an error depending on timing
-		case <-time.After(5 * time.Second):
-			t.Fatal("timeout waiting for client A to return")
-		}
-
-		// Wait for background download to complete
-		select {
-		case <-downloadComplete:
-			t.Log("Background download completed")
-		case <-time.After(10 * time.Second):
-			t.Fatal("timeout waiting for background download to complete")
-		}
-
-		// Wait for client B to complete (should succeed)
-		select {
-		case <-doneB:
-			t.Logf("Client B completed with error: %v", getNarErrB)
-			require.NoError(t, getNarErrB, "client B should complete successfully despite client A cancellation")
-		case <-time.After(5 * time.Second):
-			t.Fatal("timeout waiting for client B to complete")
-		}
-
-		// Verify client B got the complete data
-		require.NotNil(t, readerB, "client B reader should not be nil")
-
-		// Bounded io.ReadAll: previously this could hang for the 20 min outer
-		// `go test -timeout` if client A's cancellation left the shared streaming
-		// goroutine in a state where the writer never closed. See ncps #1252.
-		// Fail fast with a goroutine dump so future hangs are actionable.
-		var (
-			bodyB   []byte
-			readErr error
-		)
-
-		runWithTimeout(t, 30*time.Second, "io.ReadAll(readerB)", func() {
-			bodyB, readErr = io.ReadAll(readerB)
-		})
-
-		require.NoError(t, readErr, "should be able to read NAR content from client B")
-		readerB.Close()
-
-		assert.Equal(t, entry.NarText, string(bodyB), "NAR content should match for client B")
-
-		if sizeB != -1 {
-			assert.Equal(t, int64(len(entry.NarText)), sizeB, "size should match for client B")
-		}
-
-		// Verify the asset is in storage
-		assert.FileExists(t, narPath, "NAR should exist in cache")
+	wg.Go(func() {
+		defer close(doneA)
 
 		nu := nar.URL{Hash: entry.NarHash, Compression: entry.NarCompression}
-		assert.True(t, localStore.HasNar(newContext(), nu), "HasNar should return true")
+		_, _, r, err := c.GetNar(ctxA, nu)
+		getNarErrA = err
 
-		runWithTimeout(t, 30*time.Second, "wg.Wait()", wg.Wait)
+		if r != nil {
+			// Try to read some data
+			buf := make([]byte, 1024)
+			_, _ = r.Read(buf)
+			r.Close()
+		}
+	})
 
-		t.Log("✅ Client B completed successfully despite client A cancellation - download coordination works!")
+	// Client B - should complete successfully despite A's cancellation
+
+	wg.Go(func() {
+		defer close(doneB)
+
+		nu := nar.URL{Hash: entry.NarHash, Compression: entry.NarCompression}
+
+		var err error
+
+		_, sizeB, readerB, err = c.GetNar(ctxB, nu)
+		getNarErrB = err
+	})
+
+	// Wait for the download to start
+	select {
+	case <-slowNarServed:
+		// Good, download started
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for NAR download to start")
 	}
+
+	// Give it a moment to ensure both clients are waiting on the same download
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel client A mid-download
+	t.Log("Canceling client A mid-download")
+	cancelA()
+
+	// Wait for client A to return (should return quickly after cancellation)
+	select {
+	case <-doneA:
+		t.Logf("Client A returned with error: %v", getNarErrA)
+		// Client A may or may not have an error depending on timing
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for client A to return")
+	}
+
+	// Wait for background download to complete
+	select {
+	case <-downloadComplete:
+		t.Log("Background download completed")
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for background download to complete")
+	}
+
+	// Wait for client B to complete (should succeed)
+	select {
+	case <-doneB:
+		t.Logf("Client B completed with error: %v", getNarErrB)
+		require.NoError(t, getNarErrB, "client B should complete successfully despite client A cancellation")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for client B to complete")
+	}
+
+	// Verify client B got the complete data
+	require.NotNil(t, readerB, "client B reader should not be nil")
+
+	// Bounded io.ReadAll: previously this could hang for the 20 min outer
+	// `go test -timeout` if client A's cancellation left the shared streaming
+	// goroutine in a state where the writer never closed. See ncps #1252.
+	// Fail fast with a goroutine dump so future hangs are actionable.
+	var (
+		bodyB   []byte
+		readErr error
+	)
+
+	runWithTimeout(t, 30*time.Second, "io.ReadAll(readerB)", func() {
+		bodyB, readErr = io.ReadAll(readerB)
+	})
+
+	require.NoError(t, readErr, "should be able to read NAR content from client B")
+	readerB.Close()
+
+	assert.Equal(t, entry.NarText, string(bodyB), "NAR content should match for client B")
+
+	if sizeB != -1 {
+		assert.Equal(t, int64(len(entry.NarText)), sizeB, "size should match for client B")
+	}
+
+	// Verify the asset is in storage
+	assert.FileExists(t, narPath, "NAR should exist in cache")
+
+	nu := nar.URL{Hash: entry.NarHash, Compression: entry.NarCompression}
+	assert.True(t, localStore.HasNar(newContext(), nu), "HasNar should return true")
+
+	runWithTimeout(t, 30*time.Second, "wg.Wait()", wg.Wait)
+
+	t.Log("✅ Client B completed successfully despite client A cancellation - download coordination works!")
 }
 
 func newContext() context.Context {
@@ -4180,7 +4188,9 @@ func TestConcurrentDownloadCancelStress(t *testing.T) {
 		t.Skip("skipping stress test in short mode")
 	}
 
-	for i := range 50 { //nolint:paralleltest // t.Parallel() is called inside the returned func
-		t.Run(fmt.Sprintf("iter%02d", i), testConcurrentDownloadCancelOneClientOthersContinue(setupSQLiteFactory))
+	for i := range 50 { //nolint:paralleltest // sequential by design: each iter must finish before next
+		t.Run(fmt.Sprintf("iter%02d", i), func(t *testing.T) {
+			runConcurrentDownloadCancelOneClientOthersContinue(t, setupSQLiteFactory)
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- The per-client streaming goroutine in `GetNar` had two blocking points with
  no context cancellation escape, causing a once-in-CI 20-minute hang when one
  client cancelled a shared in-flight download (ncps #1252).

- **`cond.Wait()` loop**: added a watcher goroutine per streaming SafeGo that
  calls `ds.cond.Broadcast()` when the client's `ctx` is cancelled, waking the
  loop immediately. Added `ctx.Err() != nil` alongside the existing
  `downloadError` check so the goroutine exits without waiting for the next
  data broadcast.

- **Storage-wait `select`**: extended both the regular and decompression path
  selects (`ds.stored` / `ds.done`) with `case <-ctx.Done():` so a cancelled
  client does not block indefinitely if storage stalls under I/O pressure.

- **`fileAvailableReader`**: added `ctx context.Context` field; `Read()` now
  returns `ctx.Err()` after any `cond.Wait()` wakeup when the context is done,
  covering the decompression streaming path.

- Added `TestConcurrentDownloadCancelStress` (50 iterations, skipped under
  `-short`) to surface the race reliably. 50/50 pass with fix under `-race`.

## Test plan

- [x] `task fmt` — no changes
- [x] `task lint` — 0 issues
- [x] `task test` — all pass including `ConcurrentDownloadCancelOneClientOthersContinue`
- [x] `TestConcurrentDownloadCancelStress` — 50/50 iterations pass under `-race`

Closes #1252