### PR TITLE
fix(storage/local): don't wipe store/tmp on startup

### DIFF
--- a/openspec/changes/archive/2026-06-01-fix-store-tmp-mkdir-idempotent/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-01-fix-store-tmp-mkdir-idempotent/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/archive/2026-06-01-fix-store-tmp-mkdir-idempotent/design.md
+++ b/openspec/changes/archive/2026-06-01-fix-store-tmp-mkdir-idempotent/design.md
@@ -1,0 +1,43 @@
+## Context
+
+`pkg/storage/local/local.go` `setupDirs()` is called on every pod startup. It currently calls `os.RemoveAll(s.storeTMPPath())` before creating the tmp directory, intending to start each process with a clean tmp directory.
+
+In production, the local storage backend runs on a shared NFS RWX PVC across two replicas. During a rolling update, the incoming pod's `setupDirs()` runs while the outgoing pod is still serving and may have in-flight downloads in `store/tmp`. `RemoveAll` on a shared PVC races with those active writes and removes files the outgoing pod is using — either crashing the incoming pod (if `RemoveAll` returns an error) or corrupting the outgoing pod's in-flight work.
+
+The write path already uses an atomic tmp-then-rename pattern, so partial tmp files left behind by crashed pods are benign.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `setupDirs()` idempotent and safe to call when the tmp directory already exists on the shared PVC.
+- Eliminate the rolling-update crashloop.
+
+**Non-Goals:**
+- Per-pod tmp namespacing (not required; leftover partials are harmless).
+- Cleaning up stale tmp files on startup (out of scope; acceptable operational trade-off).
+- S3 or chunk storage backends (not affected by this change).
+
+## Decisions
+
+### Remove `os.RemoveAll` from `setupDirs()`
+
+**Decision:** Delete the `os.RemoveAll(s.storeTMPPath())` call and its error check from `setupDirs()`. The immediately following `os.MkdirAll(p, dirMode)` loop already handles both "directory exists" and "directory doesn't exist" correctly.
+
+**Alternatives considered:**
+- *Rename to per-pod tmp dir (e.g. `store/tmp/<pod-uuid>`)* — would scope cleanup correctly but requires plumbing pod identity into the store, adds complexity, and makes no difference for correctness since partials are already safe.
+- *Keep `RemoveAll` but only on non-shared mounts* — requires detecting mount type at runtime; fragile and unnecessary.
+
+## Risks / Trade-offs
+
+- [Stale tmp files accumulate if pods crash mid-download] → Acceptable: files are partial and never promoted to the NAR path. An operator can run `rm -rf store/tmp/*` manually during a maintenance window. A future periodic-cleanup task could address this, but is out of scope here.
+
+## Migration Plan
+
+1. Remove the three lines (`RemoveAll` call + error check + blank line) from `setupDirs()`.
+2. Unit test: add a test that calls `setupDirs()` twice on the same directory and asserts it succeeds both times.
+3. Deploy the new image. ArgoCD rolling update will no longer trigger the crashloop.
+4. No rollback complexity — the removed code only worsened availability; reverting would reintroduce the bug.
+
+## Open Questions
+
+_(none)_

--- a/openspec/changes/archive/2026-06-01-fix-store-tmp-mkdir-idempotent/proposal.md
+++ b/openspec/changes/archive/2026-06-01-fix-store-tmp-mkdir-idempotent/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+During a rolling update, the incoming pod calls `setupDirs()` which unconditionally deletes the `store/tmp` directory on the shared PVC — wiping any in-flight downloads the outgoing pod owns and returning an error if `RemoveAll` races with active writes, causing an immediate crashloop. We need to fix this before ArgoCD re-applies and re-triggers the crash.
+
+## What Changes
+
+- Remove the `os.RemoveAll(s.storeTMPPath())` call from `setupDirs()` in `pkg/storage/local/local.go`. The subsequent `os.MkdirAll` is already idempotent and handles both the "dir exists" and "dir doesn't exist" cases.
+- Each pod will inherit whatever tmp files prior pods left behind; stale partial files are harmless — the write path uses atomic rename (tmp → final) so they are never surfaced as valid entries.
+
+## Non-goals
+
+- Per-pod tmp namespacing (subdirectory per pod UID) — out of scope; leftover tmp files from crashes already converge safely.
+- S3/chunk storage backends — not affected; this is local-backend only.
+- Startup tmp-dir validation (`EnsureDirWritable`) — kept as-is; it only writes and removes a probe file, which is safe on a shared PVC.
+
+## Capabilities
+
+### Modified Capabilities
+
+- **Local store initialization** (`pkg/storage/local/local.go` `setupDirs`): no longer purges `store/tmp` on startup; directory creation is idempotent via `os.MkdirAll`.
+
+### New Capabilities
+
+_(none)_
+
+## Impact
+
+- `pkg/storage/local/local.go` — remove 3 lines (`RemoveAll` call + error check).
+- No API, config, or migration changes.
+- No I/O, latency, or memory impact.
+- Rolling updates on a shared PVC become safe; single-node deployments are unaffected.

--- a/openspec/changes/archive/2026-06-01-fix-store-tmp-mkdir-idempotent/specs/local-store-initialization/spec.md
+++ b/openspec/changes/archive/2026-06-01-fix-store-tmp-mkdir-idempotent/specs/local-store-initialization/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Local store directory setup is idempotent
+
+`setupDirs()` must succeed regardless of whether the `store/tmp` directory already exists on disk, so that rolling updates on shared PVCs do not crash the incoming pod.
+
+#### Scenario: First startup (no existing directories)
+- **WHEN** `setupDirs()` is called and no store directories exist yet
+- **THEN** all required directories (`store/`, `store/nar/`, `store/tmp/`) are created and the call returns nil
+
+#### Scenario: Restart or rolling update (tmp directory already exists)
+- **WHEN** `setupDirs()` is called and `store/tmp` already exists (created by a prior pod on a shared PVC)
+- **THEN** the call succeeds without error and the tmp directory remains intact
+
+#### Scenario: Existing tmp files are not removed on startup
+- **WHEN** `setupDirs()` is called and `store/tmp` contains partial download files left by a previous process
+- **THEN** those files are left in place and the call returns nil (cleanup is not performed at startup)

--- a/openspec/changes/archive/2026-06-01-fix-store-tmp-mkdir-idempotent/tasks.md
+++ b/openspec/changes/archive/2026-06-01-fix-store-tmp-mkdir-idempotent/tasks.md
@@ -1,0 +1,16 @@
+## 1. Tests (Red)
+
+- [x] 1.1 In `pkg/storage/local/local_test.go`, add a test `TestSetupDirsIdempotent` that calls `setupDirs()` twice on the same temp directory and asserts both calls return nil
+- [x] 1.2 Add a test `TestSetupDirsPreservesExistingTmpFiles` that creates a partial file in `store/tmp/`, calls `setupDirs()`, and asserts the file still exists and the call returns nil
+- [x] 1.3 Run `task test` — confirm both new tests fail (red)
+
+## 2. Implementation (Green)
+
+- [x] 2.1 In `pkg/storage/local/local.go` `setupDirs()`, remove the `os.RemoveAll(s.storeTMPPath())` call and its error check (lines 629–631)
+- [x] 2.2 Run `task test` — confirm both new tests pass (green)
+
+## 3. Verification
+
+- [x] 3.1 Run `task fmt` and apply any formatting changes
+- [x] 3.2 Run `task lint` and fix any issues
+- [x] 3.3 Run `task test` — confirm all tests pass

--- a/openspec/specs/local-store-initialization/spec.md
+++ b/openspec/specs/local-store-initialization/spec.md
@@ -1,0 +1,23 @@
+# Spec: Local Store Initialization
+
+## Purpose
+
+Defines requirements for initializing the local store directory structure on startup, ensuring the setup process is safe and idempotent across pod restarts and rolling updates on shared persistent volumes.
+
+## Requirements
+
+### Requirement: Local store directory setup is idempotent
+
+`setupDirs()` must succeed regardless of whether the `store/tmp` directory already exists on disk, so that rolling updates on shared PVCs do not crash the incoming pod.
+
+#### Scenario: First startup (no existing directories)
+- **WHEN** `setupDirs()` is called and no store directories exist yet
+- **THEN** all required directories (`store/`, `store/nar/`, `store/tmp/`) are created and the call returns nil
+
+#### Scenario: Restart or rolling update (tmp directory already exists)
+- **WHEN** `setupDirs()` is called and `store/tmp` already exists (created by a prior pod on a shared PVC)
+- **THEN** the call succeeds without error and the tmp directory remains intact
+
+#### Scenario: Existing tmp files are not removed on startup
+- **WHEN** `setupDirs()` is called and `store/tmp` contains partial download files left by a previous process
+- **THEN** those files are left in place and the call returns nil (cleanup is not performed at startup)

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -625,11 +625,6 @@ func (s *Store) storeNarPath() string     { return filepath.Join(s.storePath(), 
 func (s *Store) storeTMPPath() string     { return filepath.Join(s.storePath(), "tmp") }
 
 func (s *Store) setupDirs() error {
-	// RemoveAll is safe to call on non-existent directories
-	if err := os.RemoveAll(s.storeTMPPath()); err != nil {
-		return fmt.Errorf("error removing the temporary download directory: %w", err)
-	}
-
 	allPaths := []string{
 		s.storePath(),
 		s.storeNarPath(),

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -126,6 +126,7 @@ func TestNew(t *testing.T) {
 
 		f, err := os.CreateTemp(filepath.Join(dir, "store", "tmp"), "hello")
 		require.NoError(t, err)
+		require.NoError(t, f.Close())
 
 		_, err = local.New(newContext(), dir)
 		require.NoError(t, err)

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -112,7 +112,7 @@ func TestNew(t *testing.T) {
 		}
 	})
 
-	t.Run("store/tmp is removed on boot", func(t *testing.T) {
+	t.Run("store/tmp files are preserved on boot", func(t *testing.T) {
 		t.Parallel()
 
 		dir, err := os.MkdirTemp("", "cache-path-")
@@ -130,8 +130,43 @@ func TestNew(t *testing.T) {
 		_, err = local.New(newContext(), dir)
 		require.NoError(t, err)
 
-		assert.NoFileExists(t, f.Name())
+		assert.FileExists(t, f.Name())
 	})
+}
+
+func TestSetupDirsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "cache-path-")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	_, err = local.New(newContext(), dir)
+	require.NoError(t, err)
+
+	_, err = local.New(newContext(), dir)
+	require.NoError(t, err)
+}
+
+func TestSetupDirsPreservesExistingTmpFiles(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "cache-path-")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "store", "tmp"), 0o700))
+
+	f, err := os.CreateTemp(filepath.Join(dir, "store", "tmp"), "partial-")
+	require.NoError(t, err)
+	f.Close()
+
+	_, err = local.New(newContext(), dir)
+	require.NoError(t, err)
+
+	assert.FileExists(t, f.Name())
 }
 
 func TestGetSecretKey(t *testing.T) {


### PR DESCRIPTION
## Summary

- Remove `os.RemoveAll(storeTMPPath())` from `setupDirs()` in `pkg/storage/local`
- On a shared NFS PVC with two replicas, the incoming pod was deleting
  in-flight downloads owned by the outgoing pod during rolling updates,
  racing with active writes and crashing on startup
- `os.MkdirAll` (called immediately after) already handles both the
  "dir exists" and "dir doesn't exist" cases idempotently — the `RemoveAll`
  was never necessary for correctness, only for a "clean slate" that is
  unsafe in a multi-pod topology
- Leftover partial files are benign: the write path uses atomic
  tmp-then-rename and partials are never promoted to the NAR path

## Test plan

- [x] `task fmt` — no changes
- [x] `task lint` — 0 issues
- [x] `task test` — all packages pass
- [x] `TestSetupDirsIdempotent` — calling `New()` twice on same dir succeeds
- [x] `TestSetupDirsPreservesExistingTmpFiles` — existing tmp files survive startup
- [x] `TestNew/store/tmp_files_are_preserved_on_boot` — updated to assert new behaviour