### PR TITLE
refactor(cache): standardize not-found checks

### DIFF
--- a/openspec/changes/archive/2026-05-29-standardize-notfound-checks/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-29-standardize-notfound-checks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/archive/2026-05-29-standardize-notfound-checks/design.md
+++ b/openspec/changes/archive/2026-05-29-standardize-notfound-checks/design.md
@@ -1,0 +1,45 @@
+## Context
+
+`database.IsNotFoundError(err)` (in `pkg/database/errors.go`) is defined as:
+
+```go
+return errors.Is(err, ErrNotFound) || isEntNotFound(err) // ent.IsNotFound
+```
+
+It is the intended single not-found predicate but is used once (`cache.go:5259`). Meanwhile `pkg/cache` calls `ent.IsNotFound(err)` directly at ~20 sites. The cache test fakes in `cache_internal_test.go` return `database.ErrNotFound`; production code that uses `ent.IsNotFound` would not classify that sentinel as not-found.
+
+`cache.go` already imports `pkg/database`; `build_trace.go` does not (its single site will need the import added).
+
+## Goals / Non-Goals
+
+**Goals:**
+- One not-found predicate (`database.IsNotFoundError`) across the cache package.
+- Behavior-preserving for Ent errors; strictly-more-correct for the sentinel.
+
+**Non-Goals:**
+- Removing the sentinel or the dual-mode check.
+- Touching `pkg/ncps`, `pkg/config`, `testhelper`, or non-database sentinels (`storage`/`upstream`/`chunk`/`config` ErrNotFound).
+
+## Decisions
+
+**Decision 1 — Mechanical replacement, preserving negation.**
+Each `ent.IsNotFound(x)` becomes `database.IsNotFoundError(x)`; `!ent.IsNotFound(x)` becomes `!database.IsNotFoundError(x)`. The argument variable (err, nrErr, batchErr, …) is preserved exactly. No surrounding control flow changes.
+
+**Decision 2 — Keep `database.ErrNotFound` + dual mode.**
+The test fakes return the sentinel; standardizing on `database.IsNotFoundError` makes the production cache paths honor it, so the dual-mode branch becomes load-bearing. Removing it would break the fakes and reduce robustness. Alternative (migrate fakes to return a real `*ent.NotFoundError`) rejected as out-of-scope churn with no benefit.
+
+**Decision 3 — Leave the `narInfoByHash` doc comment as-is.**
+`queries.go` documents that the helper "returns an error for which `ent.IsNotFound` reports true" — still accurate (the helper returns Ent's error). Callers classify it via `database.IsNotFoundError`, which is a superset. No comment change needed beyond accuracy.
+
+## Risks / Trade-offs
+
+- [A site that intentionally wanted Ent-only matching gets broadened to also match the sentinel] → No such site exists: the sentinel is a not-found signal everywhere, so broadening is always correct. Confirmed by reviewing each of the ~20 sites — all treat the predicate as "is this a missing row?".
+- [Adding the `database` import to `build_trace.go` creates an import cycle] → None: `pkg/cache` already depends on `pkg/database` (via `cache.go`); adding the import to a second file in the same package changes nothing structurally.
+
+## Migration Plan
+
+Pure code refactor in one package, single stacked PR, straight revert to roll back. No DB/runtime state.
+
+## Open Questions
+
+- None. Whether to extend to `pkg/ncps`/`pkg/config` is deferred; this change is scoped to the cache package.

--- a/openspec/changes/archive/2026-05-29-standardize-notfound-checks/proposal.md
+++ b/openspec/changes/archive/2026-05-29-standardize-notfound-checks/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The cache layer detects "row not found" inconsistently. `pkg/cache` calls `ent.IsNotFound(err)` directly at ~20 sites, while the purpose-built `database.IsNotFoundError(err)` helper is used exactly once. `database.IsNotFoundError` is the intended single predicate: it matches both Ent's `*NotFoundError` and the package-level `database.ErrNotFound` sentinel (which the cache test fakes return). Calling `ent.IsNotFound` directly means those call sites silently fail to recognize the sentinel, and the not-found policy is scattered instead of centralized.
+
+## What Changes
+
+- Replace direct `ent.IsNotFound(err)` checks in `pkg/cache` production code (`cache.go`, `build_trace.go`) with `database.IsNotFoundError(err)`, so the cache layer has one not-found predicate.
+- This is behavior-preserving for real Ent errors (`database.IsNotFoundError` is a superset matcher) and strictly more correct for the sentinel: code paths that may receive a `database.ErrNotFound` now recognize it.
+- Keep the `database.ErrNotFound` sentinel and the dual-mode check in `database.IsNotFoundError` — the cache test fakes return the sentinel, and after this change the production cache code correctly honors it, so the dual mode is now load-bearing rather than vestigial.
+- Leave package-specific sentinels untouched: `storage.ErrNotFound`, `upstream.ErrNotFound`, `chunk.ErrNotFound`, and `config.ErrConfigNotFound` are distinct and matched via `errors.Is` as before. Out of scope: `pkg/ncps` and `pkg/config` (separate packages, separate change if desired).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `database-orm`: add a requirement that the cache layer detects not-found through the single `database.IsNotFoundError` predicate (which recognizes both Ent's `*NotFoundError` and the `database.ErrNotFound` sentinel) rather than calling `ent.IsNotFound` directly.
+
+## Impact
+
+- Code: `pkg/cache/cache.go` (~19 sites) and `pkg/cache/build_trace.go` (1 site, plus a new `database` import).
+- No public API change, no schema/migration change. Behavior is identical for Ent errors and a superset for the sentinel.
+- Tests: existing `pkg/cache` suite (including the fakes in `cache_internal_test.go` that return `database.ErrNotFound`) is the safety net.
+
+## Non-goals
+
+- Not removing the `database.ErrNotFound` sentinel or simplifying the dual-mode predicate.
+- Not changing `pkg/ncps`, `pkg/config`, or `testhelper` call sites.
+- Not altering any returned error values — only the predicate used to classify them.
+
+## I/O, latency, memory impact
+
+None. `database.IsNotFoundError` performs the same `errors.As`/type check as `ent.IsNotFound` plus one cheap `errors.Is` against a sentinel. No I/O, allocation, or latency change.

--- a/openspec/changes/archive/2026-05-29-standardize-notfound-checks/specs/database-orm/spec.md
+++ b/openspec/changes/archive/2026-05-29-standardize-notfound-checks/specs/database-orm/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: The cache layer detects not-found through a single predicate
+
+The cache layer (`pkg/cache`) SHALL classify "database row not found" exclusively through the `database.IsNotFoundError` predicate, rather than calling `ent.IsNotFound` directly. `database.IsNotFoundError` SHALL report true for both Ent's `*NotFoundError` and the package-level `database.ErrNotFound` sentinel, so a single helper governs the cache layer's not-found policy. Package-specific sentinels (`storage.ErrNotFound`, `upstream.ErrNotFound`, `chunk.ErrNotFound`, `config.ErrConfigNotFound`) remain distinct and continue to be matched via `errors.Is`.
+
+#### Scenario: Ent missing-row error is classified as not-found
+
+- **WHEN** a `pkg/cache` query returns Ent's `*NotFoundError`
+- **THEN** the cache layer SHALL classify it as not-found via `database.IsNotFoundError`
+- **AND** the resulting behavior SHALL be identical to the previous direct `ent.IsNotFound` check
+
+#### Scenario: The not-found sentinel is recognized
+
+- **WHEN** a code path receives `database.ErrNotFound` (e.g. from a test fake or a helper that returns the sentinel)
+- **THEN** `database.IsNotFoundError` SHALL report true for it
+- **AND** the cache layer SHALL treat it as a missing row rather than an unexpected error
+
+#### Scenario: Unrelated package sentinels are not conflated
+
+- **WHEN** an error is `storage.ErrNotFound`, `upstream.ErrNotFound`, `chunk.ErrNotFound`, or `config.ErrConfigNotFound`
+- **THEN** it SHALL continue to be matched by its own `errors.Is` check
+- **AND** `database.IsNotFoundError` SHALL NOT be used in place of those package-specific matches

--- a/openspec/changes/archive/2026-05-29-standardize-notfound-checks/tasks.md
+++ b/openspec/changes/archive/2026-05-29-standardize-notfound-checks/tasks.md
@@ -1,0 +1,16 @@
+## 1. Baseline & inventory
+
+- [x] 1.1 Confirm `pkg/cache` suite is green before changes (committed Change 2 state).
+- [x] 1.2 Listed every `ent.IsNotFound(` call site in `pkg/cache/cache.go` (19) and `pkg/cache/build_trace.go` (1), including negated forms.
+
+## 2. Standardize the predicate
+
+- [x] 2.1 Replaced every `ent.IsNotFound(x)` with `database.IsNotFoundError(x)` in `pkg/cache/cache.go` (negations preserved, arguments unchanged).
+- [x] 2.2 Replaced the single site in `pkg/cache/build_trace.go` and added the `github.com/kalbasit/ncps/pkg/database` import.
+- [x] 2.3 Verified `ent` is still used in both files (`ent.Tx`, `ent.BuildTraceSignatureCreate`, entity clients), so the import stays. The only remaining `ent.IsNotFound` reference in `pkg/cache` is the accurate doc comment in `queries.go`.
+
+## 3. Verify
+
+- [x] 3.1 Ran `task fmt` and `task lint` — 0 issues.
+- [x] 3.2 Ran `task test` — full suite green (0 failures), including `pkg/cache` (32s) with the fakes that return `database.ErrNotFound`.
+- [x] 3.3 No new test added: existing cache tests already cover the not-found paths; behavior is identical for Ent errors and a correct superset for the sentinel.

--- a/openspec/specs/database-orm/spec.md
+++ b/openspec/specs/database-orm/spec.md
@@ -144,3 +144,25 @@ The cache layer SHALL obtain the common single-entity-by-hash lookups and the to
 - **WHEN** a helper is invoked with `tx.<Entity>` inside a transaction and elsewhere with `c.dbClient.Ent().<Entity>` outside one
 - **THEN** both invocations SHALL execute the same query against their respective connection/transaction
 - **AND** no call site SHALL re-declare the extracted query inline
+
+### Requirement: The cache layer detects not-found through a single predicate
+
+The cache layer (`pkg/cache`) SHALL classify "database row not found" exclusively through the `database.IsNotFoundError` predicate, rather than calling `ent.IsNotFound` directly. `database.IsNotFoundError` SHALL report true for both Ent's `*NotFoundError` and the package-level `database.ErrNotFound` sentinel, so a single helper governs the cache layer's not-found policy. Package-specific sentinels (`storage.ErrNotFound`, `upstream.ErrNotFound`, `chunk.ErrNotFound`, `config.ErrConfigNotFound`) remain distinct and continue to be matched via `errors.Is`.
+
+#### Scenario: Ent missing-row error is classified as not-found
+
+- **WHEN** a `pkg/cache` query returns Ent's `*NotFoundError`
+- **THEN** the cache layer SHALL classify it as not-found via `database.IsNotFoundError`
+- **AND** the resulting behavior SHALL be identical to the previous direct `ent.IsNotFound` check
+
+#### Scenario: The not-found sentinel is recognized
+
+- **WHEN** a code path receives `database.ErrNotFound` (e.g. from a test fake or a helper that returns the sentinel)
+- **THEN** `database.IsNotFoundError` SHALL report true for it
+- **AND** the cache layer SHALL treat it as a missing row rather than an unexpected error
+
+#### Scenario: Unrelated package sentinels are not conflated
+
+- **WHEN** an error is `storage.ErrNotFound`, `upstream.ErrNotFound`, `chunk.ErrNotFound`, or `config.ErrConfigNotFound`
+- **THEN** it SHALL continue to be matched by its own `errors.Is` check
+- **AND** `database.IsNotFoundError` SHALL NOT be used in place of those package-specific matches

--- a/pkg/cache/build_trace.go
+++ b/pkg/cache/build_trace.go
@@ -15,6 +15,7 @@ import (
 	entbuildtracesignature "github.com/kalbasit/ncps/ent/buildtracesignature"
 
 	"github.com/kalbasit/ncps/ent"
+	"github.com/kalbasit/ncps/pkg/database"
 	"github.com/kalbasit/ncps/pkg/storage"
 )
 
@@ -101,7 +102,7 @@ func (c *Cache) GetBuildTrace(ctx context.Context, drvName, outputName string) (
 		WithSignatures().
 		Only(ctx)
 	if err != nil {
-		if ent.IsNotFound(err) {
+		if database.IsNotFoundError(err) {
 			return nil, storage.ErrNotFound
 		}
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1040,7 +1040,7 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (nar.URL, int64, io.
 				if time.Since(*nr.ChunkingStartedAt) < cdcChunkingLockTTL {
 					hasNar = true
 				}
-			} else if nrErr != nil && !ent.IsNotFound(nrErr) {
+			} else if nrErr != nil && !database.IsNotFoundError(nrErr) {
 				return fmt.Errorf("failed to check nar file record for progressive streaming: %w", nrErr)
 			}
 		}
@@ -1366,7 +1366,7 @@ func (c *Cache) GetNarFileSize(ctx context.Context, nu nar.URL) (int64, error) {
 
 	nr, err := c.getNarFileFromDB(ctx, c.dbClient.Ent().NarFile, nu)
 	if err != nil {
-		if !ent.IsNotFound(err) {
+		if !database.IsNotFoundError(err) {
 			zerolog.Ctx(ctx).Error().Err(err).Msg("error querying nar file size from database")
 		}
 
@@ -1398,7 +1398,7 @@ func (c *Cache) lookupOriginalNarURL(ctx context.Context, normalizedNarURL nar.U
 		First(ctx)
 	if err != nil {
 		// Not found is an expected case. We should log any other database errors.
-		if !ent.IsNotFound(err) {
+		if !database.IsNotFoundError(err) {
 			zerolog.Ctx(ctx).Warn().Err(err).Msg("Failed to lookup original nar URL")
 		}
 
@@ -1431,7 +1431,7 @@ func (c *Cache) lookupPreferredUpstreamURL(ctx context.Context, narURL nar.URL) 
 		Where(entnarinfo.URL(narURL.String())).
 		First(ctx)
 	if err != nil {
-		if !ent.IsNotFound(err) {
+		if !database.IsNotFoundError(err) {
 			zerolog.Ctx(ctx).Warn().Err(err).Msg("Failed to lookup narinfo hash by nar URL")
 		}
 
@@ -3092,7 +3092,7 @@ func (c *Cache) getNarFromStore(
 	err = c.withEntTransaction(ctx, "getNarFromStore", func(tx *ent.Tx) error {
 		nr, err := c.getNarFileFromDB(ctx, tx.NarFile, *narURL)
 		if err != nil {
-			if ent.IsNotFound(err) {
+			if database.IsNotFoundError(err) {
 				// NAR is in storage but has no DB record — this is an orphan left by a
 				// crash between narStore.PutNar and ensureNarFileRecord. Schedule healing.
 				needsDBRecord = true
@@ -3832,7 +3832,7 @@ func (c *Cache) getNarFileFromDB(
 		return nr, nil
 	}
 
-	if ent.IsNotFound(err) && first != second {
+	if database.IsNotFoundError(err) && first != second {
 		return nfc.Query().
 			Where(
 				entnarfile.HashEQ(narURL.Hash),
@@ -3962,7 +3962,7 @@ func (c *Cache) getNarInfoFromStore(ctx context.Context, hash string) (*narinfo.
 	err = c.withEntTransaction(ctx, "getNarInfoFromStore", func(tx *ent.Tx) error {
 		nir, err := narInfoByHash(ctx, tx.NarInfo, hash)
 		if err != nil {
-			if ent.IsNotFound(err) {
+			if database.IsNotFoundError(err) {
 				c.backgroundMigrateNarInfo(ctx, hash, ni)
 
 				return nil
@@ -4215,7 +4215,7 @@ func (c *Cache) populateNarInfoFromDatabase(
 		WithSignatures().
 		Only(ctx)
 	if err != nil {
-		if ent.IsNotFound(err) {
+		if database.IsNotFoundError(err) {
 			return nil, nil, storage.ErrNotFound
 		}
 
@@ -4483,7 +4483,7 @@ func upsertNarInfoFromParsed(
 	existing, err := narInfoByHash(ctx, tx.NarInfo, hash)
 
 	switch {
-	case ent.IsNotFound(err):
+	case database.IsNotFoundError(err):
 		// Insert new, ignoring a concurrent insert racing between our
 		// SELECT above and this INSERT. Using DO NOTHING instead of
 		// DO UPDATE keeps the transaction alive on conflict — a
@@ -4772,7 +4772,7 @@ func (c *Cache) fixNarInfoFileSize(
 func (c *Cache) getNarActualSize(ctx context.Context, nu nar.URL) (int64, error) {
 	narFileRow, err := c.getNarFileFromDB(ctx, c.dbClient.Ent().NarFile, nu)
 	if err != nil {
-		if ent.IsNotFound(err) {
+		if database.IsNotFoundError(err) {
 			return -1, nil
 		}
 
@@ -4790,7 +4790,7 @@ func (c *Cache) CheckAndFixNarInfo(ctx context.Context, hash string) error {
 	// to avoid higher-level cache logic (like purging or storage checks)
 	niRow, err := narInfoByHash(ctx, c.dbClient.Ent().NarInfo, hash)
 	if err != nil {
-		if ent.IsNotFound(err) {
+		if database.IsNotFoundError(err) {
 			return nil
 		}
 
@@ -5008,7 +5008,7 @@ func MigrateNarInfo(
 
 			return nil
 		}
-	case ent.IsNotFound(err):
+	case database.IsNotFoundError(err):
 		// Expected: narinfo not yet in DB; fall through to migrate.
 	default:
 		// Unexpected DB error — log but still attempt migration; if the
@@ -5181,7 +5181,7 @@ func (c *Cache) deleteNarInfoFromStore(ctx context.Context, hash string) error {
 	inStorage := c.narInfoStore.HasNarInfo(ctx, hash)
 
 	_, err := c.dbClient.Ent().NarInfo.Query().Where(entnarinfo.HashEQ(hash)).First(ctx)
-	if err != nil && !ent.IsNotFound(err) {
+	if err != nil && !database.IsNotFoundError(err) {
 		return fmt.Errorf("error checking for narinfo in database: %w", err)
 	}
 
@@ -6643,7 +6643,7 @@ func (c *Cache) HasNarInChunks(ctx context.Context, narURL nar.URL) (bool, error
 
 	nr, err := c.getNarFileFromDB(ctx, c.dbClient.Ent().NarFile, narURL)
 	if err != nil {
-		if ent.IsNotFound(err) {
+		if database.IsNotFoundError(err) {
 			return false, nil
 		}
 
@@ -6659,7 +6659,7 @@ func (c *Cache) HasNarInChunks(ctx context.Context, narURL nar.URL) (bool, error
 func (c *Cache) HasNarFileRecord(ctx context.Context, narURL nar.URL) (bool, error) {
 	_, err := c.getNarFileFromDB(ctx, c.dbClient.Ent().NarFile, narURL)
 	if err != nil {
-		if ent.IsNotFound(err) {
+		if database.IsNotFoundError(err) {
 			return false, nil
 		}
 
@@ -6921,7 +6921,7 @@ func (c *Cache) streamProgressiveChunks(ctx context.Context, w io.Writer, narFil
 				WithChunk().
 				Limit(progressivePollBatchSize).
 				All(ctx)
-			if err != nil && !ent.IsNotFound(err) {
+			if err != nil && !database.IsNotFoundError(err) {
 				chunkChan <- &prefetchedChunk{err: fmt.Errorf("error querying chunks from index %d: %w", chunkIndex, err)}
 
 				return
@@ -7027,7 +7027,7 @@ func (c *Cache) streamProgressiveChunks(ctx context.Context, w io.Writer, narFil
 					WithChunk().
 					Limit(progressivePollBatchSize).
 					All(ctx)
-				if batchErr != nil && !ent.IsNotFound(batchErr) {
+				if batchErr != nil && !database.IsNotFoundError(batchErr) {
 					chunkChan <- &prefetchedChunk{err: fmt.Errorf("error querying chunks from index %d: %w", chunkIndex, batchErr)}
 
 					return
@@ -7406,7 +7406,7 @@ func (c *Cache) PinClosure(ctx context.Context, hash string) error {
 	if _, err := c.dbClient.Ent().NarInfo.Query().
 		Where(entnarinfo.HashEQ(hash)).
 		First(ctx); err != nil {
-		if ent.IsNotFound(err) {
+		if database.IsNotFoundError(err) {
 			return storage.ErrNotFound
 		}
 
@@ -7512,7 +7512,7 @@ func (c *Cache) GetPinnedClosureHashes(ctx context.Context) (map[string]struct{}
 				WithReferences().
 				Only(ctx)
 			if err != nil {
-				if ent.IsNotFound(err) {
+				if database.IsNotFoundError(err) {
 					continue // Narinfo not in database, skip
 				}
 


### PR DESCRIPTION
## Summary

The cache layer detected missing rows inconsistently: `pkg/cache` called `ent.IsNotFound` directly at ~20 sites while the purpose-built `database.IsNotFoundError` helper was used only once. That helper is the intended single predicate — it matches both Ent's `*NotFoundError` and the `database.ErrNotFound` sentinel returned by the cache test fakes. Calling `ent.IsNotFound` directly meant those sites silently failed to recognize the sentinel.

- Replace every direct `ent.IsNotFound(x)` in `cache.go` and `build_trace.go` with `database.IsNotFoundError(x)`, preserving each argument and negation; add the `pkg/database` import to `build_trace.go`.
- Behavior-preserving for real Ent errors (the helper is a superset matcher) and strictly more correct for the sentinel, which the cache paths now honor.
- Package-specific sentinels (`storage`/`upstream`/`chunk`/`config` `ErrNotFound`) are left matched by their own `errors.Is` checks.
- Records a `database-orm` spec requirement for the single-predicate contract.

## Test plan

- [x] `task fmt` / `task lint` (0 issues) / `task test` (full suite green)
- [x] Existing cache suite (incl. fakes returning `database.ErrNotFound`) covers the not-found paths