### PR TITLE
fix(ci): don't checkout PR head in pull_request_target

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -18,7 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.GHA_PAT_TOKEN }}
       - name: Log current API rate limits
         env:


### PR DESCRIPTION
## Summary

- Removes `ref: ${{ github.event.pull_request.head.sha }}` from the `actions/checkout` step in the backport workflow
- `pull_request_target` runs with write access to secrets (needed to create backport PRs); checking out the unreviewed fork head in this context is a CodeQL high-severity finding (alert #1): a malicious fork PR could place code that gets executed while the PAT is in scope
- The `korthout/backport-action` resolves commit SHAs via the GitHub API — it does not require the PR branch to be the current HEAD; removing `ref:` makes the checkout use the base branch (trusted, reviewed code) instead

## Test plan

- [ ] Merge a PR with a `backport` label and verify the backport action still creates the backport PR correctly