### PR TITLE
docs: populate CHANGELOG for v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,105 @@ project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- **`build-trace-v2` endpoint.** `nix copy` unconditionally PUTs and GETs
+  build-trace entries at `/build-trace-v2/{drvName}/{outputName}.doi` for
+  content-addressed derivations. Previously ncps had no routes for these paths
+  and returned 404, causing `nix copy` to exit non-zero even when the NAR
+  upload succeeded. (#1272)
+
+- **CDC drain mode.** Disabling CDC (`--cache-cdc-enabled=false`) on a
+  deployment that still has chunked NARs in the database no longer makes those
+  NARs cache misses. On startup ncps detects the mismatch, initialises the chunk
+  store read-only, and continues serving chunked NARs while writes go to whole
+  files. Once all chunks have been migrated away the drain completes
+  automatically — the next restart starts fully CDC-disabled with no operator
+  action required. (#1305)
+
+- **`ncps migrate-chunks-to-nar` command.** Reverse of `migrate-nar-to-chunks`:
+  reconstitutes whole NAR files from their stored chunks, updates the database,
+  and reclaims the chunk objects. Supports `--dry-run`, `--concurrency`, and
+  `--force-reclaim` (bypasses the in-flight-serve safety check). Per-NAR
+  failures are isolated — the batch continues and the command exits non-zero
+  only if any NAR failed. (#1301)
+
+- **`--cache-cdc-chunk-wait-timeout` flag** (env: `CACHE_CDC_CHUNK_WAIT_TIMEOUT`,
+  default `30s`). Controls how long progressive CDC streaming waits for each
+  chunk before giving up. Previously hard-coded, the new flag lets operators
+  align the timeout with their reverse-proxy timeout to avoid spurious 504s on
+  high-latency storage. Exposed as `cache.cdc.chunkWaitTimeout` in the Helm
+  chart. (#1299, #1300)
+
+- **Helm: `migrate-nar-to-chunks` Job.** The forward CDC migration Job (whole
+  NAR → chunks) now has a chart representation. Both `migrate-nar-to-chunks` and
+  `migrate-chunks-to-nar` Jobs are disabled by default (`enabled: false`) and
+  auto-cleanup via `ttlSecondsAfterFinished: 3600`. (#1306)
+
+### Fixed
+
+- **Helm: migration Job no longer mounts storage or tmp volumes for non-SQLite
+  databases.** The migration Job was unconditionally mounting the storage PVC and
+  an 8 GiB in-memory `tmp` emptyDir even for PostgreSQL/MySQL deployments.
+  `ncps migrate up` only opens a database connection and never touches the
+  filesystem, so both mounts were unnecessary and wasted resources. (#1267)
+
+- **Helm: migration Jobs are no longer ArgoCD sync hooks.** The
+  `helm.sh/hook` annotations caused OOMKilled jobs to block all subsequent ArgoCD
+  syncs until manually deleted. Both migration Jobs are now regular release
+  resources. (#1306)
+
+- **Cache reliability on shared/high-latency storage (NFS, multi-replica).** A
+  cluster of related fixes for deployments using the `local` backend on a network
+  filesystem:
+
+  - `HasNar` previously collapsed every storage error into `false`, making an
+    ambiguous NFS stat indistinguishable from a confirmed absence and triggering
+    a destructive narinfo purge. `HasNar` now distinguishes *present* /
+    *confirmed-absent* / *unknown*; unknown results skip the purge and let the
+    next request re-evaluate. (#1299)
+  - Hardened NAR cache-miss recovery: transient errors are retried, genuine 404s
+    are not, and the recovery sweep correctly re-drives rows that have a backing
+    file but a stale database state. (#1296)
+  - CDC recovery follow-ups: improved GC, exponential backoff, and streaming
+    robustness. (#1297)
+  - Download-lock contention no longer returns HTTP 500 to the client. (#1290)
+  - Fixed a hang when a client cancels a request mid-stream during a concurrent
+    NAR download. (#1280)
+  - Fixed spurious narinfo purge triggered by a concurrent fetch that raced the
+    narinfo insert. (#1279)
+
+- **CDC: fixed compression mismatch in lazy-chunking.** CDC lazy-chunking was
+  writing chunks with the wrong compressor in some cases, producing corrupt
+  reassembly on read. (#1255)
+
+- **PostgreSQL: fsck no longer hits the 65 535-parameter IN-clause cap.** Large
+  databases caused fsck queries to exceed PostgreSQL's bind-parameter limit.
+  Queries are now batched. (#1268)
+
+- **PostgreSQL: identity sequence reliably synced on existing databases.** The
+  `postgres_serial_to_identity` migration could leave sequences at their initial
+  low value on databases that already had rows, causing duplicate-key errors on
+  insert. The migration now uses `ALTER TABLE … ALTER COLUMN id RESTART WITH (MAX(id)+1)` inside a DO block, which targets the identity sequence directly
+  regardless of its internal name. (#1258)
+
+- **PostgreSQL: concurrent narinfo inserts no longer produce 25P02 errors.**
+  Chunk inserts now use `DO NOTHING` with 25P02 (in-failed-transaction) recovery,
+  and concurrent narinfo upserts are serialised correctly. (#1259, #1262)
+
+- **Cache: stub narinfo filled correctly under concurrent race.** A race between
+  two goroutines resolving the same stub narinfo could leave one with an empty
+  result. (#1263)
+
 ### Changed
+
+- **CDC lazy chunking is now opt-in (default: `false`).** In v0.9, lazy
+  chunking was enabled by default after being introduced in #1081. Enabling it
+  silently on upgrade starts background workers, a cleanup cron job, and delays
+  compressed NAR deletion without operator consent. The default has been
+  reverted to `false`; set `--cache-cdc-lazy-chunking-enabled=true` (or
+  `cache.cdc.lazyChunkingEnabled: true` in the Helm chart) to restore the
+  previous behaviour. (#1172)
 
 - **Helm chart: security context defaults removed; `containerDefaults.securityContext` added.**
   All default values have been removed from `podSecurityContext`, `securityContext`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **CDC drain mode.** Disabling CDC (`--cache-cdc-enabled=false`) on a
   deployment that still has chunked NARs in the database no longer makes those
-  NARs cache misses. On startup ncps detects the mismatch, initialises the chunk
+  NARs cache misses. On startup ncps detects the mismatch, initializes the chunk
   store read-only, and continues serving chunked NARs while writes go to whole
   files. Once all chunks have been migrated away the drain completes
   automatically — the next restart starts fully CDC-disabled with no operator
@@ -78,7 +78,7 @@ project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   writing chunks with the wrong compressor in some cases, producing corrupt
   reassembly on read. (#1255)
 
-- **PostgreSQL: fsck no longer hits the 65 535-parameter IN-clause cap.** Large
+- **PostgreSQL: fsck no longer hits the 65,535-parameter IN-clause cap.** Large
   databases caused fsck queries to exceed PostgreSQL's bind-parameter limit.
   Queries are now batched. (#1268)
 
@@ -90,7 +90,7 @@ project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **PostgreSQL: concurrent narinfo inserts no longer produce 25P02 errors.**
   Chunk inserts now use `DO NOTHING` with 25P02 (in-failed-transaction) recovery,
-  and concurrent narinfo upserts are serialised correctly. (#1259, #1262)
+  and concurrent narinfo upserts are serialized correctly. (#1259, #1262)
 
 - **Cache: stub narinfo filled correctly under concurrent race.** A race between
   two goroutines resolving the same stub narinfo could leave one with an empty
@@ -104,7 +104,7 @@ project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   compressed NAR deletion without operator consent. The default has been
   reverted to `false`; set `--cache-cdc-lazy-chunking-enabled=true` (or
   `cache.cdc.lazyChunkingEnabled: true` in the Helm chart) to restore the
-  previous behaviour. (#1172)
+  previous behavior. (#1172)
 
 - **Helm chart: security context defaults removed; `containerDefaults.securityContext` added.**
   All default values have been removed from `podSecurityContext`, `securityContext`,


### PR DESCRIPTION
## Summary

Fills in the `[Unreleased]` section of `CHANGELOG.md` ahead of the v0.10.0
release, covering all user-facing changes since v0.9.4.

**Added**
- `build-trace-v2` endpoint — fixes `nix copy` with CA derivations
- CDC drain mode — graceful transition when disabling CDC while chunks remain
- `ncps migrate-chunks-to-nar` command — reverse CDC migration with `--dry-run` / `--force-reclaim`
- `--cache-cdc-chunk-wait-timeout` flag — replaces the hard-coded 30 s per-chunk wait
- Helm `migrate-nar-to-chunks` Job — the forward migration Job now has a chart representation

**Fixed**
- Helm: migration Job incorrectly mounted storage/tmp volumes for PostgreSQL/MySQL
- Helm: migration Jobs were ArgoCD sync hooks (OOMKill → blocked all syncs)
- Cache reliability on NFS/multi-replica: false-purge cascade, cache-miss recovery
  hardening, HTTP 500 on lock contention, client-cancel hang, spurious narinfo purge
- CDC lazy-chunking compression mismatch
- PostgreSQL fsck IN-clause cap (65 535 params)
- PostgreSQL identity sequence sync on existing databases
- PostgreSQL concurrent 25P02 errors on narinfo/chunk inserts
- Stub narinfo concurrent race

**Changed**
- CDC lazy chunking default flipped to `false` (was `true` in v0.9) — opt-in now required
- Helm security context defaults removed; `containerDefaults.securityContext` added (breaking)
- Database tooling migrated from sqlc + dbmate to Ent + Atlas + Goose

## Test plan

- [x] `nix fmt` — exit 0 (formatter touched one blank-line in the list)
- [x] No code changes — CHANGELOG only