### PR TITLE
fix(cache): address review feedback on #1296/#1297

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -6576,6 +6576,13 @@ func (c *Cache) loadRecoveryCursor(ctx context.Context) int {
 		Where(entconfigentry.KeyEQ(cdcRecoveryCursorKey)).
 		Only(ctx)
 	if err != nil {
+		// A missing entry is expected (first run / after a wrap to 0). Any other
+		// error (transient DB issue, lock) resets the scan to 0, which can revive the
+		// low-id starvation this cursor prevents, so surface it for diagnosis.
+		if !database.IsNotFoundError(err) {
+			zerolog.Ctx(ctx).Warn().Err(err).Msg("failed to load CDC lazy-recovery cursor; resuming from 0")
+		}
+
 		return 0
 	}
 
@@ -6612,17 +6619,39 @@ func (c *Cache) saveRecoveryCursor(ctx context.Context, cursorID int) {
 // re-scanned every sweep; on-delete cascades clean up its narinfo_nar_files and
 // nar_file_chunks links. Otherwise the row is left for on-demand GetNar recovery.
 func (c *Cache) gcOrSkipBackingLessNarFile(ctx context.Context, narFileID int, narURL nar.URL, log *zerolog.Logger) {
-	// The narinfo path is unambiguous to probe (unlike the CDC-normalized NAR path),
-	// so resolve ALL narinfos linked to this nar_file by its URL. Several store paths
-	// can reference the same NAR, so every one of them must be genuinely gone upstream
-	// before we delete the row — otherwise an active store path would lose its NAR.
+	// Resolve every narinfo linked to this nar_file via the narinfo_nar_files relation
+	// (the source of truth for linkage; URL equality is narrower and can miss links).
+	// Several store paths can reference the same NAR, so every linked narinfo must be
+	// genuinely gone upstream before we delete the row — otherwise an active store path
+	// would lose its NAR.
 	nis, err := c.dbClient.Ent().NarInfo.Query().
-		Where(entnarinfo.URL(narURL.String())).
+		Where(entnarinfo.HasNarInfoNarFilesWith(entnarinfonarfile.NarFileID(narFileID))).
 		All(ctx)
-	if err != nil || len(nis) == 0 {
+	if err != nil {
 		log.Debug().
+			Err(err).
 			Str("hash", narURL.Hash).
-			Msg("skipping backing-less stuck NAR file (no narinfo to verify upstream absence)")
+			Msg("skipping backing-less stuck NAR file (failed to query linked narinfos)")
+
+		return
+	}
+
+	// An orphan with no linked narinfo can never be resolved or served, so it is dead
+	// weight that would be re-scanned forever; garbage-collect it outright. A later
+	// request re-creates it on demand.
+	if len(nis) == 0 {
+		if err := c.dbClient.Ent().NarFile.DeleteOneID(narFileID).Exec(ctx); err != nil {
+			log.Warn().
+				Err(err).
+				Str("hash", narURL.Hash).
+				Msg("failed to garbage-collect orphaned placeholder nar_file")
+
+			return
+		}
+
+		log.Info().
+			Str("hash", narURL.Hash).
+			Msg("garbage-collected orphaned placeholder nar_file (no linked narinfo)")
 
 		return
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -6568,11 +6568,13 @@ func (c *Cache) runCDCLazyRecovery(ctx context.Context, schedule cron.Schedule, 
 // nar_file_chunks links. Otherwise the row is left for on-demand GetNar recovery.
 func (c *Cache) gcOrSkipBackingLessNarFile(ctx context.Context, narFileID int, narURL nar.URL, log *zerolog.Logger) {
 	// The narinfo path is unambiguous to probe (unlike the CDC-normalized NAR path),
-	// so resolve the narinfo linked to this nar_file by its URL.
-	ni, err := c.dbClient.Ent().NarInfo.Query().
+	// so resolve ALL narinfos linked to this nar_file by its URL. Several store paths
+	// can reference the same NAR, so every one of them must be genuinely gone upstream
+	// before we delete the row — otherwise an active store path would lose its NAR.
+	nis, err := c.dbClient.Ent().NarInfo.Query().
 		Where(entnarinfo.URL(narURL.String())).
-		First(ctx)
-	if err != nil {
+		All(ctx)
+	if err != nil || len(nis) == 0 {
 		log.Debug().
 			Str("hash", narURL.Hash).
 			Msg("skipping backing-less stuck NAR file (no narinfo to verify upstream absence)")
@@ -6580,12 +6582,14 @@ func (c *Cache) gcOrSkipBackingLessNarFile(ctx context.Context, narFileID int, n
 		return
 	}
 
-	if !c.narInfoGenuinelyAbsentUpstream(ctx, ni.Hash) {
-		log.Debug().
-			Str("hash", narURL.Hash).
-			Msg("skipping backing-less stuck NAR file (still present or unverifiable upstream)")
+	for _, ni := range nis {
+		if !c.narInfoGenuinelyAbsentUpstream(ctx, ni.Hash) {
+			log.Debug().
+				Str("hash", narURL.Hash).
+				Msg("skipping backing-less stuck NAR file (still present or unverifiable upstream)")
 
-		return
+			return
+		}
 	}
 
 	if err := c.dbClient.Ent().NarFile.DeleteOneID(narFileID).Exec(ctx); err != nil {
@@ -6599,7 +6603,7 @@ func (c *Cache) gcOrSkipBackingLessNarFile(ctx context.Context, narFileID int, n
 
 	log.Info().
 		Str("hash", narURL.Hash).
-		Str("narinfo_hash", ni.Hash).
+		Int("narinfo_count", len(nis)).
 		Msg("garbage-collected genuinely-absent placeholder nar_file")
 }
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	entchunk "github.com/kalbasit/ncps/ent/chunk"
+	entconfigentry "github.com/kalbasit/ncps/ent/configentry"
 	entnarfile "github.com/kalbasit/ncps/ent/narfile"
 	entnarfilechunk "github.com/kalbasit/ncps/ent/narfilechunk"
 	entnarinfo "github.com/kalbasit/ncps/ent/narinfo"
@@ -6430,17 +6432,13 @@ func (c *Cache) runCDCDeletedCleanup(ctx context.Context) func() {
 	}
 }
 
+// cdcRecoveryCursorKey is the config-table key under which the CDC lazy-recovery
+// keyset cursor is persisted, so the scan resumes across restarts and lock handoffs
+// instead of restarting at 0 (which would let a low-id backlog starve higher-id rows).
+const cdcRecoveryCursorKey = "cdc_lazy_recovery_cursor"
+
 // runCDCLazyRecovery runs the CDC lazy recovery job to recover stuck NAR files.
 func (c *Cache) runCDCLazyRecovery(ctx context.Context, schedule cron.Schedule, batchSize int) func() {
-	// cursorID is a keyset cursor over nar_files.id that persists across cron
-	// invocations (the returned closure is scheduled once). Each run resumes after
-	// the highest id it examined last time and resets to 0 once it reaches the end.
-	// Backing-less rows are skipped without being mutated, so without this cursor a
-	// backlog of them at the low end of the id space (e.g. the failed-download
-	// placeholders this job exists to tolerate) would fill every batchSize-limited
-	// snapshot and permanently starve genuinely re-drivable rows with higher ids.
-	var cursorID int
-
 	return func() {
 		startTime := time.Now()
 
@@ -6470,6 +6468,13 @@ func (c *Cache) runCDCLazyRecovery(ctx context.Context, schedule cron.Schedule, 
 				batchSize = math.MaxInt32
 			}
 
+			// Resume the keyset scan from the persisted cursor so progress survives
+			// restarts and lock handoffs to other instances; a per-process cursor would
+			// restart at 0 and let a low-id backlog (e.g. failed-download placeholders)
+			// starve genuinely re-drivable higher-id rows. Backing-less rows are skipped
+			// without mutation, so this cursor is the only thing advancing past them.
+			cursorID := c.loadRecoveryCursor(ctx)
+
 			stuckFiles, err := c.dbClient.Ent().NarFile.Query().
 				Where(
 					entnarfile.TotalChunksEQ(0),
@@ -6491,6 +6496,7 @@ func (c *Cache) runCDCLazyRecovery(ctx context.Context, schedule cron.Schedule, 
 				// the cursor); wrap back to the start so the next run rescans from the
 				// beginning and picks up newly-stuck rows.
 				cursorID = 0
+				c.saveRecoveryCursor(ctx, cursorID)
 
 				log.Debug().Msg("no stuck NAR files found for recovery")
 
@@ -6504,6 +6510,8 @@ func (c *Cache) runCDCLazyRecovery(ctx context.Context, schedule cron.Schedule, 
 			if len(stuckFiles) < batchSize {
 				cursorID = 0
 			}
+
+			c.saveRecoveryCursor(ctx, cursorID)
 
 			log.Info().Int("count", len(stuckFiles)).Msg("found stuck NAR files for recovery")
 
@@ -6558,6 +6566,43 @@ func (c *Cache) runCDCLazyRecovery(ctx context.Context, schedule cron.Schedule, 
 		} else if !acquired {
 			zerolog.Ctx(ctx).Debug().Msg("another instance is running CDC lazy recovery, skipping")
 		}
+	}
+}
+
+// loadRecoveryCursor reads the persisted CDC lazy-recovery keyset cursor, returning 0
+// (start of scan) when it is unset or unreadable.
+func (c *Cache) loadRecoveryCursor(ctx context.Context) int {
+	e, err := c.dbClient.Ent().ConfigEntry.Query().
+		Where(entconfigentry.KeyEQ(cdcRecoveryCursorKey)).
+		Only(ctx)
+	if err != nil {
+		return 0
+	}
+
+	id, err := strconv.Atoi(e.Value)
+	if err != nil || id < 0 {
+		return 0
+	}
+
+	return id
+}
+
+// saveRecoveryCursor persists the CDC lazy-recovery keyset cursor. The
+// cdc-lazy-recovery distributed lock serializes sweeps, so a plain upsert suffices. A
+// failure is non-fatal: the next sweep simply resumes from the last persisted value.
+func (c *Cache) saveRecoveryCursor(ctx context.Context, cursorID int) {
+	value := strconv.Itoa(cursorID)
+
+	if err := c.dbClient.Ent().ConfigEntry.Create().
+		SetKey(cdcRecoveryCursorKey).
+		SetValue(value).
+		OnConflictColumns(entconfigentry.FieldKey).
+		Update(func(u *ent.ConfigEntryUpsert) {
+			u.SetValue(value)
+			u.SetUpdatedAt(time.Now())
+		}).
+		Exec(ctx); err != nil {
+		zerolog.Ctx(ctx).Warn().Err(err).Msg("failed to persist CDC lazy-recovery cursor")
 	}
 }
 

--- a/pkg/cache/recovery_cursor_internal_test.go
+++ b/pkg/cache/recovery_cursor_internal_test.go
@@ -1,0 +1,91 @@
+package cache
+
+import (
+	"context"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	entconfigentry "github.com/kalbasit/ncps/ent/configentry"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage/chunk"
+)
+
+func readRecoveryCursor(ctx context.Context, t *testing.T, c *Cache) string {
+	t.Helper()
+
+	e, err := c.dbClient.Ent().ConfigEntry.Query().
+		Where(entconfigentry.KeyEQ(cdcRecoveryCursorKey)).
+		Only(ctx)
+	if err != nil {
+		return "" // not persisted
+	}
+
+	return e.Value
+}
+
+// TestRunCDCLazyRecoveryCursorPersists verifies the lazy-recovery keyset cursor is
+// persisted in the DB (not just process memory), so it survives a pod restart or a
+// lock handoff to another instance — otherwise the scan restarts at 0 and a low-id
+// backlog can keep starving higher-id rows.
+func TestRunCDCLazyRecoveryCursorPersists(t *testing.T) {
+	t.Parallel()
+
+	c, db, _, dir, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	chunkStore, err := chunk.NewLocalStore(filepath.Join(dir, "chunks-store"))
+	require.NoError(t, err)
+	c.SetChunkStore(chunkStore)
+	require.NoError(t, c.SetCDCConfiguration(true, 1024, 4096, 8192))
+
+	ctx := context.Background()
+
+	// Three backing-less rows with no narinfo and no upstream: the sweep skips them
+	// (nothing to migrate, nothing to GC) but the cursor still advances over them.
+	hashes := []string{
+		"cursorrowaaaaaaaaaaaaaaaaaaaaaaaa",
+		"cursorrowbbbbbbbbbbbbbbbbbbbbbbbb",
+		"cursorrowcccccccccccccccccccccccc",
+	}
+
+	ids := make([]int, 0, len(hashes))
+
+	for _, h := range hashes {
+		nf, err := c.dbClient.Ent().NarFile.Create().
+			SetHash(h).
+			SetCompression(nar.CompressionTypeNone.String()).
+			SetQuery("").
+			SetFileSize(1).
+			Save(ctx)
+		require.NoError(t, err)
+
+		ids = append(ids, nf.ID)
+	}
+
+	_, err = db.DB().ExecContext(ctx,
+		"UPDATE nar_files SET total_chunks = 0, chunking_started_at = NULL, created_at = ?",
+		time.Now().Add(-10*time.Minute))
+	require.NoError(t, err)
+
+	schedule, err := cron.ParseStandard("@every 5m")
+	require.NoError(t, err)
+
+	// First sweep (one process), batch size 2: processes the first two rows and must
+	// persist the cursor at the second row's id.
+	c.runCDCLazyRecovery(ctx, schedule, 2)()
+	assert.Equal(t, strconv.Itoa(ids[1]), readRecoveryCursor(ctx, t, c),
+		"cursor must be persisted after advancing past the first batch")
+
+	// A FRESH closure (simulating a restart / different instance) must resume from the
+	// persisted cursor, reach the last row, hit the end (short batch) and wrap to 0.
+	c.runCDCLazyRecovery(ctx, schedule, 2)()
+	assert.Equal(t, "0", readRecoveryCursor(ctx, t, c),
+		"a fresh sweep must resume from the persisted cursor and wrap at the end")
+}

--- a/pkg/cache/recovery_gc_internal_test.go
+++ b/pkg/cache/recovery_gc_internal_test.go
@@ -64,7 +64,7 @@ func (f *gcTestFixture) seedBackingLessRow(t *testing.T, narHash, narInfoHash st
 
 	narURL := nar.URL{Hash: narHash, Compression: nar.CompressionTypeNone}
 
-	_, err := f.c.dbClient.Ent().NarFile.Create().
+	nf, err := f.c.dbClient.Ent().NarFile.Create().
 		SetHash(narHash).
 		SetCompression(nar.CompressionTypeNone.String()).
 		SetQuery("").
@@ -72,11 +72,18 @@ func (f *gcTestFixture) seedBackingLessRow(t *testing.T, narHash, narInfoHash st
 		Save(f.ctx)
 	require.NoError(t, err)
 
-	_, err = f.c.dbClient.Ent().NarInfo.Create().
+	ni, err := f.c.dbClient.Ent().NarInfo.Create().
 		SetHash(narInfoHash).
 		SetURL(narURL.String()).
 		Save(f.ctx)
 	require.NoError(t, err)
+
+	// Link the narinfo to the nar_file via narinfo_nar_files (the relation the GC
+	// resolves through), mirroring how storeInDatabase wires them.
+	require.NoError(t, f.c.dbClient.Ent().NarInfoNarFile.Create().
+		SetNarinfoID(ni.ID).
+		SetNarFileID(nf.ID).
+		Exec(f.ctx))
 
 	if old {
 		_, err = f.db.DB().ExecContext(f.ctx,

--- a/pkg/cache/recovery_gc_multi_internal_test.go
+++ b/pkg/cache/recovery_gc_multi_internal_test.go
@@ -1,0 +1,61 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/testdata"
+)
+
+// TestRecoveryGCKeepsWhenAnyLinkedNarInfoPresent verifies that when several narinfos
+// reference the same NAR (same URL, e.g. different store paths sharing a NAR), the
+// backing-less placeholder is GC'd only if EVERY linked narinfo is genuinely absent
+// upstream. If any one is still present, the row must be kept.
+func TestRecoveryGCKeepsWhenAnyLinkedNarInfoPresent(t *testing.T) {
+	t.Parallel()
+
+	f := newGCTestFixture(t)
+
+	const narHash = "5lid9xrpirkzcpqsxfq02qwiq0yd70ch"
+
+	const absentNarInfoHash = "gcmultiabsent00000000000000000aa"
+
+	narURL := nar.URL{Hash: narHash, Compression: nar.CompressionTypeNone}
+
+	_, err := f.c.dbClient.Ent().NarFile.Create().
+		SetHash(narHash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(1234).
+		Save(f.ctx)
+	require.NoError(t, err)
+
+	// Insert the ABSENT narinfo first so a single-row First() query would pick it
+	// (lowest id) and wrongly conclude the NAR is gone.
+	_, err = f.c.dbClient.Ent().NarInfo.Create().
+		SetHash(absentNarInfoHash).
+		SetURL(narURL.String()).
+		Save(f.ctx)
+	require.NoError(t, err)
+
+	// A second narinfo for the same NAR whose narinfo IS still served upstream.
+	_, err = f.c.dbClient.Ent().NarInfo.Create().
+		SetHash(testdata.Nar1.NarInfoHash).
+		SetURL(narURL.String()).
+		Save(f.ctx)
+	require.NoError(t, err)
+
+	_, err = f.db.DB().ExecContext(f.ctx,
+		"UPDATE nar_files SET created_at = ? WHERE hash = ?",
+		time.Now().Add(-10*time.Minute), narHash)
+	require.NoError(t, err)
+
+	f.runRecovery(t)
+
+	assert.True(t, f.narFileExists(t, narHash),
+		"the placeholder must be kept when any linked narinfo is still present upstream")
+}

--- a/pkg/cache/recovery_gc_multi_internal_test.go
+++ b/pkg/cache/recovery_gc_multi_internal_test.go
@@ -26,7 +26,7 @@ func TestRecoveryGCKeepsWhenAnyLinkedNarInfoPresent(t *testing.T) {
 
 	narURL := nar.URL{Hash: narHash, Compression: nar.CompressionTypeNone}
 
-	_, err := f.c.dbClient.Ent().NarFile.Create().
+	nf, err := f.c.dbClient.Ent().NarFile.Create().
 		SetHash(narHash).
 		SetCompression(nar.CompressionTypeNone.String()).
 		SetQuery("").
@@ -36,18 +36,27 @@ func TestRecoveryGCKeepsWhenAnyLinkedNarInfoPresent(t *testing.T) {
 
 	// Insert the ABSENT narinfo first so a single-row First() query would pick it
 	// (lowest id) and wrongly conclude the NAR is gone.
-	_, err = f.c.dbClient.Ent().NarInfo.Create().
+	niAbsent, err := f.c.dbClient.Ent().NarInfo.Create().
 		SetHash(absentNarInfoHash).
 		SetURL(narURL.String()).
 		Save(f.ctx)
 	require.NoError(t, err)
 
 	// A second narinfo for the same NAR whose narinfo IS still served upstream.
-	_, err = f.c.dbClient.Ent().NarInfo.Create().
+	niPresent, err := f.c.dbClient.Ent().NarInfo.Create().
 		SetHash(testdata.Nar1.NarInfoHash).
 		SetURL(narURL.String()).
 		Save(f.ctx)
 	require.NoError(t, err)
+
+	// Link both narinfos to the nar_file via narinfo_nar_files (the relation the GC
+	// resolves through).
+	for _, niID := range []int{niAbsent.ID, niPresent.ID} {
+		require.NoError(t, f.c.dbClient.Ent().NarInfoNarFile.Create().
+			SetNarinfoID(niID).
+			SetNarFileID(nf.ID).
+			Exec(f.ctx))
+	}
 
 	_, err = f.db.DB().ExecContext(f.ctx,
 		"UPDATE nar_files SET created_at = ? WHERE hash = ?",
@@ -58,4 +67,35 @@ func TestRecoveryGCKeepsWhenAnyLinkedNarInfoPresent(t *testing.T) {
 
 	assert.True(t, f.narFileExists(t, narHash),
 		"the placeholder must be kept when any linked narinfo is still present upstream")
+}
+
+// TestRecoveryGCDeletesOrphanedPlaceholder verifies that a backing-less nar_file with
+// no linked narinfo at all (an orphan that can never be resolved or served) is
+// garbage-collected outright rather than re-scanned every sweep.
+func TestRecoveryGCDeletesOrphanedPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	f := newGCTestFixture(t)
+
+	const narHash = "6lid9xrpirkzcpqsxfq02qwiq0yd70ch"
+
+	_, err := f.c.dbClient.Ent().NarFile.Create().
+		SetHash(narHash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(1234).
+		Save(f.ctx)
+	require.NoError(t, err)
+
+	_, err = f.db.DB().ExecContext(f.ctx,
+		"UPDATE nar_files SET created_at = ? WHERE hash = ?",
+		time.Now().Add(-10*time.Minute), narHash)
+	require.NoError(t, err)
+
+	require.True(t, f.narFileExists(t, narHash))
+
+	f.runRecovery(t)
+
+	assert.False(t, f.narFileExists(t, narHash),
+		"an orphan nar_file with no linked narinfo must be garbage-collected")
 }

--- a/pkg/cache/upstream/backoff_guard_test.go
+++ b/pkg/cache/upstream/backoff_guard_test.go
@@ -47,6 +47,10 @@ func TestDoRequest_NoBackoffOnFinalAttempt(t *testing.T) {
 
 	require.Error(t, err, "an always-failing transient request must ultimately error")
 
+	// All attempts must run (3 == defaultHTTPRetries): this guards against a
+	// regression that skips retries entirely, which the timing check alone would miss.
+	assert.Equal(t, 3, rt.count, "every retry attempt must be made")
+
 	// Backoffs are base*2^i for i = 0, 1 (after attempts 1 and 2) but NOT after the
 	// final attempt (i = 2). Total ~= base + 2*base = 3*base. With a needless final
 	// backoff it would be ~3*base + 4*base = 7*base.

--- a/pkg/cache/upstream/backoff_guard_test.go
+++ b/pkg/cache/upstream/backoff_guard_test.go
@@ -1,0 +1,55 @@
+package upstream_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/cache/upstream"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// alwaysTransientRoundTripper always fails with a retriable transport error,
+// counting attempts.
+type alwaysTransientRoundTripper struct {
+	count int
+}
+
+func (r *alwaysTransientRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	r.count++
+
+	return nil, errConnReset
+}
+
+// TestDoRequest_NoBackoffOnFinalAttempt verifies that the backoff wait is not
+// applied after the last attempt, which would just add latency to an
+// already-doomed request without enabling another retry.
+func TestDoRequest_NoBackoffOnFinalAttempt(t *testing.T) {
+	t.Parallel()
+
+	const base = 60 * time.Millisecond
+
+	rt := &alwaysTransientRoundTripper{}
+	c, err := upstream.New(
+		context.Background(),
+		testhelper.MustParseURL(t, "https://cache.nixos.org"),
+		&upstream.Options{Transport: rt, RetryBackoff: base},
+	)
+	require.NoError(t, err)
+
+	start := time.Now()
+	_, err = c.GetNarInfo(context.Background(), "hash")
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "an always-failing transient request must ultimately error")
+
+	// Backoffs are base*2^i for i = 0, 1 (after attempts 1 and 2) but NOT after the
+	// final attempt (i = 2). Total ~= base + 2*base = 3*base. With a needless final
+	// backoff it would be ~3*base + 4*base = 7*base.
+	assert.Less(t, elapsed, 5*base,
+		"backoff must not be applied after the final attempt (elapsed %s)", elapsed)
+}

--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -360,28 +360,32 @@ func (c *Cache) doRequest(
 		}
 
 		resp, err = c.httpClient.Do(r)
-		if err != nil {
-			if (method == http.MethodGet || method == http.MethodHead) &&
-				isRetriableTransportError(err) {
-				zerolog.Ctx(ctx).Warn().
-					Err(err).
-					Int("attempt", i+1).
-					Int("max_retries", defaultHTTPRetries).
-					Msg("transient transport error from upstream, retrying request")
+		if err == nil {
+			return resp, nil
+		}
 
-				// Back off before retrying so a brown-out upstream is not
-				// hammered. Abort promptly if the context is cancelled.
-				if waitErr := c.waitRetryBackoff(ctx, i); waitErr != nil {
-					return nil, waitErr
-				}
-
-				continue
-			}
-
+		// Only idempotent requests that failed with a transient transport error are
+		// retried; everything else fails immediately.
+		retriable := (method == http.MethodGet || method == http.MethodHead) &&
+			isRetriableTransportError(err)
+		if !retriable {
 			return nil, fmt.Errorf("error performing %s request to %s: %w", method, url, err)
 		}
 
-		return resp, nil
+		zerolog.Ctx(ctx).Warn().
+			Err(err).
+			Int("attempt", i+1).
+			Int("max_retries", defaultHTTPRetries).
+			Msg("transient transport error from upstream, retrying request")
+
+		// Back off before retrying so a brown-out upstream is not hammered, aborting
+		// promptly if the context is cancelled. Skip the wait on the final attempt —
+		// no retry follows it, so a backoff would only add latency.
+		if i < defaultHTTPRetries-1 {
+			if waitErr := c.waitRetryBackoff(ctx, i); waitErr != nil {
+				return nil, waitErr
+			}
+		}
 	}
 
 	return nil, fmt.Errorf("error performing %s request to %s: %w", method, url, err)


### PR DESCRIPTION
## Summary

Follow-up to #1297 (stacked on it) addressing review feedback from CodeRabbit
(#1296 outside-diff) and Gemini (#1297). Each fix is its own commit, TDD'd.

- **Persist the lazy-recovery cursor** (CodeRabbit, #1296): the keyset cursor lived
  only in the scheduled closure's memory, so a pod restart or `cdc-lazy-recovery`
  lock handoff reset the scan to 0 — a low-id backlog of backing-less placeholders
  could then refill every batch and starve higher-id re-drivable rows in
  clustered/restarting deployments. Persist it in the existing config KV table
  (`cdc_lazy_recovery_cursor`) via `loadRecoveryCursor`/`saveRecoveryCursor`. The
  distributed lock serializes sweeps, so a plain upsert suffices; **no migration**.

- **GC only when all linked narinfos are absent** (Gemini, #1297): the placeholder GC
  resolved a single narinfo via `First()`; multiple store paths can share one NAR, so
  a still-present narinfo could be missed and an active NAR wrongly deleted. Query
  **all** linked narinfos and delete only when every one is genuinely absent upstream.

- **Skip backoff on the final retry attempt** (Gemini, #1297): `waitRetryBackoff` ran
  after the last failed attempt too, padding the latency of an already-doomed request.
  Guard with `i < defaultHTTPRetries-1` (and flatten `doRequest` into guard clauses).

## Test plan

- [x] `task fmt` clean; changed packages lint clean
- [x] `pkg/cache/...` (cache + upstream) pass under `-race`; full unit suite green
- [x] Cursor: `TestRunCDCLazyRecoveryCursorPersists` (persists + resumes across a fresh closure)
- [x] GC: `TestRecoveryGCKeepsWhenAnyLinkedNarInfoPresent`
- [x] Backoff: `TestDoRequest_NoBackoffOnFinalAttempt`
- [ ] CI cohorts green