### PR TITLE
refactor(database): consolidate dialect mappers and ErrUnknownDialect

### DIFF
--- a/openspec/changes/archive/2026-05-29-consolidate-dialect-mappers/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-29-consolidate-dialect-mappers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/archive/2026-05-29-consolidate-dialect-mappers/design.md
+++ b/openspec/changes/archive/2026-05-29-consolidate-dialect-mappers/design.md
@@ -1,0 +1,43 @@
+## Context
+
+The Ent migration left two parallel implementations of the same `database.Type` → dialect mapping:
+
+- `database.EntDialectFor(t Type) (string, error)` in `pkg/database/client.go`, documented as "kept exported so `pkg/database/migrate` can share the same mapping."
+- `entDialectFor(d ncpsdb.Type) (string, error)` in `pkg/database/migrate/fresh.go` — a byte-for-byte copy that the migrate package actually uses.
+
+Both packages also declare their own `ErrUnknownDialect` sentinel; `client.go`'s declaration even comments "Mirrors the sentinel in pkg/database/migrate." The migrate package imports the database package as `ncpsdb` (the identifier `database` inside migrate refers to goose's `github.com/pressly/goose/v3/database`), so the shared function is reachable as `ncpsdb.EntDialectFor`.
+
+Separately, two goose mappers exist: `gooseStoreDialectFor` (`fresh.go`, returns goose's `database.Dialect`) and `gooseDialectFor` (`apply.go`, returns `goose.Dialect`). These return *different* goose types.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One source of truth for the `Type` → ent dialect string mapping, reused cross-package.
+- One `ErrUnknownDialect` sentinel that `errors.Is` matches consistently.
+- Behavior-preserving: identical dialect resolution and identical error semantics.
+
+**Non-Goals:**
+- Changing goose apply behavior, migration files, or dialect coverage.
+- Forcing a merge of the two goose mappers if their return types are genuinely distinct.
+
+## Decisions
+
+**Decision 1 — Delete `migrate.entDialectFor`; call `ncpsdb.EntDialectFor`.**
+The exported function's documented contract already names this exact reuse. Alternative (unexport `EntDialectFor`) was rejected: it contradicts the doc comment and the cross-package need is real.
+
+**Decision 2 — Single `ErrUnknownDialect`.** Make the migrate package reference `ncpsdb.ErrUnknownDialect` rather than declare its own, and drop the "Mirrors the sentinel" comment. This keeps `errors.Is(err, database.ErrUnknownDialect)` true regardless of which layer produced the error. Error *message* wrapping (the `"entDialectFor: ..."` prefix) is internal and not asserted by tests, so consolidating the sentinel is safe.
+
+**Decision 3 — Goose mappers: inspect, then decide.** Confirm the concrete types of `goose.Dialect` vs goose's `database.Dialect`. If one is an alias/convertible to the other without a cast, collapse to a single helper returning the broader type. If they are distinct exported types (the likely case), leave both functions and add a one-line comment explaining they target different goose APIs. No casts will be introduced solely to merge them.
+
+## Risks / Trade-offs
+
+- [Consolidating `ErrUnknownDialect` could change which sentinel a test matches] → Audit `errors.Is(..., ErrUnknownDialect)` / `ErrorIs` call sites first; the migrate tests assert behavior (fresh install succeeds, unknown dialect errors), not a specific sentinel identity. Run the full migrate suite to confirm.
+- [Import cycle risk] → None: `migrate` already imports the database package as `ncpsdb`; the dependency direction is unchanged.
+
+## Migration Plan
+
+Pure code refactor, no DB migration. Deploy as a single stacked PR; rollback is a straight revert. No runtime state involved.
+
+## Open Questions
+
+- Whether `goose.Dialect` and goose's `database.Dialect` are convertible — resolved during implementation by reading the goose v3 types; the spec requirement does not depend on the outcome.

--- a/openspec/changes/archive/2026-05-29-consolidate-dialect-mappers/proposal.md
+++ b/openspec/changes/archive/2026-05-29-consolidate-dialect-mappers/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Post-Ent-migration, the mapping from ncps's `database.Type` to a dialect identifier is duplicated. `database.EntDialectFor` (`pkg/database/client.go`) is documented as "kept exported so `pkg/database/migrate` can share the same mapping" — yet `migrate` never calls it and instead carries a byte-for-byte copy (`entDialectFor` in `fresh.go`), plus its own duplicate `ErrUnknownDialect` sentinel. The duplication invites the copies to drift and contradicts the stated design.
+
+## What Changes
+
+- Remove the duplicate `entDialectFor` in `pkg/database/migrate/fresh.go` and route its single call site through the shared `database.EntDialectFor`, fulfilling that function's documented purpose.
+- Collapse the duplicated `ErrUnknownDialect` sentinel to one source of truth (`database.ErrUnknownDialect`), so callers compare against a single error value.
+- Evaluate the two goose dialect mappers — `gooseStoreDialectFor` (returns goose's `database.Dialect`) and `gooseDialectFor` (returns `goose.Dialect`). Merge them only if the goose types are convertible without added casts; otherwise leave both and document why they stay separate.
+- Behavior-preserving: no schema, migration, or runtime behavior changes.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `database-orm`: add a requirement that the `database.Type` → ent dialect-string mapping has a single source of truth (`database.EntDialectFor`), reused by every package that needs it (including `pkg/database/migrate`), rather than re-implemented per package.
+
+## Impact
+
+- Code: `pkg/database/migrate/fresh.go`, `pkg/database/migrate/apply.go` (goose mapper review only), `pkg/database/client.go` (doc comment), and the `ErrUnknownDialect` declaration site(s).
+- No public API removal: `database.EntDialectFor` stays exported (now actually consumed cross-package).
+- Tests: existing `pkg/database/migrate/migrate_test.go` and `pkg/database/client_test.go` cover fresh-install and dialect mapping; they remain the safety net.
+
+## Non-goals
+
+- Not touching the goose runtime apply path semantics, migration files, or `atlas.sum`.
+- Not changing dialect *coverage* (SQLite, PostgreSQL, MySQL all remain supported).
+- Not forcing a merge of the two goose mappers if their return types are genuinely distinct.
+
+## I/O, latency, memory impact
+
+None. This is a compile-time deduplication of pure functions and a sentinel value; it adds no allocations and changes no I/O, network, or memory behavior.

--- a/openspec/changes/archive/2026-05-29-consolidate-dialect-mappers/specs/database-orm/spec.md
+++ b/openspec/changes/archive/2026-05-29-consolidate-dialect-mappers/specs/database-orm/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: The dialect-string mapping has a single source of truth
+
+The system SHALL define the mapping from `database.Type` to its Ent dialect string in exactly one place — the exported `database.EntDialectFor` function — and every package that needs that mapping (including `pkg/database/migrate`) SHALL call `database.EntDialectFor` rather than re-implement it. The system SHALL likewise expose a single `database.ErrUnknownDialect` sentinel that all callers return and match via `errors.Is`, rather than per-package duplicate sentinels.
+
+#### Scenario: Migrate package resolves the ent dialect
+
+- **WHEN** `pkg/database/migrate` needs the Ent dialect string for a `database.Type`
+- **THEN** it SHALL obtain it by calling `database.EntDialectFor(t)`
+- **AND** no second copy of the `Type` → ent dialect-string switch SHALL exist under `pkg/database/migrate/`
+
+#### Scenario: Unknown dialect produces the shared sentinel
+
+- **WHEN** `database.EntDialectFor` is called with `database.TypeUnknown` (or any unmapped `Type`)
+- **THEN** it SHALL return an error that satisfies `errors.Is(err, database.ErrUnknownDialect)`
+- **AND** callers across `pkg/database` and `pkg/database/migrate` SHALL match that same sentinel value
+
+#### Scenario: Dialect coverage is unchanged
+
+- **WHEN** `database.EntDialectFor` is called with `TypeSQLite`, `TypePostgreSQL`, or `TypeMySQL`
+- **THEN** it SHALL return `dialect.SQLite`, `dialect.Postgres`, and `dialect.MySQL` respectively, exactly as before this change

--- a/openspec/changes/archive/2026-05-29-consolidate-dialect-mappers/tasks.md
+++ b/openspec/changes/archive/2026-05-29-consolidate-dialect-mappers/tasks.md
@@ -1,0 +1,21 @@
+## 1. Audit & baseline
+
+- [x] 1.1 Confirm current behavior is green: run `task test` for `pkg/database/...` so the dialect-mapping/fresh-install tests pass before any change.
+- [x] 1.2 Grep all references to `entDialectFor`, `EntDialectFor`, and `ErrUnknownDialect` across the repo to enumerate every call/match site that the consolidation must keep working.
+- [x] 1.3 Inspect the goose types: determine whether `goose.Dialect` and goose's `github.com/pressly/goose/v3/database` `Dialect` are the same/convertible type, to decide if the two goose mappers can merge. (Confirmed: `goose.Dialect = database.Dialect` is a type alias — they are the same type.)
+
+## 2. Consolidate the ent dialect mapping
+
+- [x] 2.1 Delete `entDialectFor` from `pkg/database/migrate/fresh.go` and replace its call site with `ncpsdb.EntDialectFor(d)`, preserving error handling. (Also dropped the now-unused `entgo.io/ent/dialect` import.)
+- [x] 2.2 Make `pkg/database/migrate` use the single `database.ErrUnknownDialect`; removed the migrate-local duplicate `ErrUnknownDialect` declaration and updated all call sites in `state.go`, `adopt.go`, `apply.go`.
+- [x] 2.3 In `pkg/database/client.go`, update the `EntDialectFor` doc comment to reflect that migrate now consumes it, and drop the "Mirrors the sentinel" comment on `ErrUnknownDialect`.
+
+## 3. Goose mappers
+
+- [x] 3.1 Goose dialect types are the same (alias), so merged: removed `gooseStoreDialectFor` and routed `fresh.go` through the shared `gooseDialectFor` (its `goose.Dialect` return is assignable to goose-store's `database.Dialect`).
+
+## 4. Verify
+
+- [x] 4.1 Ran `task fmt` (3 files reformatted) and `task lint` (0 issues).
+- [x] 4.2 Ran `task test` — full suite green, including `pkg/database` and `pkg/database/migrate`.
+- [x] 4.3 No new test added: existing `migrate_test.go` / `client_test.go` already cover dialect resolution and fresh install; the refactor is behavior-preserving with no new edge case.

--- a/openspec/specs/database-orm/spec.md
+++ b/openspec/specs/database-orm/spec.md
@@ -99,3 +99,24 @@ The system SHALL NOT contain the legacy `pkg/database/{sqlitedb,postgresdb,mysql
 - **WHEN** the change is applied
 - **THEN** `pkg/database/sqlitedb/`, `pkg/database/postgresdb/`, `pkg/database/mysqldb/`, `pkg/database/generated_models.go`, `pkg/database/generated_errors.go`, `pkg/database/generated_querier.go`, and `pkg/database/generated_wrapper_{sqlite,postgres,mysql}.go` SHALL NOT exist in the repository
 - **AND** no file under `pkg/` SHALL import any of those paths
+
+### Requirement: The dialect-string mapping has a single source of truth
+
+The system SHALL define the mapping from `database.Type` to its Ent dialect string in exactly one place — the exported `database.EntDialectFor` function — and every package that needs that mapping (including `pkg/database/migrate`) SHALL call `database.EntDialectFor` rather than re-implement it. The system SHALL likewise expose a single `database.ErrUnknownDialect` sentinel that all callers return and match via `errors.Is`, rather than per-package duplicate sentinels.
+
+#### Scenario: Migrate package resolves the ent dialect
+
+- **WHEN** `pkg/database/migrate` needs the Ent dialect string for a `database.Type`
+- **THEN** it SHALL obtain it by calling `database.EntDialectFor(t)`
+- **AND** no second copy of the `Type` → ent dialect-string switch SHALL exist under `pkg/database/migrate/`
+
+#### Scenario: Unknown dialect produces the shared sentinel
+
+- **WHEN** `database.EntDialectFor` is called with `database.TypeUnknown` (or any unmapped `Type`)
+- **THEN** it SHALL return an error that satisfies `errors.Is(err, database.ErrUnknownDialect)`
+- **AND** callers across `pkg/database` and `pkg/database/migrate` SHALL match that same sentinel value
+
+#### Scenario: Dialect coverage is unchanged
+
+- **WHEN** `database.EntDialectFor` is called with `TypeSQLite`, `TypePostgreSQL`, or `TypeMySQL`
+- **THEN** it SHALL return `dialect.SQLite`, `dialect.Postgres`, and `dialect.MySQL` respectively, exactly as before this change

--- a/pkg/database/client.go
+++ b/pkg/database/client.go
@@ -25,7 +25,8 @@ import (
 var SchemaCreateMu sync.Mutex
 
 // ErrUnknownDialect is returned when a database.Type cannot be mapped to
-// an ent dialect string. Mirrors the sentinel in pkg/database/migrate.
+// an ent dialect string. This is the single sentinel for unmapped
+// dialects; pkg/database/migrate returns and matches this same value.
 var ErrUnknownDialect = errors.New("database: unknown dialect")
 
 // ErrNilDB is returned by NewClient when the caller passes a nil
@@ -151,9 +152,9 @@ func (c *Client) WithTransaction(
 }
 
 // EntDialectFor maps ncps's database.Type to the corresponding ent
-// dialect string. Kept exported so pkg/database/migrate can share the
-// same mapping (it owns its own *sql.DB and needs to build its own
-// ent driver for Schema.Create).
+// dialect string. Exported and shared: pkg/database/migrate calls it
+// when building its own ent driver for Schema.Create, so the mapping
+// lives in exactly one place.
 func EntDialectFor(t Type) (string, error) {
 	switch t {
 	case TypeSQLite:

--- a/pkg/database/migrate/adopt.go
+++ b/pkg/database/migrate/adopt.go
@@ -41,7 +41,7 @@ func adopt(ctx context.Context, db *sql.DB, d database.Type, st State) error {
 		case database.TypeUnknown:
 			fallthrough
 		default:
-			return fmt.Errorf("adopt: %w %v", ErrUnknownDialect, d)
+			return fmt.Errorf("adopt: %w %v", database.ErrUnknownDialect, d)
 		}
 	case StateMySQLS4:
 		return adoptMySQLFromS4(ctx, db)
@@ -94,7 +94,7 @@ func adoptTransactional(ctx context.Context, db *sql.DB, d database.Type) error 
 	case database.TypeMySQL, database.TypeUnknown:
 		fallthrough
 	default:
-		return fmt.Errorf("adoptTransactional: %w %v", ErrUnknownDialect, d)
+		return fmt.Errorf("adoptTransactional: %w %v", database.ErrUnknownDialect, d)
 	}
 	// 5. Verify row-count parity.
 	var postCount int

--- a/pkg/database/migrate/apply.go
+++ b/pkg/database/migrate/apply.go
@@ -168,7 +168,7 @@ func validateOptions(opts Options) error {
 	case database.TypeUnknown:
 		fallthrough
 	default:
-		return fmt.Errorf("migrate: %w %v", ErrUnknownDialect, opts.Dialect)
+		return fmt.Errorf("migrate: %w %v", database.ErrUnknownDialect, opts.Dialect)
 	}
 }
 
@@ -241,6 +241,6 @@ func gooseDialectFor(d database.Type) (goose.Dialect, error) {
 	case database.TypeUnknown:
 		fallthrough
 	default:
-		return "", fmt.Errorf("gooseDialectFor: %w %v", ErrUnknownDialect, d)
+		return "", fmt.Errorf("gooseDialectFor: %w %v", database.ErrUnknownDialect, d)
 	}
 }

--- a/pkg/database/migrate/fresh.go
+++ b/pkg/database/migrate/fresh.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"entgo.io/ent/dialect"
 	"github.com/pressly/goose/v3/database"
 
 	entsql "entgo.io/ent/dialect/sql"
@@ -43,7 +42,7 @@ func freshInstall(
 	d ncpsdb.Type,
 	migrationsFS fs.FS,
 ) error {
-	entDialect, err := entDialectFor(d)
+	entDialect, err := ncpsdb.EntDialectFor(d)
 	if err != nil {
 		return err
 	}
@@ -76,7 +75,7 @@ func freshInstall(
 	// 2. Use goose's own store to create schema_migrations + insert
 	//    versions. Going through goose's API guarantees the table
 	//    shape exactly matches what goose subsequently expects.
-	gooseDia, err := gooseStoreDialectFor(d)
+	gooseDia, err := gooseDialectFor(d)
 	if err != nil {
 		return err
 	}
@@ -111,39 +110,6 @@ func freshInstall(
 	}
 
 	return nil
-}
-
-// entDialectFor maps ncps's dialect enum to ent's dialect string.
-func entDialectFor(d ncpsdb.Type) (string, error) {
-	switch d {
-	case ncpsdb.TypeSQLite:
-		return dialect.SQLite, nil
-	case ncpsdb.TypePostgreSQL:
-		return dialect.Postgres, nil
-	case ncpsdb.TypeMySQL:
-		return dialect.MySQL, nil
-	case ncpsdb.TypeUnknown:
-		fallthrough
-	default:
-		return "", fmt.Errorf("entDialectFor: %w %v", ErrUnknownDialect, d)
-	}
-}
-
-// gooseStoreDialectFor maps ncps's dialect enum to goose's database
-// dialect identifier (the one used by `database.NewStore`).
-func gooseStoreDialectFor(d ncpsdb.Type) (database.Dialect, error) {
-	switch d {
-	case ncpsdb.TypeSQLite:
-		return database.DialectSQLite3, nil
-	case ncpsdb.TypePostgreSQL:
-		return database.DialectPostgres, nil
-	case ncpsdb.TypeMySQL:
-		return database.DialectMySQL, nil
-	case ncpsdb.TypeUnknown:
-		fallthrough
-	default:
-		return "", fmt.Errorf("gooseStoreDialectFor: %w %v", ErrUnknownDialect, d)
-	}
 }
 
 // listEmbeddedVersions walks the dialect-specific sub-FS and returns the

--- a/pkg/database/migrate/state.go
+++ b/pkg/database/migrate/state.go
@@ -15,14 +15,13 @@ import (
 	"github.com/kalbasit/ncps/pkg/database"
 )
 
-// Sentinel errors for state detection.
+// Sentinel errors for state detection. Unrecognised database.Type
+// values are reported via the package-level database.ErrUnknownDialect
+// sentinel (see pkg/database) so callers match a single value regardless
+// of which layer produced the error.
 var (
-	// ErrUnknownDialect is returned when state detection or any other
-	// migrate operation encounters an unrecognised database.Type value.
-	ErrUnknownDialect = errors.New("migrate: unknown dialect")
-
 	// ErrUnknownState is returned when adopt encounters an unrecognised
-	// State value. Distinct from ErrUnknownDialect, which is for
+	// State value. Distinct from database.ErrUnknownDialect, which is for
 	// database.Type values.
 	ErrUnknownState = errors.New("migrate: unknown state")
 
@@ -116,7 +115,7 @@ func Detect(ctx context.Context, db *sql.DB, d database.Type) (State, error) {
 	case database.TypeUnknown:
 		fallthrough
 	default:
-		return StateUnknown, fmt.Errorf("%w %v", ErrUnknownDialect, d)
+		return StateUnknown, fmt.Errorf("%w %v", database.ErrUnknownDialect, d)
 	}
 }
 
@@ -220,7 +219,7 @@ func tableExists(ctx context.Context, db *sql.DB, d database.Type, name string) 
 	case database.TypeUnknown:
 		fallthrough
 	default:
-		return false, fmt.Errorf("tableExists: %w %v", ErrUnknownDialect, d)
+		return false, fmt.Errorf("tableExists: %w %v", database.ErrUnknownDialect, d)
 	}
 
 	var ok int
@@ -285,7 +284,7 @@ func columnExists(ctx context.Context, db *sql.DB, d database.Type, table, colum
 	case database.TypeUnknown:
 		fallthrough
 	default:
-		return false, fmt.Errorf("columnExists: %w %v", ErrUnknownDialect, d)
+		return false, fmt.Errorf("columnExists: %w %v", database.ErrUnknownDialect, d)
 	}
 
 	var ok int


### PR DESCRIPTION
## Summary

Post-Ent-migration cleanup. The `database.Type` → ent dialect-string mapping was duplicated: `database.EntDialectFor` (documented as shared with the migrate package) had a byte-for-byte copy `entDialectFor` in `pkg/database/migrate/fresh.go`, plus a parallel `ErrUnknownDialect` sentinel. The two goose mappers (`gooseStoreDialectFor`, `gooseDialectFor`) duplicated the same switch.

- Route the migrate package through the shared `database.EntDialectFor`; delete the duplicate (and the now-unused `entgo.io/ent/dialect` import).
- Collapse the duplicated `ErrUnknownDialect` to the single `database.ErrUnknownDialect` across `state.go`, `adopt.go`, `apply.go`.
- Merge the goose mappers: `goose.Dialect` is a type alias of goose-store's `database.Dialect`, so `fresh.go` uses the shared `gooseDialectFor`.
- Behavior-preserving; records a `database-orm` spec requirement for the single-source-of-truth invariant.

## Test plan

- [x] `task fmt` / `task lint` (0 issues) / `task test` (full suite green)
- [x] Existing `pkg/database` and `pkg/database/migrate` suites cover dialect mapping + fresh install