### PR TITLE
feat(cache): implement CDC drain mode

### DIFF
--- a/openspec/changes/archive/2026-05-30-cdc-drain-mode/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-30-cdc-drain-mode/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-31

--- a/openspec/changes/archive/2026-05-30-cdc-drain-mode/design.md
+++ b/openspec/changes/archive/2026-05-30-cdc-drain-mode/design.md
@@ -1,0 +1,146 @@
+## Context
+
+`isCDCEnabled()` in `pkg/cache/cache.go` returns `c.cdcEnabled && c.chunkStore != nil`.
+It is used as a single gate for **both writes and reads**: whether to store a new NAR
+as chunks (write) and whether to serve an existing NAR from the chunk store (read).
+`SetChunkStore` is only called from `serve.go` when `cdcEnabled=true`, so setting
+`cdc.enabled: false` leaves `chunkStore == nil`, making every call to `isCDCEnabled()`
+return false — including the read paths that check for existing chunks.
+
+Affected read-path call sites:
+- `isServable` (line 3900): short-circuits to `false` when `!isCDCEnabled()`,
+  so chunked NARs are never considered servable → cache miss → upstream re-fetch.
+- `HasNarInChunks` (line 6994): same guard, returns `false` unconditionally.
+- `GetNarInfo` normalization (line 1585): skips the in-memory chunk normalization.
+
+PR #1304 (`allow-disabling-cdc`) introduced `DeleteCDCConfig` which clears
+`cdc_enabled` from the DB at startup when `cdc.enabled: false`. This breaks
+`migrate-chunks-to-nar`, which checks `cdc_enabled=true` in the DB before proceeding.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Separate the chunk-write gate from the chunk-read gate so chunked NARs continue
+  to serve during the drain period.
+- Initialize the chunk store in read-only (drain) mode when `cdc.enabled: false`
+  but `cdc_enabled=true` is still in the DB (i.e. chunks may exist).
+- Preserve the DB config during drain so `migrate-chunks-to-nar` can run concurrently
+  with a CDC-disabled server.
+- Revert the `DeleteCDCConfig` call from PR #1304.
+- Remove the `cdc_enabled` DB check from `migrate-chunks-to-nar`; use chunk count instead.
+
+**Non-Goals:**
+- Automatic background drain job (tracked separately).
+- Auto-clearing DB config when drain completes (tracked separately).
+- Enforcing chunk-store write prohibition at the storage layer (cache layer is sufficient).
+- Changing the chunk-store flags or configuration surface.
+
+## Decisions
+
+### 1. Split `isCDCEnabled()` into write-gate and read-gate
+
+**Decision**: Add `isChunkStoreAvailable() bool { return c.chunkStore != nil }` for
+reads. Keep `isCDCEnabled()` for writes (unchanged semantics: `c.cdcEnabled && c.chunkStore != nil`).
+
+Change ~3 read-path call sites from `isCDCEnabled()` to `isChunkStoreAvailable()`:
+- `isServable`: the CDC branch that queries `nar_file` and calls `narFileServable`
+- `HasNarInChunks`: the early-return guard
+- `GetNarInfo` normalization: the in-memory rewrite of `Compression`/`URL`
+
+All ~22 write-path call sites (`putNarWithCDC`, `storeNarWithCDC`,
+`maybeBackgroundMigrateNarToChunks`, lazy-chunking paths, etc.) remain gated on
+`isCDCEnabled()` — they must NOT fire during drain.
+
+**Why**: Targeted change with minimal blast radius. Adds one small helper; all existing
+write-path logic is untouched. The split is the minimal expression of "reads from
+chunks are independent of whether new chunks are being written."
+
+**Alternative considered**: Rename all `isCDCEnabled()` call sites to either
+`isChunkWriteEnabled()` or `isChunkStoreAvailable()`. Rejected: too broad a rename
+with high merge-conflict risk; the targeted 3-site change is safer.
+
+### 2. Initialize chunk store in drain mode from `serve.go`
+
+**Decision**: In `createCache`, after `ValidateOrStoreCDCConfig` returns nil for the
+enabled→disabled case, check whether the stored DB config had `cdc_enabled=true`
+(using the `storedWasEnabled` value obtained before the validate call). If drain mode
+is detected (`storedWasEnabled && !cdcEnabled`), call `getChunkStorageBackend` and
+`c.SetChunkStore` even though `cdcEnabled=false`. Do NOT call `SetCDCConfiguration`
+with `enabled=true` — the chunker is not created, `c.cdcEnabled` stays false.
+
+**Why**: The chunk store is a pure I/O backend; initializing it for reads when writes
+are disabled is safe. The gate against new-chunk writes remains `isCDCEnabled()`, which
+returns false because `c.cdcEnabled=false`.
+
+**Alternative considered**: Add a dedicated `SetDrainMode` method to `Cache`. Rejected:
+not needed — `SetChunkStore` already sets the store; the write gate is already correct;
+no new state required.
+
+### 3. Revert `DeleteCDCConfig` from PR #1304; auto-clear DB config when drain completes
+
+**Decision**: In `validateCDCConfig`, the `storedEnabled && !enabled` branch returns
+`nil` without calling `DeleteCDCConfig`. The four DB config keys (`cdc_enabled`,
+`cdc_min`, `cdc_avg`, `cdc_max`) are left intact during the drain period so that
+`migrate-chunks-to-nar` can proceed concurrently and the chunk store can be initialized
+on every restart.
+
+The stored config is cleared automatically at startup when drain mode is entered AND
+the chunk count is zero — meaning all NARs have already been migrated. In that case
+the startup code calls `DeleteCDCConfig`, logs "CDC drain complete, stored config
+cleared", does NOT initialize the chunk store, and starts in fully-disabled mode. This
+is the only path that auto-clears the config.
+
+This produces a clean state machine:
+
+| DB `cdc_enabled` | config `cdc.enabled` | chunks remain | Mode |
+|---|---|---|---|
+| absent | false | — | fully disabled |
+| true | true | — | full CDC (read + write) |
+| true | false | yes | drain (read chunks, write whole) |
+| true | false | no | auto-clears config → fully disabled |
+
+`DeleteCDCConfig` is kept in `pkg/config/config.go`; the `validateCDCConfig` call
+to it is removed (that was the PR #1304 mistake). The function is now called from
+`serve.go` when drain-complete is detected.
+
+**Why**: Without auto-clear, `cdc_enabled=true` persists in the DB indefinitely —
+the chunk store is initialized on every restart forever, even years after the last
+chunk was migrated. Auto-clear at startup (on zero-chunk detection) makes the
+transition self-completing without any operator command. The check is a single count
+query and is only evaluated when drain mode is active.
+
+### 4. Remove `cdc_enabled` DB check from `migrate-chunks-to-nar`
+
+**Decision**: Remove the early check in `migrateChunksToNarCommand` that fails when
+`cdc_enabled != "true"`. Replace it with a count query: if
+`dbClient.Ent().NarFile.Query().Where(entnarfile.TotalChunksGT(0)).Count(ctx) == 0`,
+print "nothing to migrate" and exit 0. Otherwise proceed normally.
+
+**Why**: The `cdc_enabled` flag is a write-config concern, not a data-existence concern.
+During drain mode `cdc_enabled` remains `"true"` in the DB anyway, so this check would
+pass — but coupling the migration command to that flag is fragile. The authoritative
+signal is whether chunked NAR records exist.
+
+## Risks / Trade-offs
+
+- **PR ordering**: This change supersedes PR #1304. PR #1304 must be closed or its
+  `DeleteCDCConfig` call reverted before or alongside merging this change. Merging #1304
+  first and this second is safe; the revert is a no-op locally.
+- **Drain mode detection is per-restart**: Each `serve` startup queries the DB to detect
+  drain mode. If the DB is unavailable at startup, drain mode cannot be detected —
+  same failure mode as all DB-dependent startup logic.
+- **Chunk store flags required in drain mode**: Operators must still supply
+  `--cache-storage-local` (or S3 flags) matching the original chunk storage when running
+  in drain mode. The chunk store configuration does not change between CDC-on and drain.
+- **`maybeBackgroundMigrateNarToChunks` correctly disabled in drain**: It is gated on
+  `isCDCEnabled()` (write gate), so it will not push whole-file NARs into chunks during
+  drain. Correct.
+
+## Migration Plan
+
+1. Merge this change (supersedes / closes PR #1304).
+2. Operator sets `cdc.enabled: false` and deploys — drain mode activates automatically.
+3. Operator runs `migrate-chunks-to-nar` concurrently (or afterward) at their own pace.
+4. Chunked NARs are served from the chunk store until migrated.
+5. Once migration completes (`total_chunks=0` for all rows), the DB config can be
+   cleared manually if desired (operator command or future feature).

--- a/openspec/changes/archive/2026-05-30-cdc-drain-mode/design.md
+++ b/openspec/changes/archive/2026-05-30-cdc-drain-mode/design.md
@@ -31,7 +31,7 @@ PR #1304 (`allow-disabling-cdc`) introduced `DeleteCDCConfig` which clears
 
 **Non-Goals:**
 - Automatic background drain job (tracked separately).
-- Auto-clearing DB config when drain completes (tracked separately).
+- Automatic background drain job (not implemented; operator runs migrate-chunks-to-nar manually).
 - Enforcing chunk-store write prohibition at the storage layer (cache layer is sufficient).
 - Changing the chunk-store flags or configuration surface.
 
@@ -143,4 +143,4 @@ signal is whether chunked NAR records exist.
 3. Operator runs `migrate-chunks-to-nar` concurrently (or afterward) at their own pace.
 4. Chunked NARs are served from the chunk store until migrated.
 5. Once migration completes (`total_chunks=0` for all rows), the DB config can be
-   cleared manually if desired (operator command or future feature).
+   startup auto-clears the stored CDC config and the server runs fully disabled.

--- a/openspec/changes/archive/2026-05-30-cdc-drain-mode/proposal.md
+++ b/openspec/changes/archive/2026-05-30-cdc-drain-mode/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+Turning CDC off is not symmetric with turning it on. When CDC is enabled on a
+cluster that has whole-file NARs, those whole files keep serving normally while
+operators optionally run `migrate-nar-to-chunks` in the background — the
+`cdcEnabled` flag only gates the write path; reads stay independent.
+
+When CDC is disabled, the opposite should hold: new NARs go to whole-file
+storage immediately, but existing chunked NARs should continue to serve from
+the chunk store while `migrate-chunks-to-nar` drains them in the background.
+Instead, the current implementation treats disable as a hard cutover:
+
+1. The chunk store is never initialized, so all chunked NARs become cache misses
+   (upstream re-fetches) the moment the new binary starts — even mid-transfer.
+2. `allow-disabling-cdc` (PR #1304) clears `cdc_enabled` from the DB at startup,
+   so running `migrate-chunks-to-nar` in parallel immediately fails ("CDC was
+   never enabled").
+3. Large deployments with millions of NARs can never reach zero chunked NARs
+   before the operator needs to disable CDC — a graceful drain is the only
+   viable operational path.
+
+## What Changes
+
+- **Separate write gate from read gate**: `cdcEnabled` continues to gate the
+  write path only. Chunk reads are gated solely on whether the chunk store is
+  initialized (`chunkStore != nil`).
+- **Drain mode**: When `cdc.enabled: false` but `cdc_enabled=true` is still in
+  the DB (i.e. chunked NARs may exist), initialize the chunk store in read-only
+  mode so existing chunks can be served without writing new ones.
+- **Preserve DB config while draining**: Do not clear `cdc_enabled` from the DB
+  at startup. Clear it only when the operator's intent is verified complete
+  (zero chunked NARs remain) or explicitly forced. This allows
+  `migrate-chunks-to-nar` to run concurrently with a CDC-disabled ncps.
+- **Revert the `DeleteCDCConfig` call from `allow-disabling-cdc`**: The startup
+  clear introduced in PR #1304 is the root cause; drain mode supersedes it.
+- **Optional background drain job**: When drain mode is active, optionally start
+  a background worker (analogous to the lazy-chunking recovery job) that calls
+  `migrate-chunks-to-nar` internally on a schedule, so the cluster self-heals
+  without requiring a separate operator step.
+
+## Capabilities
+
+### New Capabilities
+
+- `cdc-drain-mode`: Describes the read-only chunk-serving state entered when
+  `cdc.enabled: false` but chunked NARs still exist in the database. Covers
+  write-gate/read-gate separation, DB config lifecycle, concurrency with
+  `migrate-chunks-to-nar`, and completion detection (transition to fully
+  disabled once no chunks remain).
+
+### Modified Capabilities
+
+- `cdc-chunking`: CDC startup validation lifecycle changes — the
+  enabled→disabled transition no longer clears DB config; drain mode is entered
+  instead. The `cdcEnabled` runtime flag only controls the write path.
+- `cdc-disable`: Replaces the hard-cutover semantics with drain-mode semantics;
+  the "chunked NARs become cache misses" requirement is removed.
+
+## Impact
+
+- `pkg/config/config.go`: Remove the `DeleteCDCConfig` call from
+  `validateCDCConfig`; the enabled→disabled case just returns nil and leaves
+  stored config intact.
+- `pkg/ncps/serve.go`: Initialize chunk store even when `cdcEnabled=false` if
+  stored DB config has `cdc_enabled=true`. Rename / introduce a
+  `cdcDraining` concept to distinguish write-disabled-but-read-active state.
+- `pkg/cache/cache.go`: Split `isCDCEnabled()` into write-gate
+  (`cdcEnabled && chunkStore != nil`) and read-gate (`chunkStore != nil`); all
+  chunk read paths use the read gate.
+- `pkg/ncps/migrate_chunks_to_nar.go`: Remove the hard fail on
+  `cdc_enabled != "true"` — if chunked NARs exist in the DB, the migration
+  should proceed regardless of the stored enabled flag.
+- No schema changes. No new CLI flags required (drain mode is automatic).

--- a/openspec/changes/archive/2026-05-30-cdc-drain-mode/specs/cdc-chunking/spec.md
+++ b/openspec/changes/archive/2026-05-30-cdc-drain-mode/specs/cdc-chunking/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: CDC startup validation MUST allow enabled→disabled transition
+
+When CDC configuration is validated at startup via `ValidateOrStoreCDCConfig`, the
+system SHALL permit the transition from a stored `cdc_enabled=true` to a current
+`enabled=false`. The system SHALL return nil without modifying any stored configuration
+keys. The four stored CDC config keys (`cdc_enabled`, `cdc_min`, `cdc_avg`, `cdc_max`)
+SHALL remain intact in the database so that drain mode can initialize the chunk store
+on every subsequent restart and `migrate-chunks-to-nar` can proceed concurrently.
+
+The updated validation rules are:
+- If no stored CDC config exists and `enabled=false`: no-op, return nil.
+- If no stored CDC config exists and `enabled=true`: store the new config (first boot), return nil.
+- If stored config exists and `enabled=true`: validate that all four stored values match current values; return error on mismatch.
+- If stored config exists and `enabled=false` (enabled→disabled transition): return nil, leave all stored keys intact.
+
+#### Scenario: Disabling CDC after being enabled returns nil and preserves stored config
+
+- **GIVEN** `cdc_enabled=true` is stored in the configuration database
+- **WHEN** `ValidateOrStoreCDCConfig` is called with `enabled=false`
+- **THEN** it SHALL return nil (no error)
+- **AND** the configuration database SHALL still contain `cdc_enabled=true`
+- **AND** `cdc_min`, `cdc_avg`, `cdc_max` SHALL remain unchanged
+
+#### Scenario: Keeping CDC enabled with matching config succeeds
+
+- **GIVEN** `cdc_enabled=true` is stored with matching min/avg/max values
+- **WHEN** `ValidateOrStoreCDCConfig` is called with `enabled=true` and the same sizes
+- **THEN** it SHALL return nil
+
+#### Scenario: Keeping CDC enabled with mismatched sizes fails
+
+- **GIVEN** `cdc_enabled=true` is stored with `cdc_min=16384`
+- **WHEN** `ValidateOrStoreCDCConfig` is called with `enabled=true` and `minSize=32768`
+- **THEN** it SHALL return a non-nil error describing the mismatch

--- a/openspec/changes/archive/2026-05-30-cdc-drain-mode/specs/cdc-disable/spec.md
+++ b/openspec/changes/archive/2026-05-30-cdc-drain-mode/specs/cdc-disable/spec.md
@@ -1,12 +1,4 @@
-# Capability Spec: CDC Disable
-
-## Purpose
-
-Defines requirements for disabling Content-Defined Chunking (CDC) after it has been
-previously enabled, including the startup drain-mode transition behavior, stored config
-preservation, and how un-migrated chunked NARs are served during the drain period.
-
-## Requirements
+## MODIFIED Requirements
 
 ### Requirement: CDC MAY be disabled after being enabled — chunked NARs continue to serve during drain
 

--- a/openspec/changes/archive/2026-05-30-cdc-drain-mode/specs/cdc-drain-mode/spec.md
+++ b/openspec/changes/archive/2026-05-30-cdc-drain-mode/specs/cdc-drain-mode/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Chunk reads MUST be gated on chunk-store availability, not CDC write-enabled state
+
+The system SHALL gate chunk-read operations (servability check, HasNarInChunks, GetNarInfo
+normalization) solely on whether a chunk store is initialized (`chunkStore != nil`),
+independently of the CDC write-enabled flag (`cdcEnabled`). The write gate
+(`cdcEnabled && chunkStore != nil`) remains unchanged and controls only whether new
+NARs are stored as chunks.
+
+#### Scenario: Chunked NAR is served when CDC writes are disabled but chunk store is initialized
+
+- **GIVEN** the cache is configured with `cdcEnabled=false` and a non-nil chunk store
+- **AND** a `nar_file` record for hash `H` has `total_chunks > 0`
+- **WHEN** `GetNar` is called for `H`
+- **THEN** the system SHALL treat `H` as servable from the chunk store
+- **AND** SHALL stream `H` from its chunks
+- **AND** SHALL NOT attempt to re-fetch `H` from upstream
+
+#### Scenario: New NAR is stored as whole file when CDC writes are disabled
+
+- **GIVEN** the cache is configured with `cdcEnabled=false` and a non-nil chunk store
+- **WHEN** a new NAR `H` is fetched from upstream
+- **THEN** the system SHALL store `H` as a whole file in the NAR store
+- **AND** SHALL NOT create any chunk records for `H`
+
+### Requirement: The server MUST enter drain mode when `cdc.enabled: false` but chunked NARs may exist
+
+When the server starts with `cdc.enabled: false` and the stored database configuration
+has `cdc_enabled=true` (indicating CDC was previously active and chunked NARs may
+remain), the server SHALL enter drain mode by initializing the chunk store for reads
+without enabling chunk writes. Drain mode SHALL:
+
+- Initialize the chunk store backend (local or S3) using the same storage flags as
+  a CDC-enabled deployment.
+- Leave `cdcEnabled=false` so no new NAR is stored as chunks.
+- Leave the four stored CDC config keys (`cdc_enabled`, `cdc_min`, `cdc_avg`,
+  `cdc_max`) intact in the database so `migrate-chunks-to-nar` can run concurrently.
+- Log a warning with the count of remaining chunked NARs.
+
+#### Scenario: Server enters drain mode on startup
+
+- **GIVEN** `cdc_enabled=true` is stored in the configuration database
+- **AND** the server starts with `cdc.enabled: false`
+- **THEN** the server SHALL initialize the chunk store
+- **AND** SHALL set `cdcEnabled=false` (write gate off)
+- **AND** SHALL NOT clear `cdc_enabled` or any other CDC config key from the database
+- **AND** SHALL log a warning with the count of `nar_file` rows where `total_chunks > 0`
+- **AND** SHALL start successfully
+
+#### Scenario: `migrate-chunks-to-nar` runs concurrently with a drain-mode server
+
+- **GIVEN** the server is running in drain mode (chunk store initialized, writes disabled)
+- **WHEN** `migrate-chunks-to-nar` is executed against the same database
+- **THEN** it SHALL find `cdc_enabled=true` in the database and proceed
+- **AND** SHALL reconstruct and verify whole NARs from chunks
+- **AND** SHALL NOT conflict with in-flight chunk-serve requests from the running server
+
+#### Scenario: Drain mode auto-completes when no chunked NARs remain
+
+- **GIVEN** `cdc_enabled=true` is stored in the configuration database
+- **AND** the server starts with `cdc.enabled: false`
+- **AND** no `nar_file` row has `total_chunks > 0` (drain is complete)
+- **THEN** the server SHALL clear all four stored CDC config keys from the database
+- **AND** SHALL NOT initialize the chunk store
+- **AND** SHALL log that the CDC drain is complete and the stored config has been cleared
+- **AND** SHALL start in fully-disabled mode (no chunk reads, no chunk writes)
+
+#### Scenario: Server with no prior CDC history starts with `cdc.enabled: false`
+
+- **GIVEN** `cdc_enabled` is absent from the configuration database (CDC was never used)
+- **AND** the server starts with `cdc.enabled: false`
+- **THEN** the server SHALL NOT initialize the chunk store
+- **AND** SHALL start normally with no CDC-related warnings
+
+### Requirement: `migrate-chunks-to-nar` MUST use chunk count as the migration guard, not the DB enabled flag
+
+The `migrate-chunks-to-nar` command SHALL determine whether migration is needed by
+querying the count of `nar_file` rows with `total_chunks > 0`, not by checking
+`cdc_enabled` in the configuration database. If the count is zero, the command SHALL
+report that there is nothing to migrate and exit with status 0. If the count is
+positive, the command SHALL proceed with migration regardless of the value of
+`cdc_enabled` in the database.
+
+#### Scenario: Migration proceeds when drain mode server cleared the DB write flag
+
+- **GIVEN** the server was restarted with `cdc.enabled: false`
+- **AND** chunked `nar_file` rows still exist (`total_chunks > 0`)
+- **WHEN** `migrate-chunks-to-nar` is executed
+- **THEN** it SHALL proceed with migration
+- **AND** SHALL NOT fail with "CDC was never enabled in the database"
+
+#### Scenario: Migration exits cleanly when no chunked NARs exist
+
+- **GIVEN** `cdc_enabled` is absent from the database OR set to any value
+- **AND** no `nar_file` row has `total_chunks > 0`
+- **WHEN** `migrate-chunks-to-nar` is executed
+- **THEN** it SHALL report that there is nothing to migrate
+- **AND** SHALL exit with status 0

--- a/openspec/changes/archive/2026-05-30-cdc-drain-mode/tasks.md
+++ b/openspec/changes/archive/2026-05-30-cdc-drain-mode/tasks.md
@@ -1,0 +1,32 @@
+## 1. Config Layer — Revert DeleteCDCConfig on disable
+
+- [x] 1.1 In `pkg/config/config.go`: remove the `DeleteCDCConfig` call from `validateCDCConfig` for the `storedEnabled && !enabled` case — return nil without touching the stored keys
+- [x] 1.2 Update `ValidateOrStoreCDCConfig` doc comment to reflect the new behavior: enabled→disabled returns nil and leaves stored config intact
+- [x] 1.3 Update `pkg/config/config_test.go` test `testValidateCDCDisableAfterEnabled`: assert nil return AND that all four CDC config keys are still present in the database (opposite of what PR #1304 asserted)
+
+## 2. Cache Layer — Split write gate from read gate
+
+- [x] 2.1 In `pkg/cache/cache.go`: add `isChunkStoreAvailable() bool { return c.chunkStore != nil }` (with `cdcMu.RLock`)
+- [x] 2.2 Change `isServable`: replace the `!c.isCDCEnabled()` guard with `!c.isChunkStoreAvailable()`
+- [x] 2.3 Change `HasNarInChunks`: replace the `!c.isCDCEnabled()` guard with `!c.isChunkStoreAvailable()`
+- [x] 2.4 Change `GetNarInfo` normalization: replace the `c.isCDCEnabled()` guard with `c.isChunkStoreAvailable()`
+- [x] 2.5 Write a unit test that verifies: with `cdcEnabled=false` and a non-nil chunk store (drain mode), `isServable` returns true for a `nar_file` with `total_chunks > 0`
+
+## 3. Serve Layer — Initialize chunk store in drain mode with auto-complete detection
+
+- [x] 3.1 In `serve.go` `createCache`, before calling `ValidateOrStoreCDCConfig`, read `cfg.GetCDCEnabled(ctx)` to capture the stored value (`storedWasEnabled`)
+- [x] 3.2 After `ValidateOrStoreCDCConfig` returns nil, detect drain mode: `storedWasEnabled=true && !cdcEnabled`
+- [x] 3.3 In drain mode: query `dbClient.Ent().NarFile.Query().Where(entnarfile.TotalChunksGT(0)).Count(ctx)` to get the remaining chunk count
+- [x] 3.4 If drain count == 0: call `cfg.DeleteCDCConfig(ctx)`, log "CDC drain complete, stored config cleared", and skip chunk store initialization (fully disabled)
+- [x] 3.5 If drain count > 0: call `getChunkStorageBackend` and `c.SetChunkStore` WITHOUT `SetCDCConfiguration(true, ...)` and without starting lazy-chunking; log warning with the chunk count
+- [x] 3.6 Ensure the existing `if cdcEnabled { ... c.SetChunkStore(...) }` block still runs for full CDC-enabled mode (no regression)
+
+## 4. migrate-chunks-to-nar — Use chunk count, not DB flag
+
+- [x] 4.1 In `pkg/ncps/migrate_chunks_to_nar.go`: remove the early check that fails when `cdc_enabled != "true"` in the DB
+- [x] 4.2 Replace it with a count query: `dbClient.Ent().NarFile.Query().Where(entnarfile.TotalChunksGT(0)).Count(ctx)`; if count == 0, log "nothing to migrate" and return nil
+- [x] 4.3 Update any test that expected the "CDC was never enabled" error path to instead expect success-with-zero-work
+
+## 5. Verification
+
+- [x] 5.1 Run `task fmt && task lint && task test` and confirm all pass

--- a/openspec/specs/cdc-chunking/spec.md
+++ b/openspec/specs/cdc-chunking/spec.md
@@ -231,20 +231,26 @@ stuck row SHALL NOT permanently cause reads to fail.
 
 ### Requirement: CDC startup validation MUST allow enabled→disabled transition
 
-When CDC configuration is validated at startup via `ValidateOrStoreCDCConfig`, the system SHALL permit the transition from a stored `cdc_enabled=true` to a current `enabled=false`. The previous behavior of returning `ErrCDCDisabledAfterEnabled` for this transition is removed.
+When CDC configuration is validated at startup via `ValidateOrStoreCDCConfig`, the
+system SHALL permit the transition from a stored `cdc_enabled=true` to a current
+`enabled=false`. The system SHALL return nil without modifying any stored configuration
+keys. The four stored CDC config keys (`cdc_enabled`, `cdc_min`, `cdc_avg`, `cdc_max`)
+SHALL remain intact in the database so that drain mode can initialize the chunk store
+on every subsequent restart and `migrate-chunks-to-nar` can proceed concurrently.
 
 The updated validation rules are:
 - If no stored CDC config exists and `enabled=false`: no-op, return nil.
 - If no stored CDC config exists and `enabled=true`: store the new config (first boot), return nil.
 - If stored config exists and `enabled=true`: validate that all four stored values match current values; return error on mismatch.
-- If stored config exists and `enabled=false` (enabled→disabled transition): clear all four stored CDC config keys (`cdc_enabled`, `cdc_min`, `cdc_avg`, `cdc_max`); return nil.
+- If stored config exists and `enabled=false` (enabled→disabled transition): return nil, leave all stored keys intact.
 
-#### Scenario: Disabling CDC after being enabled clears stored config and succeeds
+#### Scenario: Disabling CDC after being enabled returns nil and preserves stored config
 
 - **GIVEN** `cdc_enabled=true` is stored in the configuration database
 - **WHEN** `ValidateOrStoreCDCConfig` is called with `enabled=false`
 - **THEN** it SHALL return nil (no error)
-- **AND** the configuration database SHALL have no entry for `cdc_enabled`, `cdc_min`, `cdc_avg`, or `cdc_max`
+- **AND** the configuration database SHALL still contain `cdc_enabled=true`
+- **AND** `cdc_min`, `cdc_avg`, `cdc_max` SHALL remain unchanged
 
 #### Scenario: Keeping CDC enabled with matching config succeeds
 

--- a/openspec/specs/cdc-disable/spec.md
+++ b/openspec/specs/cdc-disable/spec.md
@@ -28,7 +28,7 @@ When this transition is detected at startup, the system SHALL:
 - **AND** all `nar_file` rows have `total_chunks = 0` (migration complete)
 - **WHEN** the server starts with `cdc.enabled: false`
 - **THEN** the server SHALL start successfully
-- **AND** the stored CDC config keys SHALL remain intact
+- **AND** the stored CDC config keys SHALL be auto-cleared from the database
 - **AND** no warning about un-migrated chunks SHALL be logged
 
 #### Scenario: Drain mode — un-migrated chunks remain, still served

--- a/openspec/specs/cdc-drain-mode/spec.md
+++ b/openspec/specs/cdc-drain-mode/spec.md
@@ -1,0 +1,109 @@
+# Capability Spec: CDC Drain Mode
+
+## Purpose
+
+Defines the drain-mode behavior that allows a server previously running with CDC
+enabled to transition to `cdc.enabled: false` while continuing to serve existing
+chunked NARs from the chunk store. Drain mode bridges the gap between disabling CDC
+writes and completing the `migrate-chunks-to-nar` migration, ensuring zero downtime
+and no upstream re-fetches for already-chunked data.
+
+## Requirements
+
+### Requirement: Chunk reads MUST be gated on chunk-store availability, not CDC write-enabled state
+
+The system SHALL gate chunk-read operations (servability check, HasNarInChunks, GetNarInfo
+normalization) solely on whether a chunk store is initialized (`chunkStore != nil`),
+independently of the CDC write-enabled flag (`cdcEnabled`). The write gate
+(`cdcEnabled && chunkStore != nil`) remains unchanged and controls only whether new
+NARs are stored as chunks.
+
+#### Scenario: Chunked NAR is served when CDC writes are disabled but chunk store is initialized
+
+- **GIVEN** the cache is configured with `cdcEnabled=false` and a non-nil chunk store
+- **AND** a `nar_file` record for hash `H` has `total_chunks > 0`
+- **WHEN** `GetNar` is called for `H`
+- **THEN** the system SHALL treat `H` as servable from the chunk store
+- **AND** SHALL stream `H` from its chunks
+- **AND** SHALL NOT attempt to re-fetch `H` from upstream
+
+#### Scenario: New NAR is stored as whole file when CDC writes are disabled
+
+- **GIVEN** the cache is configured with `cdcEnabled=false` and a non-nil chunk store
+- **WHEN** a new NAR `H` is fetched from upstream
+- **THEN** the system SHALL store `H` as a whole file in the NAR store
+- **AND** SHALL NOT create any chunk records for `H`
+
+### Requirement: The server MUST enter drain mode when `cdc.enabled: false` but chunked NARs may exist
+
+When the server starts with `cdc.enabled: false` and the stored database configuration
+has `cdc_enabled=true` (indicating CDC was previously active and chunked NARs may
+remain), the server SHALL enter drain mode by initializing the chunk store for reads
+without enabling chunk writes. Drain mode SHALL:
+
+- Initialize the chunk store backend (local or S3) using the same storage flags as
+  a CDC-enabled deployment.
+- Leave `cdcEnabled=false` so no new NAR is stored as chunks.
+- Leave the four stored CDC config keys (`cdc_enabled`, `cdc_min`, `cdc_avg`,
+  `cdc_max`) intact in the database so `migrate-chunks-to-nar` can run concurrently.
+- Log a warning with the count of remaining chunked NARs.
+
+#### Scenario: Server enters drain mode on startup
+
+- **GIVEN** `cdc_enabled=true` is stored in the configuration database
+- **AND** the server starts with `cdc.enabled: false`
+- **THEN** the server SHALL initialize the chunk store
+- **AND** SHALL set `cdcEnabled=false` (write gate off)
+- **AND** SHALL NOT clear `cdc_enabled` or any other CDC config key from the database
+- **AND** SHALL log a warning with the count of `nar_file` rows where `total_chunks > 0`
+- **AND** SHALL start successfully
+
+#### Scenario: `migrate-chunks-to-nar` runs concurrently with a drain-mode server
+
+- **GIVEN** the server is running in drain mode (chunk store initialized, writes disabled)
+- **WHEN** `migrate-chunks-to-nar` is executed against the same database
+- **THEN** it SHALL find `cdc_enabled=true` in the database and proceed
+- **AND** SHALL reconstruct and verify whole NARs from chunks
+- **AND** SHALL NOT conflict with in-flight chunk-serve requests from the running server
+
+#### Scenario: Drain mode auto-completes when no chunked NARs remain
+
+- **GIVEN** `cdc_enabled=true` is stored in the configuration database
+- **AND** the server starts with `cdc.enabled: false`
+- **AND** no `nar_file` row has `total_chunks > 0` (drain is complete)
+- **THEN** the server SHALL clear all four stored CDC config keys from the database
+- **AND** SHALL NOT initialize the chunk store
+- **AND** SHALL log that the CDC drain is complete and the stored config has been cleared
+- **AND** SHALL start in fully-disabled mode (no chunk reads, no chunk writes)
+
+#### Scenario: Server with no prior CDC history starts with `cdc.enabled: false`
+
+- **GIVEN** `cdc_enabled` is absent from the configuration database (CDC was never used)
+- **AND** the server starts with `cdc.enabled: false`
+- **THEN** the server SHALL NOT initialize the chunk store
+- **AND** SHALL start normally with no CDC-related warnings
+
+### Requirement: `migrate-chunks-to-nar` MUST use chunk count as the migration guard, not the DB enabled flag
+
+The `migrate-chunks-to-nar` command SHALL determine whether migration is needed by
+querying the count of `nar_file` rows with `total_chunks > 0`, not by checking
+`cdc_enabled` in the configuration database. If the count is zero, the command SHALL
+report that there is nothing to migrate and exit with status 0. If the count is
+positive, the command SHALL proceed with migration regardless of the value of
+`cdc_enabled` in the database.
+
+#### Scenario: Migration proceeds when drain mode server cleared the DB write flag
+
+- **GIVEN** the server was restarted with `cdc.enabled: false`
+- **AND** chunked `nar_file` rows still exist (`total_chunks > 0`)
+- **WHEN** `migrate-chunks-to-nar` is executed
+- **THEN** it SHALL proceed with migration
+- **AND** SHALL NOT fail with "CDC was never enabled in the database"
+
+#### Scenario: Migration exits cleanly when no chunked NARs exist
+
+- **GIVEN** `cdc_enabled` is absent from the database OR set to any value
+- **AND** no `nar_file` row has `total_chunks > 0`
+- **WHEN** `migrate-chunks-to-nar` is executed
+- **THEN** it SHALL report that there is nothing to migrate
+- **AND** SHALL exit with status 0

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -924,6 +924,16 @@ func (c *Cache) isCDCEnabled() bool {
 	return c.cdcEnabled && c.chunkStore != nil
 }
 
+// isChunkStoreAvailable returns true when a chunk store is initialized, regardless of whether CDC
+// writes are enabled. Used to gate read-path operations (serving, HasNarInChunks, GetNarInfo
+// normalization) so chunked NARs continue to be served during drain mode.
+func (c *Cache) isChunkStoreAvailable() bool {
+	c.cdcMu.RLock()
+	defer c.cdcMu.RUnlock()
+
+	return c.chunkStore != nil
+}
+
 func (c *Cache) getChunkStore() chunk.Store {
 	c.cdcMu.RLock()
 	defer c.cdcMu.RUnlock()
@@ -3897,7 +3907,7 @@ func (c *Cache) isServable(ctx context.Context, narURL nar.URL) (bool, error) {
 		return true, nil
 	}
 
-	if !c.isCDCEnabled() {
+	if !c.isChunkStoreAvailable() {
 		return false, nil
 	}
 
@@ -6966,7 +6976,7 @@ func derefInt64Ptr(p *int64) int64 {
 // recognized". The DB update happens asynchronously via migrateNarToChunksCleanup;
 // this call makes the in-flight response correct immediately.
 func (c *Cache) maybeCDCNormalizeNarInfoURL(ctx context.Context, narURL nar.URL, narInfo *narinfo.NarInfo) {
-	if !c.isCDCEnabled() {
+	if !c.isChunkStoreAvailable() {
 		return
 	}
 
@@ -6991,7 +7001,7 @@ func (c *Cache) maybeCDCNormalizeNarInfoURL(ctx context.Context, narURL nar.URL,
 
 // HasNarInChunks returns true if the NAR is already in chunks and chunking is complete.
 func (c *Cache) HasNarInChunks(ctx context.Context, narURL nar.URL) (bool, error) {
-	if !c.isCDCEnabled() {
+	if !c.isChunkStoreAvailable() {
 		return false, nil
 	}
 
@@ -7024,10 +7034,11 @@ func (c *Cache) HasNarFileRecord(ctx context.Context, narURL nar.URL) (bool, err
 }
 
 func (c *Cache) getNarFromChunks(ctx context.Context, narURL *nar.URL) (int64, io.ReadCloser, error) {
-	// Guard: if CDC is not configured, we cannot stream from chunks even if DB records exist.
-	// This can happen if CDC was previously enabled and then disabled (config change or rollback).
-	if !c.isCDCEnabled() {
-		return 0, nil, fmt.Errorf("CDC is not enabled, cannot serve NAR from chunks: %w", storage.ErrNotFound)
+	// Guard: chunk store must be initialized to stream from chunks. In drain mode the chunk store
+	// is initialized even though CDC writes are disabled (cdcEnabled=false), so this correctly
+	// allows reads throughout the drain period.
+	if !c.isChunkStoreAvailable() {
+		return 0, nil, fmt.Errorf("chunk store not initialized, cannot serve NAR from chunks: %w", storage.ErrNotFound)
 	}
 
 	ctx, span := tracer.Start(

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -3022,6 +3022,7 @@ func runCacheTestSuite(t *testing.T, factory cacheFactory) {
 	t.Run("GetNarInfo_CDCNormalizesCompressionWhenChunked", testGetNarInfoCDCNormalizesCompressionWhenChunked(factory))
 	t.Run("GetNarInfo_CDCNoNormalizationWhenNotChunked", testGetNarInfoCDCNoNormalizationWhenNotChunked(factory))
 	t.Run("GetNarInfo_CDCDisabledNoNormalization", testGetNarInfoCDCDisabledNoNormalization(factory))
+	t.Run("GetNarInfo_DrainModeNormalizesChunkedNar", testGetNarInfoDrainModeNormalizesChunkedNar(factory))
 	t.Run("GetNar_CDCXzRequestReturnsErrWhenChunked", testGetNarCDCXzRequestReturnsErrWhenChunked(factory))
 	t.Run("GetNar_CDCXzServesFromStoreWhenBothExist", testGetNarCDCXzServesFromStoreWhenBothExist(factory))
 
@@ -4070,6 +4071,71 @@ func testGetNarInfoCDCDisabledNoNormalization(factory cacheFactory) func(*testin
 			"GetNarInfo should NOT normalize Compression when CDC is disabled")
 		assert.Equal(t, xzURL.String(), ni.URL,
 			"GetNarInfo should NOT normalize URL when CDC is disabled")
+	}
+}
+
+// testGetNarInfoDrainModeNormalizesChunkedNar verifies that in drain mode
+// (chunk store initialized but CDC writes disabled via cdcEnabled=false), GetNarInfo
+// still normalizes the URL for a nar_file with total_chunks > 0.
+// This proves isServable and maybeCDCNormalizeNarInfoURL gate on isChunkStoreAvailable,
+// not isCDCEnabled, so chunked NARs are served correctly during the drain period.
+func testGetNarInfoDrainModeNormalizesChunkedNar(factory cacheFactory) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		// Drain mode: SetChunkStore without SetCDCConfiguration → cdcEnabled=false, chunkStore!=nil.
+		c, dbClient, _, dir, _, cleanup := factory(t)
+		t.Cleanup(cleanup)
+
+		cs, err := chunk.NewLocalStore(dir)
+		require.NoError(t, err)
+
+		c.SetChunkStore(cs)
+		// Intentionally NOT calling c.SetCDCConfiguration — that leaves cdcEnabled=false.
+
+		// Insert a narinfo with xz compression (as stored before chunking completed).
+		parsed, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
+		require.NoError(t, err)
+
+		xzURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeXz}
+
+		_, err = dbClient.Ent().NarInfo.Create().
+			SetHash(testdata.Nar1.NarInfoHash).
+			SetURL(xzURL.String()).
+			SetCompression(xzURL.Compression.String()).
+			SetStorePath(parsed.StorePath).
+			SetNarHash(parsed.NarHash.String()).
+			//nolint:gosec // G115: NarSize is non-negative by spec
+			SetNarSize(int64(parsed.NarSize)).
+			SetFileHash(parsed.FileHash.String()).
+			//nolint:gosec // G115: FileSize is non-negative by spec
+			SetFileSize(int64(parsed.FileSize)).
+			Save(ctx)
+		require.NoError(t, err)
+
+		// Insert a nar_file record with TotalChunks > 0 to simulate a fully chunked NAR.
+		noneURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeNone}
+
+		_, err = dbClient.Ent().NarFile.Create().
+			SetHash(noneURL.Hash).
+			SetCompression(noneURL.Compression.String()).
+			SetQuery(noneURL.Query.Encode()).
+			SetFileSize(0).
+			SetTotalChunks(1).
+			Save(ctx)
+		require.NoError(t, err)
+
+		ni, err := c.GetNarInfo(ctx, testdata.Nar1.NarInfoHash)
+		require.NoError(t, err)
+
+		assert.Equal(t, noneURL.Compression.String(), ni.Compression,
+			"GetNarInfo must normalize Compression to none in drain mode when NAR is in CDC chunks")
+		assert.Equal(t, noneURL.String(), ni.URL,
+			"GetNarInfo must normalize URL to .nar in drain mode when NAR is in CDC chunks")
+		assert.Nil(t, ni.FileHash, "FileHash must be nil for normalized narinfo in drain mode")
+		assert.Equal(t, uint64(0), ni.FileSize, "FileSize must be 0 for normalized narinfo in drain mode")
 	}
 }
 

--- a/pkg/cache/cdc_test.go
+++ b/pkg/cache/cdc_test.go
@@ -189,6 +189,8 @@ func runCDCTestSuite(t *testing.T, factory cacheFactory) {
 		testCDCFirstPullCompletesBeforeChunking(factory))
 	t.Run("GetNar does not panic when CDC is disabled but DB has chunked NARs",
 		testCDCDisabledWithChunkedNARsInDB(factory))
+	t.Run("GetNar serves from chunks in drain mode (cdcEnabled=false, chunkStore≠nil)",
+		testCDCDrainModeGetNarServesFromChunks(factory))
 	t.Run("GetNar with TransparentZstd returns decompressed content from CDC chunks",
 		testCDCGetNarTransparentZstd(factory))
 	t.Run("lazy chunking preserves old nar_file record", testCDCLazyChunkingPreservesOldNarFile(factory))
@@ -1796,9 +1798,10 @@ func testCDCFirstPullCompletesBeforeChunking(factory cacheFactory) func(*testing
 	}
 }
 
-// testCDCDisabledWithChunkedNARsInDB verifies that disabling CDC after NARs have been
-// stored as chunks does not cause a nil pointer panic. When CDC is disabled, GetNar must
-// not attempt to stream from chunks (which would dereference a nil chunkStore).
+// testCDCDisabledWithChunkedNARsInDB verifies drain mode behavior: when CDC writes are
+// disabled (cdcEnabled=false) but the chunk store is still initialized, HasNarInChunks
+// returns true for NARs that remain in chunks, allowing them to continue being served.
+// When the chunk store is cleared entirely, HasNarInChunks returns false (no nil panic).
 func testCDCDisabledWithChunkedNARsInDB(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
@@ -1836,16 +1839,69 @@ func testCDCDisabledWithChunkedNARsInDB(factory cacheFactory) func(*testing.T) {
 		require.NoError(t, err)
 		require.True(t, hasChunks, "HasNarInChunks should return true while CDC is enabled")
 
-		// Step 2: Disable CDC (simulates config change or deployment rollback).
-		// The DB still has total_chunks > 0 for the NAR we stored above.
+		// Step 2: Disable CDC writes (simulates drain mode: cdcEnabled=false, chunkStore still set).
+		// The DB still has total_chunks > 0 for the NAR stored above.
 		err = c.SetCDCConfiguration(false, 0, 0, 0)
 		require.NoError(t, err)
 
-		// Step 3: HasNarInChunks must return false when CDC is disabled,
-		// so the system does not try the chunk path.
+		// Step 3: HasNarInChunks must return true in drain mode (chunk store still initialized)
+		// so that existing chunked NARs continue to be served without re-fetching from upstream.
 		hasChunks, err = c.HasNarInChunks(ctx, nu)
 		require.NoError(t, err)
-		assert.False(t, hasChunks, "HasNarInChunks should return false when CDC is disabled")
+		assert.True(t, hasChunks, "HasNarInChunks should return true in drain mode (chunk store still set)")
+
+		// Step 4: Clearing the chunk store (fully disabled, not drain mode) must prevent
+		// HasNarInChunks from returning true and must not cause any nil pointer panic.
+		c.SetChunkStore(nil)
+
+		hasChunks, err = c.HasNarInChunks(ctx, nu)
+		require.NoError(t, err)
+		assert.False(t, hasChunks, "HasNarInChunks should return false when chunk store is nil")
+	}
+}
+
+// testCDCDrainModeGetNarServesFromChunks verifies the core drain mode contract:
+// GetNar successfully streams a NAR from its chunks when cdcEnabled=false but the
+// chunk store is still initialized. This tests getNarFromChunks using isChunkStoreAvailable
+// instead of isCDCEnabled so reads continue to work throughout the drain period.
+func testCDCDrainModeGetNarServesFromChunks(factory cacheFactory) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		c, _, _, dir, _, cleanup := factory(t)
+		t.Cleanup(cleanup)
+
+		// Step 1: Enable full CDC and store a NAR as chunks.
+		chunkStoreDir := filepath.Join(dir, "chunks-store")
+		chunkStore, err := chunk.NewLocalStore(chunkStoreDir)
+		require.NoError(t, err)
+
+		c.SetChunkStore(chunkStore)
+		err = c.SetCDCConfiguration(true, 1024, 4096, 8192)
+		require.NoError(t, err)
+
+		content := "drain mode test: this NAR content must be served from chunks after CDC is disabled"
+		nu := nar.URL{Hash: "testnar-drain-mode", Compression: nar.CompressionTypeNone}
+
+		err = c.PutNar(ctx, nu, io.NopCloser(strings.NewReader(content)))
+		require.NoError(t, err)
+
+		// Step 2: Enter drain mode — disable CDC writes, keep chunk store.
+		err = c.SetCDCConfiguration(false, 0, 0, 0)
+		require.NoError(t, err)
+
+		// Step 3: GetNar must stream the NAR from its chunks (no whole-file exists).
+		_, size, rc, err := c.GetNar(ctx, nu)
+		require.NoError(t, err, "GetNar must succeed in drain mode for a chunked NAR")
+
+		t.Cleanup(func() { _ = rc.Close() })
+
+		data, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		assert.Equal(t, content, string(data), "GetNar must return original content from chunks in drain mode")
+		assert.Equal(t, int64(len(content)), size)
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -244,8 +244,10 @@ func (c *Config) DeleteCDCConfig(ctx context.Context) error {
 // ValidateOrStoreCDCConfig validates CDC configuration against stored values or stores them if not yet configured.
 // If CDC is disabled and no config exists, returns nil (no-op).
 // If CDC is enabled and no config exists, stores all 4 values.
-// If config exists, validates that enabled flag matches and all values are identical.
-// If CDC was previously enabled but now disabled, clears the stored config and returns nil.
+// If config exists and CDC is still enabled, validates that all four values are identical.
+// If CDC was previously enabled but now disabled (enabled→disabled transition), returns nil and leaves the
+// stored config intact so that drain mode can initialize the chunk store on every subsequent restart and
+// migrate-chunks-to-nar can proceed concurrently.
 func (c *Config) ValidateOrStoreCDCConfig(
 	ctx context.Context,
 	enabled bool,
@@ -317,10 +319,11 @@ func (c *Config) validateCDCConfig(
 ) error {
 	storedEnabled := storedEnabledStr == "true"
 
-	// CDC is being disabled after having been enabled — clear stored config so a future
-	// re-enable is treated as a fresh first boot with the new chunk sizes.
+	// CDC is being disabled after having been enabled — leave the stored config intact so that
+	// drain mode can initialize the chunk store on every restart and migrate-chunks-to-nar can
+	// proceed concurrently. The serve layer will call DeleteCDCConfig when drain completes.
 	if storedEnabled && !enabled {
-		return c.DeleteCDCConfig(ctx)
+		return nil
 	}
 
 	// Get stored values for comparison

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -475,29 +475,33 @@ func testValidateCDCDisableAfterEnabled(factory databaseFactory) func(*testing.T
 		err := c.ValidateOrStoreCDCConfig(ctx, true, 65536, 262144, 1048576)
 		require.NoError(t, err)
 
-		// Second boot with CDC disabled - should now succeed (migrate-chunks-to-nar exists)
+		// Second boot with CDC disabled - must succeed and leave stored config intact for drain mode
 		err = c.ValidateOrStoreCDCConfig(ctx, false, 65536, 262144, 1048576)
 		require.NoError(t, err)
 
-		// All four CDC config keys must be cleared from the database
-		_, err = c.GetCDCEnabled(ctx)
-		require.ErrorIs(t, err, config.ErrConfigNotFound, "cdc_enabled must be cleared")
-
-		_, err = c.GetCDCMin(ctx)
-		require.ErrorIs(t, err, config.ErrConfigNotFound, "cdc_min must be cleared")
-
-		_, err = c.GetCDCAvg(ctx)
-		require.ErrorIs(t, err, config.ErrConfigNotFound, "cdc_avg must be cleared")
-
-		_, err = c.GetCDCMax(ctx)
-		require.ErrorIs(t, err, config.ErrConfigNotFound, "cdc_max must be cleared")
-
-		// Re-enabling with new sizes must succeed (treated as a fresh first boot)
-		err = c.ValidateOrStoreCDCConfig(ctx, true, 32768, 131072, 524288)
-		require.NoError(t, err)
-
+		// All four CDC config keys must still be present so drain mode and migrate-chunks-to-nar work
 		enabled, err := c.GetCDCEnabled(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, "true", enabled)
+		assert.Equal(t, "true", enabled, "cdc_enabled must be preserved during drain")
+
+		storedMin, err := c.GetCDCMin(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "65536", storedMin, "cdc_min must be preserved during drain")
+
+		storedAvg, err := c.GetCDCAvg(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "262144", storedAvg, "cdc_avg must be preserved during drain")
+
+		storedMax, err := c.GetCDCMax(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "1048576", storedMax, "cdc_max must be preserved during drain")
+
+		// Re-enabling with the same sizes must succeed (stored config still present, values match)
+		err = c.ValidateOrStoreCDCConfig(ctx, true, 65536, 262144, 1048576)
+		require.NoError(t, err)
+
+		// Re-enabling with different sizes must fail (mismatch against preserved config)
+		err = c.ValidateOrStoreCDCConfig(ctx, true, 32768, 131072, 524288)
+		require.ErrorIs(t, err, config.ErrCDCConfigMismatch)
 	}
 }

--- a/pkg/ncps/migrate_chunks_to_nar.go
+++ b/pkg/ncps/migrate_chunks_to_nar.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/kalbasit/ncps/ent"
 	"github.com/kalbasit/ncps/pkg/cache"
-	"github.com/kalbasit/ncps/pkg/config"
 	"github.com/kalbasit/ncps/pkg/nar"
 	"github.com/kalbasit/ncps/pkg/otel"
 )
@@ -230,24 +229,17 @@ func migrateChunksToNarAction(registerShutdown registerShutdownFn) cli.ActionFun
 			return fmt.Errorf("error creating lockers: %w", err)
 		}
 
-		cfg := config.New(dbClient, rwLocker)
-
-		cdcEnabledStr, err := cfg.GetCDCEnabled(ctx)
+		chunkedCount, err := dbClient.Ent().NarFile.Query().
+			Where(entnarfile.TotalChunksGT(0)).
+			Count(ctx)
 		if err != nil {
-			if errors.Is(err, config.ErrConfigNotFound) {
-				//nolint:err113 // no need to define a package-level error for this one-off message.
-				return errors.New(
-					"migrate-chunks-to-nar command requires CDC to have been enabled in the database; " +
-						"there is nothing chunked to migrate back",
-				)
-			}
-
-			return fmt.Errorf("error loading CDC enabled flag from database: %w", err)
+			return fmt.Errorf("error querying chunked NAR count: %w", err)
 		}
 
-		if cdcEnabledStr != configValueTrue {
-			//nolint:err113 // no need to define a package-level error for this one-off message.
-			return errors.New("migrate-chunks-to-nar command requires CDC to have been enabled in the database")
+		if chunkedCount == 0 {
+			zerolog.Ctx(ctx).Info().Msg("migrate-chunks-to-nar: nothing to migrate; no chunked NARs found")
+
+			return nil
 		}
 
 		extraResourceAttrs, err := detectExtraResourceAttrs(ctx, cmd, dbClient, rwLocker)

--- a/pkg/ncps/migrate_chunks_to_nar_test.go
+++ b/pkg/ncps/migrate_chunks_to_nar_test.go
@@ -90,6 +90,29 @@ func countChunks(ctx context.Context, t *testing.T, dbClient *database.Client) i
 	return n
 }
 
+// TestMigrateChunksToNar_CLI_NothingToMigrate verifies that the command exits cleanly
+// when no chunked NARs exist — regardless of whether cdc_enabled is in the database.
+// This covers both the "CDC never used" case and the "drain complete" case.
+func TestMigrateChunksToNar_CLI_NothingToMigrate(t *testing.T) {
+	t.Parallel()
+
+	ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+	_, _, dir, dbURL, cleanup := setupNarToChunksMigrationSQLite(t)
+	t.Cleanup(cleanup)
+
+	// No configureCDCInDatabase call — cdc_enabled absent from DB.
+	// No setupChunkedNar call — no nar_file rows with total_chunks > 0.
+
+	app, err := ncps.New()
+	require.NoError(t, err)
+
+	require.NoError(t, app.Run(ctx, []string{
+		"ncps", "migrate-chunks-to-nar",
+		"--cache-database-url", dbURL,
+		"--cache-storage-local", dir,
+	}))
+}
+
 func TestMigrateChunksToNar_CLI_Success(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -1130,7 +1130,13 @@ func createCache(
 
 	// Capture stored CDC state before validation so drain mode can be detected afterward.
 	storedEnabledStr, storedEnabledErr := cfg.GetCDCEnabled(ctx)
-	storedWasEnabled := storedEnabledErr == nil && storedEnabledStr == "true"
+	storedWasEnabled := false
+
+	if storedEnabledErr == nil {
+		storedWasEnabled = storedEnabledStr == configValueTrue
+	} else if !errors.Is(storedEnabledErr, config.ErrConfigNotFound) {
+		return nil, fmt.Errorf("failed to read stored CDC enabled state: %w", storedEnabledErr)
+	}
 
 	if err := cfg.ValidateOrStoreCDCConfig(ctx, cdcEnabled, cdcMin, cdcAvg, cdcMax); err != nil {
 		return nil, fmt.Errorf("CDC configuration validation failed: %w", err)

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -1023,6 +1023,48 @@ func getChunkStorageBackend(ctx context.Context, cmd *cli.Command, locker lock.L
 	}
 }
 
+// initCDCDrainMode handles drain mode startup: CDC was previously enabled but is now disabled.
+// It counts remaining chunked NARs and either auto-completes the drain (clearing the stored
+// config when none remain) or initializes the chunk store read-only for in-progress drain.
+func initCDCDrainMode(
+	ctx context.Context,
+	cmd *cli.Command,
+	locker lock.Locker,
+	c *cache.Cache,
+	cfg *config.Config,
+	dbClient *database.Client,
+) error {
+	chunkedCount, err := dbClient.Ent().NarFile.Query().
+		Where(entnarfile.TotalChunksGT(0)).
+		Count(ctx)
+	if err != nil {
+		return fmt.Errorf("error querying chunked NAR count for drain mode detection: %w", err)
+	}
+
+	if chunkedCount == 0 {
+		if err := cfg.DeleteCDCConfig(ctx); err != nil {
+			return fmt.Errorf("error clearing CDC config after drain completion: %w", err)
+		}
+
+		zerolog.Ctx(ctx).Info().Msg("CDC drain complete: all NARs migrated, stored config cleared")
+
+		return nil
+	}
+
+	chunkStore, err := getChunkStorageBackend(ctx, cmd, locker)
+	if err != nil {
+		return fmt.Errorf("error creating chunk storage backend for CDC drain mode: %w", err)
+	}
+
+	c.SetChunkStore(chunkStore)
+
+	zerolog.Ctx(ctx).Warn().
+		Int("chunked_nar_count", chunkedCount).
+		Msg("CDC disabled with chunked NARs remaining; drain mode active; run migrate-chunks-to-nar")
+
+	return nil
+}
+
 func createCache(
 	ctx context.Context,
 	cmd *cli.Command,
@@ -1086,21 +1128,12 @@ func createCache(
 		}
 	}
 
+	// Capture stored CDC state before validation so drain mode can be detected afterward.
+	storedEnabledStr, storedEnabledErr := cfg.GetCDCEnabled(ctx)
+	storedWasEnabled := storedEnabledErr == nil && storedEnabledStr == "true"
+
 	if err := cfg.ValidateOrStoreCDCConfig(ctx, cdcEnabled, cdcMin, cdcAvg, cdcMax); err != nil {
 		return nil, fmt.Errorf("CDC configuration validation failed: %w", err)
-	}
-
-	if !cdcEnabled {
-		chunkedCount, countErr := dbClient.Ent().NarFile.Query().
-			Where(entnarfile.TotalChunksGT(0)).
-			Count(ctx)
-		if countErr != nil {
-			zerolog.Ctx(ctx).Warn().Err(countErr).Msg("failed to count remaining chunked NARs")
-		} else if chunkedCount > 0 {
-			zerolog.Ctx(ctx).Warn().
-				Int("chunked_nar_count", chunkedCount).
-				Msg("CDC is disabled but chunked NARs remain; run 'ncps migrate-chunks-to-nar' to convert")
-		}
 	}
 
 	zerolog.Ctx(ctx).
@@ -1130,7 +1163,12 @@ func createCache(
 
 	c.SetCDCLazyChunking(cdcLazyChunkingEnabled, cdcBackgroundWorkers)
 
-	// Configure Chunk Store
+	// Configure Chunk Store.
+	//
+	// Full CDC mode: chunk store initialized with write gate on.
+	// Drain mode (storedWasEnabled && !cdcEnabled): CDC was previously active; chunked NARs may
+	// still exist. Initialize the chunk store for reads only (cdcEnabled=false keeps the write
+	// gate off). If no chunked NARs remain, clear the stored config and start fully disabled.
 	if cdcEnabled {
 		chunkStore, err := getChunkStorageBackend(ctx, cmd, locker)
 		if err != nil {
@@ -1138,6 +1176,10 @@ func createCache(
 		}
 
 		c.SetChunkStore(chunkStore)
+	} else if storedWasEnabled {
+		if err := initCDCDrainMode(ctx, cmd, locker, c, cfg, dbClient); err != nil {
+			return nil, err
+		}
 	}
 
 	c.AddUpstreamCaches(ctx, ucs...)


### PR DESCRIPTION
## Summary

Fixes a fundamental design flaw in PR #1304 (`allow-disabling-cdc`):
when CDC was disabled after having been enabled, chunked NARs became
cache misses and the stored DB config was cleared at startup, breaking
concurrent `migrate-chunks-to-nar` runs. Large deployments need a
graceful transition where existing chunks continue to serve while
migration runs at its own pace — mirroring the existing off→on behavior.

### Changes

**Cache layer — split write gate from read gate**
- Add `isChunkStoreAvailable() bool { return c.chunkStore != nil }` in
  `pkg/cache/cache.go`
- Change 4 read-path sites from `isCDCEnabled()` to
  `isChunkStoreAvailable()`: `isServable`, `HasNarInChunks`,
  `maybeCDCNormalizeNarInfoURL`, `getNarFromChunks`
- All ~22 write-path sites (`putNarWithCDC`, lazy-chunking, GC, etc.)
  remain gated on `isCDCEnabled()` — no writes in drain mode

**Config layer — preserve stored config during disable**
- Revert `validateCDCConfig`'s `DeleteCDCConfig` call from PR #1304;
  return `nil` and leave all four CDC keys intact so drain mode can
  re-initialize the chunk store on every restart

**Serve layer — drain mode with auto-complete detection**
- Extract `initCDCDrainMode` helper in `pkg/ncps/serve.go`
- Detect drain mode at startup: `storedWasEnabled=true && !cdcEnabled`
- If chunk count > 0: init chunk store read-only, log warning with count
- If chunk count = 0: call `DeleteCDCConfig`, log "drain complete",
  start fully disabled (self-completing transition, no operator command)

**migrate-chunks-to-nar — use chunk count not DB flag**
- Remove the `cdc_enabled=true` DB check
- Replace with `TotalChunksGT(0)` count; if 0 → "nothing to migrate"
  and exit 0; otherwise proceed regardless of DB enabled flag

### State machine

| DB `cdc_enabled` | config `cdc.enabled` | chunks | Mode |
|---|---|---|---|
| absent | false | — | fully disabled |
| true | true | — | full CDC (read + write) |
| true | false | yes | drain (reads from chunks, writes whole-file) |
| true | false | no | auto-clears config → fully disabled |

## Test plan

- [x] `task fmt` passes
- [x] `task lint` passes (removed 1 nestif issue vs baseline)
- [x] `task test` passes — all unit tests green
- [x] New test `testCDCDrainModeGetNarServesFromChunks`: end-to-end
  GetNar streaming in drain mode (cdcEnabled=false, chunkStore≠nil)
- [x] New test `testGetNarInfoDrainModeNormalizesChunkedNar`: GetNarInfo
  URL normalization in drain mode
- [x] New test `TestMigrateChunksToNar_CLI_NothingToMigrate`: command
  exits 0 when no chunked NARs exist regardless of DB state
- [x] Updated `testCDCDisabledWithChunkedNARsInDB`: reflects drain mode
  semantics (HasNarInChunks=true with chunk store set; false when nil)
- [x] Updated `testValidateCDCDisableAfterEnabled`: asserts all 4 DB
  keys still present after disable (opposite of PR #1304 assertion)