### PR TITLE
feat(cache): allow disabling CDC after migrate-chunks-to-nar

### DIFF
--- a/docs/docs/User Guide/Operations/Chunks to NAR Migration.md
+++ b/docs/docs/User Guide/Operations/Chunks to NAR Migration.md
@@ -103,6 +103,47 @@ migrateChunksToNar:
 
 `forceReclaim` maps to `--force-reclaim` and `dryRun` to `--dry-run`. The Job reuses the deployment's database, storage, and Redis configuration. Because it is gated by `migrateChunksToNar.enabled`, nothing is rendered when disabled (the default).
 
+## Exiting CDC
+
+After running `migrate-chunks-to-nar` to completion, disable CDC to stop storing new NARs as chunks:
+
+**1. Confirm no chunked NARs remain** (optional but recommended):
+
+```sql
+-- Should return 0 after a complete migration:
+SELECT count(*) FROM nar_files WHERE total_chunks > 0;
+```
+
+**2. Set `cdc.enabled: false`** in your config or Helm values and restart:
+
+```yaml
+# values.yaml (Helm) — set both in the same upgrade
+config:
+  cdc:
+    enabled: false
+migrateChunksToNar:
+  enabled: false   # turn off the migration job after it has run
+```
+
+Or in the ncps config file:
+
+```yaml
+cache:
+  cdc:
+    enabled: false
+```
+
+**3. Restart the server.** On startup, ncps:
+
+- Clears the stored CDC configuration from the database.
+- Logs a warning if any chunked NARs remain, including the count, so you can decide whether to re-run the migration before traffic ramps up.
+- Starts normally regardless — any remaining chunked NARs are treated as cache misses and re-fetched from upstream on demand.
+
+> [!NOTE]
+> Skipped NARs ("no narinfo NarHash to verify against") are left chunked. If you disable CDC with these remaining, they will be re-fetched from upstream on the next request for each one. This is safe but may result in upstream traffic for those NARs.
+
+**Re-enabling CDC** after disabling it is treated as a fresh first boot — you can change chunk sizes freely.
+
 ## Exit Codes & Failure Isolation
 
 A per-NAR failure (hash mismatch, missing chunk, I/O error) is recorded and does **not** abort the batch — every other NAR is still processed. The command **exits non-zero** if any NAR failed, reporting the count. A NAR that fails verification keeps its chunks and record intact.

--- a/openspec/changes/archive/2026-05-30-allow-disabling-cdc/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-30-allow-disabling-cdc/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-31

--- a/openspec/changes/archive/2026-05-30-allow-disabling-cdc/design.md
+++ b/openspec/changes/archive/2026-05-30-allow-disabling-cdc/design.md
@@ -1,0 +1,59 @@
+## Context
+
+CDC (content-defined chunking) has a one-way guard in `pkg/config/config.go:validateCDCConfig`: when `storedEnabled=true` (DB) and `enabled=false` (current config), the server hard-fails at startup with `ErrCDCDisabledAfterEnabled`. This was correct before `migrate-chunks-to-nar` existed, because no migration path existed.
+
+PR #1301 added `migrate-chunks-to-nar`, which reconstructs whole NARs from chunks and flips their DB records. Operators can now safely drain the chunked NAR inventory before disabling CDC. The hard startup error is now an unnecessary blocker.
+
+The config validation call site is `pkg/ncps/serve.go:1088`. The `Config` struct (`pkg/config/config.go`) holds only the config store (key/value pairs); it does not have access to the NarFile Ent table. The NarFile count query lives at the `dbClient.Ent()` layer, available in `serve.go` but not in `config.go`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow `cdc.enabled: false` to succeed on a cluster that previously had CDC enabled.
+- Log a warning at startup if un-migrated chunked NARs remain, nudging operators to run `migrate-chunks-to-nar`.
+- Clear stored CDC config keys in the DB when transitioning enabled→disabled, so a future re-enable is treated as a first boot.
+
+**Non-Goals:**
+- Automatically running `migrate-chunks-to-nar` at startup.
+- Blocking startup when un-migrated chunks exist.
+- Serving un-migrated chunked NARs after CDC is disabled (existing cache-miss-recovery handles re-downloading on demand).
+- Any changes to the CDC chunking write path.
+
+## Decisions
+
+### Remove the hard error; clear stored keys on transition
+
+**Decision**: In `validateCDCConfig`, remove the `if storedEnabled && !enabled { return ErrCDCDisabledAfterEnabled }` block. Replace it with a call to clear the four stored CDC config keys (`cdc_enabled`, `cdc_min`, `cdc_avg`, `cdc_max`) from the config DB.
+
+**Why**: The error was a safety guard against making chunks unservable. With `migrate-chunks-to-nar`, operators have the tool to drain chunks before disabling. Clearing stored keys gives a clean first-boot state on any future re-enable, avoiding stale size mismatches.
+
+**Alternative considered**: Leave stored keys and just remove the error. Rejected: stale `cdc_enabled=true` in DB would confuse `loadCDCConfigFromDB` on a future restart without the explicit `--cache-cdc-enabled=false` flag.
+
+### Count remaining chunked NARs in `serve.go`, not `config.go`
+
+**Decision**: After `ValidateOrStoreCDCConfig` returns nil for a CDC-disable transition, `serve.go` queries `dbClient.Ent().NarFile.Query().Where(entnarfile.TotalChunksGT(0)).Count(ctx)` and logs a structured warning if the count is > 0.
+
+**Why**: `config.go` has no access to the Ent client. Putting the count in `serve.go` keeps `config.go` as a pure key/value store and avoids a new dependency injection. The warning is a startup UX concern, not a config validation concern.
+
+**Alternative considered**: Add a `CountChunkedNars func(context.Context) (int, error)` hook to `ValidateOrStoreCDCConfig`. Rejected: overcomplicates the config API for a one-time startup message.
+
+### Un-migrated chunks become cache misses, not errors
+
+**Decision**: After CDC is disabled, any `nar_file` row still with `total_chunks > 0` is simply not served by the chunk-serving path (which is skipped when CDC is disabled). Clients requesting those NARs trigger the normal cache-miss-recovery path (upstream re-fetch).
+
+**Why**: This is already how the system behaves for any cache miss. No special handling needed. The warning at startup informs operators; the recovery path handles individual request failures gracefully.
+
+## Risks / Trade-offs
+
+- **Un-migrated chunks served as misses**: Operators who disable CDC without running `migrate-chunks-to-nar` first will see cache misses for previously-cached chunked NARs. Mitigation: structured warning at startup shows the count of remaining chunked NARs.
+- **DB state after clear**: If the server crashes between clearing `cdc_enabled` and clearing the size keys, `cdc_enabled` is absent but size keys remain. `loadCDCConfigFromDB` checks `cdc_enabled` first and returns early on `ErrConfigNotFound`, so orphaned size keys are harmless.
+- **Helm/operator restart timing**: A rolling restart may have pods with CDC enabled and pods with it disabled simultaneously. The write path is gated on `cdcEnabled`, so newly arriving NARs during the rollout go to whole-file storage. Existing chunked NARs continue to be served by the still-enabled pods until rollout completes.
+
+## Migration Plan
+
+1. Run `ncps migrate-chunks-to-nar` to completion (all chunked NARs converted to whole files).
+2. Set `cdc.enabled: false` (or remove the `cdc` block) in the ncps config.
+3. Restart the server. Startup logs a warning if any chunks remain (count = 0 means clean).
+4. No database migration required; config keys are cleared at runtime.
+
+**Rollback**: To re-enable CDC, set `cdc.enabled: true` with desired chunk sizes. Because stored keys were cleared, the server treats it as a fresh first-boot and stores the new sizes.

--- a/openspec/changes/archive/2026-05-30-allow-disabling-cdc/proposal.md
+++ b/openspec/changes/archive/2026-05-30-allow-disabling-cdc/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+CDC (content-defined chunking) is currently a one-way door: once enabled, the server hard-fails at startup if you try to turn it off, because chunked NARs would be unservable. Now that `migrate-chunks-to-nar` (PR #1301) exists as an explicit migration path to reconstruct whole NARs from chunks, the guard is no longer necessary — operators can run the migration first and then safely disable CDC.
+
+## What Changes
+
+- Remove the hard startup error that blocks disabling CDC after it was previously enabled.
+- Replace it with a warning that logs how many chunked NARs remain, nudging operators to run `migrate-chunks-to-nar` first if they haven't.
+- If zero chunked NARs remain (all migrated), allow the transition silently.
+- Clear the `cdc_enabled` stored config key when CDC is disabled, so a future re-enable is treated as a fresh start.
+
+## Capabilities
+
+### New Capabilities
+
+- `cdc-disable`: Operators can transition a deployment from CDC-enabled to CDC-disabled by first running `migrate-chunks-to-nar`, then setting `cdc.enabled: false`. The server warns (not errors) if un-migrated chunked NARs are detected but starts successfully.
+
+### Modified Capabilities
+
+- `cdc-chunking`: The startup validation requirement changes — disabling CDC after enabling it is now allowed (with a warning), not forbidden.
+
+## Impact
+
+- `pkg/config/config.go`: Remove `ErrCDCDisabledAfterEnabled` guard; add chunked-NAR count check for the warning.
+- `pkg/cache/`: Any code relying on the assumption that `cdc_enabled` stored = current must handle the false→false transition.
+- No API surface changes. No migration required. No performance impact.
+- **Non-goals**: Automatically running `migrate-chunks-to-nar` at startup. Blocking startup when un-migrated chunks exist. Any changes to the CDC chunking write path.

--- a/openspec/changes/archive/2026-05-30-allow-disabling-cdc/proposal.md
+++ b/openspec/changes/archive/2026-05-30-allow-disabling-cdc/proposal.md
@@ -21,7 +21,8 @@ CDC (content-defined chunking) is currently a one-way door: once enabled, the se
 
 ## Impact
 
-- `pkg/config/config.go`: Remove `ErrCDCDisabledAfterEnabled` guard; add chunked-NAR count check for the warning.
+- `pkg/config/config.go`: Remove `ErrCDCDisabledAfterEnabled` guard; add `DeleteCDCConfig` helper.
+- `pkg/ncps/serve.go`: Add chunked-NAR count warning when CDC is disabled but chunks remain.
 - `pkg/cache/`: Any code relying on the assumption that `cdc_enabled` stored = current must handle the false→false transition.
 - No API surface changes. No migration required. No performance impact.
 - **Non-goals**: Automatically running `migrate-chunks-to-nar` at startup. Blocking startup when un-migrated chunks exist. Any changes to the CDC chunking write path.

--- a/openspec/changes/archive/2026-05-30-allow-disabling-cdc/specs/cdc-chunking/spec.md
+++ b/openspec/changes/archive/2026-05-30-allow-disabling-cdc/specs/cdc-chunking/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: CDC startup validation MUST allow enabled→disabled transition
+
+When CDC configuration is validated at startup via `ValidateOrStoreCDCConfig`, the system SHALL permit the transition from a stored `cdc_enabled=true` to a current `enabled=false`. The previous behavior of returning `ErrCDCDisabledAfterEnabled` for this transition is removed.
+
+The updated validation rules are:
+- If no stored CDC config exists and `enabled=false`: no-op, return nil.
+- If no stored CDC config exists and `enabled=true`: store the new config (first boot), return nil.
+- If stored config exists and `enabled=true`: validate that all four stored values match current values; return error on mismatch.
+- If stored config exists and `enabled=false` (enabled→disabled transition): clear all four stored CDC config keys (`cdc_enabled`, `cdc_min`, `cdc_avg`, `cdc_max`); return nil.
+
+#### Scenario: Disabling CDC after being enabled clears stored config and succeeds
+
+- **GIVEN** `cdc_enabled=true` is stored in the configuration database
+- **WHEN** `ValidateOrStoreCDCConfig` is called with `enabled=false`
+- **THEN** it SHALL return nil (no error)
+- **AND** the configuration database SHALL have no entry for `cdc_enabled`, `cdc_min`, `cdc_avg`, or `cdc_max`
+
+#### Scenario: Keeping CDC enabled with matching config succeeds
+
+- **GIVEN** `cdc_enabled=true` is stored with matching min/avg/max values
+- **WHEN** `ValidateOrStoreCDCConfig` is called with `enabled=true` and the same sizes
+- **THEN** it SHALL return nil
+
+#### Scenario: Keeping CDC enabled with mismatched sizes fails
+
+- **GIVEN** `cdc_enabled=true` is stored with `cdc_min=16384`
+- **WHEN** `ValidateOrStoreCDCConfig` is called with `enabled=true` and `minSize=32768`
+- **THEN** it SHALL return a non-nil error describing the mismatch

--- a/openspec/changes/archive/2026-05-30-allow-disabling-cdc/specs/cdc-disable/spec.md
+++ b/openspec/changes/archive/2026-05-30-allow-disabling-cdc/specs/cdc-disable/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: CDC MAY be disabled after being enabled when migrate-chunks-to-nar has been run
+
+The system SHALL allow transitioning from `cdc_enabled=true` (stored in DB) to `cdc.enabled: false` (current config) without returning a startup error. When this transition is detected, the system SHALL:
+- Clear the four stored CDC config keys (`cdc_enabled`, `cdc_min`, `cdc_avg`, `cdc_max`) from the configuration database.
+- Log a structured warning if any `nar_file` rows with `total_chunks > 0` remain, including the count of un-migrated NARs.
+- Proceed with startup normally regardless of whether un-migrated chunks remain.
+
+#### Scenario: Clean disable — all NARs migrated
+
+- **GIVEN** `cdc_enabled=true` is stored in the configuration database
+- **AND** all `nar_file` rows have `total_chunks = 0` (migration complete)
+- **WHEN** the server starts with `cdc.enabled: false`
+- **THEN** the server SHALL start successfully
+- **AND** the stored CDC config keys SHALL be cleared from the database
+- **AND** no warning about un-migrated chunks SHALL be logged
+
+#### Scenario: Partial disable — un-migrated chunks remain
+
+- **GIVEN** `cdc_enabled=true` is stored in the configuration database
+- **AND** at least one `nar_file` row still has `total_chunks > 0`
+- **WHEN** the server starts with `cdc.enabled: false`
+- **THEN** the server SHALL start successfully
+- **AND** the stored CDC config keys SHALL be cleared from the database
+- **AND** a warning log entry SHALL be emitted that includes the count of remaining chunked NARs
+- **AND** the warning SHALL reference `migrate-chunks-to-nar` as the remediation command
+
+#### Scenario: Re-enable after disable is treated as a fresh first boot
+
+- **GIVEN** CDC was previously disabled (stored config keys cleared)
+- **WHEN** the server starts with `cdc.enabled: true` and new chunk sizes
+- **THEN** the server SHALL store the new CDC configuration (enabled=true, min, avg, max)
+- **AND** no mismatch error SHALL be returned for the new chunk sizes
+
+### Requirement: Chunked NARs become cache misses when CDC is disabled
+
+After CDC is disabled, any `nar_file` rows with `total_chunks > 0` that were not migrated SHALL NOT be served from the chunk store (CDC is off). A client request for such a NAR SHALL trigger the normal cache-miss-recovery path (upstream re-fetch), treating the NAR as absent from local storage.
+
+#### Scenario: Un-migrated chunked NAR triggers upstream re-fetch
+
+- **GIVEN** CDC is disabled
+- **AND** a `nar_file` row for hash `H` has `total_chunks > 0`
+- **AND** no whole-file for `H` exists in the NAR store
+- **WHEN** a client requests `GET /nar/H...`
+- **THEN** the system SHALL treat `H` as a cache miss
+- **AND** SHALL attempt to re-fetch `H` from upstream caches
+- **AND** SHALL NOT attempt to reconstruct `H` from chunks

--- a/openspec/changes/archive/2026-05-30-allow-disabling-cdc/tasks.md
+++ b/openspec/changes/archive/2026-05-30-allow-disabling-cdc/tasks.md
@@ -1,0 +1,20 @@
+## 1. Config Layer
+
+- [x] 1.1 In `pkg/config/config.go`: add a `DeleteCDCConfig(ctx)` helper that deletes all four CDC config keys (`cdc_enabled`, `cdc_min`, `cdc_avg`, `cdc_max`) using the existing `deleteConfig` pattern (or equivalent)
+- [x] 1.2 In `validateCDCConfig`: remove the `if storedEnabled && !enabled { return ErrCDCDisabledAfterEnabled }` block; replace with a call to `DeleteCDCConfig` and return nil for the enabled→disabled transition
+- [x] 1.3 Remove `ErrCDCDisabledAfterEnabled` sentinel error (definition and any remaining references)
+- [x] 1.4 Write unit tests in `pkg/config/config_test.go` for the enabled→disabled transition: validate that `ValidateOrStoreCDCConfig(ctx, false, ...)` returns nil and the four stored keys are absent afterward
+
+## 2. Serve Layer Warning
+
+- [x] 2.1 In `pkg/ncps/serve.go`: after `ValidateOrStoreCDCConfig` returns nil, detect the CDC-disable transition (previous stored enabled=true, current enabled=false) by checking the count of `nar_file` rows with `total_chunks > 0` using `dbClient.Ent().NarFile.Query().Where(entnarfile.TotalChunksGT(0)).Count(ctx)`
+- [x] 2.2 Log a structured `Warn`-level log entry when the count > 0, including the chunk count and a reference to `migrate-chunks-to-nar`; log nothing (or `Debug`) when count = 0
+
+## 3. Test Cleanup
+
+- [x] 3.1 Update any existing tests in `pkg/config/config_test.go` that assert `ErrCDCDisabledAfterEnabled` is returned — flip them to assert nil is returned and stored keys are cleared
+- [x] 3.2 Update any existing tests in `pkg/ncps/` that reference `ErrCDCDisabledAfterEnabled`
+
+## 4. Verification
+
+- [x] 4.1 Run `task fmt && task lint && task test` and confirm all pass

--- a/openspec/specs/cdc-chunking/spec.md
+++ b/openspec/specs/cdc-chunking/spec.md
@@ -229,6 +229,35 @@ stuck row SHALL NOT permanently cause reads to fail.
 - **WHEN** a client requests `GET /nar/H...`
 - **THEN** `GetNar` SHALL re-attempt the upstream download rather than returning a terminal 404
 
+### Requirement: CDC startup validation MUST allow enabled→disabled transition
+
+When CDC configuration is validated at startup via `ValidateOrStoreCDCConfig`, the system SHALL permit the transition from a stored `cdc_enabled=true` to a current `enabled=false`. The previous behavior of returning `ErrCDCDisabledAfterEnabled` for this transition is removed.
+
+The updated validation rules are:
+- If no stored CDC config exists and `enabled=false`: no-op, return nil.
+- If no stored CDC config exists and `enabled=true`: store the new config (first boot), return nil.
+- If stored config exists and `enabled=true`: validate that all four stored values match current values; return error on mismatch.
+- If stored config exists and `enabled=false` (enabled→disabled transition): clear all four stored CDC config keys (`cdc_enabled`, `cdc_min`, `cdc_avg`, `cdc_max`); return nil.
+
+#### Scenario: Disabling CDC after being enabled clears stored config and succeeds
+
+- **GIVEN** `cdc_enabled=true` is stored in the configuration database
+- **WHEN** `ValidateOrStoreCDCConfig` is called with `enabled=false`
+- **THEN** it SHALL return nil (no error)
+- **AND** the configuration database SHALL have no entry for `cdc_enabled`, `cdc_min`, `cdc_avg`, or `cdc_max`
+
+#### Scenario: Keeping CDC enabled with matching config succeeds
+
+- **GIVEN** `cdc_enabled=true` is stored with matching min/avg/max values
+- **WHEN** `ValidateOrStoreCDCConfig` is called with `enabled=true` and the same sizes
+- **THEN** it SHALL return nil
+
+#### Scenario: Keeping CDC enabled with mismatched sizes fails
+
+- **GIVEN** `cdc_enabled=true` is stored with `cdc_min=16384`
+- **WHEN** `ValidateOrStoreCDCConfig` is called with `enabled=true` and `minSize=32768`
+- **THEN** it SHALL return a non-nil error describing the mismatch
+
 ### Requirement: Unrecoverable backing-less placeholder rows MUST be garbage-collected
 
 The recovery process SHALL garbage-collect a backing-less placeholder `nar_file` row —

--- a/openspec/specs/cdc-disable/spec.md
+++ b/openspec/specs/cdc-disable/spec.md
@@ -1,0 +1,56 @@
+# Capability Spec: CDC Disable
+
+## Purpose
+
+Defines requirements for disabling Content-Defined Chunking (CDC) after it has been
+previously enabled, including the startup transition behavior, stored config cleanup,
+and how un-migrated chunked NARs are handled during subsequent read requests.
+
+## Requirements
+
+### Requirement: CDC MAY be disabled after being enabled when migrate-chunks-to-nar has been run
+
+The system SHALL allow transitioning from `cdc_enabled=true` (stored in DB) to `cdc.enabled: false` (current config) without returning a startup error. When this transition is detected, the system SHALL:
+- Clear the four stored CDC config keys (`cdc_enabled`, `cdc_min`, `cdc_avg`, `cdc_max`) from the configuration database.
+- Log a structured warning if any `nar_file` rows with `total_chunks > 0` remain, including the count of un-migrated NARs.
+- Proceed with startup normally regardless of whether un-migrated chunks remain.
+
+#### Scenario: Clean disable — all NARs migrated
+
+- **GIVEN** `cdc_enabled=true` is stored in the configuration database
+- **AND** all `nar_file` rows have `total_chunks = 0` (migration complete)
+- **WHEN** the server starts with `cdc.enabled: false`
+- **THEN** the server SHALL start successfully
+- **AND** the stored CDC config keys SHALL be cleared from the database
+- **AND** no warning about un-migrated chunks SHALL be logged
+
+#### Scenario: Partial disable — un-migrated chunks remain
+
+- **GIVEN** `cdc_enabled=true` is stored in the configuration database
+- **AND** at least one `nar_file` row still has `total_chunks > 0`
+- **WHEN** the server starts with `cdc.enabled: false`
+- **THEN** the server SHALL start successfully
+- **AND** the stored CDC config keys SHALL be cleared from the database
+- **AND** a warning log entry SHALL be emitted that includes the count of remaining chunked NARs
+- **AND** the warning SHALL reference `migrate-chunks-to-nar` as the remediation command
+
+#### Scenario: Re-enable after disable is treated as a fresh first boot
+
+- **GIVEN** CDC was previously disabled (stored config keys cleared)
+- **WHEN** the server starts with `cdc.enabled: true` and new chunk sizes
+- **THEN** the server SHALL store the new CDC configuration (enabled=true, min, avg, max)
+- **AND** no mismatch error SHALL be returned for the new chunk sizes
+
+### Requirement: Chunked NARs become cache misses when CDC is disabled
+
+After CDC is disabled, any `nar_file` rows with `total_chunks > 0` that were not migrated SHALL NOT be served from the chunk store (CDC is off). A client request for such a NAR SHALL trigger the normal cache-miss-recovery path (upstream re-fetch), treating the NAR as absent from local storage.
+
+#### Scenario: Un-migrated chunked NAR triggers upstream re-fetch
+
+- **GIVEN** CDC is disabled
+- **AND** a `nar_file` row for hash `H` has `total_chunks > 0`
+- **AND** no whole-file for `H` exists in the NAR store
+- **WHEN** a client requests `GET /nar/H...`
+- **THEN** the system SHALL treat `H` as a cache miss
+- **AND** SHALL attempt to re-fetch `H` from upstream caches
+- **AND** SHALL NOT attempt to reconstruct `H` from chunks

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -41,10 +41,6 @@ var (
 	// ErrConfigNotFound is returned if no config with this key was found.
 	ErrConfigNotFound = errors.New("no config was found for this key")
 
-	// ErrCDCDisabledAfterEnabled is returned when attempting to disable CDC after being enabled.
-	ErrCDCDisabledAfterEnabled = errors.New(
-		"CDC cannot be disabled after being enabled; existing chunked NARs would not be reconstructed",
-	)
 	// ErrCDCConfigMismatch is returned when CDC configuration values differ from stored values.
 	ErrCDCConfigMismatch = errors.New(
 		"CDC config changed; different chunk sizes create new chunks without reusing old ones, causing storage duplication",
@@ -202,11 +198,54 @@ func (c *Config) setConfig(ctx context.Context, key, value string) error {
 		Exec(ctx)
 }
 
+// deleteConfig removes a configuration entry by key, acquiring a write lock.
+// Returns nil if the key does not exist.
+func (c *Config) deleteConfig(ctx context.Context, key string) error {
+	lockKey := getLockKey(key)
+
+	if err := c.rwLocker.Lock(ctx, lockKey, lockTTL); err != nil {
+		zerolog.Ctx(ctx).Error().
+			Err(err).
+			Str("key", key).
+			Msg("failed to acquire write lock")
+
+		return fmt.Errorf("failed to acquire write lock: %w", err)
+	}
+
+	defer func() {
+		if err := c.rwLocker.Unlock(ctx, lockKey); err != nil {
+			zerolog.Ctx(ctx).Error().
+				Err(err).
+				Str("key", key).
+				Msg("failed to release write lock")
+		}
+	}()
+
+	_, err := c.dbClient.Ent().ConfigEntry.Delete().
+		Where(entconfigentry.KeyEQ(key)).
+		Exec(ctx)
+
+	return err
+}
+
+// DeleteCDCConfig removes all four CDC configuration keys from the database.
+// Used when transitioning from CDC-enabled to CDC-disabled so that a future
+// re-enable is treated as a fresh first boot.
+func (c *Config) DeleteCDCConfig(ctx context.Context) error {
+	for _, key := range []string{KeyCDCEnabled, KeyCDCMin, KeyCDCAvg, KeyCDCMax} {
+		if err := c.deleteConfig(ctx, key); err != nil {
+			return fmt.Errorf("failed to delete CDC config key %q: %w", key, err)
+		}
+	}
+
+	return nil
+}
+
 // ValidateOrStoreCDCConfig validates CDC configuration against stored values or stores them if not yet configured.
 // If CDC is disabled and no config exists, returns nil (no-op).
 // If CDC is enabled and no config exists, stores all 4 values.
 // If config exists, validates that enabled flag matches and all values are identical.
-// If CDC was previously enabled (config exists) but now disabled, returns an error.
+// If CDC was previously enabled but now disabled, clears the stored config and returns nil.
 func (c *Config) ValidateOrStoreCDCConfig(
 	ctx context.Context,
 	enabled bool,
@@ -278,13 +317,10 @@ func (c *Config) validateCDCConfig(
 ) error {
 	storedEnabled := storedEnabledStr == "true"
 
-	// Check if user is trying to disable CDC after it was previously enabled
+	// CDC is being disabled after having been enabled — clear stored config so a future
+	// re-enable is treated as a fresh first boot with the new chunk sizes.
 	if storedEnabled && !enabled {
-		return fmt.Errorf(
-			"%w; stored cdc_enabled=%s, current cdc_enabled=%v",
-			ErrCDCDisabledAfterEnabled,
-			storedEnabledStr, enabled,
-		)
+		return c.DeleteCDCConfig(ctx)
 	}
 
 	// Get stored values for comparison

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -475,9 +475,29 @@ func testValidateCDCDisableAfterEnabled(factory databaseFactory) func(*testing.T
 		err := c.ValidateOrStoreCDCConfig(ctx, true, 65536, 262144, 1048576)
 		require.NoError(t, err)
 
-		// Second boot with CDC disabled - should fail
+		// Second boot with CDC disabled - should now succeed (migrate-chunks-to-nar exists)
 		err = c.ValidateOrStoreCDCConfig(ctx, false, 65536, 262144, 1048576)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "CDC cannot be disabled after being enabled")
+		require.NoError(t, err)
+
+		// All four CDC config keys must be cleared from the database
+		_, err = c.GetCDCEnabled(ctx)
+		require.ErrorIs(t, err, config.ErrConfigNotFound, "cdc_enabled must be cleared")
+
+		_, err = c.GetCDCMin(ctx)
+		require.ErrorIs(t, err, config.ErrConfigNotFound, "cdc_min must be cleared")
+
+		_, err = c.GetCDCAvg(ctx)
+		require.ErrorIs(t, err, config.ErrConfigNotFound, "cdc_avg must be cleared")
+
+		_, err = c.GetCDCMax(ctx)
+		require.ErrorIs(t, err, config.ErrConfigNotFound, "cdc_max must be cleared")
+
+		// Re-enabling with new sizes must succeed (treated as a fresh first boot)
+		err = c.ValidateOrStoreCDCConfig(ctx, true, 32768, 131072, 524288)
+		require.NoError(t, err)
+
+		enabled, err := c.GetCDCEnabled(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "true", enabled)
 	}
 }

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/otel/log"
 	"golang.org/x/sync/errgroup"
 
+	entnarfile "github.com/kalbasit/ncps/ent/narfile"
 	s3config "github.com/kalbasit/ncps/pkg/s3"
 	localstorage "github.com/kalbasit/ncps/pkg/storage/local"
 	storageS3 "github.com/kalbasit/ncps/pkg/storage/s3"
@@ -1089,6 +1090,17 @@ func createCache(
 		return nil, fmt.Errorf("CDC configuration validation failed: %w", err)
 	}
 
+	if !cdcEnabled {
+		chunkedCount, countErr := dbClient.Ent().NarFile.Query().
+			Where(entnarfile.TotalChunksGT(0)).
+			Count(ctx)
+		if countErr == nil && chunkedCount > 0 {
+			zerolog.Ctx(ctx).Warn().
+				Int("chunked_nar_count", chunkedCount).
+				Msg("CDC is disabled but chunked NARs remain; run 'ncps migrate-chunks-to-nar' to convert them to whole files")
+		}
+	}
+
 	zerolog.Ctx(ctx).
 		Info().
 		Bool("cdc-enabled", cdcEnabled).
@@ -1255,8 +1267,8 @@ func loadCDCConfigFromDB(
 
 	// CDC is configured in the database.
 	// If the flag wasn't explicitly set on the command line, adopt the database value.
-	// If the user explicitly passed --cache-cdc-enabled=false, keep it as-is and let
-	// ValidateOrStoreCDCConfig return ErrCDCDisabledAfterEnabled.
+	// If the user explicitly passed --cache-cdc-enabled=false, keep it as-is so
+	// ValidateOrStoreCDCConfig will clear the stored config and allow the transition.
 	if !wasExplicitlySet {
 		enabled = true
 	}

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -1094,10 +1094,12 @@ func createCache(
 		chunkedCount, countErr := dbClient.Ent().NarFile.Query().
 			Where(entnarfile.TotalChunksGT(0)).
 			Count(ctx)
-		if countErr == nil && chunkedCount > 0 {
+		if countErr != nil {
+			zerolog.Ctx(ctx).Warn().Err(countErr).Msg("failed to count remaining chunked NARs")
+		} else if chunkedCount > 0 {
 			zerolog.Ctx(ctx).Warn().
 				Int("chunked_nar_count", chunkedCount).
-				Msg("CDC is disabled but chunked NARs remain; run 'ncps migrate-chunks-to-nar' to convert them to whole files")
+				Msg("CDC is disabled but chunked NARs remain; run 'ncps migrate-chunks-to-nar' to convert")
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Removes the hard startup error (`ErrCDCDisabledAfterEnabled`) that prevented operators from setting `cdc.enabled: false` on a cluster that previously had CDC enabled
- Replaces the guard with a `DeleteCDCConfig` call that clears all four stored CDC config keys (`cdc_enabled`, `cdc_min`, `cdc_avg`, `cdc_max`), so a future re-enable is treated as a fresh first boot
- After `ValidateOrStoreCDCConfig` succeeds with CDC disabled, `serve.go` queries the count of `nar_file` rows with `total_chunks > 0` and logs a structured `Warn` if any remain — pointing operators to `migrate-chunks-to-nar` as the remediation
- Any un-migrated chunked NARs become cache misses after CDC is disabled and are re-fetched from upstream on demand (handled by the existing cache-miss-recovery path)
- Adds an **Exiting CDC** section to the Chunks to NAR Migration doc with a step-by-step disable procedure

## Test plan

- [x] `task fmt` passes (no changes)
- [x] `task lint` passes for all changed packages
- [x] `task test` passes — all unit tests green
- [x] Existing `testValidateCDCDisableAfterEnabled` updated: asserts `nil` return, all four CDC config keys absent after disable, and re-enable succeeds as a fresh first boot