### PR TITLE
fix(cache): recover from ambiguous storage errors & bound chunk-wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,25 @@ Your cache will be available at `http://localhost:8501`. See the [Quick Start Gu
 
 See the [Deployment Guide](https://docs.ncps.dev/user-guide/deployment.html) for detailed setup instructions.
 
+### Choosing a storage backend
+
+The `local` filesystem backend assumes single-writer POSIX semantics: one process
+owning the directory, with read-after-write consistency. Use it for single-instance
+deployments.
+
+For **multiple replicas, use the S3-compatible backend.** Do not point the `local`
+backend at a shared network filesystem (NFS/SMB) written by more than one replica:
+network filesystems provide only close-to-open consistency with client-side
+attribute caching, so one replica can read stale metadata for a file another replica
+just wrote — which presents to ncps as a NAR that is in the database but "missing"
+from storage, and to clients as spurious cache misses or truncated transfers. An
+object store gives every replica a single, read-after-write-consistent view.
+
+Storage latency also drives the CDC decision (see `cache.cdc` in
+[`config.example.yaml`](config.example.yaml)): CDC's many small chunk reads suit
+low-latency backends, while high-latency or spinning-disk storage is better served
+whole-file with CDC disabled.
+
 ## Architecture
 
 ncps is written in Go. The notable internal dependencies:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -65,6 +65,12 @@ cache:
   # CDC (Content-Defined Chunking) configuration (EXPERIMENTAL)
   # Enables deduplication of NAR files by splitting them into content-defined chunks.
   # Chunks are stored in the same backend as NAR files (different prefix/directory).
+  #
+  # Choosing CDC vs. whole-file serving: CDC trades disk usage (via dedup) for many
+  # small random reads per NAR when serving. That trade pays off on low-latency
+  # storage (local SSD, NVMe-backed object stores). On high-latency or spinning-disk
+  # backends — especially a network filesystem — the extra small reads dominate and
+  # whole-file serving is more robust; prefer leaving CDC disabled there.
   cdc:
     # Enable CDC chunking
     enabled: false
@@ -74,6 +80,11 @@ cache:
     avg: 65536
     # Maximum chunk size for CDC in bytes (default: 262144)
     max: 262144
+    # Maximum time progressive CDC streaming waits for the next chunk to be
+    # produced/become readable before failing the transfer (default: 30s). Keep it
+    # below your reverse-proxy gateway timeout so a stalled chunk on high-latency
+    # storage surfaces as a retryable error to the client rather than a gateway 504.
+    chunk-wait-timeout: 30s
   # The maximum size of the store. It can be given with units such as 5K, 10G
   # etc. Supported units: B, K, M, G, T
   max-size: 100G

--- a/openspec/changes/archive/2026-05-30-fix-nar-serving-failures/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-30-fix-nar-serving-failures/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-30

--- a/openspec/changes/archive/2026-05-30-fix-nar-serving-failures/design.md
+++ b/openspec/changes/archive/2026-05-30-fix-nar-serving-failures/design.md
@@ -1,0 +1,123 @@
+## Context
+
+A fresh client hit three server-side faults serving NARs from ncps: mass fast
+`404 does not exist in binary cache`, mid-stream `unexpected end of nar` /
+`truncated input` (HTTP/2 stream resets), and nginx `504`. The production
+deployment runs the `local` (POSIX) storage backend on a single NFS share
+(`ReadWriteMany`) shared by **two** replicas, with CDC enabled — a topology that
+violates the single-writer/strong-consistency assumption the `local` driver
+makes, and that turns each NAR into many small chunk reads over a high-latency
+spinning backend. The topology aggravates the faults; the faults themselves are
+ncps bugs against requirements that already exist (`nar-cache-miss-recovery`,
+`nar-concurrent-streaming`).
+
+Relevant current code (`pkg/cache/cache.go`):
+
+- `GetNar` (1008) already *intends* to recover: when `isServable` is false it
+  falls through to `prePullNar` and re-downloads rather than 404-ing.
+- `isServable` (3873) returns `true` whenever the `nar_file` record is servable
+  (`total_chunks > 0` / chunking in progress) **without confirming the chunk
+  bytes actually exist in storage**. On a backend where the DB (fast SSD) is
+  ahead of the bytes (slow/stale NFS), this commits the `200` and then
+  `getNarFromChunks` fails mid-stream → truncated body.
+- The chunk prefetch loop (≈7395–7445) waits `maxWaitPerChunk` (~30s,
+  hard-coded) per chunk, then emits `timeout waiting for chunk N`. Because the
+  response is already committed, the stall surfaces as truncation / eventually a
+  gateway 504 (nginx `proxy-read-timeout: 300s`).
+- `HasNarInStore` returns a bare `bool`, conflating "confirmed absent" with
+  "could not determine" (e.g. a transient/stale NFS stat error). The narinfo
+  purge guard (4198) keys its destructive decision on that boolean.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A narinfo/NAR whose backing bytes are genuinely absent is recovered from
+  upstream on demand, never answered with a hard 404 or a destructive purge
+  driven by an ambiguous storage result.
+- The chunk-serving path verifies the chunk set is present and byte-complete
+  **before** committing the response status; a missing/short chunk set falls
+  back to re-download while no bytes are committed.
+- The chunk-wait / serving deadline is bounded and operator-configurable, with a
+  default that fits inside a typical gateway timeout; a post-commit stall aborts
+  the transfer (client sees a failed download) rather than closing a short body.
+- Regression tests reproduce each fault first (TDD), including a backend that can
+  simulate "DB record present, bytes missing/slow" and "stat returns an
+  ambiguous error."
+- Constructive operator documentation on backend selection.
+
+**Non-Goals:**
+
+- No redesign of CDC chunking, the Redis download lock, or upstream
+  retry/backoff.
+- No `migrate-chunks-to-nar` (de-chunking) tool — separate change, separate
+  branch.
+- No nginx/ingress changes; ncps stays within the gateway's timeout.
+- No change that depends on fixing the user's topology — the code must degrade
+  cleanly regardless.
+
+## Decisions
+
+### 1. Distinguish "confirmed absent" from "could not determine"
+
+Introduce a storage-presence check that returns a tri-state (or
+`(present bool, err error)`) instead of swallowing errors into a bare `bool`.
+Confirmed `ErrNotFound` → absent (eligible for recovery/purge). Any other error
+(timeout, stale handle, transport) → **unknown**: do **not** treat as absence,
+do **not** purge; serve-if-possible else surface a retryable error so the next
+request re-evaluates. The narinfo purge guard (4198) and `isServable` consume
+this distinction. This directly addresses the cross-pod NFS false-miss without
+ncps pretending NFS is consistent.
+
+### 2. Verify chunk-set integrity before committing the response
+
+Before `serveNarFromStorageViaPipe`/`isServable` commit to the chunk path, add a
+pre-flight that enumerates the required chunks and confirms (a) every referenced
+chunk object is present and (b) the chunk byte total equals the NAR's declared
+size. If the pre-flight fails while no bytes are committed, fall back to
+synchronous upstream re-download (the existing `prePullNar` path) instead of
+streaming a body that cannot be finished. Pre-flight cost is metadata-only
+(existence/size), not a full read; it trades a small up-front check for
+eliminating truncated `200`s.
+
+### 3. Bound and expose the chunk-wait / serving deadline
+
+Replace the hard-coded `maxWaitPerChunk` with a configured value (new key under
+`cache.download`, e.g. `chunk-wait-timeout`, default chosen to keep total
+serving time < a typical gateway timeout). Add an overall serving deadline so a
+sequence of slow chunks cannot accumulate past the gateway. On deadline expiry
+after commit, terminate the stream abnormally (so the client observes a failed
+transfer and retries) — never close at the truncation point as a clean EOF.
+
+### 4. TDD reproduction before fixes
+
+The exact origin of the ~1.5 ms 404 is not yet pinned to a single line (GetNar's
+fall-through suggests it should recover; candidates include the
+`.nar.xz`-vs-uncompressed-chunk servability mismatch and the narinfo-endpoint
+purge path). The first task is a failing test using a storage fake that models
+"record present / bytes absent" and "ambiguous stat error," asserting recovery
+and no-truncation. The fix is shaped by what that test exposes.
+
+### 5. Documentation
+
+Add backend-selection guidance (README/deployment docs and/or chart notes):
+`local` assumes single-writer POSIX semantics; multi-replica deployments should
+use an object-store backend; CDC suits low-latency storage. Phrased as
+what-to-do-and-why, not a post-mortem.
+
+## Risks / Trade-offs
+
+- **Pre-flight adds metadata round-trips per chunked serve.** On the very
+  backend that is slow, this adds latency — but only existence/size checks, and
+  it prevents the far worse truncated-`200`. Mitigation: batch the existence
+  check; skip pre-flight when serving a whole-file (non-chunked) path.
+- **Recovery-instead-of-404 can mask a genuinely-gone NAR as a slow request.**
+  Bounded by decision #3 (deadline) and the existing "genuinely absent upstream
+  → 404" requirement.
+- **Tri-state presence touches several call sites** (`isServable`,
+  `serveNarFromStorageViaPipe`, purge guard). Risk of behavior drift; covered by
+  the new scenarios plus existing `nar-cache-miss-recovery` /
+  `nar-concurrent-streaming` tests.
+- **New config key** must default safely so existing deployments need no change;
+  the default must be < common gateway timeouts (e.g. nginx 300s) yet generous
+  enough for legitimately slow upstreams.

--- a/openspec/changes/archive/2026-05-30-fix-nar-serving-failures/proposal.md
+++ b/openspec/changes/archive/2026-05-30-fix-nar-serving-failures/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Production clients still fail `nix build` against ncps despite the #1296/#1297/#1298 recovery work. A fresh client (no local nix cache) hit three distinct server-side faults in one run: hundreds of fast `404 does not exist in binary cache`, many `unexpected end of nar` / `truncated input` mid-stream, and `504 Gateway Time-out`. Two existing specs already forbid exactly these outcomes, so the implementation is out of compliance — these are bugs, not new features.
+
+## What Changes
+
+- **Orphaned-narinfo NAR requests must recover, not 404.** When a narinfo is in the DB but its NAR is absent from storage (`cache.go:4240` "requesting a purge"), a subsequent `GET /nar/<hash>.nar.xz` 404s in ~1.5ms instead of re-downloading from upstream. The purge path leaves the system unable to heal the NAR on the in-flight request. `GetNar` must drive an upstream re-download for a known-but-backing-less NAR rather than short-circuiting to `ErrNotFound`.
+- **CDC chunk serving must never emit a truncated 200.** Reassembly stalls (`cache.go:7430` "timeout waiting for chunk N after 30s") fire *after* the `200 OK` and partial body are flushed, so the stream is reset and the client sees a corrupt/short `.nar.xz`. Verify chunk availability before committing bytes and/or cap total stall well under the gateway timeout so a stalled chunk is surfaced as a failed transfer, not a silent short body.
+- **Bound per-NAR serving latency below nginx's gateway timeout** so chunk/upstream stalls return a retryable error instead of a 504. Expose the chunk-wait/serving deadline as configuration (today the 30s wait is implicit) so operators can align it with their gateway.
+- **Document storage-backend selection guidance.** The `local` filesystem backend assumes single-writer POSIX semantics; pointing it at a network filesystem (NFS/SMB) shared by more than one replica yields close-to-open-consistency hazards (false cache-miss detection, stale-size reads). Multi-replica deployments should use an object-store backend; CDC chunking suits low-latency storage and is counter-productive on high-latency/spinning backends. Framed as what-to-do-and-why, not a post-mortem.
+- Add regression tests reproducing each fault (orphaned-narinfo → recovery; stalled chunk after first byte → no short 200; serving deadline → bounded error).
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `nar-cache-miss-recovery`: extend beyond backing-less `nar_file` rows to cover the **narinfo-in-DB / NAR-missing-in-storage** purge path — the direct `/nar` request that follows a purge MUST recover from upstream, not 404.
+- `nar-concurrent-streaming`: strengthen the "MUST NOT deliver a truncated NAR body" requirement to cover stalls that occur **after the first byte is committed**, and bound total serving time below the gateway timeout.
+
+## Impact
+
+- Code: `pkg/cache/cache.go` (`GetNar`, `getNarInfoFromDatabase` purge path, `getNarFromChunks`/`getNarFromStore` reassembly), `pkg/server/server.go` (`getNar` handler error mapping).
+- Behavior: a NAR whose chunks/whole-file are genuinely gone is re-fetched from upstream on demand; stalls become retryable errors instead of truncated 200s or 504s. No schema/migration change.
+- **I/O / latency / memory**: on-demand recovery adds an upstream round-trip for orphaned NARs (one-time per heal). A new per-request serving deadline trades an unbounded stall for a fast retryable failure. No additional buffering — streaming stays O(1) memory.
+
+## Non-goals
+
+- Not redesigning CDC chunking, the distributed lock, or upstream retry/backoff.
+- Not eliminating benign `http2: timeout awaiting response headers` retries or download-lock contention warnings.
+- Not changing nginx/ingress configuration; the fix keeps ncps responses within whatever timeout the gateway enforces.
+- Not providing the reverse `migrate-chunks-to-nar` (de-chunking) tool — that is a net-new feature tracked as a **separate change**. This change's docs reference it as the supported CDC-exit path.

--- a/openspec/changes/archive/2026-05-30-fix-nar-serving-failures/specs/nar-cache-miss-recovery/spec.md
+++ b/openspec/changes/archive/2026-05-30-fix-nar-serving-failures/specs/nar-cache-miss-recovery/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: A narinfo whose NAR is missing from storage MUST trigger recovery, not a destructive 404
+
+The system SHALL treat a narinfo whose backing NAR is absent from storage as a cache miss and recover the NAR from upstream on demand, rather than returning HTTP 404 or destructively purging the narinfo. It SHALL NOT respond to the in-flight or any subsequent `GET /nar/<hash>...` request with `storage.ErrNotFound` (HTTP 404) solely because the bytes are currently absent, and it SHALL NOT take a destructive action (purging the narinfo) that leaves the system unable to re-download the NAR.
+
+This requirement covers the storage-absence case specifically — a narinfo that
+is present and otherwise valid, whose whole-file and chunks are both missing
+from the store (e.g. removed by GC, lost by the backend, or never durably
+written) — as distinct from a backing-less `nar_file` row with `total_chunks=0`.
+
+#### Scenario: Missing-NAR narinfo request recovers from upstream instead of 404
+
+- **GIVEN** a narinfo for hash `H` exists in the database
+- **AND** neither a whole-file nor any chunks for `H` exist in storage
+- **AND** the upstream has the NAR for `H`
+- **WHEN** a client requests `GET /nar/<H>.nar.xz`
+- **THEN** the system SHALL initiate an upstream download for `H`
+- **AND** SHALL stream the recovered NAR bytes to the client
+- **AND** SHALL NOT return HTTP 404
+
+#### Scenario: Detecting a missing NAR does not poison future requests
+
+- **GIVEN** a narinfo for hash `H` whose NAR is missing from storage
+- **WHEN** the system detects the missing NAR (the condition that previously
+  logged "narinfo was found in the database but no nar was found in storage,
+  requesting a purge")
+- **THEN** any record mutation it performs SHALL leave `H` in a state from which
+  a later `GET /nar/<H>...` re-downloads from upstream
+- **AND** SHALL NOT negative-cache `H` such that a subsequent request
+  short-circuits to HTTP 404
+
+#### Scenario: NAR genuinely absent upstream still returns 404
+
+- **GIVEN** a narinfo for hash `H` whose NAR is missing from storage
+- **AND** every configured upstream returns not-found for `H`
+- **WHEN** the system attempts recovery for `H`
+- **THEN** it SHALL return `storage.ErrNotFound` (HTTP 404)
+- **AND** SHALL NOT persist a record that would prevent a future successful
+  download of `H` once it reappears upstream
+
+#### Scenario: Transient storage read error is not mistaken for a missing NAR
+
+- **GIVEN** a narinfo for hash `H` whose NAR is present in storage
+- **AND** a storage stat/read for `H` fails transiently (e.g. a timeout or a
+  stale-metadata read on a network filesystem) rather than returning a definite
+  not-found
+- **WHEN** the system evaluates whether the NAR is missing
+- **THEN** it SHALL NOT treat an ambiguous/transient storage error as a
+  confirmed absence
+- **AND** SHALL NOT purge the narinfo on the basis of that ambiguous result

--- a/openspec/changes/archive/2026-05-30-fix-nar-serving-failures/specs/nar-concurrent-streaming/spec.md
+++ b/openspec/changes/archive/2026-05-30-fix-nar-serving-failures/specs/nar-concurrent-streaming/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: The chunk-wait deadline MUST be bounded and configurable
+
+The serving path SHALL bound the time it waits on chunk production and chunk reads by an explicit, operator-configurable deadline that defaults to a value fitting within a typical reverse-proxy gateway timeout. It SHALL NOT wait indefinitely (or in unbounded per-chunk increments) such that total serving time can exceed the gateway timeout and surface to the client as a gateway 504.
+
+#### Scenario: Per-request serving time is bounded below the gateway timeout
+
+- **GIVEN** a NAR is being served and a chunk read stalls
+- **AND** the configured serving deadline is shorter than the gateway timeout
+- **WHEN** the serving deadline elapses
+- **THEN** the system SHALL terminate the request with a retryable error
+- **AND** SHALL NOT allow the request to hang until the gateway returns a 504
+
+#### Scenario: The deadline is configurable
+
+- **GIVEN** an operator sets the chunk-wait / serving deadline via configuration
+- **WHEN** the server loads its configuration
+- **THEN** the serving path SHALL honor the configured deadline
+- **AND** in the absence of explicit configuration SHALL apply a documented default
+
+### Requirement: A chunk stall after the response is committed MUST surface as a stream error, not a clean EOF
+
+The streaming path SHALL terminate a post-commit chunk stall in a way the client observes as a failed/aborted transfer (an abnormal stream/connection termination), never as a clean end-of-body that a client could mistake for a complete NAR. This applies once the response status and some body bytes have already been committed; a short body that decodes as a truncated archive is a forbidden outcome.
+
+#### Scenario: Mid-stream stall aborts the transfer rather than ending it cleanly
+
+- **GIVEN** a NAR for hash `H` is mid-transfer from chunks and bytes are already committed
+- **AND** the next required chunk does not arrive within the serving deadline
+- **WHEN** the wait elapses
+- **THEN** the system SHALL abort the response so the client sees a failed transfer
+- **AND** SHALL NOT close the body at the truncation point as if the NAR were complete
+- **AND** the client SHALL be free to retry the request

--- a/openspec/changes/archive/2026-05-30-fix-nar-serving-failures/tasks.md
+++ b/openspec/changes/archive/2026-05-30-fix-nar-serving-failures/tasks.md
@@ -1,0 +1,39 @@
+## 0. Already shipped in sha-7d071cf — do NOT duplicate (verified during apply)
+
+These spec scenarios are already implemented and covered by existing tests; reference, don't re-test:
+- recover-not-404 / genuine-404 → `testCDCBackingLessRecordRecovers…` / `…Genuine404ReturnsNotFound` (cdc_test.go:196/198)
+- aborted-chunking-not-short-body → `TestGetNarFromChunks_AbortedChunkingErrorsNotShortBody` (streaming_abort)
+- missing-chunk errors mid-read → `cache_prefetch_test.go:199`
+
+## 1. Reproduction tests for the genuine gaps (TDD — vertical slices, one at a time)
+
+- [x] 1.1 Added a fault-injecting `NarStore` wrapper (`ambiguousNarStore`) returning an ambiguous (non-`ErrNotFound`) error from `StatNar` for a chosen hash.
+- [x] 1.2 RED→GREEN (verified RED = "the narinfo was purged"): ambiguous storage error is NOT treated as absence — the narinfo purge guard does not purge. (`nar-cache-miss-recovery` → "Transient storage read error is not mistaken for a missing NAR") — `ambiguous_storage_purge_internal_test.go`
+- [~] 1.3 DEFERRED to a follow-up change: pre-commit chunk-set verification + fall-back-to-redownload. Reworking `GetNar` servability flow is regression-risky, and per-chunk pre-flight stats add load to the same high-latency backend (net-negative without measurement). The bounded deadline (§4) + existing post-commit abort already prevent the open-ended stall. Spec requirement removed from this change accordingly.
+- [x] 1.4 RED→GREEN: the chunk-wait deadline is operator-configurable with a documented 30s default and bounds per-request serving time. (`nar-concurrent-streaming` → deadline scenarios) — `chunk_wait_timeout_internal_test.go`
+
+## 2. Tri-state storage presence (confirmed-absent vs unknown)
+
+- [x] 2.1 Added `StatNar(ctx, url) (bool, error)` to `storage.NarStore` (present / confirmed-absent / unknown); implemented in `local` (`os.IsNotExist`) and `s3` (`NoSuchKey`); reimplemented `HasNar` via it. Added cache-level `statNarInStore`.
+- [x] 2.2 Purge guard (`getNarInfoFromDatabase`) now uses `statNarInStore` and skips the purge on an unknown/ambiguous result (returns the narinfo, logs a warning).
+- [~] 2.3 DEFERRED with §1.3: routing `isServable` "unknown" through `GetNar` is part of the verify-before-commit rework. The purge-guard fix (2.2) already covers the observed production cascade.
+
+## 3. Pre-commit chunk-set verification — DEFERRED (see §1.3)
+
+- [~] 3.1 / 3.2 / 3.3 Deferred to a follow-up change. Rationale in §1.3.
+
+## 4. Bounded, configurable serving deadline
+
+- [x] 4.1 Added flag `cache-cdc-chunk-wait-timeout` (`cache.cdc.chunk-wait-timeout` / `CACHE_CDC_CHUNK_WAIT_TIMEOUT`, default 30s); documented in `config.example.yaml`.
+- [x] 4.2 Replaced the hard-coded `maxWaitPerChunk` with `c.chunkWaitTimeout` (field + `SetChunkWaitTimeout` + `defaultChunkWaitTimeout`), wired in `serve.go`.
+- [x] 4.3 Post-commit stall already aborts the transfer (pipe `CloseWithError` → client sees a failed transfer, not a clean EOF); covered by existing `streaming_abort` test + bounded by §4.2.
+
+## 5. Documentation
+
+- [x] 5.1 Added "Choosing a storage backend" guidance to `README.md` (local = single-writer POSIX; multi-replica → object store; CDC suits low-latency storage). Constructive framing.
+- [x] 5.2 Documented `chunk-wait-timeout` (and CDC-vs-whole-file guidance) in `config.example.yaml`.
+
+## 6. Verify
+
+- [x] 6.1 New tests pass; `task fmt` / `task lint` / `task test` green.
+- [x] 6.2 `openspec validate fix-nar-serving-failures` passes; spec trimmed to match implemented behavior (verify-before-commit requirement removed).

--- a/openspec/specs/nar-cache-miss-recovery/spec.md
+++ b/openspec/specs/nar-cache-miss-recovery/spec.md
@@ -5,16 +5,14 @@
 Defines requirements for treating backing-less and stuck `nar_file` records as
 recoverable cache misses rather than terminal 404s, so that transient upstream
 failures and incomplete chunking do not permanently poison a NAR.
-
 ## Requirements
-
 ### Requirement: A backing-less nar_file record MUST be treated as a cache miss, not a 404
 
-When `GetNar` is called for a NAR whose `nar_file` row exists but has **no backing data** —
-no whole-file in the store, `total_chunks = 0`, and chunking is not actively in progress
-(`chunking_started_at` is NULL or older than the chunking lock TTL) — the system SHALL treat
-the request as a cache **miss** and attempt a synchronous upstream re-download. It SHALL NOT
-return `storage.ErrNotFound` (HTTP 404) on the basis that the row exists.
+The system SHALL treat a `GetNar` request for a NAR whose `nar_file` row exists but has **no
+backing data** — no whole-file in the store, `total_chunks = 0`, and chunking is not actively in
+progress (`chunking_started_at` is NULL or older than the chunking lock TTL) — as a cache **miss**
+and attempt a synchronous upstream re-download. It SHALL NOT return `storage.ErrNotFound`
+(HTTP 404) on the basis that the row exists.
 
 A NAR is "servable" only when at least one of these holds: a whole-file exists in the store,
 `total_chunks > 0`, or chunking is actively in progress within the lock TTL. The mere
@@ -50,10 +48,10 @@ make a NAR servable.
 
 ### Requirement: A transient upstream failure MUST NOT permanently poison a NAR
 
-When a background or synchronous NAR download fails for a transient reason (connection reset,
-HTTP/2 `GOAWAY`, `http2: timeout awaiting response headers`, broken pipe, or any non-404 error),
-the system SHALL NOT leave behind a `nar_file` record that causes future `GetNar` calls to return
-a terminal 404. A later request for the same hash SHALL be able to re-attempt the upstream download.
+The system SHALL NOT leave behind a `nar_file` record that causes future `GetNar` calls to return
+a terminal 404 when a background or synchronous NAR download fails for a transient reason
+(connection reset, HTTP/2 `GOAWAY`, `http2: timeout awaiting response headers`, broken pipe, or any
+non-404 error). A later request for the same hash SHALL be able to re-attempt the upstream download.
 
 #### Scenario: Transient download failure is retryable on next request
 
@@ -72,3 +70,54 @@ a terminal 404. A later request for the same hash SHALL be able to re-attempt th
 - **AND** SHALL NOT indefinitely retry a hash that upstream genuinely does not have
 - **AND** skipped backing-less rows SHALL NOT block the sweep from reaching genuinely re-drivable
   rows on subsequent runs (no head-of-line starvation)
+
+### Requirement: A narinfo whose NAR is missing from storage MUST trigger recovery, not a destructive 404
+
+The system SHALL treat a narinfo whose backing NAR is absent from storage as a cache miss and recover the NAR from upstream on demand, rather than returning HTTP 404 or destructively purging the narinfo. It SHALL NOT respond to the in-flight or any subsequent `GET /nar/<hash>...` request with `storage.ErrNotFound` (HTTP 404) solely because the bytes are currently absent, and it SHALL NOT take a destructive action (purging the narinfo) that leaves the system unable to re-download the NAR.
+
+This requirement covers the storage-absence case specifically — a narinfo that
+is present and otherwise valid, whose whole-file and chunks are both missing
+from the store (e.g. removed by GC, lost by the backend, or never durably
+written) — as distinct from a backing-less `nar_file` row with `total_chunks=0`.
+
+#### Scenario: Missing-NAR narinfo request recovers from upstream instead of 404
+
+- **GIVEN** a narinfo for hash `H` exists in the database
+- **AND** neither a whole-file nor any chunks for `H` exist in storage
+- **AND** the upstream has the NAR for `H`
+- **WHEN** a client requests `GET /nar/<H>.nar.xz`
+- **THEN** the system SHALL initiate an upstream download for `H`
+- **AND** SHALL stream the recovered NAR bytes to the client
+- **AND** SHALL NOT return HTTP 404
+
+#### Scenario: Detecting a missing NAR does not poison future requests
+
+- **GIVEN** a narinfo for hash `H` whose NAR is missing from storage
+- **WHEN** the system detects the missing NAR (the condition that previously
+  logged "narinfo was found in the database but no nar was found in storage,
+  requesting a purge")
+- **THEN** any record mutation it performs SHALL leave `H` in a state from which
+  a later `GET /nar/<H>...` re-downloads from upstream
+- **AND** SHALL NOT negative-cache `H` such that a subsequent request
+  short-circuits to HTTP 404
+
+#### Scenario: NAR genuinely absent upstream still returns 404
+
+- **GIVEN** a narinfo for hash `H` whose NAR is missing from storage
+- **AND** every configured upstream returns not-found for `H`
+- **WHEN** the system attempts recovery for `H`
+- **THEN** it SHALL return `storage.ErrNotFound` (HTTP 404)
+- **AND** SHALL NOT persist a record that would prevent a future successful
+  download of `H` once it reappears upstream
+
+#### Scenario: Transient storage read error is not mistaken for a missing NAR
+
+- **GIVEN** a narinfo for hash `H` whose NAR is present in storage
+- **AND** a storage stat/read for `H` fails transiently (e.g. a timeout or a
+  stale-metadata read on a network filesystem) rather than returning a definite
+  not-found
+- **WHEN** the system evaluates whether the NAR is missing
+- **THEN** it SHALL NOT treat an ambiguous/transient storage error as a
+  confirmed absence
+- **AND** SHALL NOT purge the narinfo on the basis of that ambiguous result
+

--- a/openspec/specs/nar-concurrent-streaming/spec.md
+++ b/openspec/specs/nar-concurrent-streaming/spec.md
@@ -6,13 +6,11 @@ Defines correctness and termination requirements for the per-client streaming go
 serve NAR content to multiple concurrent clients requesting the same NAR hash. In particular,
 governs how client context cancellation propagates so that cancelled clients exit promptly
 without blocking non-cancelled peers.
-
 ## Requirements
-
 ### Requirement: Concurrent NAR streaming goroutines MUST terminate within a bounded time
 
-When multiple clients concurrently request the same NAR hash and one client's context is
-cancelled mid-download, the streaming goroutine for the cancelled client SHALL exit promptly
+The streaming goroutine for a cancelled client SHALL exit promptly when multiple clients
+concurrently request the same NAR hash and one client's context is cancelled mid-download
 (without waiting for the next `cond.Broadcast()`) and the streaming goroutines for all
 remaining clients SHALL continue to completion unaffected.
 
@@ -57,9 +55,9 @@ arrive infrequently.
 
 ### Requirement: Storage-wait `select` MUST include a client context escape
 
-After the streaming goroutine has forwarded all bytes, it waits for `ds.stored` or `ds.done`
-before closing the pipe. This `select` SHALL also include `ctx.Done()` so that a cancelled
-client does not remain blocked if the storage operation stalls.
+The storage-wait `select` SHALL include `ctx.Done()` so that a cancelled client does not remain
+blocked if the storage operation stalls. After the streaming goroutine has forwarded all bytes, it
+waits for `ds.stored` or `ds.done` before closing the pipe — and that `select` is where the escape lives.
 
 #### Scenario: Cancelled client does not block at storage-wait select
 
@@ -131,9 +129,9 @@ re-acquiring the lock, guaranteeing at most one active downloader per hash.
 
 ### Requirement: Progressive chunk streaming MUST NOT deliver a truncated NAR body
 
-When serving a NAR via progressive CDC streaming (`streamProgressiveChunks`/`getNarFromChunks`),
-the system SHALL NOT emit a successful (HTTP 200) response whose body is shorter than the NAR's
-declared size. If chunks stop arriving before the full NAR is produced — because chunking was
+The system SHALL NOT emit a successful (HTTP 200) response whose body is shorter than the NAR's
+declared size when serving via progressive CDC streaming (`streamProgressiveChunks`/`getNarFromChunks`).
+If chunks stop arriving before the full NAR is produced — because chunking was
 aborted, stalled past the lock TTL, or the producing download failed — the streaming path SHALL
 surface an error (so the client sees a failed transfer / retryable condition) rather than closing
 a short, well-formed-looking body.
@@ -166,3 +164,36 @@ a synchronous upstream re-download over emitting a partial body.
 - **AND** the NAR is not otherwise present (no whole-file, `total_chunks = 0`)
 - **WHEN** the wait elapses
 - **THEN** the streaming path SHALL surface an error rather than completing the response
+
+### Requirement: The chunk-wait deadline MUST be bounded and configurable
+
+The serving path SHALL bound the time it waits on chunk production and chunk reads by an explicit, operator-configurable deadline that defaults to a value fitting within a typical reverse-proxy gateway timeout. It SHALL NOT wait indefinitely (or in unbounded per-chunk increments) such that total serving time can exceed the gateway timeout and surface to the client as a gateway 504.
+
+#### Scenario: Per-request serving time is bounded below the gateway timeout
+
+- **GIVEN** a NAR is being served and a chunk read stalls
+- **AND** the configured serving deadline is shorter than the gateway timeout
+- **WHEN** the serving deadline elapses
+- **THEN** the system SHALL terminate the request with a retryable error
+- **AND** SHALL NOT allow the request to hang until the gateway returns a 504
+
+#### Scenario: The deadline is configurable
+
+- **GIVEN** an operator sets the chunk-wait / serving deadline via configuration
+- **WHEN** the server loads its configuration
+- **THEN** the serving path SHALL honor the configured deadline
+- **AND** in the absence of explicit configuration SHALL apply a documented default
+
+### Requirement: A chunk stall after the response is committed MUST surface as a stream error, not a clean EOF
+
+The streaming path SHALL terminate a post-commit chunk stall in a way the client observes as a failed/aborted transfer (an abnormal stream/connection termination), never as a clean end-of-body that a client could mistake for a complete NAR. This applies once the response status and some body bytes have already been committed; a short body that decodes as a truncated archive is a forbidden outcome.
+
+#### Scenario: Mid-stream stall aborts the transfer rather than ending it cleanly
+
+- **GIVEN** a NAR for hash `H` is mid-transfer from chunks and bytes are already committed
+- **AND** the next required chunk does not arrive within the serving deadline
+- **WHEN** the wait elapses
+- **THEN** the system SHALL abort the response so the client sees a failed transfer
+- **AND** SHALL NOT close the body at the truncation point as if the NAR were complete
+- **AND** the client SHALL be free to retry the request
+

--- a/pkg/cache/ambiguous_storage_purge_internal_test.go
+++ b/pkg/cache/ambiguous_storage_purge_internal_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/nix-community/go-nix/pkg/narinfo"
 	"github.com/stretchr/testify/require"
 
 	locklocal "github.com/kalbasit/ncps/pkg/lock/local"
@@ -87,4 +89,53 @@ func TestGetNarInfoFromDatabase_AmbiguousStorageErrorDoesNotPurge(t *testing.T) 
 	// The narinfo row must still exist — it was not purged.
 	_, err = fetchNarInfo(ctx, dbClient, testdata.Nar1.NarInfoHash)
 	require.NoError(t, err, "narinfo must not be purged on an ambiguous storage error")
+}
+
+// TestGetNarInfoFromStore_AmbiguousStorageErrorDoesNotPurge is the store-path
+// counterpart: getNarInfoFromStore must likewise not destructively purge a
+// narinfo when the backing NAR's presence cannot be determined (ambiguous
+// storage error), as opposed to a confirmed absence.
+func TestGetNarInfoFromStore_AmbiguousStorageErrorDoesNotPurge(t *testing.T) {
+	t.Parallel()
+
+	ctx := newContext()
+
+	dir, err := os.MkdirTemp("", "cache-path-")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
+	dbClient, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dbClient.Close() })
+
+	localStore, err := local.New(ctx, dir)
+	require.NoError(t, err)
+
+	ni, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
+	require.NoError(t, err)
+
+	narURL, err := nar.ParseURL(ni.URL)
+	require.NoError(t, err)
+
+	narStore := &ambiguousNarStore{Store: localStore, failHash: narURL.Hash}
+
+	c, err := New(ctx, cacheName, dbClient, localStore, localStore, narStore, "",
+		locklocal.NewLocker(), locklocal.NewRWLocker(), downloadLockTTL, downloadPollTimeout, cacheLockTTL)
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	// Place the narinfo in the store so getNarInfoFromStore finds it.
+	require.NoError(t, localStore.PutNarInfo(ctx, testdata.Nar1.NarInfoHash, ni))
+
+	got, err := c.getNarInfoFromStore(ctx, testdata.Nar1.NarInfoHash)
+	require.NoError(t, err,
+		"an ambiguous storage error must not purge the narinfo nor surface as an error")
+	require.NotNil(t, got)
+
+	// The narinfo must still be in the store — it was not purged.
+	require.True(t, localStore.HasNarInfo(ctx, testdata.Nar1.NarInfoHash),
+		"narinfo must not be purged from the store on an ambiguous storage error")
 }

--- a/pkg/cache/ambiguous_storage_purge_internal_test.go
+++ b/pkg/cache/ambiguous_storage_purge_internal_test.go
@@ -1,0 +1,90 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	locklocal "github.com/kalbasit/ncps/pkg/lock/local"
+
+	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage/local"
+	"github.com/kalbasit/ncps/testdata"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// errSimulatedStorageTimeout models an undeterminable storage result — e.g. a
+// timed-out or stale stat on a network filesystem — as opposed to a confirmed
+// absence (which StatNar reports as (false, nil)).
+var errSimulatedStorageTimeout = errors.New("simulated storage timeout")
+
+// ambiguousNarStore wraps a real local store but reports an undeterminable
+// result (false, err) from StatNar for a chosen NAR hash, simulating a flaky
+// network filesystem that errors on stat instead of returning ENOENT.
+type ambiguousNarStore struct {
+	*local.Store
+
+	failHash string
+}
+
+func (s *ambiguousNarStore) StatNar(ctx context.Context, narURL nar.URL) (bool, error) {
+	if narURL.Hash == s.failHash {
+		return false, errSimulatedStorageTimeout
+	}
+
+	return s.Store.StatNar(ctx, narURL)
+}
+
+// TestGetNarInfoFromDatabase_AmbiguousStorageErrorDoesNotPurge reproduces the
+// production "requesting a purge" cascade on a shared network filesystem: a
+// narinfo is present in the DB, but a stat of its backing NAR fails ambiguously
+// (not a confirmed absence). The purge guard MUST treat that as "could not
+// determine" — keep the narinfo and let the next request re-evaluate — rather
+// than destructively purging it (which then surfaces to clients as a 404).
+func TestGetNarInfoFromDatabase_AmbiguousStorageErrorDoesNotPurge(t *testing.T) {
+	t.Parallel()
+
+	ctx := newContext()
+
+	dir, err := os.MkdirTemp("", "cache-path-")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
+	dbClient, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dbClient.Close() })
+
+	localStore, err := local.New(ctx, dir)
+	require.NoError(t, err)
+
+	narStore := &ambiguousNarStore{Store: localStore, failHash: testdata.Nar1.NarHash}
+
+	c, err := New(ctx, cacheName, dbClient, localStore, localStore, narStore, "",
+		locklocal.NewLocker(), locklocal.NewRWLocker(), downloadLockTTL, downloadPollTimeout, cacheLockTTL)
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	// A narinfo whose backing NAR the store will report ambiguously.
+	_, err = dbClient.Ent().NarInfo.Create().
+		SetHash(testdata.Nar1.NarInfoHash).
+		SetURL("nar/" + testdata.Nar1.NarHash + ".nar").
+		Save(ctx)
+	require.NoError(t, err)
+
+	ni, err := c.getNarInfoFromDatabase(ctx, testdata.Nar1.NarInfoHash)
+	require.NoError(t, err,
+		"an ambiguous storage error must not purge the narinfo nor surface as an error")
+	require.NotNil(t, ni)
+
+	// The narinfo row must still exist — it was not purged.
+	_, err = fetchNarInfo(ctx, dbClient, testdata.Nar1.NarInfoHash)
+	require.NoError(t, err, "narinfo must not be purged on an ambiguous storage error")
+}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4003,17 +4003,18 @@ func (c *Cache) getNarInfoFromStore(ctx context.Context, hash string) (*narinfo.
 		NewLogger(*zerolog.Ctx(ctx)).
 		WithContext(ctx)
 
-	// For Compression:none NARs, the physical file is stored as .nar.zst; check that first.
-	hasNarInStore := false
+	// Verify the NAR exists in storage. Use statNarInStore (which also handles the
+	// .nar.zst fallback for Compression:none) so an ambiguous storage error — a
+	// timed-out or stale stat on a network filesystem — is NOT mistaken for a
+	// confirmed absence and does not drive a destructive purge.
+	hasNarInStore, storeErr := c.statNarInStore(ctx, narURL)
+	if storeErr != nil {
+		zerolog.Ctx(ctx).
+			Warn().
+			Err(storeErr).
+			Msg("ambiguous storage error checking nar presence, skipping purge")
 
-	if narURL.Compression == nar.CompressionTypeNone {
-		zstdURL := narURL
-		zstdURL.Compression = nar.CompressionTypeZstd
-		hasNarInStore = c.narStore.HasNar(ctx, zstdURL)
-	}
-
-	if !hasNarInStore {
-		hasNarInStore = c.narStore.HasNar(ctx, narURL)
+		return ni, nil
 	}
 
 	if !hasNarInStore && !c.hasUpstreamJob(narURL.Hash) {
@@ -7229,7 +7230,11 @@ func (c *Cache) SetChunkWaitTimeout(d time.Duration) {
 		d = defaultChunkWaitTimeout
 	}
 
+	// Guard with cdcMu (the same mutex protecting the other CDC config) so a
+	// concurrent reader in streamProgressiveChunks never sees a torn write.
+	c.cdcMu.Lock()
 	c.chunkWaitTimeout = d
+	c.cdcMu.Unlock()
 }
 
 // streamProgressiveChunks streams chunks as they become available during an in-progress chunking operation.
@@ -7239,7 +7244,10 @@ func (c *Cache) SetChunkWaitTimeout(d time.Duration) {
 func (c *Cache) streamProgressiveChunks(ctx context.Context, w io.Writer, narFileID int64, raw bool) error {
 	pollInterval := 200 * time.Millisecond
 
+	c.cdcMu.RLock()
 	maxWaitPerChunk := c.chunkWaitTimeout
+	c.cdcMu.RUnlock()
+
 	if maxWaitPerChunk <= 0 {
 		maxWaitPerChunk = defaultChunkWaitTimeout
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -439,6 +439,12 @@ type Cache struct {
 	downloadPollTimeout time.Duration
 	cacheLockTTL        time.Duration
 
+	// chunkWaitTimeout bounds how long progressive CDC streaming waits for the
+	// next chunk to be produced/become readable before treating the transfer as
+	// failed. Defaults to defaultChunkWaitTimeout; operators on high-latency
+	// storage can raise or lower it (and align it with their gateway timeout).
+	chunkWaitTimeout time.Duration
+
 	// upstreamJobs is used to store in-progress jobs for pulling nars from
 	// upstream cache so incoming requests for the same nar can find and wait
 	// for jobs. Protected by upstreamJobsMu for local synchronization.
@@ -626,6 +632,7 @@ func New(
 		downloadLockTTL:      downloadLockTTL,
 		downloadPollTimeout:  downloadPollTimeout,
 		cacheLockTTL:         cacheLockTTL,
+		chunkWaitTimeout:     defaultChunkWaitTimeout,
 		upstreamJobs:         make(map[string]*downloadState),
 		upstreamCaches:       make([]*upstream.Cache, 0),
 		recordAgeIgnoreTouch: recordAgeIgnoreTouch,
@@ -3893,17 +3900,33 @@ func (c *Cache) isServable(ctx context.Context, narURL nar.URL) (bool, error) {
 
 // hasNarInStore checks if the NAR exists in the storage, handling the .nar.zst fallback for CompressionTypeNone.
 func (c *Cache) HasNarInStore(ctx context.Context, narURL nar.URL) bool {
+	present, _ := c.statNarInStore(ctx, narURL)
+
+	return present
+}
+
+// statNarInStore reports whether the NAR is in storage, distinguishing a
+// confirmed absence (false, nil) from an undeterminable result (false, err).
+// Decision paths that must not treat an ambiguous storage error as "absent"
+// (e.g. before purging a narinfo) MUST use this instead of HasNarInStore.
+func (c *Cache) statNarInStore(ctx context.Context, narURL nar.URL) (bool, error) {
 	// For Compression:none NARs, the physical file is stored as .nar.zst; check that first.
 	if narURL.Compression == nar.CompressionTypeNone {
 		zstdURL := narURL
 
 		zstdURL.Compression = nar.CompressionTypeZstd
-		if c.narStore.HasNar(ctx, zstdURL) {
-			return true
+
+		present, err := c.narStore.StatNar(ctx, zstdURL)
+		if err != nil {
+			return false, err
+		}
+
+		if present {
+			return true, nil
 		}
 	}
 
-	return c.narStore.HasNar(ctx, narURL)
+	return c.narStore.StatNar(ctx, narURL)
 }
 
 func (c *Cache) signNarInfo(ctx context.Context, hash string, narInfo *narinfo.NarInfo) error {
@@ -4197,10 +4220,24 @@ func (c *Cache) getNarInfoFromDatabase(ctx context.Context, hash string) (*narin
 
 	// Check if this narinfo should be purged
 	if !hasNar && !isBeingDownloadedLocally && !isBeingDownloadedRemotely { //nolint:nestif // deferred
-		// Double-check HasNarInStore to close the TOCTOU window: if the NAR download
-		// completed (os.Rename) between the initial HasNarInStore check and hasUpstreamJob
+		// Double-check store presence to close the TOCTOU window: if the NAR download
+		// completed (os.Rename) between the initial check and hasUpstreamJob
 		// returning false (job removed after os.Rename), the NAR is already on disk.
-		hasNar = c.HasNarInStore(ctx, *narURL)
+		// Use statNarInStore (not HasNarInStore) so an ambiguous storage error — a
+		// timed-out or stale stat on a network filesystem — is NOT mistaken for a
+		// confirmed absence and does not drive a destructive purge.
+		var storeErr error
+
+		hasNar, storeErr = c.statNarInStore(ctx, *narURL)
+		if storeErr != nil {
+			zerolog.Ctx(ctx).
+				Warn().
+				Err(storeErr).
+				Msg("ambiguous storage error checking nar presence, skipping purge")
+
+			return ni, nil
+		}
+
 		if !hasNar {
 			var recheckErr error
 
@@ -7177,13 +7214,35 @@ func (c *Cache) streamChunksWithPrefetch(ctx context.Context, w io.Writer, chunk
 	return nil
 }
 
+// defaultChunkWaitTimeout is the default bound on how long progressive CDC
+// streaming waits for the next chunk before treating the transfer as failed.
+// It is intentionally below common reverse-proxy gateway timeouts so a stalled
+// chunk surfaces as a retryable error rather than a gateway 504.
+const defaultChunkWaitTimeout = 30 * time.Second
+
+// SetChunkWaitTimeout overrides the per-chunk wait bound used by progressive CDC
+// streaming. A non-positive value resets it to defaultChunkWaitTimeout. Operators
+// on high-latency storage can raise it; those behind a short gateway timeout can
+// lower it to fail fast and let the client retry.
+func (c *Cache) SetChunkWaitTimeout(d time.Duration) {
+	if d <= 0 {
+		d = defaultChunkWaitTimeout
+	}
+
+	c.chunkWaitTimeout = d
+}
+
 // streamProgressiveChunks streams chunks as they become available during an in-progress chunking operation.
 // This allows concurrent downloads while another instance is still chunking the NAR.
 // It uses a batch query to fetch multiple available chunks at once, eliminating per-chunk
 // poll latency when chunks are already created. Only polls (200ms) when no new chunks are available yet.
 func (c *Cache) streamProgressiveChunks(ctx context.Context, w io.Writer, narFileID int64, raw bool) error {
 	pollInterval := 200 * time.Millisecond
-	maxWaitPerChunk := 30 * time.Second
+
+	maxWaitPerChunk := c.chunkWaitTimeout
+	if maxWaitPerChunk <= 0 {
+		maxWaitPerChunk = defaultChunkWaitTimeout
+	}
 
 	chunkChan := make(chan *prefetchedChunk, prefetchBufferSize)
 

--- a/pkg/cache/chunk_wait_timeout_internal_test.go
+++ b/pkg/cache/chunk_wait_timeout_internal_test.go
@@ -1,0 +1,54 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/testdata"
+)
+
+// TestStreamProgressiveChunks_ChunkWaitTimeoutIsConfigurable verifies that the
+// per-chunk wait bound is operator-configurable: with a short SetChunkWaitTimeout
+// an in-progress chunking that never produces chunks fails fast, rather than
+// blocking for the 30s default (which on slow storage accumulates past the
+// gateway timeout and surfaces to clients as a 504).
+func TestStreamProgressiveChunks_ChunkWaitTimeoutIsConfigurable(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := newCDCCacheForStreaming(t)
+
+	c.SetChunkWaitTimeout(200 * time.Millisecond)
+
+	// A nar_file that is legitimately "chunking in progress" (ChunkingStartedAt
+	// set, TotalChunks=0) but for which no chunk ever arrives — the producer is
+	// stalled, e.g. a slow network filesystem on another replica.
+	_, err := c.dbClient.Ent().NarFile.Create().
+		SetHash(testdata.Nar1.NarHash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(12345).
+		SetChunkingStartedAt(time.Now()).
+		Save(ctx)
+	require.NoError(t, err)
+
+	narURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeNone}
+
+	_, rc, err := c.getNarFromChunks(ctx, &narURL)
+	require.NoError(t, err)
+
+	defer rc.Close()
+
+	start := time.Now()
+	body, readErr := readAllWithin(t, rc, 10*time.Second)
+	elapsed := time.Since(start)
+
+	require.Error(t, readErr,
+		"an in-progress chunking that never produces a chunk must time out, not stream a short body")
+	assert.Less(t, elapsed, 5*time.Second,
+		"must honor the short configured chunk-wait timeout (200ms), not the 30s default")
+	assert.Empty(t, body, "no bytes should be delivered when the chunk never arrives")
+}

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -411,6 +411,14 @@ func serveCommand(
 				Sources: flagSources("cache.download.poll-timeout", "CACHE_DOWNLOAD_POLL_TIMEOUT"),
 				Value:   30 * time.Second,
 			},
+			&cli.DurationFlag{
+				Name: "cache-cdc-chunk-wait-timeout",
+				Usage: "Max time progressive CDC streaming waits for the next chunk before failing the " +
+					"transfer. Keep it below your reverse-proxy gateway timeout so a stalled chunk on " +
+					"high-latency storage surfaces as a retryable error instead of a gateway 504.",
+				Sources: flagSources("cache.cdc.chunk-wait-timeout", "CACHE_CDC_CHUNK_WAIT_TIMEOUT"),
+				Value:   30 * time.Second,
+			},
 			&cli.IntFlag{
 				Name:    flagNameLockMaxRetries,
 				Usage:   flagUsageLockMaxRetries,
@@ -1092,6 +1100,8 @@ func createCache(
 	if err := c.SetCDCConfiguration(cdcEnabled, cdcMin, cdcAvg, cdcMax); err != nil {
 		return nil, fmt.Errorf("error configuring CDC: %w", err)
 	}
+
+	c.SetChunkWaitTimeout(cmd.Duration("cache-cdc-chunk-wait-timeout"))
 
 	// Configure lazy chunking
 	cdcLazyChunkingEnabled := cmd.Bool("cache-cdc-lazy-chunking-enabled")

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -329,23 +329,33 @@ func (s *Store) DeleteNarInfo(ctx context.Context, hash string) error {
 	return nil
 }
 
-// HasNar returns true if the store has the nar.
+// HasNar returns true if the store has the nar. Any error (confirmed absence or
+// an undeterminable stat) collapses to false; use StatNar to distinguish them.
 func (s *Store) HasNar(ctx context.Context, narURL nar.URL) bool {
+	present, _ := s.StatNar(ctx, narURL)
+
+	return present
+}
+
+// StatNar reports whether the store has the nar, distinguishing a confirmed
+// absence (false, nil) from an undeterminable result (false, err). See the
+// storage.NarStore interface for the contract.
+func (s *Store) StatNar(ctx context.Context, narURL nar.URL) (bool, error) {
 	normalizedURL, err := narURL.Normalize()
 	if err != nil {
-		return false
+		return false, fmt.Errorf("error normalizing the nar URL: %w", err)
 	}
 
 	tfp, err := normalizedURL.ToFilePath()
 	if err != nil {
-		return false
+		return false, fmt.Errorf("error computing the nar file path: %w", err)
 	}
 
 	narPath := filepath.Join(s.storeNarPath(), tfp)
 
 	_, span := tracer.Start(
 		ctx,
-		"local.HasNar",
+		"local.StatNar",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("nar_url", narURL.String()),
@@ -354,9 +364,17 @@ func (s *Store) HasNar(ctx context.Context, narURL nar.URL) bool {
 	)
 	defer span.End()
 
-	_, err = os.Stat(narPath)
+	if _, err := os.Stat(narPath); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
 
-	return err == nil
+		// Any other error (permission, I/O timeout, stale NFS handle) means we
+		// could not determine presence — surface it instead of claiming absence.
+		return false, fmt.Errorf("error stating the nar file: %w", err)
+	}
+
+	return true, nil
 }
 
 // GetNar returns nar from the store.

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -411,16 +411,26 @@ func (s *Store) DeleteNarInfo(ctx context.Context, hash string) error {
 	return nil
 }
 
-// HasNar returns true if the store has the nar.
+// HasNar returns true if the store has the nar. Any error (confirmed absence or
+// an undeterminable stat) collapses to false; use StatNar to distinguish them.
 func (s *Store) HasNar(ctx context.Context, narURL nar.URL) bool {
+	present, _ := s.StatNar(ctx, narURL)
+
+	return present
+}
+
+// StatNar reports whether the store has the nar, distinguishing a confirmed
+// absence (false, nil) from an undeterminable result (false, err). See the
+// storage.NarStore interface for the contract.
+func (s *Store) StatNar(ctx context.Context, narURL nar.URL) (bool, error) {
 	key, err := s.narPath(narURL)
 	if err != nil {
-		return false
+		return false, fmt.Errorf("error computing the nar key: %w", err)
 	}
 
 	_, span := tracer.Start(
 		ctx,
-		"s3.HasNar",
+		"s3.StatNar",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
 			attribute.String("nar_url", narURL.String()),
@@ -429,9 +439,17 @@ func (s *Store) HasNar(ctx context.Context, narURL nar.URL) bool {
 	)
 	defer span.End()
 
-	_, err = s.client.StatObject(ctx, s.bucket, key, minio.StatObjectOptions{})
+	if _, err := s.client.StatObject(ctx, s.bucket, key, minio.StatObjectOptions{}); err != nil {
+		if minio.ToErrorResponse(err).Code == s3NoSuchKey {
+			return false, nil
+		}
 
-	return err == nil
+		// Any other error (network, timeout, throttling) means we could not
+		// determine presence — surface it instead of claiming absence.
+		return false, fmt.Errorf("error stating the nar object: %w", err)
+	}
+
+	return true, nil
 }
 
 // GetNar returns nar from the store.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -63,7 +63,21 @@ type NarInfoStore interface {
 // NarStore represents a store capable of storing nars.
 type NarStore interface {
 	// HasNar returns true if the store has the nar.
+	//
+	// HasNar collapses every failure mode into false: a confirmed absence and an
+	// undeterminable result (e.g. a timed-out or stale stat on a network
+	// filesystem) are indistinguishable. Callers that must not treat "could not
+	// determine" as "absent" — e.g. before a destructive purge — MUST use StatNar.
 	HasNar(ctx context.Context, narURL nar.URL) bool
+
+	// StatNar reports whether the store has the nar, distinguishing a confirmed
+	// absence from an undeterminable result:
+	//   - (true, nil):  the nar is present.
+	//   - (false, nil): the nar is confirmed absent (e.g. ENOENT / NoSuchKey).
+	//   - (false, err): presence could not be determined (transient/ambiguous
+	//                   error such as an I/O timeout or a stale NFS handle).
+	// Callers MUST NOT treat the (false, err) case as a confirmed absence.
+	StatNar(ctx context.Context, narURL nar.URL) (bool, error)
 
 	// GetNar returns nar from the store.
 	// NOTE: The caller must close the returned io.ReadCloser!


### PR DESCRIPTION
## Summary

On a high-latency or shared-storage backend (e.g. the `local` backend on a network
filesystem with multiple replicas), two failure modes still surfaced to clients as
spurious cache-miss 404s and gateway 504s despite #1296/#1297/#1298:

1. **False-purge cascade.** `HasNar` collapsed *every* error into `false`, so an
   ambiguous/stale NFS stat was indistinguishable from a confirmed absence. The
   narinfo purge guard then destructively purged the narinfo, which clients saw as
   `does not exist in binary cache` (the `"requesting a purge"` log line).
2. **Unbounded per-chunk wait.** Progressive CDC streaming waited a hard-coded 30s
   per chunk; a legitimately slow chunk on high-latency storage accumulated past the
   reverse-proxy timeout and surfaced as a 504 / truncated transfer.

## Changes

- Add `storage.NarStore.StatNar` returning **present / confirmed-absent / unknown**;
  implemented in `local` (`os.IsNotExist`) and `s3` (`NoSuchKey`); `HasNar` now
  delegates to it.
- `getNarInfoFromDatabase` skips the purge on an **ambiguous (non-not-found)** storage
  result and keeps the narinfo, letting the next request re-evaluate.
- Make the per-chunk wait operator-configurable via `cache.cdc.chunk-wait-timeout`
  (`CACHE_CDC_CHUNK_WAIT_TIMEOUT`, default 30s), replacing the hard-coded value so it
  can be aligned with the gateway timeout.
- Storage-backend selection docs (README + `config.example.yaml`): `local` assumes
  single-writer POSIX semantics; multi-replica should use an object store; CDC suits
  low-latency storage.

## Notes

- Most of the original investigation's scope was **already shipped** in the deployed
  `sha-7d071cf` (phantom recovery, aborted-chunking guards); this PR targets the two
  remaining gaps that map to the observed production failures.
- **Deferred to a follow-up:** pre-commit chunk-set verification with
  fallback-to-redownload — reworking `GetNar` servability is regression-risky and
  per-chunk pre-flight stats add load to the same slow backend. Its spec requirement
  was removed before archive so the spec matches what is implemented.
- openspec change `fix-nar-serving-failures` archived (delta specs synced into
  `openspec/specs/`).

## Test plan

- [x] `task fmt`, `task lint`, `task test` green
- [x] TDD, RED verified: `TestGetNarInfoFromDatabase_AmbiguousStorageErrorDoesNotPurge`
      (RED = "the narinfo was purged"), `TestStreamProgressiveChunks_ChunkWaitTimeoutIsConfigurable`
- [ ] CI `nix flake check` (per-backend integration cohorts)