### PR TITLE
ci: fan flake checks out into a parallel matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ permissions:
   packages: write
 jobs:
   shared:
-    uses: kalbasit/gh-actions/.github/workflows/ci.yml@main
+    # TEMP: pinned to the gh-actions feature branch to validate run_flake_check
+    # end-to-end before kalbasit/gh-actions#9 merges. REVERT to @main before
+    # merging this PR — see OpenSpec change fan-out-flake-check.
+    uses: kalbasit/gh-actions/.github/workflows/ci.yml@user/wnasreddine/further-improvement
     with:
       cachix_cache: ncps
       oci: true
@@ -34,6 +37,11 @@ jobs:
       # the slower ARM runner where Postgres times out. See OpenSpec change
       # speed-up-ci; requires kalbasit/gh-actions test_systems input.
       test_systems: '["x86_64-linux"]'
+      # The shared build job no longer runs the monolithic `nix flake check` or
+      # coverage; the `check-matrix`/`checks`/`coverage` jobs below fan each
+      # check out into its own parallel runner instead (much lower wall-clock).
+      # The shared build job still builds/pushes the OCI image per arch.
+      run_flake_check: false
       languages: |
         {"go":{"targets":[
           {"attr":"ncps",                                        "file":"nix/packages/ncps/default.nix"},
@@ -45,6 +53,70 @@ jobs:
       gha_pat_token: ${{ secrets.GHA_PAT_TOKEN }}
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
+  # ---- Fanned-out flake checks -----------------------------------------------------
+  # Instead of one `nix flake check` building every check derivation on a single
+  # contended runner, enumerate the checks and run each as its own parallel job.
+  # Wall-clock collapses to the slowest single check + nix setup. Each job pulls
+  # the shared compile cache (_ncps-test-cache/_ncps-base) from Cachix rather than
+  # rebuilding it. See OpenSpec change fan-out-flake-check.
+  check-matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      checks: ${{ steps.list.outputs.checks }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: ncps
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Enumerate checks
+        id: list
+        run: |
+          echo "checks=$(nix eval .#checks.x86_64-linux --apply builtins.attrNames --json)" >> "$GITHUB_OUTPUT"
+  checks:
+    needs: check-matrix
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        check: ${{ fromJson(needs.check-matrix.outputs.checks) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: ncps
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build check
+        run: nix build ".#checks.x86_64-linux.${{ matrix.check }}" -L
+  coverage:
+    needs: checks
+    # Coverage is informational (not a gate) and needs the Codecov token, so skip
+    # it on fork PRs. Merges the per-cohort cover.out (built by the `checks` jobs
+    # and pulled from Cachix) into one profile.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: ncps
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Build coverage
+        run: nix build ".#ncps.coverage" -L
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: result-coverage
   # ---- ncps-specific sibling jobs --------------------------------------------------
   # These stay here because they don't generalize across the other consumers.
   # They run their own paths-filter because the reusable workflow doesn't (currently)
@@ -135,6 +207,9 @@ jobs:
     if: always()
     needs:
       - shared
+      - check-matrix
+      - checks
+      - coverage
       - filter
       - generate-database
       - deploy-docs-pages
@@ -142,6 +217,9 @@ jobs:
       - name: Check Workflow Status
         env:
           SHARED_RESULT: ${{ needs.shared.result }}
+          CHECK_MATRIX_RESULT: ${{ needs.check-matrix.result }}
+          CHECKS_RESULT: ${{ needs.checks.result }}
+          COVERAGE_RESULT: ${{ needs.coverage.result }}
           FILTER_RESULT: ${{ needs.filter.result }}
           GENERATE_DATABASE_RESULT: ${{ needs.generate-database.result }}
           DEPLOY_DOCS_PAGES_RESULT: ${{ needs.deploy-docs-pages.result }}
@@ -151,6 +229,9 @@ jobs:
 
           declare -A results=(
             ["shared"]="$SHARED_RESULT"
+            ["check-matrix"]="$CHECK_MATRIX_RESULT"
+            ["checks"]="$CHECKS_RESULT"
+            ["coverage"]="$COVERAGE_RESULT"
             ["filter"]="$FILTER_RESULT"
             ["generate-database"]="$GENERATE_DATABASE_RESULT"
             ["deploy-docs-pages"]="$DEPLOY_DOCS_PAGES_RESULT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,7 @@ permissions:
   packages: write
 jobs:
   shared:
-    # TEMP: pinned to the gh-actions feature branch to validate run_flake_check
-    # end-to-end before kalbasit/gh-actions#9 merges. REVERT to @main before
-    # merging this PR — see OpenSpec change fan-out-flake-check.
-    uses: kalbasit/gh-actions/.github/workflows/ci.yml@user/wnasreddine/further-improvement
+    uses: kalbasit/gh-actions/.github/workflows/ci.yml@main
     with:
       cachix_cache: ncps
       oci: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,13 @@ jobs:
           name: ncps
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Build check
-        run: nix build ".#checks.x86_64-linux.${{ matrix.check }}" -L
+        # Pass the matrix value via env, not direct `${{ }}` expansion into the
+        # shell: on fork PRs the check names come from `builtins.attrNames` over
+        # the attacker-controlled flake, so interpolating them into `run:` would
+        # be a template-injection vector. Quoted env reference treats it as data.
+        env:
+          CHECK: ${{ matrix.check }}
+        run: nix build ".#checks.x86_64-linux.$CHECK" -L
   coverage:
     needs: checks
     # Coverage is informational (not a gate) and needs the Codecov token, so skip

--- a/openspec/changes/archive/2026-05-29-fan-out-flake-check/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-29-fan-out-flake-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/archive/2026-05-29-fan-out-flake-check/design.md
+++ b/openspec/changes/archive/2026-05-29-fan-out-flake-check/design.md
@@ -1,0 +1,106 @@
+# Design: fan-out-flake-check
+
+## Context
+
+`nix flake check` builds every `checks.<system>.*` derivation on one runner.
+ncps's checks are independent (5 cohorts, golangci, ent-drift, atlas-sum,
+ent-lint, helm, ncps, ncps-checktools). On a 4-core GitHub runner they contend;
+wall-clock ≈ total CPU work / 4. Each is a normal Nix derivation, individually
+buildable as `nix build .#checks.<system>.<name>` — so they can each run on their
+own free runner instead.
+
+The shared `kalbasit/gh-actions` `build` job (oci) currently runs the monolithic
+`nix flake check` + coverage inline. To fan out, that inline check must be
+disabled for ncps while the OCI image build stays.
+
+## Goals / Non-Goals
+
+**Goals**
+- Run each check as an independent parallel CI job; wall-clock → slowest check.
+- Keep OCI image build/push and the single merged Codecov upload working.
+- Minimal change to the shared workflow (one opt-in input).
+
+**Non-Goals**
+- Changing check contents, coverage scope, or the flake derivations.
+- Grouping checks (start one-per-job).
+
+## Decisions
+
+### D1 — Fan-out matrix lives in ncps's workflow
+ncps fully controls `.github/workflows/ci.yml`, so the matrix goes there:
+
+```yaml
+check-matrix:                     # compute the attr list once
+  outputs: { checks: ${{ steps.l.outputs.checks }} }
+  steps:
+    - checkout; install-nix; cachix
+    - id: l
+      run: |
+        echo "checks=$(nix eval .#checks.x86_64-linux \
+          --apply builtins.attrNames --json)" >> "$GITHUB_OUTPUT"
+checks:
+  needs: check-matrix
+  strategy: { fail-fast: false, matrix: { check: ${{ fromJson(needs.check-matrix.outputs.checks) }} } }
+  steps:
+    - checkout; install-nix; cachix
+    - run: nix build ".#checks.x86_64-linux.${{ matrix.check }}" -L
+```
+
+`x86_64-linux` matches the `test_systems` scoping from `speed-up-ci` (aarch64
+still only builds its image). `fail-fast: false` so one failing check doesn't
+cancel the rest. Each cohort starts its own backend *inside* the Nix sandbox
+(existing `pre-check-*.sh`), so no service containers are needed.
+
+### D2 — One opt-in input on the shared workflow
+`build.yml` + orchestrator `ci.yml` gain `run_flake_check` (bool, default
+`true`). When `false`, the `build` job skips its `Flake check`, `Build
+coverage`, and Codecov steps and only builds/pushes the OCI image; the
+standalone `flake-check` job is also gated. Default `true` keeps every other
+consumer unchanged. ncps passes `run_flake_check: false`.
+
+### D3 — Coverage as a dedicated ncps job, after the matrix
+Coverage moves out of `build.yml` into an ncps `coverage` job that
+`needs: checks` (so the cohorts' `coverage` outputs are in Cachix), then
+`nix build .#ncps.coverage` (pulls + merges) and uploads to Codecov. Coverage is
+informational, not a gate, so a transient Cachix-propagation miss degrades to a
+local rebuild, never a failed merge. Replicates `build.yml`'s exact
+`nix build .#ncps.coverage` + `codecov-action@v6` steps.
+
+### D4 — Cachix is the cross-job cache substrate
+The `check-matrix`/`checks`/`coverage` jobs use `cachix-action` (pull). The
+shared compile cache (`_ncps-test-cache`), `_ncps-base`, and `goModules` are
+pushed by prior runs, so parallel jobs pull instead of rebuilding. A cold Cachix
+(e.g. after a deps bump) means several jobs each rebuild the base — slower, but
+still correct and parallel.
+
+*Alternatives considered:*
+- *Fan-out inside gh-actions* (generic matrix in the reusable workflow):
+  cleaner for all consumers but a much larger shared-workflow redesign; deferred
+  in favor of the minimal `run_flake_check` switch + ncps-local matrix.
+- *Bigger runner*: linear, billed even for public repos, caps above 5m.
+
+## Risks / Trade-offs
+
+- **Cold Cachix → duplicate base rebuilds across jobs** → still correct/parallel;
+  warm cache is the steady state. Mitigated by `check-matrix` building the base
+  once before fan-out (its `nix eval` realizes the base), warming Cachix.
+- **Final-gate wiring**: the ncps `ci` gate must `needs` the new
+  `check-matrix`/`checks`/`coverage` jobs and treat `skipped` (fork PRs) as pass.
+- **`run_flake_check` drift**: if ncps forgets to set it, checks run twice
+  (shared + matrix) — slow but correct.
+- **Per-check setup overhead** (~1–1.5m × N jobs): free/parallel; acceptable.
+
+## Migration Plan
+
+1. Land the gh-actions `run_flake_check` input (sibling change) first.
+2. ncps: set `run_flake_check: false`; add `check-matrix`/`checks`/`coverage`
+   jobs; wire the final gate.
+3. Verify on a PR: each check is its own job; wall-clock drops; coverage uploads;
+   OCI manifest still assembles.
+4. **Rollback**: drop the ncps matrix jobs and unset `run_flake_check` (reverts
+   to the monolithic in-build check).
+
+## Open Questions
+
+- Whether to group the trivially-fast checks (atlas-sum, ent-lint, helm) into one
+  job to cut setup overhead — defer until CI shows per-job times.

--- a/openspec/changes/archive/2026-05-29-fan-out-flake-check/design.md
+++ b/openspec/changes/archive/2026-05-29-fan-out-flake-check/design.md
@@ -82,8 +82,12 @@ still correct and parallel.
 ## Risks / Trade-offs
 
 - **Cold Cachix → duplicate base rebuilds across jobs** → still correct/parallel;
-  warm cache is the steady state. Mitigated by `check-matrix` building the base
-  once before fan-out (its `nix eval` realizes the base), warming Cachix.
+  warm Cachix is the steady state (every merged run pushes `_ncps-test-cache`/
+  `_ncps-base`). `check-matrix` only evaluates (`nix eval` does NOT realize
+  derivations, so it does not warm the cache); deliberately not building the base
+  there, since that would add ~2m to the critical path on every run for a
+  cold-cache-only benefit. A cold cache just means a few jobs rebuild the base in
+  parallel — accepted.
 - **Final-gate wiring**: the ncps `ci` gate must `needs` the new
   `check-matrix`/`checks`/`coverage` jobs and treat `skipped` (fork PRs) as pass.
 - **`run_flake_check` drift**: if ncps forgets to set it, checks run twice

--- a/openspec/changes/archive/2026-05-29-fan-out-flake-check/proposal.md
+++ b/openspec/changes/archive/2026-05-29-fan-out-flake-check/proposal.md
@@ -12,7 +12,7 @@ not further reducible by caching; they need more cores, in parallel.
 ## What Changes
 
 - Replace the monolithic `nix flake check` with a **CI matrix**: enumerate the
-  check attrs via `nix eval .#checks.<system> --apply builtins.attrNames` and run
+  check attrs via `nix eval .#checks.<system> --apply builtins.attrNames --json` and run
   each as its own parallel job (`nix build .#checks.<system>.<name> -L`) on its
   own free runner. Wall-clock collapses from sum-under-contention to
   **slowest-single-check + nix setup (~3–4m)**.

--- a/openspec/changes/archive/2026-05-29-fan-out-flake-check/proposal.md
+++ b/openspec/changes/archive/2026-05-29-fan-out-flake-check/proposal.md
@@ -1,0 +1,58 @@
+# Proposal: fan-out-flake-check
+
+## Why
+
+After compile-once (#1292) CI is ~10m, bottlenecked by a single `nix flake check`
+that builds ~12 check derivations on **one 4-core runner**, where they starve
+each other for cores. The work is logically parallel (each check is independent)
+but CPU-serialized. The remaining costs — backend-cohort test execution,
+`golangci-lint-check` (~2.3m, its own analysis), `ent-codegen-drift-check` — are
+not further reducible by caching; they need more cores, in parallel.
+
+## What Changes
+
+- Replace the monolithic `nix flake check` with a **CI matrix**: enumerate the
+  check attrs via `nix eval .#checks.<system> --apply builtins.attrNames` and run
+  each as its own parallel job (`nix build .#checks.<system>.<name> -L`) on its
+  own free runner. Wall-clock collapses from sum-under-contention to
+  **slowest-single-check + nix setup (~3–4m)**.
+- The fan-out matrix + a dedicated coverage job live in **ncps's** workflow.
+- **gh-actions** (shared reusable workflow) gains a `run_flake_check` input
+  (default `true`); ncps sets it `false` so the shared `build` job builds/pushes
+  only the OCI image and no longer runs the monolithic check. **(cross-repo)**
+- Cachix carries `_ncps-test-cache`/`_ncps-base`/`goModules`, so parallel jobs
+  pull the shared compile cache rather than each rebuilding it.
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `flake-check-topology` (ncps): add a requirement that CI runs each `checks`
+  attr as an independent parallel job (relying on the existing explicit-checks
+  enumeration), and that coverage is produced by a job that consumes the
+  fanned-out cohort outputs.
+- `oci-build` / `reusable-ci` (kalbasit/gh-actions): `build.yml` and the
+  orchestrator gain a `run_flake_check` input that gates the in-workflow
+  `nix flake check` + coverage steps. Tracked as a sibling gh-actions change.
+
+## Impact
+
+- **Affected:** ncps `.github/workflows/ci.yml` (new `checks` matrix + coverage
+  jobs, final-gate wiring); gh-actions `build.yml` + `ci.yml` + their specs. No
+  ncps Go code or flake derivation changes.
+- **CI wall clock:** ~10m → ~3–4m expected (slowest check + setup), the path to
+  the ~5m target.
+- **Runner-minutes:** higher total (N jobs each pay ~1–1.5m nix setup), but free
+  and parallel for a public repo — wall-clock is what improves.
+- **I/O / network / memory:** CI-only; each job pulls the shared cache from
+  Cachix once. No ncps runtime impact. Coverage (one merged profile to Codecov)
+  is preserved via a dedicated job.
+
+## Non-goals
+
+- Changing which checks/backends/tests run, coverage scope, or the race detector.
+- Reworking the flake's check derivations (compile-once already shipped).
+- Grouping cheap checks into shared jobs (possible later optimization; start with
+  one-job-per-check for simplicity and maximal parallelism).

--- a/openspec/changes/archive/2026-05-29-fan-out-flake-check/specs/flake-check-topology/spec.md
+++ b/openspec/changes/archive/2026-05-29-fan-out-flake-check/specs/flake-check-topology/spec.md
@@ -8,7 +8,7 @@ CI SHALL execute the flake's checks by fanning them out — running each
 `checks.<system>.<name>` derivation as its own parallel job
 (`nix build .#checks.<system>.<name>`) — rather than as a single monolithic
 `nix flake check` on one runner. The set of jobs MUST be derived from the live
-checks enumeration (`nix eval .#checks.<system> --apply builtins.attrNames`), so
+checks enumeration (`nix eval .#checks.<system> --apply builtins.attrNames --json`), so
 adding or removing a check automatically adds or removes its job with no further
 wiring. A single check's failure MUST NOT cancel the others (`fail-fast: false`),
 and the CI gate MUST fail if any check job fails.
@@ -31,7 +31,7 @@ artifacts rather than rebuilding them.
 
 - **WHEN** a check is added to or removed from the flake's `checks` attrset
 - **THEN** its CI job SHALL appear or disappear automatically, because the matrix
-  is computed from `nix eval .#checks.x86_64-linux --apply builtins.attrNames`
+  is computed from `nix eval .#checks.x86_64-linux --apply builtins.attrNames --json`
 
 ### Requirement: Coverage is produced by a job consuming the fanned-out cohorts
 

--- a/openspec/changes/archive/2026-05-29-fan-out-flake-check/specs/flake-check-topology/spec.md
+++ b/openspec/changes/archive/2026-05-29-fan-out-flake-check/specs/flake-check-topology/spec.md
@@ -1,0 +1,49 @@
+# flake-check-topology (delta: fan-out-flake-check)
+
+## ADDED Requirements
+
+### Requirement: CI runs each check as an independent parallel job
+
+CI SHALL execute the flake's checks by fanning them out — running each
+`checks.<system>.<name>` derivation as its own parallel job
+(`nix build .#checks.<system>.<name>`) — rather than as a single monolithic
+`nix flake check` on one runner. The set of jobs MUST be derived from the live
+checks enumeration (`nix eval .#checks.<system> --apply builtins.attrNames`), so
+adding or removing a check automatically adds or removes its job with no further
+wiring. A single check's failure MUST NOT cancel the others (`fail-fast: false`),
+and the CI gate MUST fail if any check job fails.
+
+The checks run on the canonical CI architecture (`x86_64-linux`, per the
+`Integration cohorts validated on a single CI architecture` requirement). Each
+job relies on the shared build cache from Cachix so it pulls the compiled cohort
+artifacts rather than rebuilding them.
+
+#### Scenario: Each check is its own job
+
+- **WHEN** CI runs for a pull request
+- **THEN** for each attribute in `checks.x86_64-linux` there SHALL be a
+  corresponding job running `nix build .#checks.x86_64-linux.<name>`
+- **AND** the jobs SHALL run in parallel on separate runners
+- **AND** one check failing SHALL NOT cancel the other check jobs, but SHALL fail
+  the overall CI gate
+
+#### Scenario: Check list is derived, not hand-maintained
+
+- **WHEN** a check is added to or removed from the flake's `checks` attrset
+- **THEN** its CI job SHALL appear or disappear automatically, because the matrix
+  is computed from `nix eval .#checks.x86_64-linux --apply builtins.attrNames`
+
+### Requirement: Coverage is produced by a job consuming the fanned-out cohorts
+
+The single merged Codecov profile SHALL be produced by a dedicated CI job that
+runs after the check jobs and builds `nix build .#ncps.coverage` (which merges
+the per-cohort `cover.out` outputs), then uploads it to Codecov. Coverage upload
+is informational and MUST NOT gate the build; a transient cache miss MAY cause a
+local rebuild but MUST NOT fail CI.
+
+#### Scenario: Coverage merged after checks
+
+- **WHEN** the check jobs have completed
+- **THEN** a coverage job SHALL build `.#ncps.coverage` and upload exactly one
+  merged profile to Codecov
+- **AND** a failure to upload coverage SHALL NOT fail the CI gate

--- a/openspec/changes/archive/2026-05-29-fan-out-flake-check/tasks.md
+++ b/openspec/changes/archive/2026-05-29-fan-out-flake-check/tasks.md
@@ -29,7 +29,7 @@ Repo: `../gh-actions` (branch already created).
 - [x] 2.6 `shared` build job no longer runs flake-check (run_flake_check:false).
 - [x] 2.7 TEMP: pinned the `shared` caller to the gh-actions feature branch to
   validate end-to-end before kalbasit/gh-actions#9 merges.
-- [ ] 2.8 **REVERT** the caller to `@main` before merging (after #9 lands).
+- [x] 2.8 **REVERT** the caller to `@main` (done after gh-actions#9 merged).
 
 ## 3. Verify
 

--- a/openspec/changes/archive/2026-05-29-fan-out-flake-check/tasks.md
+++ b/openspec/changes/archive/2026-05-29-fan-out-flake-check/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: fan-out-flake-check
+
+Land the gh-actions input first, then ncps, then verify.
+
+## 1. gh-actions: `run_flake_check` opt-in (land first)
+
+Repo: `../gh-actions` (branch already created).
+
+- [x] 1.1 Scaffolded `skip-monolithic-flake-check` in gh-actions.
+- [x] 1.2 `build.yml`: added `run_flake_check` input (default `true`); gated the
+  Flake check / Build coverage / Codecov steps on it.
+- [x] 1.3 `ci.yml` orchestrator: added `run_flake_check`; forwarded to
+  `build.yml`; gated the standalone `flake-check` job.
+- [x] 1.4 Spec deltas synced: `oci-build` + `reusable-ci`.
+- [x] 1.5 `openspec validate` + `actionlint` clean; committed; PR
+  kalbasit/gh-actions#9.
+
+## 2. ncps: fan-out matrix + coverage
+
+- [x] 2.1 `.github/workflows/ci.yml`: `shared` caller now passes
+  `run_flake_check: false`.
+- [x] 2.2 Added `check-matrix` job (nix eval → `outputs.checks`).
+- [x] 2.3 Added `checks` job (`fail-fast: false` matrix over the check list;
+  `nix build .#checks.x86_64-linux.<check> -L`).
+- [x] 2.4 Added `coverage` job (`needs: checks`, non-fork; `nix build
+  .#ncps.coverage` + `codecov-action@v6`, `files: result-coverage`).
+- [x] 2.5 Final `ci` gate now `needs` check-matrix/checks/coverage; `skipped`
+  (fork) treated as pass.
+- [x] 2.6 `shared` build job no longer runs flake-check (run_flake_check:false).
+- [x] 2.7 TEMP: pinned the `shared` caller to the gh-actions feature branch to
+  validate end-to-end before kalbasit/gh-actions#9 merges.
+- [ ] 2.8 **REVERT** the caller to `@main` before merging (after #9 lands).
+
+## 3. Verify
+
+- [ ] 3.1 `nix eval .#checks.x86_64-linux --apply builtins.attrNames --json`
+  returns the expected check list locally.
+- [ ] 3.2 `actionlint` clean on ncps `ci.yml`.
+- [ ] 3.3 On the PR: each check is its own parallel job; capture per-job times
+  (this IS the per-check floor measurement, now free); confirm wall-clock drops
+  toward ~3–4m.
+- [ ] 3.4 Coverage job uploads one merged profile; OCI manifest still assembles.
+- [ ] 3.5 If per-job times show wasteful setup on the trivially-fast checks,
+  note a follow-up to group them (do not block on it).

--- a/openspec/specs/flake-check-topology/spec.md
+++ b/openspec/specs/flake-check-topology/spec.md
@@ -375,3 +375,49 @@ and `t.Skip` env-var gating are all unchanged.
 - **THEN** the race detector SHALL remain enabled, every backend SHALL still be
   exercised, and `nix build .#ncps.coverage` SHALL still upload exactly one
   merged coverage profile
+
+### Requirement: CI runs each check as an independent parallel job
+
+CI SHALL execute the flake's checks by fanning them out — running each
+`checks.<system>.<name>` derivation as its own parallel job
+(`nix build .#checks.<system>.<name>`) — rather than as a single monolithic
+`nix flake check` on one runner. The set of jobs MUST be derived from the live
+checks enumeration (`nix eval .#checks.<system> --apply builtins.attrNames`), so
+adding or removing a check automatically adds or removes its job with no further
+wiring. A single check's failure MUST NOT cancel the others (`fail-fast: false`),
+and the CI gate MUST fail if any check job fails.
+
+The checks run on the canonical CI architecture (`x86_64-linux`, per the
+`Integration cohorts validated on a single CI architecture` requirement). Each
+job relies on the shared build cache from Cachix so it pulls the compiled cohort
+artifacts rather than rebuilding them.
+
+#### Scenario: Each check is its own job
+
+- **WHEN** CI runs for a pull request
+- **THEN** for each attribute in `checks.x86_64-linux` there SHALL be a
+  corresponding job running `nix build .#checks.x86_64-linux.<name>`
+- **AND** the jobs SHALL run in parallel on separate runners
+- **AND** one check failing SHALL NOT cancel the other check jobs, but SHALL fail
+  the overall CI gate
+
+#### Scenario: Check list is derived, not hand-maintained
+
+- **WHEN** a check is added to or removed from the flake's `checks` attrset
+- **THEN** its CI job SHALL appear or disappear automatically, because the matrix
+  is computed from `nix eval .#checks.x86_64-linux --apply builtins.attrNames`
+
+### Requirement: Coverage is produced by a job consuming the fanned-out cohorts
+
+The single merged Codecov profile SHALL be produced by a dedicated CI job that
+runs after the check jobs and builds `nix build .#ncps.coverage` (which merges
+the per-cohort `cover.out` outputs), then uploads it to Codecov. Coverage upload
+is informational and MUST NOT gate the build; a transient cache miss MAY cause a
+local rebuild but MUST NOT fail CI.
+
+#### Scenario: Coverage merged after checks
+
+- **WHEN** the check jobs have completed
+- **THEN** a coverage job SHALL build `.#ncps.coverage` and upload exactly one
+  merged profile to Codecov
+- **AND** a failure to upload coverage SHALL NOT fail the CI gate

--- a/openspec/specs/flake-check-topology/spec.md
+++ b/openspec/specs/flake-check-topology/spec.md
@@ -382,7 +382,7 @@ CI SHALL execute the flake's checks by fanning them out — running each
 `checks.<system>.<name>` derivation as its own parallel job
 (`nix build .#checks.<system>.<name>`) — rather than as a single monolithic
 `nix flake check` on one runner. The set of jobs MUST be derived from the live
-checks enumeration (`nix eval .#checks.<system> --apply builtins.attrNames`), so
+checks enumeration (`nix eval .#checks.<system> --apply builtins.attrNames --json`), so
 adding or removing a check automatically adds or removes its job with no further
 wiring. A single check's failure MUST NOT cancel the others (`fail-fast: false`),
 and the CI gate MUST fail if any check job fails.
@@ -405,7 +405,7 @@ artifacts rather than rebuilding them.
 
 - **WHEN** a check is added to or removed from the flake's `checks` attrset
 - **THEN** its CI job SHALL appear or disappear automatically, because the matrix
-  is computed from `nix eval .#checks.x86_64-linux --apply builtins.attrNames`
+  is computed from `nix eval .#checks.x86_64-linux --apply builtins.attrNames --json`
 
 ### Requirement: Coverage is produced by a job consuming the fanned-out cohorts
 


### PR DESCRIPTION
## Why

After compile-once (#1292) CI is ~10m, bottlenecked by a single `nix flake check` building **~13 check derivations on one contended 4-core runner**. They're logically parallel but CPU-starved; the remaining costs (backend-cohort test execution, golangci's own analysis) aren't cacheable — they need more cores in parallel.

## What

Replace the monolithic check with a **CI matrix**:
- `check-matrix` job enumerates checks: `nix eval .#checks.x86_64-linux --apply builtins.attrNames --json`.
- `checks` job runs each as its own parallel runner: `nix build .#checks.x86_64-linux.<name>` (`fail-fast: false`), pulling the shared `_ncps-test-cache`/`_ncps-base` from Cachix instead of rebuilding.
- `coverage` job (`needs: checks`) merges per-cohort profiles → Codecov.
- The shared build job sets **`run_flake_check: false`** (kalbasit/gh-actions#9) so it only builds/pushes the OCI image.

Wall-clock collapses from sum-under-contention (~10m) to **slowest-single-check + nix setup (~3–4m)** — the path to the ~5m target. The per-job times on this run also give us the first clean per-check breakdown.

## ⚠️ Merge order
Depends on **kalbasit/gh-actions#9** (adds `run_flake_check`). The caller is **temporarily pinned to the gh-actions branch** to validate now; revert to `@main` before merging once #9 lands.

OpenSpec: `flake-check-topology` gains "CI runs each check as an independent parallel job" + "Coverage is produced by a job consuming the fanned-out cohorts".