### PR TITLE
test(cache,server): assert row counts via Ent

### DIFF
--- a/openspec/changes/archive/2026-05-29-trim-test-raw-sql-counts/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-29-trim-test-raw-sql-counts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/archive/2026-05-29-trim-test-raw-sql-counts/design.md
+++ b/openspec/changes/archive/2026-05-29-trim-test-raw-sql-counts/design.md
@@ -1,0 +1,43 @@
+## Context
+
+`Client.DB()` returns the raw `*sql.DB`; its doc comment discourages new use in favor of the Ent API. Tests use it ~110 times. A categorization shows most uses are appropriate:
+
+- **Migration verification** (`pkg/ncps/migrate_*_test.go`): asserts row counts after a data migration — must be ORM-independent.
+- **Adversarial setup** (`ExecContext` INSERT/UPDATE/DELETE to invalid states): Ent would reject or hide these.
+- **Persistence inspection** (multi-column `created_at`/`last_accessed_at` reads): verifies DB-level timestamp behavior.
+- **Pool/admin** (`SetMaxOpenConns`, `Close`, `CREATE/DROP DATABASE`, schema probes): genuinely need `*sql.DB`.
+- **`DB()` self-test** (`client_test.go`).
+
+The one clean-swap category is bare table row-count assertions in cache/server behavior tests:
+- `pkg/cache/cache_test.go`: `SELECT COUNT(*) FROM <table>` (no predicate) → `dbClient.Ent().<Entity>.Query().Count(ctx)`.
+- `pkg/server/server_test.go`: `SELECT COUNT(*) FROM narinfos WHERE hash = ?` → `dbClient.Ent().NarInfo.Query().Where(entnarinfo.HashEQ(h)).Count(ctx)`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace bare/by-hash `COUNT(*)` assertions in the two behavior-test files with Ent `.Count(ctx)`.
+- Keep identical assertion outcomes.
+
+**Non-Goals:**
+- Removing `DB()` or converting the retained categories above.
+
+## Decisions
+
+**Decision 1 — Convert only COUNT(*) row-count assertions.** This is the only read pattern where Ent is strictly cleaner and raw SQL adds no verification independence (a whole-table or by-key count has no ordering/NULL/timestamp nuance). Alternative (also converting single/multi-column reads) rejected: timestamp/precision comparisons are fiddly and raw SQL there is legitimate persistence-layer verification.
+
+**Decision 2 — Keep migration tests on raw SQL.** `pkg/ncps/migrate_*` verify that a data migration produced the right rows; using Ent (the same client the migration uses) would weaken the check. Their `COUNT(*)` stays raw by design — this is the documented boundary.
+
+**Decision 3 — `server_test.go` gains an `entnarinfo` import** for the `HashEQ` predicate. `cache_test.go` needs no new predicate import (bare counts).
+
+## Risks / Trade-offs
+
+- [Ent `Count` return type / value mismatch vs the scanned `int`] → Ent's `Count(ctx)` returns `(int, error)`; assertions compare `int`. Identical. Verified by running the suites.
+- [A "count" site actually carries a non-hash predicate] → Inspect each of the 10 sites; only convert bare-table or `WHERE hash = ?` forms. Anything else stays raw.
+
+## Migration Plan
+
+Test-only refactor, single stacked PR, straight revert. No production or DB state.
+
+## Open Questions
+
+- None. The boundary (convert behavior-test counts; keep migration/adversarial/inspection/admin raw SQL) is explicit and documented in the spec.

--- a/openspec/changes/archive/2026-05-29-trim-test-raw-sql-counts/proposal.md
+++ b/openspec/changes/archive/2026-05-29-trim-test-raw-sql-counts/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+`Client.DB()` is documented as a discouraged raw-`*sql.DB` escape hatch, yet the test suites reach for it ~110 times. Most of those uses are legitimate (migration-outcome verification, schema-shape probes, adversarial state setup, connection-pool tuning). But one pattern is a pure clean swap that loses nothing by moving to the Ent API: bare table row-count assertions (`SELECT COUNT(*) FROM <table>`) in the cache and server *behavior* tests. Converting them removes hand-written SQL strings from behavior assertions and shrinks the raw-SQL surface to only what genuinely benefits from ORM-independent verification.
+
+## What Changes
+
+- Convert the **standalone** `SELECT COUNT(*)` row-count assertions to the Ent API (`dbClient.Ent().<Entity>.Query()[.Where(HashEQ(h))].Count(ctx)`): the 5 bare table-count assertions in `pkg/cache/cache_test.go` and all 5 by-hash count assertions in `pkg/server/server_test.go` (which are clean standalone behavior checks).
+- **Retain** the by-hash `COUNT(*)` assertions in `pkg/cache/cache_test.go` that are interleaved with raw-SQL idioms in the same flow — the `rebind()` placeholder helper, adjacent `ExecContext` `DELETE`/`UPDATE` mutations, `Eventually`-polling loops, and concurrency (`wg`) verification. Converting only the COUNT while the surrounding flow stays raw would mix styles within one test; raw SQL is the right tool there.
+- Explicitly **retain raw `DB()` SQL** everywhere it is the right tool, and document why:
+  - `pkg/ncps/migrate_*_test.go` — verify the *outcome of data migrations*; ORM-independent verification is the point.
+  - `ExecContext` mutations that set up adversarial/invalid state (NULL URL, `total_chunks=0`, manual `DELETE`/`UPDATE`) that Ent would reject or obscure.
+  - Multi-column timestamp inspections (`created_at`, `last_accessed_at`) that assert persistence-layer behavior.
+  - `SetMaxOpenConns`, `Close()`, schema/`information_schema`/PRAGMA probes, and the `testhelper` `CREATE/DROP DATABASE` admin paths.
+  - `pkg/database/client_test.go`'s `assert.Same(sdb, c.DB())`, which tests `DB()` itself.
+- The production `pkg/ncps/migrate.go` use of `DB()` (goose needs raw `*sql.DB`) is unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `database-orm`: add a requirement that behavior tests assert row presence/counts through the Ent client, with raw `*sql.DB` test access reserved for migration/schema/adversarial scenarios.
+
+## Impact
+
+- Code: `pkg/cache/cache_test.go` (5 sites), `pkg/server/server_test.go` (5 sites). Test-only; no production code change.
+- No schema/migration/runtime change.
+- Tests: the converted assertions must produce identical pass/fail outcomes.
+
+## Non-goals
+
+- Not eliminating `DB()` or converting migration-verification, adversarial-setup, timestamp-inspection, pool-tuning, or schema-probe sites.
+- Not touching `pkg/ncps`, `testhelper`, or `pkg/database/client_test.go`.
+
+## I/O, latency, memory impact
+
+None. Test-only; `COUNT(*)` becomes Ent's equivalent `Count(ctx)`, issuing the same aggregate query.

--- a/openspec/changes/archive/2026-05-29-trim-test-raw-sql-counts/specs/database-orm/spec.md
+++ b/openspec/changes/archive/2026-05-29-trim-test-raw-sql-counts/specs/database-orm/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Standalone row-count assertions in behavior tests use the Ent client
+
+Where a cache or server behavior test makes a **standalone** row-count assertion — one that is not interleaved with raw `*sql.DB` setup in the same flow — it SHALL obtain the count through the Ent client (`dbClient.Ent().<Entity>.Query()[.Where(entX.HashEQ(h))].Count(ctx)`) rather than via a raw `SELECT COUNT(*)` string. Raw `*sql.DB` access in tests (via `Client.DB()`) SHALL be reserved for scenarios where it is the right tool: verifying the outcome of data migrations, seeding adversarial/invalid rows the ORM would reject, inspecting persistence-layer columns, connection-pool tuning, schema/catalog probes, database-admin operations, and count assertions that are interleaved with such raw-SQL mutation or `Eventually`-polling logic within the same test flow.
+
+#### Scenario: Standalone count assertion uses Ent
+
+- **WHEN** a cache or server behavior test makes a standalone assertion about the number of rows in a table (optionally filtered by hash) and does not interleave raw `*sql.DB` access in that flow
+- **THEN** it SHALL obtain the count via `dbClient.Ent().<Entity>.Query()[.Where(entX.HashEQ(h))].Count(ctx)`
+- **AND** it SHALL NOT issue a raw `SELECT COUNT(*)` through `Client.DB()`
+
+#### Scenario: Raw SQL retained where it is the right tool
+
+- **WHEN** a test verifies a data-migration outcome, seeds an invalid/adversarial row, inspects persistence-layer timestamps, tunes the connection pool, probes schema shape, or makes a count assertion interleaved with raw-SQL mutations/polling in the same flow
+- **THEN** it MAY continue to use `Client.DB()` raw SQL
+- **AND** any count assertion that is converted to Ent SHALL produce identical pass/fail outcomes to the raw-SQL version it replaced

--- a/openspec/changes/archive/2026-05-29-trim-test-raw-sql-counts/tasks.md
+++ b/openspec/changes/archive/2026-05-29-trim-test-raw-sql-counts/tasks.md
@@ -1,0 +1,18 @@
+## 1. Inventory
+
+- [x] 1.1 Confirmed `pkg/cache` and `pkg/server` suites green before changes.
+- [x] 1.2 Listed the `SELECT COUNT(*)` `DB()` sites: bare table counts in `cache_test.go` (5) and by-hash counts in `server_test.go` (5, all standalone). Found additional by-hash counts in `cache_test.go` interleaved with raw-SQL flows (rebind/ExecContext/Eventually/wg) — these are retained.
+
+## 2. Convert cache_test.go
+
+- [x] 2.1 Replaced the 5 bare-table `dbClient.DB().QueryRowContext(..., "SELECT COUNT(*) FROM <table>").Scan(&count)` assertions with `count, err := dbClient.Ent().<Entity>.Query().Count(context.Background())` (NarInfo / NarFile), preserving the surrounding `require.NoError` / `assert.Equal`.
+
+## 3. Convert server_test.go
+
+- [x] 3.1 Replaced all 5 `SELECT COUNT(*) FROM narinfos WHERE hash = ?` assertions with `dbClient.Ent().NarInfo.Query().Where(entnarinfo.HashEQ(testdata.Nar1.NarInfoHash)).Count(newContext())`, adding the `entnarinfo` import.
+
+## 4. Verify
+
+- [x] 4.1 Ran `task fmt` and `task lint` (gci auto-fixed the new import grouping) — 0 issues.
+- [x] 4.2 Ran `task test` — full suite green (0 failures); `pkg/cache` (30s) and `pkg/server` pass with identical assertions.
+- [x] 4.3 Confirmed retained raw-SQL categories are untouched (migration verification, adversarial setup, timestamp inspection, pool tuning, schema probes, testhelper admin, and the rebind/Eventually/wg-interleaved cache_test counts), and the only production `DB()` use (`pkg/ncps/migrate.go`) is unchanged.

--- a/openspec/specs/database-orm/spec.md
+++ b/openspec/specs/database-orm/spec.md
@@ -166,3 +166,19 @@ The cache layer (`pkg/cache`) SHALL classify "database row not found" exclusivel
 - **WHEN** an error is `storage.ErrNotFound`, `upstream.ErrNotFound`, `chunk.ErrNotFound`, or `config.ErrConfigNotFound`
 - **THEN** it SHALL continue to be matched by its own `errors.Is` check
 - **AND** `database.IsNotFoundError` SHALL NOT be used in place of those package-specific matches
+
+### Requirement: Standalone row-count assertions in behavior tests use the Ent client
+
+Where a cache or server behavior test makes a **standalone** row-count assertion — one that is not interleaved with raw `*sql.DB` setup in the same flow — it SHALL obtain the count through the Ent client (`dbClient.Ent().<Entity>.Query()[.Where(entX.HashEQ(h))].Count(ctx)`) rather than via a raw `SELECT COUNT(*)` string. Raw `*sql.DB` access in tests (via `Client.DB()`) SHALL be reserved for scenarios where it is the right tool: verifying the outcome of data migrations, seeding adversarial/invalid rows the ORM would reject, inspecting persistence-layer columns, connection-pool tuning, schema/catalog probes, database-admin operations, and count assertions that are interleaved with such raw-SQL mutation or `Eventually`-polling logic within the same test flow.
+
+#### Scenario: Standalone count assertion uses Ent
+
+- **WHEN** a cache or server behavior test makes a standalone assertion about the number of rows in a table (optionally filtered by hash) and does not interleave raw `*sql.DB` access in that flow
+- **THEN** it SHALL obtain the count via `dbClient.Ent().<Entity>.Query()[.Where(entX.HashEQ(h))].Count(ctx)`
+- **AND** it SHALL NOT issue a raw `SELECT COUNT(*)` through `Client.DB()`
+
+#### Scenario: Raw SQL retained where it is the right tool
+
+- **WHEN** a test verifies a data-migration outcome, seeds an invalid/adversarial row, inspects persistence-layer timestamps, tunes the connection pool, probes schema shape, or makes a count assertion interleaved with raw-SQL mutations/polling in the same flow
+- **THEN** it MAY continue to use `Client.DB()` raw SQL
+- **AND** any count assertion that is converted to Ent SHALL produce identical pass/fail outcomes to the raw-SQL version it replaced

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -466,13 +466,13 @@ func testGetNarInfo(factory cacheFactory) func(*testing.T) {
 			})
 
 			t.Run("narinfo does not exist in the database yet", func(t *testing.T) {
-				count, err := dbClient.Ent().NarInfo.Query().Count(context.Background())
+				count, err := dbClient.Ent().NarInfo.Query().Count(newContext())
 				require.NoError(t, err)
 				assert.Equal(t, 0, count)
 			})
 
 			t.Run("nar does not exist in the database yet", func(t *testing.T) {
-				count, err := dbClient.Ent().NarFile.Query().Count(context.Background())
+				count, err := dbClient.Ent().NarFile.Query().Count(newContext())
 				require.NoError(t, err)
 				assert.Equal(t, 0, count)
 			})
@@ -715,13 +715,13 @@ func testPutNarInfo(factory cacheFactory) func(*testing.T) {
 		})
 
 		t.Run("narinfo does not exist in the database yet", func(t *testing.T) {
-			count, err := dbClient.Ent().NarInfo.Query().Count(context.Background())
+			count, err := dbClient.Ent().NarInfo.Query().Count(newContext())
 			require.NoError(t, err)
 			assert.Equal(t, 0, count)
 		})
 
 		t.Run("nar does not exist in the database yet", func(t *testing.T) {
-			count, err := dbClient.Ent().NarFile.Query().Count(context.Background())
+			count, err := dbClient.Ent().NarFile.Query().Count(newContext())
 			require.NoError(t, err)
 			assert.Equal(t, 0, count)
 		})
@@ -928,7 +928,7 @@ func testGetNar(factory cacheFactory) func(*testing.T) {
 			})
 
 			t.Run("nar does not exist in database yet", func(t *testing.T) {
-				count, err := dbClient.Ent().NarFile.Query().Count(context.Background())
+				count, err := dbClient.Ent().NarFile.Query().Count(newContext())
 				require.NoError(t, err)
 				assert.Equal(t, 0, count)
 			})

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -466,17 +466,13 @@ func testGetNarInfo(factory cacheFactory) func(*testing.T) {
 			})
 
 			t.Run("narinfo does not exist in the database yet", func(t *testing.T) {
-				var count int
-
-				err := dbClient.DB().QueryRowContext(context.Background(), "SELECT COUNT(*) FROM narinfos").Scan(&count)
+				count, err := dbClient.Ent().NarInfo.Query().Count(context.Background())
 				require.NoError(t, err)
 				assert.Equal(t, 0, count)
 			})
 
 			t.Run("nar does not exist in the database yet", func(t *testing.T) {
-				var count int
-
-				err := dbClient.DB().QueryRowContext(context.Background(), "SELECT COUNT(*) FROM nar_files").Scan(&count)
+				count, err := dbClient.Ent().NarFile.Query().Count(context.Background())
 				require.NoError(t, err)
 				assert.Equal(t, 0, count)
 			})
@@ -719,17 +715,13 @@ func testPutNarInfo(factory cacheFactory) func(*testing.T) {
 		})
 
 		t.Run("narinfo does not exist in the database yet", func(t *testing.T) {
-			var count int
-
-			err := dbClient.DB().QueryRowContext(context.Background(), "SELECT COUNT(*) FROM narinfos").Scan(&count)
+			count, err := dbClient.Ent().NarInfo.Query().Count(context.Background())
 			require.NoError(t, err)
 			assert.Equal(t, 0, count)
 		})
 
 		t.Run("nar does not exist in the database yet", func(t *testing.T) {
-			var count int
-
-			err := dbClient.DB().QueryRowContext(context.Background(), "SELECT COUNT(*) FROM nar_files").Scan(&count)
+			count, err := dbClient.Ent().NarFile.Query().Count(context.Background())
 			require.NoError(t, err)
 			assert.Equal(t, 0, count)
 		})
@@ -936,9 +928,7 @@ func testGetNar(factory cacheFactory) func(*testing.T) {
 			})
 
 			t.Run("nar does not exist in database yet", func(t *testing.T) {
-				var count int
-
-				err := dbClient.DB().QueryRowContext(context.Background(), "SELECT COUNT(*) FROM nar_files").Scan(&count)
+				count, err := dbClient.Ent().NarFile.Query().Count(context.Background())
 				require.NoError(t, err)
 				assert.Equal(t, 0, count)
 			})

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	entnarinfo "github.com/kalbasit/ncps/ent/narinfo"
 	locklocal "github.com/kalbasit/ncps/pkg/lock/local"
 
 	"github.com/kalbasit/ncps/pkg/cache"
@@ -178,11 +179,9 @@ func TestServeHTTP(t *testing.T) {
 
 			t.Run("narInfo", func(t *testing.T) {
 				t.Run("narinfo does not exist in the database yet", func(t *testing.T) {
-					var count int
-
-					err := dbClient.DB().QueryRowContext(newContext(),
-						"SELECT COUNT(*) FROM narinfos WHERE hash = ?",
-						testdata.Nar1.NarInfoHash).Scan(&count)
+					count, err := dbClient.Ent().NarInfo.Query().
+						Where(entnarinfo.HashEQ(testdata.Nar1.NarInfoHash)).
+						Count(newContext())
 					require.NoError(t, err)
 					assert.Equal(t, 0, count)
 				})
@@ -191,11 +190,9 @@ func TestServeHTTP(t *testing.T) {
 				require.NoError(t, err)
 
 				t.Run("narinfo does exist in the database", func(t *testing.T) {
-					var count int
-
-					err := dbClient.DB().QueryRowContext(newContext(),
-						"SELECT COUNT(*) FROM narinfos WHERE hash = ?",
-						testdata.Nar1.NarInfoHash).Scan(&count)
+					count, err := dbClient.Ent().NarInfo.Query().
+						Where(entnarinfo.HashEQ(testdata.Nar1.NarInfoHash)).
+						Count(newContext())
 					require.NoError(t, err)
 					assert.Equal(t, 1, count, "narinfo should exist in database")
 				})
@@ -213,11 +210,9 @@ func TestServeHTTP(t *testing.T) {
 				})
 
 				t.Run("narinfo is gone from the database", func(t *testing.T) {
-					var count int
-
-					err := dbClient.DB().QueryRowContext(newContext(),
-						"SELECT COUNT(*) FROM narinfos WHERE hash = ?",
-						testdata.Nar1.NarInfoHash).Scan(&count)
+					count, err := dbClient.Ent().NarInfo.Query().
+						Where(entnarinfo.HashEQ(testdata.Nar1.NarInfoHash)).
+						Count(newContext())
 					require.NoError(t, err)
 					assert.Equal(t, 0, count, "narinfo should be gone from database")
 				})
@@ -616,11 +611,9 @@ Deriver: test.drv
 				})
 
 				t.Run("narinfo does exist in the database", func(t *testing.T) {
-					var count int
-
-					err := dbClient.DB().QueryRowContext(newContext(),
-						"SELECT COUNT(*) FROM narinfos WHERE hash = ?",
-						testdata.Nar1.NarInfoHash).Scan(&count)
+					count, err := dbClient.Ent().NarInfo.Query().
+						Where(entnarinfo.HashEQ(testdata.Nar1.NarInfoHash)).
+						Count(newContext())
 					require.NoError(t, err)
 					assert.Equal(t, 1, count, "narinfo should exist in database")
 				})
@@ -815,11 +808,9 @@ func TestGetNarInfo_Head(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, w.Code)
 
 	// Verify it's in the database
-	var count int
-
-	err = dbClient.DB().
-		QueryRowContext(newContext(), "SELECT COUNT(*) FROM narinfos WHERE hash = ?", testdata.Nar1.NarInfoHash).
-		Scan(&count)
+	count, err := dbClient.Ent().NarInfo.Query().
+		Where(entnarinfo.HashEQ(testdata.Nar1.NarInfoHash)).
+		Count(newContext())
 	require.NoError(t, err)
 	assert.Equal(t, 1, count, "narinfo should be in the database after PUT")
 


### PR DESCRIPTION
## Summary

`Client.DB()` is a discouraged raw-`*sql.DB` escape hatch, yet the test suites reach for it ~110 times. Most uses are legitimate (migration verification, schema probes, adversarial setup, pool tuning). One pattern is a clean swap that loses no verification independence: standalone `SELECT COUNT(*)` row-count assertions in the cache and server behavior tests.

- Convert the 5 bare table-count assertions in `cache_test.go` and all 5 by-hash count assertions in `server_test.go` to the Ent API (`dbClient.Ent().<Entity>.Query()[.Where(entnarinfo.HashEQ(h))].Count(ctx)`).
- Retain raw SQL everywhere it is the right tool, including the `cache_test.go` by-hash counts interleaved with raw-SQL idioms (rebind helper, `ExecContext` mutations, `Eventually` polling, concurrent `wg` flows) and all `pkg/ncps` migration-outcome checks (ORM-independent by design).
- The production `pkg/ncps/migrate.go` use of `DB()` is unchanged.
- Records a `database-orm` spec requirement scoping the Ent-count convention to standalone behavior-test assertions.

## Test plan

- [x] `task fmt` / `task lint` (0 issues) / `task test` (full suite green; `pkg/cache` + `pkg/server`)
- [x] Converted assertions produce identical pass/fail outcomes