### PR TITLE
feat(helm): expose cache.cdc.chunk-wait-timeout

### DIFF
--- a/charts/ncps/templates/configmap.yaml
+++ b/charts/ncps/templates/configmap.yaml
@@ -55,6 +55,9 @@ data:
         {{- if .Values.config.cdc.lazyCleanupSchedule }}
         lazy-cleanup-schedule: {{ .Values.config.cdc.lazyCleanupSchedule | quote }}
         {{- end }}
+        {{- if .Values.config.cdc.chunkWaitTimeout }}
+        chunk-wait-timeout: {{ .Values.config.cdc.chunkWaitTimeout | quote }}
+        {{- end }}
       {{- end }}
 
       {{- if and (or (eq .Values.config.database.type "postgresql") (eq .Values.config.database.type "mysql")) (or .Values.config.database.pool.maxOpenConns .Values.config.database.pool.maxIdleConns) }}

--- a/charts/ncps/tests/configmap_test.yaml
+++ b/charts/ncps/tests/configmap_test.yaml
@@ -106,6 +106,25 @@ tests:
           path: data["config.yaml"]
           pattern: 'delete-delay: "48h"'
 
+  - it: should configure CDC chunk wait timeout when set
+    set:
+      config.hostname: test.example.com
+      config.cdc.enabled: true
+      config.cdc.chunkWaitTimeout: 60s
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'chunk-wait-timeout: "60s"'
+
+  - it: should omit CDC chunk wait timeout when unset
+    set:
+      config.hostname: test.example.com
+      config.cdc.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "chunk-wait-timeout:"
+
   - it: should enable analytics reporting by default
     set:
       config.hostname: test.example.com

--- a/charts/ncps/values.yaml
+++ b/charts/ncps/values.yaml
@@ -199,6 +199,11 @@ config:
     # Use @every X format (e.g., @every 1h, @every 30m) or standard cron expressions
     lazyCleanupSchedule: "@every 1h"
 
+    # Maximum time to wait for a single chunk during progressive CDC streaming (default: 30s)
+    # Set this to align with your reverse-proxy/gateway timeout on high-latency storage,
+    # avoiding spurious 504s. Leave null to use the server default (30s).
+    chunkWaitTimeout: null
+
     # Bypass flag for HA validation without CDC
     # Use with EXTREME CAUTION. Doing so may result in timeouts and instability.
     # See https://github.com/kalbasit/ncps/issues/660 for more details.

--- a/docs/docs/User Guide/Configuration/Reference.md
+++ b/docs/docs/User Guide/Configuration/Reference.md
@@ -177,6 +177,7 @@ Content-Defined Chunking (CDC) enables deduplication of NAR files by splitting t
 | `--cache-cdc-lazy-recovery-schedule` | Cron schedule for recovering stuck NARs in lazy chunking mode | `CACHE_CDC_LAZY_RECOVERY_SCHEDULE` | `@every 5m` |
 | `--cache-cdc-lazy-recovery-batch-size` | Maximum number of stuck NARs to process per recovery cron run | `CACHE_CDC_LAZY_RECOVERY_BATCH_SIZE` | `100` |
 | `--cache-cdc-lazy-cleanup-schedule` | Cron schedule for cleaning up deleted NAR files after lazy chunking | `CACHE_CDC_LAZY_CLEANUP_SCHEDULE` | `@every 1h` |
+| `--cache-cdc-chunk-wait-timeout` | Maximum time to wait for a single chunk during progressive CDC streaming (align with the gateway timeout on high-latency storage) | `CACHE_CDC_CHUNK_WAIT_TIMEOUT` | `30s` |
 
 **Example:**
 

--- a/docs/docs/User Guide/Features/CDC.md
+++ b/docs/docs/User Guide/Features/CDC.md
@@ -57,6 +57,7 @@ cache:
 | `--cache-cdc-lazy-chunking-enabled` | Enable lazy chunking: store compressed NAR first, chunk in background | `CACHE_CDC_LAZY_CHUNKING_ENABLED` | `false` |
 | `--cache-cdc-background-workers` | Number of background workers for lazy chunking | `CACHE_CDC_BACKGROUND_WORKERS` | (number of CPUs) |
 | `--cache-cdc-delete-delay` | Delay before deleting compressed NAR files after chunking completes | `CACHE_CDC_DELETE_DELAY` | `24h` |
+| `--cache-cdc-chunk-wait-timeout` | Maximum time to wait for a single chunk during progressive CDC streaming | `CACHE_CDC_CHUNK_WAIT_TIMEOUT` | `30s` |
 
 ### Lazy Chunking
 

--- a/docs/docs/User Guide/Installation/Helm Chart.md
+++ b/docs/docs/User Guide/Installation/Helm Chart.md
@@ -496,6 +496,10 @@ config:
     # Delay before deleting compressed NAR files after chunking completes (default: 24h)
     # This allows clients to update their cache before the original compressed file is removed
     deleteDelay: 24h
+
+    # Maximum time to wait for a single chunk during progressive CDC streaming (default: 30s)
+    # Align with your reverse-proxy/gateway timeout on high-latency storage to avoid 504s
+    chunkWaitTimeout: 30s
 ```
 
 ## Temporary Volume Configuration

--- a/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
+++ b/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
@@ -185,6 +185,7 @@ Configuration for the temporary directory used for downloads and transient opera
 | `config.cdc.lazyChunkingEnabled` | Enable lazy chunking (store compressed NAR first, chunk in background) | `false` |
 | `config.cdc.backgroundWorkers` | Number of background workers for lazy chunking | `null` (server default: number of CPUs) |
 | `config.cdc.deleteDelay` | Delay before deleting compressed NAR files after chunking completes | `24h` |
+| `config.cdc.chunkWaitTimeout` | Maximum time to wait for a single chunk during progressive CDC streaming. Align with your gateway timeout on high-latency storage. | `null` (server default: `30s`) |
 | `config.cdc.iLoveTimeouts` | Bypass flag for HA validation without CDC | `false` |
 
 ### Database Configuration

--- a/openspec/changes/archive/2026-05-30-expose-chunk-wait-timeout-helm/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-30-expose-chunk-wait-timeout-helm/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-30

--- a/openspec/changes/archive/2026-05-30-expose-chunk-wait-timeout-helm/design.md
+++ b/openspec/changes/archive/2026-05-30-expose-chunk-wait-timeout-helm/design.md
@@ -1,0 +1,87 @@
+## Context
+
+Commit `9256f27c` added `cache.cdc.chunk-wait-timeout` (`CACHE_CDC_CHUNK_WAIT_TIMEOUT`,
+default `30s`), registered in `pkg/ncps/serve.go` as the `cache-cdc-chunk-wait-timeout`
+flag and applied via `c.SetChunkWaitTimeout(cmd.Duration(...))`. The Helm chart renders
+the rest of the `cdc:` block from `config.cdc.*` values but has no entry for this flag, so
+operators running the exact deployments that motivated the flag (HA + CDC + slow/shared
+storage) cannot tune it without hand-editing rendered config.
+
+The chart already establishes a clear, repeatable pattern for optional `cdc.*` knobs:
+- `values.yaml` carries the value (with a `null` default for "use the binary default").
+- `templates/configmap.yaml` wraps each key in `{{- if .Values.config.cdc.<x> }}` and
+  renders duration/string values with `| quote`.
+
+This is a chart-and-docs-only change; the Go flag already exists.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expose `config.cdc.chunkWaitTimeout` in the chart, rendering `chunk-wait-timeout` into the
+  `cache.cdc` block only when set, as a quoted duration.
+- Default the value to `null` so existing renders are byte-for-byte unchanged and the binary's
+  `30s` default continues to apply.
+- Cover the behavior with a Helm unit test (set → rendered; unset → omitted).
+- Document the knob at the Helm-chart level and the underlying flag at the CLI/CDC level.
+
+**Non-Goals:**
+- Changing the flag's default or runtime behavior.
+- Exposing any other unexposed flags or restructuring the `cdc` value layout.
+- Adding gateway-timeout coordination logic.
+
+## Decisions
+
+### D1: Render conditionally with `| quote`, mirroring `deleteDelay`
+
+Follow the established pattern at `configmap.yaml:46-48`. The value is a Go duration string
+(e.g. `60s`, `1m30s`), so it must be quoted to stay a YAML string:
+
+```yaml
+{{- if .Values.config.cdc.chunkWaitTimeout }}
+chunk-wait-timeout: {{ .Values.config.cdc.chunkWaitTimeout | quote }}
+{{- end }}
+```
+
+Placed inside the existing `{{- if .Values.config.cdc.enabled }}` guard, after
+`lazy-cleanup-schedule`.
+
+**Alternative considered:** always render with a chart-side default of `"30s"`. Rejected —
+it would duplicate the binary's default in two places (drift risk) and change existing
+rendered output for current users. `null`-default + conditional keeps a single source of truth.
+
+### D2: `null` default in `values.yaml`
+
+Matches `backgroundWorkers` (`null`, "server default"). Documented in `values.yaml` with the
+server default (`30s`) and the gateway-alignment use case noted.
+
+### D3: Helm unit test under `charts/ncps/tests/`
+
+Add assertions in the existing CDC configmap test suite (or a new test file consistent with the
+suite's conventions): one asserting `chunk-wait-timeout: "<v>"` is present when the value is set,
+one asserting the key is absent when it is null. TDD: write/extend the test first (RED), then add
+the template line (GREEN).
+
+### D4: Documentation placement
+
+- Helm: add a row to the `config.cdc.*` table in
+  `Installation/Helm Chart/Chart Reference.md` and to the `cdc:` example in `Helm Chart.md`.
+- CLI/CDC: add a row to the `--cache-cdc-*` tables in `Configuration/Reference.md` and
+  `Features/CDC.md` for `--cache-cdc-chunk-wait-timeout` (`CACHE_CDC_CHUNK_WAIT_TIMEOUT`, `30s`).
+
+## Risks / Trade-offs
+
+- **[Quoting omitted → YAML parses duration oddly]** → Use `| quote` exactly as the sibling
+  duration keys do; the unit test asserts the quoted form.
+- **[Drift between chart default and binary default]** → Avoided by D1/D2: chart omits the key
+  when unset; the binary owns the single `30s` default.
+- **[Docs tables drift further behind flags]** → This change also documents the flag the HEAD
+  commit left undocumented, reducing existing drift rather than adding to it.
+
+## Migration Plan
+
+Additive, non-breaking. Operators on existing values get identical rendered output. No rollback
+concerns; reverting the chart change simply removes the value (binary default resumes).
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-05-30-expose-chunk-wait-timeout-helm/proposal.md
+++ b/openspec/changes/archive/2026-05-30-expose-chunk-wait-timeout-helm/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+Commit `9256f27c` added the operator-configurable flag `cache.cdc.chunk-wait-timeout`
+(`CACHE_CDC_CHUNK_WAIT_TIMEOUT`, default `30s`) so the per-chunk wait in progressive
+CDC streaming can be aligned with a deployment's reverse-proxy/gateway timeout, avoiding
+spurious 504s on high-latency storage. The flag is registered in the binary but is **not
+exposed by the Helm chart**, so the very operators who hit this failure mode (HA,
+CDC-enabled, shared/slow storage) cannot tune it without hand-editing the rendered config.
+
+## What Changes
+
+- Add a `config.cdc.chunkWaitTimeout` value to `charts/ncps/values.yaml`, documented and
+  defaulted to `null` (chart omits the key → binary applies its own `30s` default), matching
+  how the other optional `cdc.*` knobs are handled.
+- Render `chunk-wait-timeout` into the `cdc:` block of `charts/ncps/templates/configmap.yaml`
+  only when the value is set, mirroring the existing conditional rendering of `deleteDelay`,
+  `lazyRecoverySchedule`, etc. (quoted, since it is a Go duration string).
+- Add a Helm unit test under `charts/ncps/tests/` asserting the key is rendered when set and
+  omitted when null.
+- Document the new knob in `docs/docs/`: add `config.cdc.chunkWaitTimeout` to the Helm
+  `Chart Reference.md` value table and the `Helm Chart.md` `cdc:` example, **and** document the
+  underlying `--cache-cdc-chunk-wait-timeout` / `CACHE_CDC_CHUNK_WAIT_TIMEOUT` flag in
+  `Configuration/Reference.md` and `Features/CDC.md` (the HEAD commit added the flag without
+  updating these tables).
+
+No application/Go code changes; the flag already exists.
+
+## Non-goals
+
+- Changing the flag's default value or its behavior in the Go binary.
+- Exposing any other unexposed flags, or restructuring the chart's `cdc` value layout.
+- Adding HA/gateway-timeout coordination logic; this only surfaces an existing knob.
+
+## Capabilities
+
+### New Capabilities
+
+- `helm-cdc-chunk-wait-timeout`: The Helm chart MUST allow operators to configure the CDC
+  per-chunk wait timeout via `config.cdc.chunkWaitTimeout`, rendering it into the cache CDC
+  config when set and omitting it (binary default applies) when unset.
+
+### Modified Capabilities
+
+<!-- none — this surfaces an existing flag through the chart; no existing spec's requirements change -->
+
+## Impact
+
+- **Code/config**: `charts/ncps/values.yaml`, `charts/ncps/templates/configmap.yaml`, new
+  test under `charts/ncps/tests/`. No Go, database, or migration impact.
+- **Docs**: `docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md`,
+  `.../Helm Chart.md`, `.../Configuration/Reference.md`, `.../Features/CDC.md`.
+- **I/O / latency / memory**: None at the chart-render level. At runtime the value only bounds
+  an existing per-chunk wait; leaving it unset preserves today's `30s` behavior exactly.
+- **Validation**: `helm unittest charts/ncps` (and `nix flake check`).

--- a/openspec/changes/archive/2026-05-30-expose-chunk-wait-timeout-helm/specs/helm-cdc-chunk-wait-timeout/spec.md
+++ b/openspec/changes/archive/2026-05-30-expose-chunk-wait-timeout-helm/specs/helm-cdc-chunk-wait-timeout/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Helm chart exposes the CDC chunk-wait timeout
+
+The Helm chart MUST allow operators to configure the CDC per-chunk wait timeout
+through a `config.cdc.chunkWaitTimeout` value. When set, the chart MUST render the
+corresponding `chunk-wait-timeout` key inside the `cache.cdc` block of the generated
+config (the ConfigMap), as a quoted Go duration string. The value MUST be defaulted
+to `null` in `values.yaml` so that, when the operator does not set it, the chart omits
+the key entirely and the ncps binary applies its own built-in default (`30s`).
+
+#### Scenario: Operator sets chunkWaitTimeout
+
+- **WHEN** the chart is rendered with `config.cdc.enabled=true` and
+  `config.cdc.chunkWaitTimeout="60s"`
+- **THEN** the rendered ConfigMap's `cache.cdc` block contains
+  `chunk-wait-timeout: "60s"`
+
+#### Scenario: Operator leaves chunkWaitTimeout unset
+
+- **WHEN** the chart is rendered with `config.cdc.enabled=true` and
+  `config.cdc.chunkWaitTimeout` left at its `null` default
+- **THEN** the rendered ConfigMap's `cache.cdc` block contains no `chunk-wait-timeout`
+  key, allowing the binary's built-in `30s` default to apply
+
+#### Scenario: CDC disabled
+
+- **WHEN** the chart is rendered with `config.cdc.enabled=false`
+- **THEN** no `cdc` block (and therefore no `chunk-wait-timeout` key) is rendered,
+  regardless of the `config.cdc.chunkWaitTimeout` value
+
+### Requirement: Documentation covers the chunk-wait timeout knob
+
+The user-facing documentation MUST describe how to configure the CDC chunk-wait
+timeout at both the Helm-chart and binary-flag levels. The Helm chart reference and
+its example MUST document `config.cdc.chunkWaitTimeout`, and the CLI/CDC references
+MUST document the underlying `--cache-cdc-chunk-wait-timeout` flag and its
+`CACHE_CDC_CHUNK_WAIT_TIMEOUT` environment variable, including the `30s` default.
+
+#### Scenario: Helm chart reference lists the value
+
+- **WHEN** a reader consults the Helm chart reference and example documentation
+- **THEN** `config.cdc.chunkWaitTimeout` is listed with its purpose and default
+
+#### Scenario: CLI reference lists the flag
+
+- **WHEN** a reader consults the configuration reference and the CDC feature docs
+- **THEN** `--cache-cdc-chunk-wait-timeout` / `CACHE_CDC_CHUNK_WAIT_TIMEOUT` is listed
+  with its purpose and `30s` default

--- a/openspec/changes/archive/2026-05-30-expose-chunk-wait-timeout-helm/tasks.md
+++ b/openspec/changes/archive/2026-05-30-expose-chunk-wait-timeout-helm/tasks.md
@@ -1,0 +1,33 @@
+## 1. Helm chart: tests first (RED)
+
+- [x] 1.1 In `charts/ncps/tests/configmap_test.yaml`, add a test asserting that when
+  `config.cdc.enabled=true` and `config.cdc.chunkWaitTimeout` is set (e.g. `"60s"`), the
+  rendered ConfigMap contains `chunk-wait-timeout: "60s"` in the `cache.cdc` block.
+- [x] 1.2 Add a test asserting that when `config.cdc.enabled=true` and `chunkWaitTimeout` is
+  left at its `null` default, no `chunk-wait-timeout` key is rendered.
+- [x] 1.3 Run `helm unittest charts/ncps` and confirm the new assertions FAIL (RED).
+
+## 2. Helm chart: implementation (GREEN)
+
+- [x] 2.1 Add `chunkWaitTimeout: null` to the `config.cdc` block in `charts/ncps/values.yaml`,
+  with a comment documenting the `30s` server default and the gateway-alignment use case.
+- [x] 2.2 In `charts/ncps/templates/configmap.yaml`, after `lazy-cleanup-schedule`, add the
+  conditional render: `{{- if .Values.config.cdc.chunkWaitTimeout }}` →
+  `chunk-wait-timeout: {{ .Values.config.cdc.chunkWaitTimeout | quote }}` → `{{- end }}`.
+- [x] 2.3 Run `helm unittest charts/ncps` and confirm all assertions PASS (GREEN).
+
+## 3. Documentation
+
+- [x] 3.1 Add a `config.cdc.chunkWaitTimeout` row to the `config.cdc.*` table in
+  `docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md`.
+- [x] 3.2 Add `chunkWaitTimeout` to the `cdc:` example block in
+  `docs/docs/User Guide/Installation/Helm Chart.md`.
+- [x] 3.3 Add a `--cache-cdc-chunk-wait-timeout` row (`CACHE_CDC_CHUNK_WAIT_TIMEOUT`, default
+  `30s`) to the CDC flags table in `docs/docs/User Guide/Configuration/Reference.md`.
+- [x] 3.4 Add the same flag row to the flags table in
+  `docs/docs/User Guide/Features/CDC.md`.
+
+## 4. Verify
+
+- [x] 4.1 Run `task fmt` and confirm it exits clean.
+- [x] 4.2 Run `helm unittest charts/ncps` (and `nix flake check` if feasible) and confirm green.

--- a/openspec/specs/helm-cdc-chunk-wait-timeout/spec.md
+++ b/openspec/specs/helm-cdc-chunk-wait-timeout/spec.md
@@ -1,0 +1,56 @@
+# Capability Spec: Helm CDC Chunk-Wait Timeout
+
+## Purpose
+
+Defines requirements for exposing the CDC per-chunk wait timeout through the Helm
+chart and documenting it across the Helm-chart and binary-flag levels.
+
+## Requirements
+
+### Requirement: Helm chart exposes the CDC chunk-wait timeout
+
+The Helm chart MUST allow operators to configure the CDC per-chunk wait timeout
+through a `config.cdc.chunkWaitTimeout` value. When set, the chart MUST render the
+corresponding `chunk-wait-timeout` key inside the `cache.cdc` block of the generated
+config (the ConfigMap), as a quoted Go duration string. The value MUST be defaulted
+to `null` in `values.yaml` so that, when the operator does not set it, the chart omits
+the key entirely and the ncps binary applies its own built-in default (`30s`).
+
+#### Scenario: Operator sets chunkWaitTimeout
+
+- **WHEN** the chart is rendered with `config.cdc.enabled=true` and
+  `config.cdc.chunkWaitTimeout="60s"`
+- **THEN** the rendered ConfigMap's `cache.cdc` block contains
+  `chunk-wait-timeout: "60s"`
+
+#### Scenario: Operator leaves chunkWaitTimeout unset
+
+- **WHEN** the chart is rendered with `config.cdc.enabled=true` and
+  `config.cdc.chunkWaitTimeout` left at its `null` default
+- **THEN** the rendered ConfigMap's `cache.cdc` block contains no `chunk-wait-timeout`
+  key, allowing the binary's built-in `30s` default to apply
+
+#### Scenario: CDC disabled
+
+- **WHEN** the chart is rendered with `config.cdc.enabled=false`
+- **THEN** no `cdc` block (and therefore no `chunk-wait-timeout` key) is rendered,
+  regardless of the `config.cdc.chunkWaitTimeout` value
+
+### Requirement: Documentation covers the chunk-wait timeout knob
+
+The user-facing documentation MUST describe how to configure the CDC chunk-wait
+timeout at both the Helm-chart and binary-flag levels. The Helm chart reference and
+its example MUST document `config.cdc.chunkWaitTimeout`, and the CLI/CDC references
+MUST document the underlying `--cache-cdc-chunk-wait-timeout` flag and its
+`CACHE_CDC_CHUNK_WAIT_TIMEOUT` environment variable, including the `30s` default.
+
+#### Scenario: Helm chart reference lists the value
+
+- **WHEN** a reader consults the Helm chart reference and example documentation
+- **THEN** `config.cdc.chunkWaitTimeout` is listed with its purpose and default
+
+#### Scenario: CLI reference lists the flag
+
+- **WHEN** a reader consults the configuration reference and the CDC feature docs
+- **THEN** `--cache-cdc-chunk-wait-timeout` / `CACHE_CDC_CHUNK_WAIT_TIMEOUT` is listed
+  with its purpose and `30s` default


### PR DESCRIPTION
## Summary

The `cache.cdc.chunk-wait-timeout` flag (`CACHE_CDC_CHUNK_WAIT_TIMEOUT`, default `30s`) added in #1299 bounds the per-chunk wait during progressive CDC streaming so operators can align it with their reverse-proxy/gateway timeout on high-latency storage. The flag was registered in the binary but not reachable from the Helm chart.

- Add `config.cdc.chunkWaitTimeout` (default `null`) to `values.yaml` and render `chunk-wait-timeout` conditionally in the ConfigMap, mirroring the existing optional `cdc.*` knobs (quoted duration, omitted when unset so the binary's `30s` default applies).
- Add helm unit tests: key rendered when set, omitted when null.
- Document the knob in the Helm chart reference and example, and document the underlying `--cache-cdc-chunk-wait-timeout` flag in the CLI and CDC references (the flag shipped in #1299 without these doc updates).

No Go, database, or migration changes — this only surfaces an existing flag through the chart.

## Test plan

- [x] `task fmt` clean (0 changed)
- [x] `helm unittest charts/ncps` — 141/141 pass (RED→GREEN on the two new assertions)
- [x] CI `nix flake check` (helm unit tests)