### PR TITLE
fix(cache): stop returning HTTP 500 on download-lock contention

### DIFF
--- a/openspec/changes/archive/2026-05-29-fix-download-coordination-500/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-29-fix-download-coordination-500/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/archive/2026-05-29-fix-download-coordination-500/design.md
+++ b/openspec/changes/archive/2026-05-29-fix-download-coordination-500/design.md
@@ -1,0 +1,173 @@
+## Context
+
+In a multi-replica deployment with a Redis lock backend, ncps coalesces duplicate
+downloads of the same NAR/narinfo hash through `coordinateDownload`
+(`pkg/cache/cache.go:5386`). Coordination has two layers:
+
+- **Intra-pod**: an in-process `upstreamJobs` map keyed by lock key. A second
+  local goroutine waits on the shared `downloadState` channels (`ds.start`,
+  `ds.stored`, `ds.done`) and can observe the holder's error via
+  `ds.getError()`.
+- **Cross-pod**: a Redis lock (`download:nar:<hash>` / narinfo equivalent).
+  Replicas do **not** share `upstreamJobs`, so a replica that fails to acquire
+  the lock has no `downloadState` to observe — it only knows "someone else holds
+  the lock."
+
+The bug lives in the cross-pod branch. When `c.downloadLocker.Lock` fails
+(`cache.go:5422`), the waiter enters a poll loop (`cache.go:5442`) that **only**
+checks `hasAsset` every 200ms until `downloadPollTimeout` (default 30s) expires.
+On timeout it sets a generic `downloadError`
+("failed to acquire download lock and timeout polling for completion", `cache.go:5469`),
+which the server maps to **HTTP 500** (non-`ErrNotFound`, non-context error).
+
+Two real-world triggers, both observed in production logs:
+
+1. The lock holder's download **fails** (upstream HTTP/2 reset → "truncated
+   input", or upstream 404). The asset will never appear, so every waiter burns
+   30s then 500s.
+2. The lock holder is **legitimately slow** (large NAR), holding and refreshing
+   its 5-minute lock TTL well past the 30s poll window. Honest slow downloads
+   also 500.
+
+A 500 is the worst outcome: Nix treats it as a hard error and retries up to 5×,
+amplifying load during exactly the concurrent-pull bursts coordination exists to
+smooth.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A lock-losing waiter NEVER returns HTTP 500 due to coordination.
+- When the holder succeeds, waiters serve the now-present asset.
+- When the holder fails/releases without producing the asset, a waiter
+  **re-acquires the lock and takes over** the download (serialized, one
+  downloader at a time).
+- When the asset is genuinely absent (upstream 404 even after take-over), return
+  a clean **cache miss (404)** so Nix falls back gracefully.
+- Keep exactly-one-downloader semantics so the unsafe concurrent-CDC path
+  (#1289, `cache_distributed_test.go:645`) is never exercised by this fix.
+
+**Non-Goals:**
+- No parallel/concurrent same-hash downloads as a fallback.
+- No change to the lock backend, retry config, or Redis algorithm.
+- No redesign of CDC serve-during-chunking (tracked separately in #1289).
+- No change to the legitimate "does not exist in binary cache" 404 path.
+- No new user-facing config tunables.
+
+## Decisions
+
+### Decision 1: Replace poll-only-then-500 with poll-or-reacquire-then-takeover
+
+The cross-pod fallback (`cache.go:5442-5477`) changes from a dead-end poll loop
+into a bounded loop that, on each tick, does two things:
+
+1. `hasAsset(ctx)` → if present, the holder succeeded; return a completed
+   `downloadState` and serve (unchanged success path).
+2. Re-attempt `c.downloadLocker.Lock(...)` → if it now succeeds, the previous
+   holder has released (finished or failed) and the asset is still absent, so
+   **this replica becomes the holder** and proceeds into the existing
+   post-lock download path (`startJob`). This is the take-over.
+
+Because the holder refreshes its TTL while actively working
+(`lock.StartRefresher`, `cache.go:5481`), re-acquisition only succeeds once the
+holder is truly done — so take-over naturally serializes and never overlaps a
+live download.
+
+**Why over alternatives:**
+- *Waiter fetches in parallel after timeout* (the original proposal wording):
+  rejected — two pods writing the same hash is safe for storage/DB (idempotent
+  upserts, atomic rename) but **not** for CDC lazy chunking, which has a known
+  concurrent-reconstruction defect (#1289). Take-over keeps a single writer.
+- *Just return 404 immediately on lock-loss*: rejected — gives up on serving an
+  asset the cache can produce; wastes the coalescing benefit.
+
+### Decision 2: Terminal give-up maps to a cache miss (404), never 500
+
+If the loop's overall deadline is reached without the asset appearing and
+without successful take-over (e.g., the holder is still legitimately mid-download
+and refreshing its TTL), the coordination path returns a result the server maps
+to **404**, not 500. Concretely, the give-up returns `storage.ErrNotFound`
+(server: `ErrNotFound → 404`) rather than a generic error.
+
+**Why:** for Nix, 404 = "not in this cache" → fall back to the next substituter
+or build locally; 500 = retry storm. 404 is the correct degraded signal.
+
+### Decision 3: Align the give-up deadline with the holder's lock TTL
+
+The 30s `downloadPollTimeout` being shorter than a legitimate large-NAR download
+is itself a 500 source. The waiter should be willing to wait up to roughly the
+holder's lock TTL (the window in which the holder could still be making
+progress) before giving up. We bound waiting by the lock TTL (or
+`min(coordCtx deadline, downloadLockTTL)`) rather than a fixed 30s, while still
+preferring take-over the moment the lock frees.
+
+**Why over alternatives:** raising the fixed poll timeout alone would still 500
+on holder failure; tying the bound to the TTL plus the take-over loop covers
+both the slow-holder and failed-holder cases.
+
+### Decision 4: Scope identically to NAR and narinfo coordination
+
+Both `waitForStorage=false` (NAR streaming) and `waitForStorage=true` (narinfo)
+flow through `coordinateDownload`, so the fix is applied once at the coordination
+layer and covered by specs for both `nar-concurrent-streaming` and
+`narinfo-concurrent-fetch`.
+
+## Risks / Trade-offs
+
+- **[Take-over after a failing upstream re-tries the same failing fetch]** →
+  Mitigation: the take-over runs the normal `startJob`, which returns
+  `ErrNotFound` for a genuine 404; that maps to a clean 404, not an infinite
+  loop. Transient upstream errors surface as the download's own error, unchanged
+  from single-pod behavior.
+- **[Waiting up to the lock TTL increases tail latency for the failed-holder
+  case]** → Mitigation: take-over fires as soon as the lock frees (holder
+  failure releases promptly), so the long wait only applies when the holder is
+  genuinely still progressing — exactly when waiting is correct.
+- **[Re-acquisition adds Redis Lock calls during contention]** → Mitigation:
+  re-attempt on the existing 200ms poll cadence (not a tight spin); negligible
+  additional Redis load versus the eliminated 5× Nix retry storm.
+- **[Thundering herd of take-over on a popular failed hash]** → Mitigation:
+  serialization still holds — only the single replica that wins re-acquisition
+  downloads; others keep polling/serving from its result.
+
+## Migration Plan
+
+- Pure behavioral fix inside `coordinateDownload` and its error mapping; no
+  schema, config, or wire-format change.
+- Deploy is a rolling restart. Mixed-version replicas during rollout remain
+  safe: old replicas still 500 on lock-loss (pre-fix behavior), new replicas
+  take over / 404; correctness of stored data is unaffected because storage/DB
+  writes are already idempotent.
+- Rollback is a redeploy of the previous image; no state to revert.
+
+## Open Questions
+
+- Should we add a lightweight "is this lock still held?" introspection to the
+  locker interface to distinguish "holder progressing" from "holder gone"
+  deterministically, instead of inferring it from a failed re-acquire? (Cleaner,
+  but expands the `Locker` interface — deferred; re-acquire inference proved
+  reliable in the regression tests.)
+
+## Resolved During Implementation
+
+- **Give-up deadline value**: `giveUpBound = max(downloadLockTTL,
+  downloadPollTimeout)`. The lock TTL is the primary bound (the window a live
+  holder could still be refreshing its lock and making progress); the legacy
+  `downloadPollTimeout` is kept as a lower bound so existing configuration still
+  has effect. Take-over fires as soon as the lock frees, so the full bound is
+  only reached when a holder is genuinely still progressing.
+- **Observability**: structured logs — `Warn` on give-up ("gave up waiting for
+  download by another server, returning cache miss") and `Debug` on take-over
+  ("re-acquired download lock, taking over the download") — plus a Prometheus
+  counter `ncps_download_coordination_fallback_total` with an `outcome`
+  attribute (`served_by_peer`, `take_over`, `give_up`, `caller_canceled`), so
+  operators can see how lock contention resolves. (Note: the counter binds the
+  global OTel meter at package `init()`, matching every other counter in this
+  package; like them, it is not unit-tested.)
+- **Implementation shape**: the fallback was extracted into
+  `(*Cache).pollForDownloadOrTakeOver`, returning `(ds, tookOver)` so
+  `coordinateDownload` stays flat (resolves a `nestif` lint finding) and the
+  take-over path simply falls through to the existing post-lock code.
+- **Tests**: covered by `pkg/cache/coordination_internal_test.go` using a
+  `takeoverLocker` mock (no Redis required, deterministic). The Redis-backed
+  distributed suite (`task test:auto` with `enable-redis-tests`) remains the
+  integration check in CI's per-backend derivations.

--- a/openspec/changes/archive/2026-05-29-fix-download-coordination-500/proposal.md
+++ b/openspec/changes/archive/2026-05-29-fix-download-coordination-500/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+When ncps runs as multiple replicas sharing a Redis lock backend, a client fetching a NAR (or narinfo) that another replica is currently downloading returns **HTTP 500** instead of being served or cleanly missed. Nix treats 500 as a hard error and retries it up to 5×, amplifying load during exactly the concurrent-pull bursts the coalescing logic was meant to smooth. This is a production-impacting correctness bug observed against a 2-pod deployment.
+
+## What Changes
+
+- Fix `coordinateDownload` (`pkg/cache/cache.go`) so a replica that **loses the distributed lock race no longer returns 500** when its storage-poll times out.
+- Make the lock-losing waiter **wait for the holder's terminal state (success *or* failure), not just success**: today the poll loop (`cache.go:5442`) only watches `hasAsset`, so it cannot learn the holder failed and dead-ends in a 500.
+- When the holder finishes or releases the lock without producing the asset, the waiter **re-attempts lock acquisition and takes over the download** (serialize, don't parallelize). This keeps coordination correctness-preserving — exactly one downloader at a time — and avoids fanning out concurrent same-hash downloads into the unsafe concurrent-CDC path (#1289).
+- On genuine give-up (the asset is absent and cannot be produced), return a **clean cache miss (404), never 500**, so Nix falls back to the next substituter instead of retrying 5×.
+- Revisit the poll-timeout vs. lock-TTL relationship so a legitimately slow large-NAR download (holder refreshing its TTL) does not trip waiters into a give-up.
+- Add a distributed regression test that reproduces the 500 by holding the lock past the poll timeout while concurrent requests arrive, asserting they succeed (or 404) instead of erroring.
+
+## Capabilities
+
+### New Capabilities
+<!-- None — this is a correctness fix to existing coalescing behavior. -->
+
+### Modified Capabilities
+- `nar-concurrent-streaming`: a replica that fails to acquire the download lock and times out polling MUST fall back to fetching/serving rather than returning 500.
+- `narinfo-concurrent-fetch`: the same lock-loss fallback applies to narinfo coordination (`waitForStorage=true`).
+
+## Impact
+
+- **Code**: `pkg/cache/cache.go` (`coordinateDownload`, the poll-timeout branch and its `downloadError` mapping); `pkg/cache/cache_distributed_test.go` (new regression scenario). Possibly `pkg/server` only if the error-to-status mapping needs adjustment.
+- **APIs / behavior**: HTTP responses under contention change from 500 → success or 404. No config schema or wire-format change.
+- **Dependencies**: none added.
+
+### Impact on I/O / network / memory
+- **Network**: replaces a 500-driven 5× Nix retry storm with either a served response or a single clean 404. Because the waiter takes over only *after* the holder releases the lock (rather than fetching in parallel), it does not add a concurrent duplicate upstream fetch; net upstream traffic should drop under bursty concurrent pulls.
+- **I/O**: serialized take-over means at most one writer per hash at a time, so no new concurrent-write contention class is introduced (and the unsafe concurrent-CDC path is avoided).
+- **Memory**: negligible — no new buffering or pooling; existing zstd/stream pooling is unchanged.
+
+## Non-goals
+
+- Not changing the lock backend, TTL/retry config defaults, or the Redis locking algorithm.
+- **Not** introducing parallel/concurrent same-hash downloads as the fallback — that would exercise the unsafe concurrent-CDC chunking path tracked in #1289 and the `cache_distributed_test.go:645` TODO.
+- Not redesigning CDC serve-during-chunking behavior (deferred to #1289).
+- Not altering the legitimate 404 ("does not exist in binary cache") path for genuinely-absent upstream paths.
+- Not adding new config tunables; any poll-timeout adjustment stays within existing semantics.

--- a/openspec/changes/archive/2026-05-29-fix-download-coordination-500/specs/nar-concurrent-streaming/spec.md
+++ b/openspec/changes/archive/2026-05-29-fix-download-coordination-500/specs/nar-concurrent-streaming/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: A lock-losing replica MUST NOT return HTTP 500 from download coordination
+
+A lock-losing replica MUST NOT return HTTP 500 from download coordination. When a replica fails to acquire the distributed download lock for a NAR hash (because another replica holds it), it SHALL instead serve the NAR (if the holder produces it), take over the download (if the holder finishes without producing it), or return a clean cache miss (HTTP 404) if the NAR is genuinely unavailable.
+
+#### Scenario: Holder completes successfully — waiter serves the NAR
+
+- **WHEN** replica B fails to acquire the download lock for hash `H` held by replica A
+- **AND** replica A completes the download and the NAR becomes present in shared storage
+- **THEN** replica B SHALL detect the asset and serve the NAR with HTTP 200
+- **AND** replica B SHALL NOT return HTTP 500
+
+#### Scenario: Holder fails and releases the lock — waiter takes over
+
+- **WHEN** replica B fails to acquire the download lock for hash `H` held by replica A
+- **AND** replica A's download fails (e.g. upstream stream reset) and replica A releases the lock without the asset appearing in storage
+- **THEN** replica B SHALL re-acquire the download lock and perform the download itself
+- **AND** replica B SHALL NOT return HTTP 500 as a result of the original lock-acquisition failure
+
+#### Scenario: NAR genuinely absent upstream — waiter returns 404 not 500
+
+- **WHEN** replica B fails to acquire the download lock for hash `H`
+- **AND** the NAR for `H` does not exist upstream (the holder, or B after take-over, observes a 404)
+- **THEN** the coordination path SHALL surface `storage.ErrNotFound`
+- **AND** the server SHALL return HTTP 404
+- **AND** the server SHALL NOT return HTTP 500
+
+#### Scenario: Holder still legitimately downloading past the poll window — waiter does not 500
+
+- **WHEN** replica B fails to acquire the download lock for hash `H` held by replica A
+- **AND** replica A is still actively downloading a large NAR and continues to refresh its lock TTL beyond the previous fixed poll timeout
+- **THEN** replica B SHALL continue waiting up to the lock TTL bound rather than returning HTTP 500
+- **AND** replica B SHALL serve the NAR once it appears, or return HTTP 404 on terminal give-up — never HTTP 500
+
+### Requirement: Lock-loss fallback MUST serialize, not start a concurrent same-hash download
+
+A replica that loses the download lock SHALL NOT begin its own concurrent
+download of the same hash while another replica still holds the lock. It SHALL
+wait for the holder's terminal state and only download after successfully
+re-acquiring the lock, guaranteeing at most one active downloader per hash.
+
+#### Scenario: Waiter does not download while holder still holds the lock
+
+- **WHEN** replica B fails to acquire the download lock for hash `H` held by replica A
+- **AND** replica A still holds the lock (download in progress)
+- **THEN** replica B SHALL poll for the asset and re-attempt lock acquisition, but SHALL NOT start fetching `H` from upstream
+- **AND** at most one replica SHALL be actively downloading hash `H` at any time
+
+#### Scenario: Serialized take-over avoids concurrent CDC chunking
+
+- **WHEN** CDC is enabled and replica B takes over a download for hash `H` after replica A released the lock
+- **THEN** only replica B SHALL chunk hash `H` at that time
+- **AND** the fix SHALL NOT introduce concurrent chunking of the same hash across replicas

--- a/openspec/changes/archive/2026-05-29-fix-download-coordination-500/specs/narinfo-concurrent-fetch/spec.md
+++ b/openspec/changes/archive/2026-05-29-fix-download-coordination-500/specs/narinfo-concurrent-fetch/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: A lock-losing replica MUST NOT return HTTP 500 from narinfo coordination
+
+A lock-losing replica MUST NOT return HTTP 500 from narinfo coordination. When a replica fails to acquire the distributed download lock for a narinfo hash (`waitForStorage=true` coordination, because another replica holds it), it SHALL serve the narinfo (if the holder stores it), take over the fetch (if the holder finishes without storing it), or return a clean cache miss (HTTP 404) if the narinfo is genuinely unavailable upstream.
+
+#### Scenario: Second concurrent narinfo request loses the lock and the holder times out
+
+- **WHEN** two replicas request narinfo for hash `H` concurrently against a cold cache
+- **AND** replica B fails to acquire the lock held by replica A
+- **AND** replica A does not store the narinfo within the previous fixed poll timeout
+- **THEN** replica B SHALL NOT return HTTP 500
+- **AND** replica B SHALL serve the narinfo once stored, take over the fetch after the lock frees, or return HTTP 404 on terminal give-up
+
+#### Scenario: Holder stores narinfo — waiter serves it
+
+- **WHEN** replica B fails to acquire the narinfo lock for hash `H` held by replica A
+- **AND** replica A successfully fetches and stores the narinfo for `H`
+- **THEN** replica B SHALL serve the narinfo with HTTP 200
+- **AND** replica B SHALL NOT return HTTP 500
+
+#### Scenario: Narinfo genuinely absent upstream — waiter returns 404 not 500
+
+- **WHEN** replica B fails to acquire the narinfo lock for hash `H`
+- **AND** the narinfo for `H` does not exist upstream
+- **THEN** the coordination path SHALL surface `storage.ErrNotFound`
+- **AND** the server SHALL return HTTP 404, not HTTP 500
+
+### Requirement: narinfo lock-loss fallback MUST serialize the upstream fetch
+
+A replica that loses the narinfo download lock SHALL NOT start its own concurrent
+upstream narinfo fetch and database write while another replica still holds the
+lock; it SHALL take over only after re-acquiring the lock, preserving the
+existing exactly-once storage invariant.
+
+#### Scenario: Storage remains exactly-once under lock-loss take-over
+
+- **WHEN** replica B takes over a narinfo fetch for hash `H` after replica A released the lock without storing it
+- **THEN** replica B SHALL store the narinfo
+- **AND** the narinfo for `H` SHALL be stored exactly once (idempotent upsert), with no duplicate-key error surfaced to the client

--- a/openspec/changes/archive/2026-05-29-fix-download-coordination-500/tasks.md
+++ b/openspec/changes/archive/2026-05-29-fix-download-coordination-500/tasks.md
@@ -1,0 +1,30 @@
+## 1. Reproduce the 500 with a failing test (RED)
+
+- [x] 1.1 Add a test that holds the download lock for a hash (simulating a slow/failed holder on another replica) while a cache instance requests the same NAR, and assert the request currently returns the coordination error mapped to HTTP 500. Confirm it FAILS against current behavior in the intended end state (i.e. it should expect success/404, not 500). — `pkg/cache/coordination_internal_test.go:TestCoordinateDownloadTakesOverNAR`, deterministic via a `takeoverLocker` mock (no Redis required).
+- [x] 1.2 Add a sibling test for the failed-holder case: holder acquires the lock then releases it WITHOUT the asset appearing (download failed); assert the waiter should take over and succeed (failed before the fix). — covered by the same `TestCoordinateDownloadTakesOverNAR` (block → release → assert serve).
+- [x] 1.3 Add a genuine-absence case: hash does not exist upstream; assert the lock-losing waiter resolves to a cache miss / HTTP 404 (not 500). All call `t.Parallel()` and run under the race detector. — `TestCoordinateDownloadNarInfoMissReturnsNotFound` (narinfo route) and `TestCoordinateDownloadNARGiveUpReturnsNotFound` (NAR route: sustained contention → give-up → `storage.ErrNotFound`, also covering the slow/stuck-holder scenario).
+
+## 2. Distinguish holder terminal state in coordinateDownload (GREEN)
+
+- [x] 2.1 In `coordinateDownload` (`pkg/cache/cache.go`), replaced the poll-only fallback loop with a poll-or-reacquire loop: each tick checks `hasAsset(coordCtx)` AND re-attempts `c.downloadLocker.Lock(...)`.
+- [x] 2.2 On successful re-acquisition, `break pollLoop` falls through into the existing post-lock holder path (refresher, double-check, `startJob`, release strategy) so this replica takes over the download.
+- [x] 2.3 Bound the overall wait by `max(c.downloadLockTTL, c.downloadPollTimeout)` (TTL as the primary bound, poll-timeout as a lower bound for config compatibility) instead of the fixed `downloadPollTimeout`, so a legitimately slow holder is not abandoned prematurely.
+- [x] 2.4 The loop never starts a concurrent download while the holder still holds the lock: it only proceeds to `startJob` after re-acquire succeeds, and the `upstreamJobs` map still de-dupes within the process.
+
+## 3. Map terminal give-up to a cache miss, not 500
+
+- [x] 3.1 On terminal give-up (deadline reached, asset absent, re-acquire never succeeded), the coordination path now wraps `storage.ErrNotFound` instead of the generic "failed to acquire download lock..." error; caller cancellation still surfaces as the context error.
+- [x] 3.2 Verified the server handlers (`pkg/server/server.go`) map `storage.ErrNotFound` → HTTP 404 for both NAR (`:835`) and narinfo (`:359`) routes, and context errors → no response. No server change needed.
+- [x] 3.3 Added structured logs (`Warn` on give-up, `Debug` on take-over) AND a Prometheus counter `ncps_download_coordination_fallback_total{outcome=served_by_peer|take_over|give_up|caller_canceled}` so operators can observe how lock contention resolves.
+
+## 4. Verify and harden
+
+- [x] 4.1 Ran the new tests with the race detector for the default (SQLite) backend; both RED tests from section 1 now pass (GREEN). Full `pkg/cache` suite passes.
+- [x] 4.2 Ran `task test:auto` (fresh services incl. Redis on random ports, full suite, teardown): the Redis-backed `pkg/cache` distributed tests and `pkg/lock/redis` pass, exercising the real cross-pod lock path.
+- [x] 4.3 No concurrent same-hash download/chunking is triggered: take-over only runs after re-acquire, and `upstreamJobs` de-dupes; the CDC concurrent-reconstruction path (#1289) is not newly exercised.
+- [x] 4.4 Cache-warm and single-request paths are unchanged: the fallback loop is only entered when the initial lock acquisition fails (contention); the existing `pkg/cache` suite (including warm-cache and single-request tests) passes.
+
+## 5. Finalize
+
+- [x] 5.1 Ran `task fmt` (0 changed), `task lint` (0 issues), and `task test` (all packages pass); each exits zero.
+- [x] 5.2 Updated `design.md` with a "Resolved During Implementation" section: deadline = `max(downloadLockTTL, downloadPollTimeout)`, logs-only observability, helper-extraction shape, and test coverage.

--- a/openspec/specs/nar-concurrent-streaming/spec.md
+++ b/openspec/specs/nar-concurrent-streaming/spec.md
@@ -75,3 +75,56 @@ client does not remain blocked if the storage operation stalls.
 - **AND** the client's context is active (not cancelled)
 - **THEN** the goroutine SHALL wait for `ds.stored` or `ds.done` before closing the pipe
 - **AND** `HasNar` SHALL return true when observed by the caller after reading completes
+
+### Requirement: A lock-losing replica MUST NOT return HTTP 500 from download coordination
+
+A lock-losing replica MUST NOT return HTTP 500 from download coordination. When a replica fails to acquire the distributed download lock for a NAR hash (because another replica holds it), it SHALL instead serve the NAR (if the holder produces it), take over the download (if the holder finishes without producing it), or return a clean cache miss (HTTP 404) if the NAR is genuinely unavailable.
+
+#### Scenario: Holder completes successfully — waiter serves the NAR
+
+- **WHEN** replica B fails to acquire the download lock for hash `H` held by replica A
+- **AND** replica A completes the download and the NAR becomes present in shared storage
+- **THEN** replica B SHALL detect the asset and serve the NAR with HTTP 200
+- **AND** replica B SHALL NOT return HTTP 500
+
+#### Scenario: Holder fails and releases the lock — waiter takes over
+
+- **WHEN** replica B fails to acquire the download lock for hash `H` held by replica A
+- **AND** replica A's download fails (e.g. upstream stream reset) and replica A releases the lock without the asset appearing in storage
+- **THEN** replica B SHALL re-acquire the download lock and perform the download itself
+- **AND** replica B SHALL NOT return HTTP 500 as a result of the original lock-acquisition failure
+
+#### Scenario: NAR genuinely absent upstream — waiter returns 404 not 500
+
+- **WHEN** replica B fails to acquire the download lock for hash `H`
+- **AND** the NAR for `H` does not exist upstream (the holder, or B after take-over, observes a 404)
+- **THEN** the coordination path SHALL surface `storage.ErrNotFound`
+- **AND** the server SHALL return HTTP 404
+- **AND** the server SHALL NOT return HTTP 500
+
+#### Scenario: Holder still legitimately downloading past the poll window — waiter does not 500
+
+- **WHEN** replica B fails to acquire the download lock for hash `H` held by replica A
+- **AND** replica A is still actively downloading a large NAR and continues to refresh its lock TTL beyond the previous fixed poll timeout
+- **THEN** replica B SHALL continue waiting up to the lock TTL bound rather than returning HTTP 500
+- **AND** replica B SHALL serve the NAR once it appears, or return HTTP 404 on terminal give-up — never HTTP 500
+
+### Requirement: Lock-loss fallback MUST serialize, not start a concurrent same-hash download
+
+A replica that loses the download lock SHALL NOT begin its own concurrent
+download of the same hash while another replica still holds the lock. It SHALL
+wait for the holder's terminal state and only download after successfully
+re-acquiring the lock, guaranteeing at most one active downloader per hash.
+
+#### Scenario: Waiter does not download while holder still holds the lock
+
+- **WHEN** replica B fails to acquire the download lock for hash `H` held by replica A
+- **AND** replica A still holds the lock (download in progress)
+- **THEN** replica B SHALL poll for the asset and re-attempt lock acquisition, but SHALL NOT start fetching `H` from upstream
+- **AND** at most one replica SHALL be actively downloading hash `H` at any time
+
+#### Scenario: Serialized take-over avoids concurrent CDC chunking
+
+- **WHEN** CDC is enabled and replica B takes over a download for hash `H` after replica A released the lock
+- **THEN** only replica B SHALL chunk hash `H` at that time
+- **AND** the fix SHALL NOT introduce concurrent chunking of the same hash across replicas

--- a/openspec/specs/narinfo-concurrent-fetch/spec.md
+++ b/openspec/specs/narinfo-concurrent-fetch/spec.md
@@ -63,3 +63,42 @@ When multiple requests arrive concurrently for a narinfo hash that is being fetc
 **And** subsequent requests arrive after the job has been removed from `upstreamJobs`
 **Then** `getNarInfoFromDatabase` behaves identically to before the fix
 **And** `HasNarInStore` returns true (NAR is in store) so the purge guard is not triggered
+
+### Requirement: A lock-losing replica MUST NOT return HTTP 500 from narinfo coordination
+
+A lock-losing replica MUST NOT return HTTP 500 from narinfo coordination. When a replica fails to acquire the distributed download lock for a narinfo hash (`waitForStorage=true` coordination, because another replica holds it), it SHALL serve the narinfo (if the holder stores it), take over the fetch (if the holder finishes without storing it), or return a clean cache miss (HTTP 404) if the narinfo is genuinely unavailable upstream.
+
+#### Scenario: Second concurrent narinfo request loses the lock and the holder times out
+
+- **WHEN** two replicas request narinfo for hash `H` concurrently against a cold cache
+- **AND** replica B fails to acquire the lock held by replica A
+- **AND** replica A does not store the narinfo within the previous fixed poll timeout
+- **THEN** replica B SHALL NOT return HTTP 500
+- **AND** replica B SHALL serve the narinfo once stored, take over the fetch after the lock frees, or return HTTP 404 on terminal give-up
+
+#### Scenario: Holder stores narinfo — waiter serves it
+
+- **WHEN** replica B fails to acquire the narinfo lock for hash `H` held by replica A
+- **AND** replica A successfully fetches and stores the narinfo for `H`
+- **THEN** replica B SHALL serve the narinfo with HTTP 200
+- **AND** replica B SHALL NOT return HTTP 500
+
+#### Scenario: Narinfo genuinely absent upstream — waiter returns 404 not 500
+
+- **WHEN** replica B fails to acquire the narinfo lock for hash `H`
+- **AND** the narinfo for `H` does not exist upstream
+- **THEN** the coordination path SHALL surface `storage.ErrNotFound`
+- **AND** the server SHALL return HTTP 404, not HTTP 500
+
+### Requirement: narinfo lock-loss fallback MUST serialize the upstream fetch
+
+A replica that loses the narinfo download lock SHALL NOT start its own concurrent
+upstream narinfo fetch and database write while another replica still holds the
+lock; it SHALL take over only after re-acquiring the lock, preserving the
+existing exactly-once storage invariant.
+
+#### Scenario: Storage remains exactly-once under lock-loss take-over
+
+- **WHEN** replica B takes over a narinfo fetch for hash `H` after replica A released the lock without storing it
+- **THEN** replica B SHALL store the narinfo
+- **AND** the narinfo for `H` SHALL be stored exactly once (idempotent upsert), with no duplicate-key error surfaced to the client

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -209,6 +209,10 @@ var (
 
 	//nolint:gochecknoglobals
 	backgroundMigrationDuration metric.Float64Histogram
+
+	// Download coordination metrics
+	//nolint:gochecknoglobals
+	downloadCoordinationFallbackTotal metric.Int64Counter
 )
 
 //nolint:gochecknoinits
@@ -370,6 +374,18 @@ func init() {
 		"ncps_background_migration_duration_seconds",
 		metric.WithDescription("Duration of background object migration operations"),
 		metric.WithUnit("s"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	downloadCoordinationFallbackTotal, err = meter.Int64Counter(
+		"ncps_download_coordination_fallback_total",
+		metric.WithDescription(
+			"Counts download-lock contention fallbacks by outcome "+
+				"(served_by_peer, take_over, give_up, caller_canceled).",
+		),
+		metric.WithUnit("{event}"),
 	)
 	if err != nil {
 		panic(err)
@@ -5411,57 +5427,18 @@ func (c *Cache) coordinateDownload(
 			Err(err).
 			Str("hash", hash).
 			Str("lock_key", lockKey).
-			Msg("failed to acquire download lock, will poll storage for completion by another server")
+			Msg("failed to acquire download lock, will poll storage and re-attempt acquisition")
 
-		// Lock acquisition failed, likely because another server is downloading.
-		// Poll storage periodically to check if the download completes.
-		// This handles distributed coordination where servers don't share the upstreamJobs map.
-		const pollInterval = 200 * time.Millisecond
-
-		pollTimeout := c.downloadPollTimeout
-
-		pollCtx, cancel := context.WithTimeout(coordCtx, pollTimeout)
-		defer cancel()
-
-		ticker := time.NewTicker(pollInterval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ticker.C:
-				if hasAsset(pollCtx) {
-					zerolog.Ctx(ctx).Debug().
-						Str("hash", hash).
-						Msg("asset appeared in storage while polling (downloaded by another server)")
-
-					// Return a completed downloadState
-					ds := newDownloadState()
-					ds.closed = true
-					ds.startOnce.Do(func() { close(ds.start) })
-					ds.storedOnce.Do(func() { close(ds.stored) })
-					ds.doneOnce.Do(func() { close(ds.done) })
-
-					return ds
-				}
-			case <-pollCtx.Done():
-				// Polling timeout or context canceled
-				zerolog.Ctx(ctx).Error().
-					Err(pollCtx.Err()).
-					Str("hash", hash).
-					Str("lock_key", lockKey).
-					Dur("poll_timeout", pollTimeout).
-					Msg("timeout waiting for download by another server")
-
-				ds := newDownloadState()
-				ds.downloadError = fmt.Errorf("failed to acquire download lock and timeout polling for completion: %w", err)
-				// Signal that the download is done (with error) to prevent deadlocks
-				ds.startOnce.Do(func() { close(ds.start) })
-				ds.storedOnce.Do(func() { close(ds.stored) })
-				ds.doneOnce.Do(func() { close(ds.done) })
-
-				return ds
-			}
+		// Another server holds the lock. Rather than dead-ending in an HTTP 500,
+		// poll storage for the asset while periodically re-attempting lock
+		// acquisition so we can take over if the holder finishes or fails.
+		ds, tookOver := c.pollForDownloadOrTakeOver(coordCtx, ctx, lockKey, hash, err, hasAsset)
+		if !tookOver {
+			return ds
 		}
+
+		// Fell through: we re-acquired the lock and now own the download.
+		// Continue into the normal post-lock path below.
 	}
 
 	// Start a background goroutine to refresh the lock TTL periodically.
@@ -5565,6 +5542,116 @@ func (c *Cache) coordinateDownload(
 	}
 
 	return ds
+}
+
+// pollForDownloadOrTakeOver runs the distributed fallback when the download lock
+// is held by another server. It polls storage for the asset while periodically
+// re-attempting lock acquisition, up to a bound of max(downloadLockTTL,
+// downloadPollTimeout) — the window during which a live holder could still be
+// refreshing its lock and making progress on a large NAR.
+//
+// It returns either:
+//   - (ds, false): a terminal downloadState the caller should return directly —
+//     a completed state if the asset appeared, or an errored state (a cache miss
+//     via storage.ErrNotFound, or the caller's context error); or
+//   - (nil, true): the lock was re-acquired, so the caller now owns the download
+//     and should continue into the normal post-lock path. Taking over only after
+//     re-acquisition keeps downloads serialized (at most one per hash across the
+//     cluster), so the concurrent-CDC path is never exercised by this fallback.
+func (c *Cache) pollForDownloadOrTakeOver(
+	coordCtx context.Context,
+	ctx context.Context,
+	lockKey string,
+	hash string,
+	initialErr error,
+	hasAsset func(context.Context) bool,
+) (*downloadState, bool) {
+	const pollInterval = 200 * time.Millisecond
+
+	giveUpBound := c.downloadLockTTL
+	if c.downloadPollTimeout > giveUpBound {
+		giveUpBound = c.downloadPollTimeout
+	}
+
+	deadlineCtx, cancel := context.WithTimeout(coordCtx, giveUpBound)
+	defer cancel()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if hasAsset(coordCtx) {
+				zerolog.Ctx(ctx).Debug().
+					Str("hash", hash).
+					Msg("asset appeared in storage while polling (downloaded by another server)")
+
+				downloadCoordinationFallbackTotal.Add(ctx, 1,
+					metric.WithAttributes(attribute.String("outcome", "served_by_peer")))
+
+				// Return a completed downloadState.
+				ds := newDownloadState()
+				ds.closed = true
+				ds.startOnce.Do(func() { close(ds.start) })
+				ds.storedOnce.Do(func() { close(ds.stored) })
+				ds.doneOnce.Do(func() { close(ds.done) })
+
+				return ds, false
+			}
+
+			// Re-attempt acquisition. Success means the previous holder released
+			// the lock (it finished or failed) without the asset appearing, so we
+			// take over as the sole downloader.
+			if lockErr := c.downloadLocker.Lock(ctx, lockKey, c.downloadLockTTL); lockErr == nil {
+				zerolog.Ctx(ctx).Debug().
+					Str("hash", hash).
+					Str("lock_key", lockKey).
+					Msg("re-acquired download lock, taking over the download")
+
+				downloadCoordinationFallbackTotal.Add(ctx, 1,
+					metric.WithAttributes(attribute.String("outcome", "take_over")))
+
+				return nil, true
+			}
+		case <-deadlineCtx.Done():
+			ds := newDownloadState()
+
+			// Distinguish caller cancellation (the client went away) from our own
+			// give-up. Caller cancellation surfaces as a context error, which the
+			// server treats as "no response"; a genuine give-up surfaces as a
+			// cache miss so Nix falls back to another substituter instead of
+			// retrying a 500.
+			if coordCtx.Err() != nil {
+				downloadCoordinationFallbackTotal.Add(ctx, 1,
+					metric.WithAttributes(attribute.String("outcome", "caller_canceled")))
+
+				ds.downloadError = coordCtx.Err()
+			} else {
+				zerolog.Ctx(ctx).Warn().
+					Err(initialErr).
+					Str("hash", hash).
+					Str("lock_key", lockKey).
+					Dur("give_up_bound", giveUpBound).
+					Msg("gave up waiting for download by another server, returning cache miss")
+
+				downloadCoordinationFallbackTotal.Add(ctx, 1,
+					metric.WithAttributes(attribute.String("outcome", "give_up")))
+
+				ds.downloadError = fmt.Errorf(
+					"gave up after %s waiting for another server to download %q: %w",
+					giveUpBound, hash, storage.ErrNotFound,
+				)
+			}
+
+			// Signal that the download is done (with error) to prevent deadlocks.
+			ds.startOnce.Do(func() { close(ds.start) })
+			ds.storedOnce.Do(func() { close(ds.stored) })
+			ds.doneOnce.Do(func() { close(ds.done) })
+
+			return ds, false
+		}
+	}
 }
 
 // withEntTransaction wraps c.dbClient.WithTransaction with the same

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -211,7 +211,7 @@ var (
 	backgroundMigrationDuration metric.Float64Histogram
 
 	// Download coordination metrics
-	//nolint:gochecknoglobals
+	//nolint:gochecknoglobals // package-level OTel metric instrument, initialized once in init() and reused.
 	downloadCoordinationFallbackTotal metric.Int64Counter
 )
 
@@ -5600,10 +5600,15 @@ func (c *Cache) pollForDownloadOrTakeOver(
 				return ds, false
 			}
 
-			// Re-attempt acquisition. Success means the previous holder released
-			// the lock (it finished or failed) without the asset appearing, so we
-			// take over as the sole downloader.
-			if lockErr := c.downloadLocker.Lock(ctx, lockKey, c.downloadLockTTL); lockErr == nil {
+			// Re-attempt acquisition without blocking, bounded by the give-up
+			// deadline. TryLock is a single non-blocking attempt, so a tick can
+			// never stall the poll loop or outlive deadlineCtx / caller
+			// cancellation (a blocking Lock retries internally and could do
+			// exactly that). Success means the previous holder released the lock
+			// (it finished or failed) without the asset appearing, so we take
+			// over as the sole downloader.
+			acquired, lockErr := c.downloadLocker.TryLock(deadlineCtx, lockKey, c.downloadLockTTL)
+			if lockErr == nil && acquired {
 				zerolog.Ctx(ctx).Debug().
 					Str("hash", hash).
 					Str("lock_key", lockKey).

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1145,6 +1145,8 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (nar.URL, int64, io.
 			// Context canceled before download started
 			metricAttrs = append(metricAttrs, attribute.String("status", "error"))
 
+			ds.wg.Done()
+
 			return ctx.Err()
 		}
 
@@ -1157,6 +1159,8 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (nar.URL, int64, io.
 				metricAttrs = append(metricAttrs,
 					attribute.String("upstream_hostname", upstreamHostname))
 			}
+
+			ds.wg.Done()
 
 			return err
 		}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -4178,6 +4178,78 @@ func testGetNarCDCXzServesFromStoreWhenBothExist(factory cacheFactory) func(*tes
 	}
 }
 
+// TestGetNarCloseDoesNotHangAfterContextCancelledBeforeStart is a regression
+// test for a ds.wg imbalance: when canStream=true, ds.wg.Add(1) is called but
+// GetNar's ctx.Done() early-return path never calls ds.wg.Done(). This leaves
+// pullNarIntoStore.func1 blocked at ds.wg.Wait() forever, causing
+// c.Close() → backgroundWG.Wait() to hang indefinitely.
+func TestGetNarCloseDoesNotHangAfterContextCancelledBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	c, _, _, _, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	entry := testdata.Nar5
+
+	ts := testdata.NewTestServer(t, 1)
+	t.Cleanup(ts.Close)
+
+	// Signal when the download goroutine's HTTP request arrives. The server
+	// responds normally (not hung) so getNarFromUpstream succeeds, the cleanup
+	// goroutine is launched into backgroundWG, and it will call ds.wg.Wait().
+	serverReceivedNar := make(chan struct{})
+
+	var serverReceivedOnce sync.Once
+
+	handlerIdx := ts.AddMaybeHandler(func(_ http.ResponseWriter, r *http.Request) bool {
+		if r.URL.Path == "/nar/"+entry.NarHash+".nar.xz" {
+			serverReceivedOnce.Do(func() { close(serverReceivedNar) })
+		}
+
+		return false // let the default handler serve the response
+	})
+	defer ts.RemoveMaybeHandler(handlerIdx)
+
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), nil)
+	require.NoError(t, err)
+
+	c.AddUpstreamCaches(newContext(), uc)
+
+	select {
+	case <-c.GetHealthChecker().Trigger():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for upstream health check")
+	}
+
+	// Pre-cancel ctxA: when GetNar enters the select, ctx.Done() is already
+	// closed while ds.start is not yet (download hasn't begun), so GetNar takes
+	// the ctx.Done() early-return path without calling ds.wg.Done() (the bug).
+	ctxA, cancelA := context.WithCancel(newContext())
+	cancelA()
+
+	nu := nar.URL{Hash: entry.NarHash, Compression: entry.NarCompression}
+
+	_, _, r, _ := c.GetNar(ctxA, nu)
+	if r != nil {
+		r.Close()
+	}
+
+	// Wait for the download goroutine to reach the upstream server. At this
+	// point getNarFromUpstream will succeed, the cleanup goroutine will be added
+	// to backgroundWG, and it will eventually call ds.wg.Wait() — blocking
+	// forever if ds.wg.Done() was never called.
+	select {
+	case <-serverReceivedNar:
+	case <-time.After(10 * time.Second):
+		t.Fatal("download goroutine never reached the upstream server")
+	}
+
+	// c.Close() must not hang. Without the fix, ds.wg count=1 (never
+	// decremented), so the cleanup goroutine blocks at ds.wg.Wait() and
+	// backgroundWG never drains.
+	runWithTimeout(t, 10*time.Second, "c.Close() must not hang after ctx cancelled before ds.start", c.Close)
+}
+
 // TestConcurrentDownloadCancelStress runs testConcurrentDownloadCancelOneClientOthersContinue
 // 50 times in sequence to surface the once-in-CI hang described in ncps #1252.
 // Skipped in short mode (-short) to avoid adding wall time to the normal test suite.

--- a/pkg/cache/coordination_internal_test.go
+++ b/pkg/cache/coordination_internal_test.go
@@ -1,0 +1,273 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	locklocal "github.com/kalbasit/ncps/pkg/lock/local"
+
+	"github.com/kalbasit/ncps/pkg/cache/upstream"
+	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
+	"github.com/kalbasit/ncps/pkg/storage/local"
+	"github.com/kalbasit/ncps/testdata"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// takeoverLocker is a test lock.Locker that simulates a distributed lock held
+// by another replica. While a key is "blocked", Lock returns an error
+// ("lock already taken"), mirroring the Redis locker's behavior under
+// contention. Once release() is called, Lock for that key succeeds again,
+// modelling the holder finishing or failing and releasing the lock.
+//
+// Intra-process download de-duplication is provided by the cache's own
+// upstreamJobs map, so this mock intentionally does NOT enforce mutual
+// exclusion — it only controls when acquisition succeeds.
+var errLockTaken = errors.New("lock already taken")
+
+type takeoverLocker struct {
+	mu      sync.Mutex
+	blocked map[string]bool
+}
+
+func newTakeoverLocker() *takeoverLocker {
+	return &takeoverLocker{blocked: make(map[string]bool)}
+}
+
+func (l *takeoverLocker) block(key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.blocked[key] = true
+}
+
+func (l *takeoverLocker) release(key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	delete(l.blocked, key)
+}
+
+func (l *takeoverLocker) Lock(_ context.Context, key string, _ time.Duration) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.blocked[key] {
+		return fmt.Errorf("%w: %s", errLockTaken, key)
+	}
+
+	return nil
+}
+
+func (l *takeoverLocker) Unlock(_ context.Context, _ string) error { return nil }
+
+func (l *takeoverLocker) TryLock(_ context.Context, key string, _ time.Duration) (bool, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return !l.blocked[key], nil
+}
+
+func (l *takeoverLocker) Extend(_ context.Context, _ string) error { return nil }
+
+// setupTakeoverCache builds a cache wired to a takeoverLocker as its download
+// locker and a real upstream test server, with a short download lock TTL so the
+// coordination give-up bound is reached quickly in tests.
+func setupTakeoverCache(t *testing.T) (*Cache, *takeoverLocker) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "cache-coord-")
+	require.NoError(t, err)
+
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
+	dbClient, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+
+	localStore, err := local.New(newContext(), dir)
+	require.NoError(t, err)
+
+	locker := newTakeoverLocker()
+	cacheLocker := locklocal.NewRWLocker()
+
+	// Short download lock TTL keeps the give-up bound small. The coordination
+	// give-up bound is max(downloadLockTTL, downloadPollTimeout) = 2s here, so a
+	// waiter that never gets to take over gives up (with a cache miss) quickly.
+	c, err := New(newContext(), cacheName, dbClient, localStore, localStore, localStore, "",
+		locker, cacheLocker, 2*time.Second, 2*time.Second, cacheLockTTL)
+	require.NoError(t, err)
+
+	ts := testdata.NewTestServer(t, 40)
+
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
+		PublicKeys: testdata.PublicKeys(),
+	})
+	require.NoError(t, err)
+
+	c.AddUpstreamCaches(newContext(), uc)
+	c.SetRecordAgeIgnoreTouch(0)
+
+	// Wait for upstream caches to become available.
+	<-c.GetHealthChecker().Trigger()
+
+	t.Cleanup(func() {
+		c.Close()
+		_ = dbClient.Close()
+		ts.Close()
+		os.RemoveAll(dir)
+	})
+
+	return c, locker
+}
+
+// TestCoordinateDownloadTakesOverNAR asserts that when a replica fails to
+// acquire the NAR download lock (held by another replica) and the holder then
+// releases the lock without producing the asset, the waiter takes over the
+// download and serves the NAR rather than returning an error (HTTP 500).
+func TestCoordinateDownloadTakesOverNAR(t *testing.T) {
+	t.Parallel()
+
+	c, locker := setupTakeoverCache(t)
+
+	narKey := narJobKey(testdata.Nar1.NarHash)
+
+	// Simulate another replica holding the NAR download lock from the start, so
+	// neither the narinfo-triggered background pre-pull nor the explicit GetNar
+	// below can acquire it until we release.
+	locker.block(narKey)
+
+	// Populate the narinfo (its lock key is not blocked) so GetNar can resolve
+	// the NAR.
+	_, err := c.GetNarInfo(newContext(), testdata.Nar1.NarInfoHash)
+	require.NoError(t, err)
+
+	type result struct {
+		body []byte
+		err  error
+	}
+
+	resCh := make(chan result, 1)
+
+	nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
+
+	go func() {
+		_, _, r, getErr := c.GetNar(newContext(), nu)
+		if getErr != nil {
+			resCh <- result{err: getErr}
+
+			return
+		}
+
+		defer r.Close()
+
+		body, readErr := io.ReadAll(r)
+		resCh <- result{body: body, err: readErr}
+	}()
+
+	// Give GetNar time to fail the initial acquisition and enter the
+	// poll-and-reacquire fallback, then let the "holder" release the lock.
+	time.Sleep(500 * time.Millisecond)
+	locker.release(narKey)
+
+	select {
+	case res := <-resCh:
+		require.NoError(t, res.err,
+			"a lock-losing waiter must take over the download and serve the NAR, not return an error (500)")
+		assert.Equal(t, testdata.Nar1.NarText, string(res.body))
+	case <-time.After(8 * time.Second):
+		t.Fatal("GetNar did not complete after the download lock was released")
+	}
+}
+
+// TestCoordinateDownloadNarInfoMissReturnsNotFound asserts that when a replica
+// fails to acquire the narinfo download lock and the narinfo is genuinely
+// absent upstream, the waiter resolves to a cache miss (storage.ErrNotFound,
+// which the server maps to HTTP 404) rather than the coordination error that
+// the server maps to HTTP 500.
+func TestCoordinateDownloadNarInfoMissReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	c, locker := setupTakeoverCache(t)
+
+	const hash = "doesnotexist"
+
+	niKey := narInfoJobKey(hash)
+	locker.block(niKey)
+
+	resCh := make(chan error, 1)
+
+	go func() {
+		_, err := c.GetNarInfo(newContext(), hash)
+		resCh <- err
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+	locker.release(niKey)
+
+	select {
+	case err := <-resCh:
+		require.Error(t, err)
+		require.ErrorIs(t, err, storage.ErrNotFound,
+			"a lock-losing waiter for a missing narinfo must return a cache miss (404), not a coordination error (500)")
+	case <-time.After(8 * time.Second):
+		t.Fatal("GetNarInfo did not complete after the download lock was released")
+	}
+}
+
+// TestCoordinateDownloadNARGiveUpReturnsNotFound asserts that when a replica
+// fails to acquire the NAR download lock and the holder neither produces the
+// asset nor releases the lock within the give-up bound (a stuck or
+// legitimately-slow holder still refreshing its lock), the waiter returns a
+// cache miss (storage.ErrNotFound, which the server maps to HTTP 404) rather
+// than the coordination error that the server maps to HTTP 500.
+func TestCoordinateDownloadNARGiveUpReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	c, locker := setupTakeoverCache(t)
+
+	narKey := narJobKey(testdata.Nar1.NarHash)
+
+	// Hold the NAR download lock for the entire test: the waiter can neither
+	// observe the asset (it is never produced) nor re-acquire the lock, so it
+	// must hit the give-up bound and degrade to a cache miss — never a 500.
+	locker.block(narKey)
+
+	// Populate the narinfo (its lock key is not blocked) so GetNar proceeds to
+	// the NAR download coordination.
+	_, err := c.GetNarInfo(newContext(), testdata.Nar1.NarInfoHash)
+	require.NoError(t, err)
+
+	resCh := make(chan error, 1)
+
+	nu := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
+
+	go func() {
+		_, _, r, getErr := c.GetNar(newContext(), nu)
+		if r != nil {
+			r.Close()
+		}
+
+		resCh <- getErr
+	}()
+
+	select {
+	case err := <-resCh:
+		require.Error(t, err)
+		require.ErrorIs(t, err, storage.ErrNotFound,
+			"a lock-losing waiter that gives up must return a cache miss (404), not a coordination error (500)")
+	case <-time.After(8 * time.Second):
+		t.Fatal("GetNar did not complete within the give-up bound")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the HTTP 500s seen during concurrent `nix` pulls against a
multi-replica ncps (the `failed to acquire download lock and timeout
polling for completion` errors).

When a replica failed to acquire the distributed download lock, it fell
into a poll-only loop that watched solely for the asset to appear. If the
lock holder's download failed (e.g. an upstream HTTP/2 reset) or simply
ran past the fixed poll timeout, the waiter timed out and returned the
coordination error → HTTP 500. Nix treats 500 as a hard error and retries
it up to 5×, amplifying load during exactly the concurrent-pull bursts
that request coalescing exists to smooth.

### What changed

- Rework the cross-pod fallback in `coordinateDownload` into a
  **poll-or-reacquire** loop (extracted to `pollForDownloadOrTakeOver`):
  each tick checks for the asset **and** re-attempts lock acquisition.
  - Asset appears → holder succeeded, serve it.
  - Lock re-acquired → the previous holder finished or failed without
    producing the asset, so we **take over** as the sole downloader. The
    `upstreamJobs` map and the lock keep downloads serialized, so the
    concurrent-CDC path is never exercised.
  - Wait up to `max(downloadLockTTL, downloadPollTimeout)` so a
    legitimately slow holder is not abandoned, then give up with a clean
    cache miss (`storage.ErrNotFound` → **HTTP 404**) so Nix falls back to
    another substituter instead of retrying a 500. Caller cancellation
    still surfaces as a context error.
- Add the `ncps_download_coordination_fallback_total` counter
  (`outcome=served_by_peer|take_over|give_up|caller_canceled`) plus
  structured logs so operators can see how contention resolves.
- Also includes earlier fixes on this branch balancing `ds.wg` on
  `GetNar` early returns.

Follow-up filed: #1289 (serve a whole NAR from shared storage during CDC
chunking instead of the progressive chunk stream).

## Test plan

- [x] New deterministic mock-locker tests (RED→GREEN): take-over serves
      the NAR, narinfo miss → 404, NAR give-up → 404
      (`pkg/cache/coordination_internal_test.go`).
- [x] `task fmt` (clean), `task lint` (0 issues), `task test` pass.
- [x] `task test:auto` — full suite incl. the Redis-backed distributed
      cohort — passes.