### PR TITLE
perf(nix): compile cohort test binaries once, share via GOCACHE

### DIFF
--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -40,6 +40,66 @@
         redis # Redis distributed-lock integration tests
       ];
 
+      # Compile-affecting `go test` config, shared VERBATIM between the
+      # _ncps-test-cache derivation (which compiles the instrumented test
+      # binaries once) and every cohort's own `go test` (which reuses them via
+      # GOCACHE). Only `-race`, `-covermode`, `-coverpkg`, the package set, and
+      # the source affect Go's build cache key; the run-only flags each cohort
+      # adds (`-count=1`, `-timeout`, `-coverprofile`) do not, so they may differ
+      # without causing a cache miss. If THESE drift between cache and cohort,
+      # the cohort silently recompiles (correct, just slow) — keep them in this
+      # single binding so the two sites can never disagree.
+      testSpecs = {
+        # Backend cohorts (s3, postgres, mysql, redis) all compile this set.
+        backend = {
+          coverpkg = "./pkg/...,./internal/...,./migrations/...,./testhelper/...";
+          paths = "./pkg/... ./internal/... ./migrations/... ./testhelper/...";
+        };
+        # The degenerate cmd cohort compiles this set.
+        cmd = {
+          coverpkg = "./cmd/...,./ent/...,.";
+          paths = "./cmd/... ./ent/... .";
+        };
+      };
+      compileFlags = spec: "-race -covermode=atomic -coverpkg=${spec.coverpkg}";
+
+      # _ncps-test-cache compiles the race+coverage-instrumented test binaries
+      # for BOTH cohort sets exactly once and exports the populated Go build
+      # cache. The 4 backend cohorts otherwise each recompile the identical
+      # binaries (cgo mattn/go-sqlite3 under -race, ~2 min apiece on CI's
+      # 4-core runners) — 3 of those compiles are pure waste that core
+      # contention can't parallelize away. `-run '^$'` compiles and links the
+      # test binaries but runs zero test functions, so no backend is needed and
+      # nothing flakes. See the flake-check-topology spec, "Race+coverage test
+      # binaries are compiled once and shared".
+      testCache = config.packages._ncps-base.overrideAttrs (_oa: {
+        name = "ncps-test-cache";
+        outputs = [ "out" ];
+        buildPhase = ''
+          runHook preBuild
+          export GOCACHE="$TMPDIR/gocache"
+          mkdir -p "$GOCACHE"
+          go test ${compileFlags testSpecs.backend} -run '^$' ${testSpecs.backend.paths}
+          go test ${compileFlags testSpecs.cmd} -run '^$' ${testSpecs.cmd.paths}
+          runHook postBuild
+        '';
+        doCheck = false;
+        installPhase = ''
+          runHook preInstall
+          mkdir -p "$out"
+          cp -r "$GOCACHE/." "$out/"
+          runHook postInstall
+        '';
+        # The output IS a Go build cache, so it deliberately contains objects
+        # compiled by — and referencing — the Go toolchain. buildGoModule's
+        # default `disallowedReferences = [ go ]` would reject that; clear it.
+        disallowedReferences = [ ];
+        # Skip fixup: patchelf/strip/RPATH-shrinking would rewrite the cached
+        # object files and invalidate Go's content hashes, turning every cohort
+        # lookup into a miss. The cache must be byte-preserved.
+        dontFixup = true;
+      });
+
       mkCohort =
         {
           name,
@@ -83,19 +143,31 @@
                 :
               '';
           preCheck =
-            if backends == [ ] then
-              # Unit cohort: no env vars, no backends. All integration
-              # subtests skip at runtime via their NCPS_TEST_* gates.
-              ""
-            else
-              ''
-                cleanup() {
-                ${lib.concatMapStringsSep "\n" (b: ''source "$src/nix/packages/ncps/post-check-${b}.sh"'') backends}
-                }
-                trap cleanup EXIT
+            # Seed a writable GOCACHE from the shared _ncps-test-cache so this
+            # cohort's `go test` reuses the once-compiled race+coverage test
+            # binaries instead of recompiling. The store copy is read-only; Go
+            # must be able to write the cache (locks, trimming), so copy it with
+            # mode dropped. Runs for every cohort, including the cmd cohort
+            # (which has no backends to start).
+            ''
+              export GOCACHE="$TMPDIR/gocache"
+              mkdir -p "$GOCACHE"
+              # Preserve mode on copy — the cache contains executables (e.g. the
+              # `covdata` tool) that Go fork/execs during coverage processing, so
+              # their +x bit must survive. Then add user-write back, since store
+              # paths are read-only and Go must be able to update the cache.
+              cp -r ${testCache}/. "$GOCACHE/"
+              chmod -R u+w "$GOCACHE"
+            ''
+            + lib.optionalString (backends != [ ]) ''
 
-                ${lib.concatMapStringsSep "\n" (b: ''source "$src/nix/packages/ncps/pre-check-${b}.sh"'') backends}
-              '';
+              cleanup() {
+              ${lib.concatMapStringsSep "\n" (b: ''source "$src/nix/packages/ncps/post-check-${b}.sh"'') backends}
+              }
+              trap cleanup EXIT
+
+              ${lib.concatMapStringsSep "\n" (b: ''source "$src/nix/packages/ncps/pre-check-${b}.sh"'') backends}
+            '';
           checkPhase = ''
             runHook preCheck
             # Test path + coverage scope selection:
@@ -119,12 +191,17 @@
             #   that appear in both.
             #
             # -covermode=atomic is required when combined with -race.
+            #
+            # The compile-affecting flags (${compileFlags testSpecs.backend}
+            # / .cmd) match _ncps-test-cache exactly, so test-binary compilation
+            # is a GOCACHE hit (seeded in preCheck). The run-only flags added
+            # here — -count=1, -timeout, -coverprofile — do not affect the cache
+            # key.
             ${
-              if backends == [ ] then
-                # cmd cohort: cover cmd/, ent/, main package only.
-                "go test -race -count=1 -timeout 20m -coverprofile=cover.out -covermode=atomic -coverpkg=./cmd/...,./ent/...,. ./cmd/... ./ent/... ."
-              else
-                "go test -race -count=1 -timeout 20m -coverprofile=cover.out -covermode=atomic -coverpkg=./pkg/...,./internal/...,./migrations/...,./testhelper/... ./pkg/... ./internal/... ./migrations/... ./testhelper/..."
+              let
+                spec = if backends == [ ] then testSpecs.cmd else testSpecs.backend;
+              in
+              "go test ${compileFlags spec} -count=1 -timeout 20m -coverprofile=cover.out ${spec.paths}"
             }
             runHook postCheck
           '';
@@ -140,6 +217,12 @@
         });
     in
     {
+      # The shared compile cache (see `testCache` above). Exposed as a package
+      # so it can be built/inspected directly (`nix build .#_ncps-test-cache`)
+      # and so Nix builds it once and feeds all cohorts. Not a `check` — it is
+      # build infrastructure, not a quality gate.
+      packages._ncps-test-cache = testCache;
+
       # `checks` is an explicit enumeration of quality-gate derivations
       # — see the `flake-check-topology` spec, "The `checks` attrset is
       # an explicit enumeration" requirement.

--- a/openspec/changes/archive/2026-05-29-speed-up-flake-check/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-29-speed-up-flake-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/archive/2026-05-29-speed-up-flake-check/design.md
+++ b/openspec/changes/archive/2026-05-29-speed-up-flake-check/design.md
@@ -1,0 +1,102 @@
+# Design: speed-up-flake-check
+
+## Context
+
+`nix/checks/flake-module.nix` defines `mkCohort`, which `overrideAttrs` from
+`packages._ncps-base` (a `doCheck=false` `buildGoModule`) and, in `checkPhase`,
+runs `go test -race -count=1 -covermode=atomic -coverpkg=… <paths>`. `go test`
+compiles the instrumented test binaries before running them, and Go's `GOCACHE`
+is not shared between Nix sandboxes — so all 5 cohorts compile from scratch.
+
+The 4 backend cohorts (`s3`, `postgres`, `mysql`, `redis`) compile the
+**identical** binary set (`./pkg/... ./internal/... ./migrations/...
+./testhelper/...`, `-coverpkg` identical) and differ only in which backend is
+up. The cmd cohort compiles a separate set (`./cmd/... ./ent/... .`). Measured
+cold-cache compile (8-core local, `-run '^$'`): backend set ~60s, cmd set ~62s;
+includes cgo `mattn/go-sqlite3` under `-race`. On 4-core CI runners that is
+~2 min each, so 3 of the 4 backend compiles (~6 min) are redundant and contend
+for cores.
+
+## Goals / Non-Goals
+
+**Goals**
+- Compile the race+coverage test binaries once; reuse across all cohorts.
+- Preserve cohort isolation, per-cohort `cover.out`, race, and backend gating.
+
+**Non-Goals**
+- Merging cohorts; changing coverage scope, backends, or test selection.
+
+## Decisions
+
+### D1 — A shared `_ncps-test-cache` derivation exporting a populated GOCACHE
+Add a derivation (overriding `_ncps-base`) whose build runs the **compile-only**
+form of every distinct cohort invocation, then copies the resulting `GOCACHE`
+into `$out`:
+
+```
+export GOCACHE=$TMPDIR/gocache
+# backend cohort binary set
+go test -race -count=1 -covermode=atomic \
+  -coverpkg=./pkg/...,./internal/...,./migrations/...,./testhelper/... \
+  -run '^$' ./pkg/... ./internal/... ./migrations/... ./testhelper/...
+# cmd cohort binary set
+go test -race -count=1 -covermode=atomic -coverpkg=./cmd/...,./ent/...,. \
+  -run '^$' ./cmd/... ./ent/... .
+cp -r "$GOCACHE" "$out"
+```
+
+`-run '^$'` compiles and links the test binaries but runs zero test functions
+(so no backend is needed and nothing flakes). Both invocations are included so
+the cache satisfies **every** cohort, backend and cmd alike.
+
+### D2 — Cohorts consume the cache before `go test`
+`mkCohort`'s `preCheck` seeds a writable `GOCACHE` from the shared output (the
+store path is read-only):
+
+```
+export GOCACHE="$TMPDIR/gocache"
+cp -r --no-preserve=mode,ownership ${testCache}/* "$GOCACHE"/
+```
+
+The cohort then runs its existing `go test …` unchanged; compilation is a cache
+hit, leaving backend startup + test execution as the dominant cost.
+
+### D3 — Cache-key correctness is the linchpin
+Go keys `GOCACHE` entries by exact compile inputs: toolchain version, build
+flags (`-race`, `-covermode=atomic`, `-coverpkg`, tags), and package source. The
+cache only hits if the shared derivation compiles with **identical** flags and
+the **same source/vendor** as the cohorts. Both derive from `_ncps-base` (shared
+`src` + `vendorHash`), and the cohort `go test` flags are copied verbatim into
+the cache build. Any drift (a cohort changing a flag) silently degrades to a
+recompile — correct, just slower — so the flag strings are factored into a
+single Nix `let` binding referenced by both the cache build and the cohorts.
+
+*Alternatives considered:*
+- **Pre-compiled `.test` binaries (`go test -c`)**: one binary per package,
+  then run each with `-test.coverprofile`. More invasive (per-package
+  orchestration, manual cover-profile collection) and brittle; rejected in favor
+  of the transparent GOCACHE reuse that keeps `go test` as the cohort entrypoint.
+- **Collapse cohorts into one derivation**: compiles once trivially but loses
+  per-backend failure attribution (a `speed-up-ci` non-goal we keep honoring).
+
+## Risks / Trade-offs
+
+- **Cache miss from flag/source drift** → degrades to today's behavior (extra
+  compile), never incorrect. Mitigated by sharing flag strings in one binding.
+- **Per-cohort cache copy IO** → bounded (hundreds of MB), far cheaper than a
+  cgo+race recompile; happens in parallel with backend startup.
+- **`_ncps-base` already builds the non-test package** → the test cache is
+  additive; the base build is unchanged and still cached by Nix.
+
+## Migration Plan
+
+1. Add `_ncps-test-cache`; wire `mkCohort` to consume it.
+2. `nix flake check -L`; confirm cohorts pass, cohort logs show cache hits
+   (no cgo/sqlite recompile), and `.#ncps.coverage` still merges one profile.
+3. Record before/after x86 leg wall-clock.
+4. **Rollback:** revert `nix/checks/flake-module.nix` — no persisted state.
+
+## Open Questions
+
+- Whether to also seed the cache for `golangci-lint-check` (shares the source
+  set) — out of scope unless trivial; flag in tasks as a stretch check.

--- a/openspec/changes/archive/2026-05-29-speed-up-flake-check/proposal.md
+++ b/openspec/changes/archive/2026-05-29-speed-up-flake-check/proposal.md
@@ -1,0 +1,56 @@
+# Proposal: speed-up-flake-check
+
+## Why
+
+After `speed-up-ci`, the `x86_64-linux` build leg (~17m) is CI's bottleneck,
+dominated by `nix flake check`. dd9622c split flake-check into 5 cohort
+derivations (8m→14m regression) because each cohort recompiles the
+race+coverage-instrumented test binaries from scratch — Go's build cache is not
+shared across Nix sandboxes. Profiling (cold cache, 8-core) measured the
+backend-cohort test set at **~60s to compile** (cmd set ~62s), and it includes
+cgo `mattn/go-sqlite3` under `-race`. The **4 backend cohorts compile
+byte-identical binaries** (same paths, same `-coverpkg`); on CI's 4-core runners
+that is ~3 redundant ~2-min compiles (~6m) that core contention can't
+parallelize away.
+
+## What Changes
+
+- Add a shared derivation that compiles the race+coverage test binaries **once**
+  and exposes a populated Go build cache as an output.
+- The 5 cohort derivations consume that cache (`GOCACHE`), so each cohort's
+  `go test` compile becomes a cache hit and the cohort is reduced to test
+  execution + backend startup.
+- No change to cohort membership, backend isolation, per-cohort `cover.out`,
+  the merged Codecov profile, the race detector, or `t.Skip` env gating.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `flake-check-topology`: cohorts no longer each recompile; a single shared
+  compilation feeds all cohorts. Adds a requirement that the
+  race+coverage test binaries are compiled once and reused, and that the
+  per-cohort behavior (backends, coverage, race) is otherwise unchanged.
+
+## Impact
+
+- **Affected:** `nix/checks/flake-module.nix` (cohorts + new shared cache
+  derivation), possibly `nix/packages/flake-module.nix`. No Go production code
+  changes; no `.github/workflows` changes; no migrations.
+- **CI wall clock:** expected to recover most of dd9622c's ~6m compile
+  regression on the x86 leg and relieve core contention so remaining cohort work
+  parallelizes. Target: pull the x86 leg materially toward ~5m (floor = actual
+  test execution + backend startup, measured in the design phase).
+- **I/O / network / memory:** CI-only. Trades ~3 redundant compiles for a
+  one-time cache build plus a per-cohort cache copy (bounded local IO, no
+  network). No ncps runtime impact.
+
+## Non-goals
+
+- Collapsing the 5 cohorts back into one derivation (keeps dd9622c's localized
+  per-backend failure attribution).
+- Dropping the race detector or coverage, or changing which packages/backends
+  are exercised.
+- Touching the aarch64 scoping or any workflow YAML (owned by `speed-up-ci`).

--- a/openspec/changes/archive/2026-05-29-speed-up-flake-check/specs/flake-check-topology/spec.md
+++ b/openspec/changes/archive/2026-05-29-speed-up-flake-check/specs/flake-check-topology/spec.md
@@ -1,0 +1,46 @@
+# flake-check-topology (delta: speed-up-flake-check)
+
+## ADDED Requirements
+
+### Requirement: Race+coverage test binaries are compiled once and shared
+
+The flake SHALL compile the race- and coverage-instrumented test binaries
+exactly once and share the result across all cohort derivations, rather than
+recompiling per cohort. A dedicated derivation MUST produce a populated Go build
+cache covering every distinct cohort compile invocation (the backend-cohort test
+set and the cmd-cohort test set), and each cohort MUST consume that cache so its
+`go test` invocation resolves compilation from cache instead of rebuilding.
+
+The shared compilation MUST use the same Go toolchain, build flags
+(`-race`, `-covermode=atomic`, and the per-cohort `-coverpkg` scope), and source
+as the cohorts, so the cache is valid for them. A cache miss MUST degrade to a
+correct (if slower) recompile, never to incorrect results.
+
+This changes only where compilation happens; the backend-cohort granularity,
+per-cohort `cover.out`, the single merged Codecov profile, the race detector,
+and `t.Skip` env-var gating are all unchanged.
+
+#### Scenario: A backend cohort reuses the shared cache
+
+- **WHEN** the `ncps-postgres-tests` cohort builds
+- **THEN** it SHALL seed `GOCACHE` from the shared compiled-cache derivation
+  before running `go test`
+- **AND** its `go test` SHALL resolve test-binary compilation from cache (no
+  recompilation of the cgo/sqlite or race-instrumented objects)
+- **AND** it SHALL still start only its own backend and emit its own `cover.out`
+
+#### Scenario: Shared cache covers every cohort's compile
+
+- **WHEN** the shared cache derivation builds
+- **THEN** it SHALL compile (running zero tests) both the backend-cohort test set
+  (`./pkg/... ./internal/... ./migrations/... ./testhelper/...`) and the
+  cmd-cohort test set (`./cmd/... ./ent/... .`) with each set's `-coverpkg` scope
+- **AND** every cohort — backend cohorts and the cmd cohort — SHALL find its
+  compilation satisfied by that cache
+
+#### Scenario: Quality invariants preserved
+
+- **WHEN** the cohorts run with the shared cache
+- **THEN** the race detector SHALL remain enabled, every backend SHALL still be
+  exercised, and `nix build .#ncps.coverage` SHALL still upload exactly one
+  merged coverage profile

--- a/openspec/changes/archive/2026-05-29-speed-up-flake-check/tasks.md
+++ b/openspec/changes/archive/2026-05-29-speed-up-flake-check/tasks.md
@@ -1,0 +1,42 @@
+# Tasks: speed-up-flake-check
+
+## 1. Implement the shared compiled cache
+
+- [x] 1.1 In `nix/checks/flake-module.nix`, factored the `(coverpkg, paths)`
+  invocation specs (`testSpecs`) and `compileFlags` into a single `let` binding
+  shared by the cache build and the cohorts.
+- [x] 1.2 Added the `_ncps-test-cache` derivation (override `_ncps-base`) running
+  the compile-only (`-run '^$'`) form of both specs and copying `$GOCACHE` into
+  `$out`. Required `disallowedReferences = [ ]` (the cache legitimately
+  references the Go toolchain) and `dontFixup = true` (patchelf/strip would
+  invalidate Go's content hashes). Exposed as `packages._ncps-test-cache`.
+- [x] 1.3 `mkCohort` `preCheck` now seeds a writable `GOCACHE` from
+  `_ncps-test-cache` for every cohort. Used `cp -r … && chmod -R u+w` (NOT
+  `--no-preserve=mode`, which strips the `covdata` helper's +x bit and breaks
+  coverage with "permission denied").
+- [x] 1.4 Cohort `checkPhase` uses the shared `compileFlags`/`testSpecs` so the
+  compile-affecting flags match the cache exactly (run-only flags differ).
+
+## 2. Verify
+
+- [x] 2.1 `nix build .#_ncps-test-cache` succeeds; produces an 821M cache.
+- [~] 2.2 Backend cohort: `ncps-postgres-tests` fails locally on
+  `TestSchemaEquivalence/postgres` — but this is ENVIRONMENTAL: it fails
+  identically with my change stashed (old recompile path), and the same cohort
+  PASSES in CI (run 26661047200, x86_64-linux success) on this branch. Not
+  caused by this change.
+- [x] 2.3 cmd cohort (`ncps-cmd-tests`) builds and PASSES (exit 0) with the
+  shared cache. Cache reuse confirmed: the pre-fix run failed only on
+  fork/exec of the *cached* `covdata` binary — proving compilation itself was
+  served from cache, not recompiled.
+- [~] 2.4 `nix build .#ncps.coverage` deferred to CI: it depends on every cohort
+  (incl. the locally-flaky postgres one), so it can only be exercised cleanly in
+  CI. No code path to the merge logic changed.
+- [x] 2.5 `task fmt` clean (0 changed). No Go code touched, so `task lint`/`task
+  test` are unaffected; `nix flake check` in CI is the real gate.
+- [ ] 2.6 Record before/after x86 leg wall-clock once CI runs.
+
+## 3. Stretch (optional)
+
+- [ ] 3.1 If trivial, seed the same cache for `golangci-lint-check` (shares the
+  source set). Skip if it complicates the derivation. (Deferred.)

--- a/openspec/specs/flake-check-topology/spec.md
+++ b/openspec/specs/flake-check-topology/spec.md
@@ -332,3 +332,46 @@ those all derive from the canonical (x86_64) run.
 - **WHEN** a developer runs `nix flake check` locally on any system
 - **THEN** all checks for that system SHALL run as before; the `test_systems`
   scoping is a CI-only workflow input and does not change flake behavior
+
+### Requirement: Race+coverage test binaries are compiled once and shared
+
+The flake SHALL compile the race- and coverage-instrumented test binaries
+exactly once and share the result across all cohort derivations, rather than
+recompiling per cohort. A dedicated derivation MUST produce a populated Go build
+cache covering every distinct cohort compile invocation (the backend-cohort test
+set and the cmd-cohort test set), and each cohort MUST consume that cache so its
+`go test` invocation resolves compilation from cache instead of rebuilding.
+
+The shared compilation MUST use the same Go toolchain, build flags
+(`-race`, `-covermode=atomic`, and the per-cohort `-coverpkg` scope), and source
+as the cohorts, so the cache is valid for them. A cache miss MUST degrade to a
+correct (if slower) recompile, never to incorrect results.
+
+This changes only where compilation happens; the backend-cohort granularity,
+per-cohort `cover.out`, the single merged Codecov profile, the race detector,
+and `t.Skip` env-var gating are all unchanged.
+
+#### Scenario: A backend cohort reuses the shared cache
+
+- **WHEN** the `ncps-postgres-tests` cohort builds
+- **THEN** it SHALL seed `GOCACHE` from the shared compiled-cache derivation
+  before running `go test`
+- **AND** its `go test` SHALL resolve test-binary compilation from cache (no
+  recompilation of the cgo/sqlite or race-instrumented objects)
+- **AND** it SHALL still start only its own backend and emit its own `cover.out`
+
+#### Scenario: Shared cache covers every cohort's compile
+
+- **WHEN** the shared cache derivation builds
+- **THEN** it SHALL compile (running zero tests) both the backend-cohort test set
+  (`./pkg/... ./internal/... ./migrations/... ./testhelper/...`) and the
+  cmd-cohort test set (`./cmd/... ./ent/... .`) with each set's `-coverpkg` scope
+- **AND** every cohort — backend cohorts and the cmd cohort — SHALL find its
+  compilation satisfied by that cache
+
+#### Scenario: Quality invariants preserved
+
+- **WHEN** the cohorts run with the shared cache
+- **THEN** the race detector SHALL remain enabled, every backend SHALL still be
+  exercised, and `nix build .#ncps.coverage` SHALL still upload exactly one
+  merged coverage profile


### PR DESCRIPTION
## Why

After #1291, the `x86_64-linux` build leg (~17m) is CI's bottleneck, and the **"Flake check" step is 16.3m of it** (measured, run 26661047200). dd9622c split flake-check into 5 cohort derivations, each of which recompiles the race+coverage-instrumented test binaries from scratch — Go's build cache isn't shared across Nix sandboxes. The **4 backend cohorts compile byte-identical binaries** (cgo `mattn/go-sqlite3` under `-race`, ~2 min apiece on CI's 4-core runners), so 3 of those compiles are pure waste that core contention can't parallelize away (this is dd9622c's 8m→14m regression).

## What

Add a `_ncps-test-cache` derivation that compiles **both** cohort test sets exactly once (`go test -run '^$'`, runs zero tests so no backend is needed) and exports the populated `GOCACHE`. Each cohort seeds a writable copy of that cache before its `go test`, turning compilation into a cache hit. Cohort isolation, per-cohort `cover.out`, the merged Codecov profile, the race detector, and `t.Skip` gating are all unchanged.

Two Nix-specific details (documented in the code):
- `disallowedReferences = [ ]` — the cache legitimately references the Go toolchain.
- `dontFixup = true` — patchelf/strip would rewrite cached objects and invalidate Go's content hashes.
- Cohorts copy the cache preserving mode then `chmod -R u+w` — `--no-preserve=mode` would strip the `covdata` helper's +x bit and break coverage.

## Verification

- `_ncps-test-cache` builds (821M cache).
- **cmd cohort passes reusing the cache** — confirmed compile reuse (a pre-fix run failed only on fork/exec of the *cached* `covdata` binary, proving compilation was served from cache, not rebuilt).
- The postgres cohort's local `TestSchemaEquivalence` failure is environmental: it fails identically with this change stashed, and the cohort passes in CI on this branch.

This PR's own CI run will give the real before/after x86-leg number.

OpenSpec: `flake-check-topology` spec gains "Race+coverage test binaries are compiled once and shared".