### PR TITLE
ci(releases): scope flake-check to x86_64

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -11,6 +11,12 @@ jobs:
     uses: kalbasit/gh-actions/.github/workflows/build.yml@main
     with:
       systems: '["x86_64-linux", "aarch64-linux"]'
+      # Validate the integration suite + coverage on x86_64-linux only (the
+      # cohorts are architecture-independent). The aarch64-linux leg still
+      # builds and pushes its OCI image for the multi-arch manifest, but no
+      # longer re-runs the suite on the slower/flakier ARM runner. Mirrors the
+      # CI workflow; see the flake-check-topology spec.
+      test_systems: '["x86_64-linux"]'
       cachix_cache: ncps
       primary_package: ncps
       dockerhub_image: kalbasit/ncps

--- a/openspec/specs/flake-check-topology/spec.md
+++ b/openspec/specs/flake-check-topology/spec.md
@@ -297,13 +297,15 @@ cache.
 
 ### Requirement: Integration cohorts validated on a single CI architecture
 
-CI SHALL validate the integration test suite (`nix flake check`, i.e. the
-backend cohorts and coverage) on exactly one canonical architecture
-(`x86_64-linux`). Non-canonical architectures in the build matrix
-(`aarch64-linux`) MUST NOT run `nix flake check` or build coverage in CI; they
-MUST still build their deployable OCI image so the multi-arch manifest remains
+Every workflow that validates the integration test suite (`nix flake check`,
+i.e. the backend cohorts and coverage) — both the CI workflow (PRs/pushes) and
+the release workflow (tag builds) — SHALL run it on exactly one canonical
+architecture (`x86_64-linux`). Non-canonical architectures in the build matrix
+(`aarch64-linux`) MUST NOT run `nix flake check` or build coverage; they MUST
+still build their deployable OCI image so the multi-arch manifest remains
 complete. This is configured by the caller passing
-`test_systems: '["x86_64-linux"]'` to the shared `kalbasit/gh-actions` workflow.
+`test_systems: '["x86_64-linux"]'` to the shared `kalbasit/gh-actions` workflow
+(both `ci.yml` and `releases.yml`).
 
 This narrows where the suite runs, not what it covers: the cohorts, backends,
 race detector, and the single merged Codecov profile are unchanged from the
@@ -326,6 +328,16 @@ those all derive from the canonical (x86_64) run.
 - **THEN** the `x86_64-linux` build leg SHALL run `nix flake check -L` across all
   backend cohorts and produce the single merged coverage profile uploaded to
   Codecov
+
+#### Scenario: Release tag build scopes the suite to x86_64
+
+- **WHEN** a `v*.*.*` tag triggers the release workflow with
+  `systems: '["x86_64-linux","aarch64-linux"]'` and
+  `test_systems: '["x86_64-linux"]'`
+- **THEN** the `x86_64-linux` leg SHALL run `nix flake check` + coverage and the
+  `aarch64-linux` leg SHALL skip them
+- **AND** both legs SHALL still build and push their OCI image, and the
+  multi-arch manifest SHALL still be assembled
 
 #### Scenario: Local flake check is unaffected
 

--- a/openspec/specs/flake-check-topology/spec.md
+++ b/openspec/specs/flake-check-topology/spec.md
@@ -302,8 +302,8 @@ i.e. the backend cohorts and coverage) — both the CI workflow (PRs/pushes) and
 the release workflow (tag builds) — SHALL run it on exactly one canonical
 architecture (`x86_64-linux`). Non-canonical architectures in the build matrix
 (`aarch64-linux`) MUST NOT run `nix flake check` or build coverage; they MUST
-still build their deployable OCI image so the multi-arch manifest remains
-complete. This is configured by the caller passing
+still build their respective deployable OCI images so the multi-arch manifest
+remains complete. This is configured by the caller passing
 `test_systems: '["x86_64-linux"]'` to the shared `kalbasit/gh-actions` workflow
 (both `ci.yml` and `releases.yml`).
 
@@ -336,8 +336,8 @@ those all derive from the canonical (x86_64) run.
   `test_systems: '["x86_64-linux"]'`
 - **THEN** the `x86_64-linux` leg SHALL run `nix flake check` + coverage and the
   `aarch64-linux` leg SHALL skip them
-- **AND** both legs SHALL still build and push their OCI image, and the
-  multi-arch manifest SHALL still be assembled
+- **AND** both legs SHALL still build and push their respective OCI images, and
+  the multi-arch manifest SHALL still be assembled
 
 #### Scenario: Local flake check is unaffected
 


### PR DESCRIPTION
## Summary

The release workflow (`v*.*.*` tag builds) called `build.yml` **without** `test_systems`, so it re-ran the full `nix flake check` + coverage on **both** x86_64 and aarch64 — including the slower, flaky aarch64 Postgres path that the CI workflow (#1291) already learned to avoid.

- `releases.yml`: pass `test_systems: '["x86_64-linux"]'` to the shared build workflow. The integration suite + coverage now run on x86_64 only; the aarch64 leg still **builds and pushes** its OCI image, so the multi-arch manifest is unchanged. `run_flake_check` stays at its default (`true`) so releases still gate on the full suite.
- Mirrors the CI workflow's scoping.
- `flake-check-topology` spec: the "Integration cohorts validated on a single CI architecture" requirement now covers **both** `ci.yml` and `releases.yml`, with a new release-tag scenario.

Independent of the fan-out PR (#1293); branched off `main`. Relies on the `test_systems` input already on `kalbasit/gh-actions@main` (merged in #8).

## Test plan

- [x] `actionlint .github/workflows/releases.yml` — exit 0
- [x] `task fmt` clean; pre-commit hooks pass
- [ ] Confirm on the next release tag that the aarch64 leg builds the image but skips `nix flake check`