### PR TITLE
refactor(cache): extract repeated Ent query helpers

### DIFF
--- a/openspec/changes/archive/2026-05-29-extract-cache-query-helpers/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-29-extract-cache-query-helpers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/archive/2026-05-29-extract-cache-query-helpers/design.md
+++ b/openspec/changes/archive/2026-05-29-extract-cache-query-helpers/design.md
@@ -1,0 +1,45 @@
+## Context
+
+`pkg/cache/cache.go` inlines identical Ent queries across many call sites. Three patterns are genuinely verbatim and safe to extract:
+
+1. **NarInfo by hash** — `q.NarInfo.Query().Where(entnarinfo.HashEQ(hash)).Only(ctx)` at the bare sites (e.g. lines ~3976, ~4496, ~4514, ~4804). Note: several *other* NarInfo queries chain `.With...()` eager-loads or extra `Where` predicates — those are **not** the same and are out of scope.
+2. **Chunks by hashes** — `q.Chunk.Query().Where(entchunk.HashIn(hashes...)).All(ctx)` (lines ~2483, ~2532).
+3. **Total NAR-file size** — `var x []struct{ Sum sql.NullInt64 }` / `q.NarFile.Query().Aggregate(ent.Sum(entnarfile.FieldFileSize)).Scan(ctx, &x)` / `len(x)>0 && x[0].Sum.Valid` unpack (lines ~724 and ~5748). The two copies differ only in their surrounding error policy (one warns and continues for a metric, the other returns the error for cleanup).
+
+Both `*ent.Client` and `*ent.Tx` expose per-entity clients of the same type (`*ent.NarInfoClient`, `*ent.NarFileClient`, `*ent.ChunkClient`). So a helper that takes the entity client works unchanged for transactional and non-transactional callers.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Remove verbatim duplication for the three patterns above.
+- One helper serves both `tx.X` and `c.dbClient.Ent().X` callers.
+- Strictly behavior-preserving: same SQL, same `Only`/`All`/`Scan` semantics, same returned error values.
+
+**Non-Goals:**
+- Touching eager-loaded or multi-predicate query variants.
+- Changing any caller's error-handling policy (the total-size callers keep their own warn-vs-return logic).
+- Relocating helpers to `database.Client`.
+
+## Decisions
+
+**Decision 1 — Helpers take the entity client, not `*ent.Client`/`*ent.Tx`.**
+Signature shape: `narInfoByHash(ctx context.Context, q *ent.NarInfoClient, hash string) (*ent.NarInfo, error)`. Callers pass `tx.NarInfo` or `c.dbClient.Ent().NarInfo`. This is the narrowest abstraction that unifies both call modes without an interface. Alternative (a `querier` interface) rejected as overkill — Ent already gives a shared concrete type.
+
+**Decision 2 — `totalNarFileSize` returns `(int64, error)`, not the metric/cleanup-specific shaping.**
+The helper owns the duplicated core: declare the `[]struct{ Sum sql.NullInt64 }`, run the aggregate scan, return the extracted `int64` (0 when no rows / NULL). Each caller keeps its existing logging/early-return behavior around the call. This preserves both call sites' distinct policies while removing the copy-pasted query+unpack.
+
+**Decision 3 — New file `pkg/cache/queries.go`.**
+Keep the helpers together and avoid growing `cache.go`. Same package, so no export needed and call sites change minimally.
+
+## Risks / Trade-offs
+
+- [Accidentally folding a non-identical query (eager-load/extra-predicate) into a helper changes behavior] → Only replace sites whose text is byte-identical to the helper body; leave the rest. Verified site list is in the design context above.
+- [`totalNarFileSize` subtly changing the zero/NULL handling] → Mirror the exact `len(x)>0 && x[0].Sum.Valid` guard; cover with the existing cleanup/metrics tests which already assert sizes.
+
+## Migration Plan
+
+Pure code refactor, single stacked PR, straight revert to roll back. No DB or runtime state.
+
+## Open Questions
+
+- None. The helper set is fixed; if a fourth verbatim pattern surfaces during implementation it can be added under the same contract.

--- a/openspec/changes/archive/2026-05-29-extract-cache-query-helpers/proposal.md
+++ b/openspec/changes/archive/2026-05-29-extract-cache-query-helpers/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+`pkg/cache/cache.go` is ~7,500 lines and inlines the same Ent queries repeatedly. The single-NarInfo-by-hash lookup (`NarInfo.Query().Where(entnarinfo.HashEQ(hash)).Only(ctx)`) appears verbatim at several sites against both `c.dbClient.Ent()` and `*ent.Tx`; chunk-by-hash batch reads (`Chunk.Query().Where(entchunk.HashIn(...)).All(ctx)`) recur; and the total-NAR-size aggregate (`Aggregate(ent.Sum(entnarfile.FieldFileSize))` + `sql.NullInt64` unpack) is duplicated as a multi-line block at two sites. The duplication makes the file harder to read and lets the copies drift.
+
+## What Changes
+
+- Add small unexported query helpers in `pkg/cache` that accept the Ent entity client (`*ent.NarInfoClient`, `*ent.NarFileClient`, `*ent.ChunkClient`) — which both `*ent.Client` and `*ent.Tx` expose — so the same helper serves transactional and non-transactional callers:
+  - `narInfoByHash(ctx, q, hash) (*ent.NarInfo, error)` — the bare `.Where(HashEQ).Only` lookup.
+  - `chunksByHashes(ctx, q, hashes) ([]*ent.Chunk, error)` — the `HashIn(...).All` batch read.
+  - `totalNarFileSize(ctx, q) (int64, error)` — the aggregate query + `sql.NullInt64` unpack, returning 0 when empty. Each caller keeps its own error-handling policy (warn-and-continue vs. return).
+- Replace the verbatim inline sites with these helpers.
+- Leave eager-loaded / multi-predicate query variants (those chaining `.With...()` or additional `Where` clauses) untouched — they are not identical and would require option plumbing that adds more complexity than it removes.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `database-orm`: add a requirement that the common single-entity-by-hash lookups and the total-NAR-size aggregate are obtained through shared `pkg/cache` query helpers with a defined behavior contract, rather than re-inlined per call site.
+
+## Impact
+
+- Code: `pkg/cache/cache.go` (call sites), and a new `pkg/cache/queries.go` holding the helpers.
+- No public API change, no schema/migration change, no runtime behavior change — identical `Only`/`All`/`Scan` semantics and identical error values.
+- Tests: the existing `pkg/cache` suite (`cache_test.go`, `cache_internal_test.go`, `cdc_test.go`) already exercises these paths and is the safety net.
+
+## Non-goals
+
+- Not changing query semantics, eager-loading, ordering, or error types.
+- Not consolidating eager-loaded or multi-predicate query variants.
+- Not moving helpers onto `database.Client` (kept local to `pkg/cache` unless a second package needs them).
+
+## I/O, latency, memory impact
+
+None. The helpers issue the exact same SQL as the inline code; no extra round-trips, allocations, or buffering. This is a readability/DRY refactor only.

--- a/openspec/changes/archive/2026-05-29-extract-cache-query-helpers/specs/database-orm/spec.md
+++ b/openspec/changes/archive/2026-05-29-extract-cache-query-helpers/specs/database-orm/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Common by-hash and aggregate reads go through shared cache query helpers
+
+The cache layer SHALL obtain the common single-entity-by-hash lookups and the total-NAR-file-size aggregate through shared `pkg/cache` query helpers rather than re-inlining the equivalent Ent query at each call site. Each helper SHALL accept the Ent entity client (e.g. `*ent.NarInfoClient`) so the same helper serves both `*ent.Client` and `*ent.Tx` callers, and SHALL preserve the underlying Ent semantics exactly.
+
+#### Scenario: NarInfo-by-hash helper returns the row or an Ent not-found error
+
+- **WHEN** the NarInfo-by-hash helper is called with a hash that exists
+- **THEN** it SHALL return the matching `*ent.NarInfo`
+- **AND WHEN** called with a hash that does not exist
+- **THEN** it SHALL return an error for which `ent.IsNotFound` reports true — identical to the inline `Query().Where(HashEQ).Only(ctx)` it replaces
+
+#### Scenario: Total-NAR-file-size helper sums file_size and is zero-safe
+
+- **WHEN** the total-size helper is called and `nar_files` contains rows
+- **THEN** it SHALL return the sum of `file_size` across all rows as an `int64`
+- **AND WHEN** there are no rows (or the sum is SQL NULL)
+- **THEN** it SHALL return `0` without error
+
+#### Scenario: Same helper serves transactional and non-transactional callers
+
+- **WHEN** a helper is invoked with `tx.<Entity>` inside a transaction and elsewhere with `c.dbClient.Ent().<Entity>` outside one
+- **THEN** both invocations SHALL execute the same query against their respective connection/transaction
+- **AND** no call site SHALL re-declare the extracted query inline

--- a/openspec/changes/archive/2026-05-29-extract-cache-query-helpers/tasks.md
+++ b/openspec/changes/archive/2026-05-29-extract-cache-query-helpers/tasks.md
@@ -1,0 +1,22 @@
+## 1. Baseline & site inventory
+
+- [x] 1.1 Run the `pkg/cache` suite to confirm green before changing anything.
+- [x] 1.2 Enumerate the exact verbatim sites for each pattern (NarInfo `.Where(HashEQ).Only`, Chunk `.Where(HashIn).All`, NarFile aggregate-sum + unpack), confirming each candidate is byte-identical to the planned helper body and excluding eager-loaded / multi-predicate variants. (`.First`-based and `.Count`-based NarInfo queries left untouched.)
+
+## 2. Add helpers
+
+- [x] 2.1 Created `pkg/cache/queries.go` with `narInfoByHash(ctx, q *ent.NarInfoClient, hash string) (*ent.NarInfo, error)`.
+- [x] 2.2 Added `chunksByHashes(ctx, q *ent.ChunkClient, hashes []string) ([]*ent.Chunk, error)`.
+- [x] 2.3 Added `totalNarFileSize(ctx, q *ent.NarFileClient) (int64, error)` returning the summed file_size (0 when empty/NULL), no logging.
+
+## 3. Replace call sites
+
+- [x] 3.1 Replaced the four verbatim `narInfoByHash` `.Only` sites (three `tx.NarInfo`, one `c.dbClient.Ent().NarInfo`).
+- [x] 3.2 Replaced the two chunk `HashIn(...).All` sites with `chunksByHashes`.
+- [x] 3.3 Replaced the two aggregate-sum blocks with `totalNarFileSize`, preserving each caller's policy (metrics: warn-and-continue, keeping totalSize in scope for the utilization ratio; cleanup: return-on-error). Dropped the now-unused `database/sql` import from cache.go.
+
+## 4. Verify
+
+- [x] 4.1 Ran `task fmt` and `task lint`; gci auto-fixed import grouping in queries.go; added two justified `//nolint:gosec` comments on `uint64(narTotalSize)` conversions (file_size is a uint64 column, so the SUM is non-negative — the conversion gosec newly flagged after provenance changed is provably safe). 0 issues.
+- [x] 4.2 Ran `task test` — full suite green, including `pkg/cache` (30s).
+- [x] 4.3 No new test added: existing cache tests already cover get/insert-by-hash, chunk batch reads, and the cleanup/metrics size paths. Behavior is unchanged.

--- a/openspec/specs/database-orm/spec.md
+++ b/openspec/specs/database-orm/spec.md
@@ -120,3 +120,27 @@ The system SHALL define the mapping from `database.Type` to its Ent dialect stri
 
 - **WHEN** `database.EntDialectFor` is called with `TypeSQLite`, `TypePostgreSQL`, or `TypeMySQL`
 - **THEN** it SHALL return `dialect.SQLite`, `dialect.Postgres`, and `dialect.MySQL` respectively, exactly as before this change
+
+### Requirement: Common by-hash and aggregate reads go through shared cache query helpers
+
+The cache layer SHALL obtain the common single-entity-by-hash lookups and the total-NAR-file-size aggregate through shared `pkg/cache` query helpers rather than re-inlining the equivalent Ent query at each call site. Each helper SHALL accept the Ent entity client (e.g. `*ent.NarInfoClient`) so the same helper serves both `*ent.Client` and `*ent.Tx` callers, and SHALL preserve the underlying Ent semantics exactly.
+
+#### Scenario: NarInfo-by-hash helper returns the row or an Ent not-found error
+
+- **WHEN** the NarInfo-by-hash helper is called with a hash that exists
+- **THEN** it SHALL return the matching `*ent.NarInfo`
+- **AND WHEN** called with a hash that does not exist
+- **THEN** it SHALL return an error for which `ent.IsNotFound` reports true — identical to the inline `Query().Where(HashEQ).Only(ctx)` it replaces
+
+#### Scenario: Total-NAR-file-size helper sums file_size and is zero-safe
+
+- **WHEN** the total-size helper is called and `nar_files` contains rows
+- **THEN** it SHALL return the sum of `file_size` across all rows as an `int64`
+- **AND WHEN** there are no rows (or the sum is SQL NULL)
+- **THEN** it SHALL return `0` without error
+
+#### Scenario: Same helper serves transactional and non-transactional callers
+
+- **WHEN** a helper is invoked with `tx.<Entity>` inside a transaction and elsewhere with `c.dbClient.Ent().<Entity>` outside one
+- **THEN** both invocations SHALL execute the same query against their respective connection/transaction
+- **AND** no call site SHALL re-declare the extracted query inline

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"io"
@@ -715,28 +714,16 @@ func (c *Cache) GetCDCDeleteDelay() time.Duration {
 
 func (c *Cache) setupMetricCallbacks() error {
 	_, err := meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
-		// Observe total size: SUM(file_size) over nar_files. SQL SUM on
-		// an empty set returns NULL, which won't scan into a plain
-		// int64 — use sql.NullInt64 and treat NULL as zero. The column
-		// alias matches the field name Ent emits via ent.Sum.
-		var totalSize int64
-
-		var totals []struct {
-			Sum sql.NullInt64 `sql:"sum"`
-		}
-
-		if err := c.dbClient.Ent().NarFile.Query().
-			Aggregate(ent.Sum(entnarfile.FieldFileSize)).
-			Scan(ctx, &totals); err != nil {
+		// Observe total size: SUM(file_size) over nar_files (0 when the
+		// table is empty). totalSize is reused below for the cache
+		// utilization ratio, so it stays in the callback scope.
+		totalSize, err := totalNarFileSize(ctx, c.dbClient.Ent().NarFile)
+		if err != nil {
 			zerolog.Ctx(ctx).
 				Warn().
 				Err(err).
 				Msg("failed to get total nar size for metrics")
 		} else {
-			if len(totals) > 0 && totals[0].Sum.Valid {
-				totalSize = totals[0].Sum.Int64
-			}
-
 			o.ObserveInt64(totalSizeMetric, totalSize)
 		}
 
@@ -2480,7 +2467,7 @@ func (c *Cache) recordChunkBatch(ctx context.Context, narFileID int64, startInde
 		// avoids generating new auto-increment PKs (and hitting the
 		// sequence-desync bug) for chunks whose hash is already in the
 		// table.
-		existing, err := tx.Chunk.Query().Where(entchunk.HashIn(uniqueHashes...)).All(ctx)
+		existing, err := chunksByHashes(ctx, tx.Chunk, uniqueHashes)
 		if err != nil {
 			return fmt.Errorf("error fetching existing chunks: %w", err)
 		}
@@ -2529,7 +2516,7 @@ func (c *Cache) recordChunkBatch(ctx context.Context, narFileID int64, startInde
 				newHashes = append(newHashes, h)
 			}
 
-			freshChunks, err := tx.Chunk.Query().Where(entchunk.HashIn(newHashes...)).All(ctx)
+			freshChunks, err := chunksByHashes(ctx, tx.Chunk, newHashes)
 			if err != nil {
 				return fmt.Errorf("error fetching new chunk IDs: %w", err)
 			}
@@ -3973,7 +3960,7 @@ func (c *Cache) getNarInfoFromStore(ctx context.Context, hash string) (*narinfo.
 	}
 
 	err = c.withEntTransaction(ctx, "getNarInfoFromStore", func(tx *ent.Tx) error {
-		nir, err := tx.NarInfo.Query().Where(entnarinfo.HashEQ(hash)).Only(ctx)
+		nir, err := narInfoByHash(ctx, tx.NarInfo, hash)
 		if err != nil {
 			if ent.IsNotFound(err) {
 				c.backgroundMigrateNarInfo(ctx, hash, ni)
@@ -4493,7 +4480,7 @@ func upsertNarInfoFromParsed(
 	hash string,
 	narInfo *narinfo.NarInfo,
 ) (*ent.NarInfo, error) {
-	existing, err := tx.NarInfo.Query().Where(entnarinfo.HashEQ(hash)).Only(ctx)
+	existing, err := narInfoByHash(ctx, tx.NarInfo, hash)
 
 	switch {
 	case ent.IsNotFound(err):
@@ -4511,7 +4498,7 @@ func upsertNarInfoFromParsed(
 
 		// Always SELECT after to get the row's ID, whether we inserted
 		// it or a concurrent writer did.
-		nir, err := tx.NarInfo.Query().Where(entnarinfo.HashEQ(hash)).Only(ctx)
+		nir, err := narInfoByHash(ctx, tx.NarInfo, hash)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching narinfo record after insert for hash %q: %w", hash, err)
 		}
@@ -4801,7 +4788,7 @@ func (c *Cache) getNarActualSize(ctx context.Context, nu nar.URL) (int64, error)
 func (c *Cache) CheckAndFixNarInfo(ctx context.Context, hash string) error {
 	// First check if we have the NarInfo in DB using direct DB access
 	// to avoid higher-level cache logic (like purging or storage checks)
-	niRow, err := c.dbClient.Ent().NarInfo.Query().Where(entnarinfo.HashEQ(hash)).Only(ctx)
+	niRow, err := narInfoByHash(ctx, c.dbClient.Ent().NarInfo, hash)
 	if err != nil {
 		if ent.IsNotFound(err) {
 			return nil
@@ -5745,21 +5732,11 @@ func (c *Cache) withTryLock(ctx context.Context, operation string, lockKey strin
 // calculateCleanupSize validates the total NAR size and calculates how much needs to be cleaned up.
 // Returns 0 if no cleanup is needed.
 func (c *Cache) calculateCleanupSize(ctx context.Context, tx *ent.Tx, log zerolog.Logger) (uint64, error) {
-	var sums []struct {
-		Sum sql.NullInt64 `sql:"sum"`
-	}
-
-	if err := tx.NarFile.Query().
-		Aggregate(ent.Sum(entnarfile.FieldFileSize)).
-		Scan(ctx, &sums); err != nil {
+	narTotalSize, err := totalNarFileSize(ctx, tx.NarFile)
+	if err != nil {
 		log.Error().Err(err).Msg("error fetching the total nar size")
 
 		return 0, err
-	}
-
-	var narTotalSize int64
-	if len(sums) > 0 && sums[0].Sum.Valid {
-		narTotalSize = sums[0].Sum.Int64
 	}
 
 	if narTotalSize == 0 {
@@ -5770,12 +5747,14 @@ func (c *Cache) calculateCleanupSize(ctx context.Context, tx *ent.Tx, log zerolo
 
 	log = log.With().Int64("nar_total_size", narTotalSize).Logger()
 
+	//nolint:gosec // G115: SUM over nar_files.file_size (a uint64 column) is non-negative
 	if uint64(narTotalSize) <= c.maxSize {
 		log.Info().Msg("store size is less than max-size, not removing any nars")
 
 		return 0, nil
 	}
 
+	//nolint:gosec // G115: SUM over nar_files.file_size (a uint64 column) is non-negative
 	cleanupSize := uint64(narTotalSize) - c.maxSize
 
 	log = log.With().Uint64("cleanup_size", cleanupSize).Logger()

--- a/pkg/cache/queries.go
+++ b/pkg/cache/queries.go
@@ -22,8 +22,14 @@ func narInfoByHash(ctx context.Context, q *ent.NarInfoClient, hash string) (*ent
 }
 
 // chunksByHashes returns every chunk row whose hash is in hashes. q may be
-// a client or transaction chunk client.
+// a client or transaction chunk client. An empty hashes slice returns no
+// rows without issuing a query — both avoiding a needless round-trip and
+// sidestepping the dialect-specific pitfalls of an empty SQL `IN ()`.
 func chunksByHashes(ctx context.Context, q *ent.ChunkClient, hashes []string) ([]*ent.Chunk, error) {
+	if len(hashes) == 0 {
+		return nil, nil
+	}
+
 	return q.Query().Where(entchunk.HashIn(hashes...)).All(ctx)
 }
 

--- a/pkg/cache/queries.go
+++ b/pkg/cache/queries.go
@@ -1,0 +1,49 @@
+package cache
+
+import (
+	"context"
+	"database/sql"
+
+	entchunk "github.com/kalbasit/ncps/ent/chunk"
+	entnarfile "github.com/kalbasit/ncps/ent/narfile"
+	entnarinfo "github.com/kalbasit/ncps/ent/narinfo"
+
+	"github.com/kalbasit/ncps/ent"
+)
+
+// narInfoByHash returns the single narinfo row with the given hash. q may
+// be either c.dbClient.Ent().NarInfo or a transaction's tx.NarInfo — both
+// are *ent.NarInfoClient — so the same helper serves transactional and
+// non-transactional callers. When no row matches it returns an error for
+// which ent.IsNotFound reports true, identical to the inline
+// Query().Where(HashEQ).Only(ctx) it replaces.
+func narInfoByHash(ctx context.Context, q *ent.NarInfoClient, hash string) (*ent.NarInfo, error) {
+	return q.Query().Where(entnarinfo.HashEQ(hash)).Only(ctx)
+}
+
+// chunksByHashes returns every chunk row whose hash is in hashes. q may be
+// a client or transaction chunk client.
+func chunksByHashes(ctx context.Context, q *ent.ChunkClient, hashes []string) ([]*ent.Chunk, error) {
+	return q.Query().Where(entchunk.HashIn(hashes...)).All(ctx)
+}
+
+// totalNarFileSize returns the sum of file_size across all nar_files rows,
+// or 0 when the table is empty (or the SUM is SQL NULL). It performs no
+// logging; callers apply their own error-handling policy.
+func totalNarFileSize(ctx context.Context, q *ent.NarFileClient) (int64, error) {
+	var rows []struct {
+		Sum sql.NullInt64 `sql:"sum"`
+	}
+
+	if err := q.Query().
+		Aggregate(ent.Sum(entnarfile.FieldFileSize)).
+		Scan(ctx, &rows); err != nil {
+		return 0, err
+	}
+
+	if len(rows) > 0 && rows[0].Sum.Valid {
+		return rows[0].Sum.Int64, nil
+	}
+
+	return 0, nil
+}


### PR DESCRIPTION
## Summary

`pkg/cache/cache.go` (~7,500 lines) inlined the same Ent queries repeatedly: the single NarInfo-by-hash lookup at several sites against both the client and `*ent.Tx`, two chunk-by-hashes batch reads, and the total-NAR-size aggregate (`SUM(file_size)` + `sql.NullInt64` unpack) duplicated as a multi-line block at two call sites.

- Add `pkg/cache/queries.go` with three unexported helpers — `narInfoByHash`, `chunksByHashes`, `totalNarFileSize` — that take the Ent entity client (`*ent.NarInfoClient` etc.), which both `*ent.Client` and `*ent.Tx` expose, so one helper serves transactional and non-transactional callers.
- Replace only the byte-identical inline sites; eager-loaded / multi-predicate variants are left untouched.
- `totalNarFileSize` returns `(int64, error)` so each caller keeps its own error policy (metrics warns and continues; cleanup returns).
- Behavior-preserving: identical SQL and error semantics. Dropped the now-unused `database/sql` import from cache.go; added two justified gosec nolints on `uint64(narTotalSize)` (file_size is a uint64 column, so the SUM is non-negative).

## Test plan

- [x] `task fmt` / `task lint` (0 issues) / `task test` (full suite green; `pkg/cache` ~30s)
- [x] Existing cache suite covers get/insert-by-hash, chunk batch reads, and cleanup/metrics size paths