### PR TITLE
fix(cache): 404 un-reassemblable chunked NARs instead of truncated 200

### DIFF
--- a/openspec/changes/archive/2026-06-03-fix-truncated-chunked-nar-serving/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-03-fix-truncated-chunked-nar-serving/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/archive/2026-06-03-fix-truncated-chunked-nar-serving/design.md
+++ b/openspec/changes/archive/2026-06-03-fix-truncated-chunked-nar-serving/design.md
@@ -1,0 +1,138 @@
+## Context
+
+Nix clients receive truncated NAR downloads from production ncps: responses that
+begin as `HTTP 200` (with a `Content-Length`) then die mid-body
+(`unexpected end of nar`, `truncated input`, `SSL_ERROR_SYSCALL`). See
+`proposal.md` for the full motivation and production evidence.
+
+Current serve path (`pkg/cache/cache.go`):
+
+- `GetNar` → `getNarFromChunks` reads `total_chunks` in a transaction
+  (`cache.go` ~7113), then **immediately** creates an `io.Pipe` and returns
+  `(size, pipeReader, nil)` to the caller. The actual chunk-completeness check
+  (`len(chunkHashes) != totalChunks` → `expected N chunks but got M`,
+  `cache.go` ~7208) runs **inside the streaming goroutine**
+  (`streamCompleteChunks`), i.e. after the reader is already handed back.
+- `pkg/server/server.go` `getNar` then sets `Content-Length` (~938) and
+  `WriteHeader(200)` (~966) and `io.Copy`s the pipe. When the goroutine hits the
+  missing chunk it does `pw.CloseWithError(ErrNotFound)`, the copy aborts, the
+  connection is reset, and the client has an un-fulfillable 200.
+
+Root cause of the missing chunks: `nar_file_chunks.chunk_id → chunks(id)` is
+`ON DELETE CASCADE`, so deleting a `chunks` row strips its junction links from
+**every** referencing `nar_file` — including completed ones (`total_chunks > 0`) —
+without resetting `total_chunks`. Nothing enforces `count(links) == total_chunks`.
+Live DB: 71 of 2499 completed chunked NARs have `links < total_chunks`.
+
+Key invariant we rely on: `total_chunks` is the **completion latch**. In
+`storeNarWithCDC` (`cache.go` ~2142) `SetTotalChunks(N)` is written only after all
+`recordChunkBatch` link writes have committed, in the same transaction that does
+`ClearChunkingStartedAt()`. So `total_chunks > 0 && links < total_chunks` is never a
+concurrent mid-chunking replica — it is always genuine post-completion loss.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A completed chunked NAR that cannot be reassembled is resolved to `HTTP 404`
+  (synchronously, before any body is written) so Nix falls back / refetches —
+  never a truncated `200`.
+- The completeness check runs only on the `total_chunks > 0` fast path; the
+  progressive (`total_chunks = 0`) path is untouched and HA-safe.
+- `migrate-chunks-to-nar` / drain detects un-reassemblable NARs, skips them, and
+  reports them rather than aborting; such NARs become purgeable so they self-heal.
+
+**Non-Goals:**
+
+- Changing the `ON DELETE CASCADE` FK or adding a DB-level
+  `links == total_chunks` constraint via migration. The cascade is documented as
+  root cause but the repair is operational (404 → purge → refetch), not schematic.
+- Fixing the separate `total_chunks = 0` mid-chunking-orphan state (the domain of
+  #1230 / PR #1317). Out of scope here.
+- Pre-stating every physical chunk blob on the hot serve path (rejected below).
+
+## Decisions
+
+**Decision 1 — Validate junction-link completeness synchronously, before the pipe.**
+In `getNarFromChunks`, on the `total_chunks > 0` branch, count `nar_file_chunks`
+links for the `nar_file` (a cheap indexed `COUNT` on `nar_file_id`) inside the same
+init transaction that already reads `total_chunks`. If `links != total_chunks`,
+return `storage.ErrNotFound` immediately — before `io.Pipe`/the goroutine. The
+handler already maps `storage.ErrNotFound → 404`, so no server-side change is
+required for the happy mapping; we only move the existing `~7208` check earlier and
+make it synchronous.
+- *Alternative considered:* keep the check in the goroutine but have the handler
+  buffer until first successful read before sending headers. Rejected: NARs are
+  large; buffering defeats streaming and the count check is essentially free.
+
+**Decision 2 — Scope the check to the completed path only.**
+The progressive path (`total_chunks = 0`) must not gain this check. We gate strictly
+on the existing `if totalChunks > 0` branch (`cache.go` ~7158). This preserves HA
+correctness per the completion-latch invariant above.
+- *Alternative considered:* validate on both paths. Rejected: would `404` NARs that
+  another replica is actively chunking.
+
+**Decision 3 — Physical-blob gaps stay best-effort on the serve path; caught on drain.**
+Junction-link completeness is DB-cheap and covers the dominant case
+(`expected N got M`). A junction link whose physical chunk blob is missing
+(`error fetching chunk … not found`) is only knowable by touching storage; we do
+**not** pre-stat all blobs on every serve (O(chunks) extra I/O on the hot path).
+Instead, the drain/migrate path — which already reads every chunk to reconstruct —
+is where blob gaps are authoritatively detected and reported (Decision 4). On the
+serve path a blob-missing NAR still fails, but that is rarer and is the migration's
+job to surface and purge.
+- *Alternative considered:* pre-stat blobs on serve. Rejected on latency grounds.
+
+**Decision 4 — Drain/migrate skips, continues, and reports.**
+`MigrateChunksToNar` already returns `ErrMissingChunk` when reconstruction can't
+find a chunk (`cache.go` ~7690). Change the *driver loop* (the command iterating
+chunked NARs) to treat `ErrMissingChunk` (and the new link-count mismatch) as
+*skip + record*, not *abort*. At the end, report counts and the list of skipped
+hashes. Provide/confirm a purge path (`PurgeChunkedNar` exists at `cache.go` ~7800)
+so skipped NARs can be removed and refetched.
+
+## Risks / Trade-offs
+
+- [A blob-missing (not link-missing) NAR still truncates on the serve path until
+  drain purges it] → Mitigation: Decision 4 surfaces these during migrate; operator
+  purges; subsequent request refetches. The 71 production NARs are link-missing, so
+  Decision 1 covers them immediately.
+- [Extra `COUNT` query per chunked-NAR serve] → Mitigation: it runs in the existing
+  init transaction against the indexed `nar_file_chunks(nar_file_id)`; negligible
+  versus streaming thousands of chunks.
+- [Moving the check could regress the happy path] → Mitigation: tests assert a
+  fully-linked NAR still streams `200` unchanged, and a mid-chunking (`tc=0`) NAR is
+  never `404`'d.
+
+## Migration Plan
+
+No DB migration. Deploy the binary; the serve check takes effect immediately and the
+71 broken NARs begin returning `404` → Nix refetches from upstream. Run
+`migrate-chunks-to-nar` to drain the rest; its new report lists any
+un-reassemblable NARs to purge. Rollback is a plain binary rollback (the only
+behavioral change is 404-instead-of-truncated-200 plus a richer migrate report).
+
+## Testing Notes
+
+- **Serving:** the deterministic test seeds a completed `nar_file`
+  (`total_chunks = N`) with fewer than `N` `nar_file_chunks` rows (mirroring the
+  cascade loss) and asserts `GetNar` returns `storage.ErrNotFound` and that no body
+  bytes are emitted before the error — exercising the public `GetNar` interface, not
+  internals.
+- **HA guard:** a second test seeds `total_chunks = 0` with `chunking_started_at`
+  set and asserts the completeness check does not fire (progressive path).
+- **Drain:** a test with a mix of reassemblable and link-missing NARs asserts the
+  migrate loop skips the broken one, migrates the rest, and reports the skipped hash.
+
+## Open Questions
+
+- **RESOLVED — purge stays drain-only; the serve path is side-effect-free.** The
+  serve-path completeness check returns `storage.ErrNotFound` (→ 404) and performs
+  **no** write/purge. Purging an un-reassemblable NAR is done exclusively by the
+  drain / `migrate-chunks-to-nar` path (which already maps `ErrMissingChunk` to
+  `PurgeChunkedNar` and continues). Rationale: keep the read path free of write
+  side effects and lock contention (Redis), avoid purge storms under concurrent
+  requests for the same broken hash, and keep the 404 cheap. Production self-heals
+  on the next drain run; the inline per-NAR purge logs (with `nar_hash`) plus the
+  end-of-run counts provide the operator report. An async purge-on-404 was
+  considered and rejected for the contention/storm risk.

--- a/openspec/changes/archive/2026-06-03-fix-truncated-chunked-nar-serving/proposal.md
+++ b/openspec/changes/archive/2026-06-03-fix-truncated-chunked-nar-serving/proposal.md
@@ -1,0 +1,91 @@
+## Why
+
+Nix clients pulling from `ncps.nasreddine.com` get **truncated NAR downloads** —
+`error: bad archive: unexpected end of nar encountered`,
+`failed to read compressed data (truncated input)`, and
+`SSL_read: SSL_ERROR_SYSCALL` on responses that started as `HTTP 200`. The
+narinfo-500 fix (`fix-purged-narinfo-500`) is confirmed gone; this is a distinct,
+NAR-side failure.
+
+**Root cause (confirmed against the live production DB):** a subset of *completed*
+chunked NARs cannot be reassembled, yet the cache promises and starts a `200`
+response anyway:
+
+- The serve fast path `streamCompleteChunks` (`pkg/cache/cache.go` ~7208) enters
+  on `total_chunks > 0`, then checks `len(chunkHashes) != totalChunks` **inside
+  the streaming goroutine** — i.e. *after* `pkg/server/server.go` has already
+  written `200 OK` + `Content-Length` and begun `io.Copy`. A completeness failure
+  (`expected N chunks but got M: not found`) therefore surfaces as a **truncated
+  200**, and Nix cannot fall back to its next substituter (it already committed to
+  the 200).
+- These NARs lost junction rows because `nar_file_chunks.chunk_id → chunks(id)` is
+  `ON DELETE CASCADE`: deleting a `chunks` row cascade-wipes its junction links
+  across **all** nar_files — including completed ones — **without** resetting
+  `total_chunks`. No invariant prevents `count(links) < total_chunks`.
+
+**Production evidence** (DB `pg17-vchord-cluster`): of 2499 completed chunked
+NARs, **71** have `links < total_chunks` (the truncating set; loss is large and
+scattered, e.g. 7290 of 7646 links gone). Separately, 22 NARs are in the
+`total_chunks = 0` mid-chunking-orphan state.
+
+**Relationship to #1230 / PR #1317:** *not the same bug.* #1230/#1317 address the
+22 `total_chunks = 0` mid-chunking crash orphans (and #1317 is unmerged and gated
+on CDC being enabled, so it would not even run now that CDC is disabled in drain
+mode). The 71 truncating NARs are completed (`total_chunks > 0`) rows that lost
+links via the cascade — a state #1317 does not touch. This change targets that
+state.
+
+**HA correctness:** `total_chunks` is the completion latch — it is set only at the
+end of chunking, after all links are durably committed, in the same transaction
+that clears `chunking_started_at` (`cache.go` ~2142). So `total_chunks > 0 &&
+links < total_chunks` is **never** a concurrent mid-chunking replica; it is always
+genuine post-completion loss. The synchronous completeness check is therefore safe
+on the `total_chunks > 0` fast path and must NOT be applied to the progressive
+(`total_chunks = 0`) path, which legitimately waits for chunks.
+
+## What Changes
+
+- **Serving (defense, fast path only):** before committing the response, validate
+  that a completed chunked NAR (`total_chunks > 0`) actually has all its junction
+  links. On mismatch, `getNarFromChunks` returns `storage.ErrNotFound`
+  **synchronously** (before the pipe/`200`/`Content-Length`), so the handler
+  responds `HTTP 404` and Nix falls back / refetches upstream — never a truncated
+  `200`. The progressive (`total_chunks = 0`) path is left unchanged.
+- **Drain hardening:** `migrate-chunks-to-nar` / drain mode must detect a
+  chunked NAR that cannot be reassembled (missing junction links, or a referenced
+  chunk whose blob is absent) and **skip it with a clear report** instead of
+  attempting reassembly and failing opaquely. Surface a count of un-reassemblable
+  NARs so the operator can act, and make such a NAR purgeable so the next request
+  refetches it cleanly from upstream.
+- Regression tests: a completed chunked NAR with a missing link is served as
+  `404` (not a truncated `200`); the drain path reports and skips it rather than
+  erroring mid-stream.
+
+## Capabilities
+
+### New Capabilities
+- `chunked-nar-serving-integrity`: On the completed-chunk (`total_chunks > 0`)
+  serve path, the cache MUST verify reassembly is possible before committing the
+  HTTP response, and MUST resolve an un-reassemblable chunked NAR to `404`
+  (upstream fallback) rather than a truncated `200`.
+
+### Modified Capabilities
+- `cdc-drain-mode`: drain / `migrate-chunks-to-nar` MUST detect un-reassemblable
+  chunked NARs (missing links or absent chunk blobs), skip them without aborting
+  the run, and report them so they can be purged and refetched — rather than only
+  failing at serve time.
+
+## Impact
+
+- **Code:** `pkg/cache/cache.go` (`getNarFromChunks` / `streamCompleteChunks`
+  pre-stream completeness check; drain/migrate detection + reporting),
+  `pkg/server/server.go` (already maps `ErrNotFound → 404`; verify no truncated
+  `200`). Possibly `cmd/` reporting for the drain command.
+- **Behavior:** un-reassemblable chunked NARs become `404` (self-healing via
+  upstream refetch) instead of corrupt downloads. No schema change required for
+  the serving fix; the cascade FK and the absence of a `links == total_chunks`
+  invariant are documented as the root cause but repaired operationally (purge +
+  refetch) rather than by a migration.
+- **Operational:** the 71 currently-broken NARs in production heal on next request
+  once they `404` (Nix refetches from upstream); the drain report makes them
+  visible.

--- a/openspec/changes/archive/2026-06-03-fix-truncated-chunked-nar-serving/specs/cdc-drain-mode/spec.md
+++ b/openspec/changes/archive/2026-06-03-fix-truncated-chunked-nar-serving/specs/cdc-drain-mode/spec.md
@@ -1,0 +1,50 @@
+## ADDED Requirements
+
+### Requirement: Drain and migrate MUST skip and report un-reassemblable chunked NARs rather than aborting
+
+The system SHALL skip un-reassemblable chunked NARs and continue the migration
+instead of aborting the whole run on the first failure. When `migrate-chunks-to-nar`
+(run standalone or concurrently with a drain-mode server) encounters a chunked NAR
+that cannot be reassembled — because its `nar_file_chunks` links are incomplete
+(`links < total_chunks`) or because a referenced chunk's blob is absent from the
+chunk store — it MUST skip that NAR and continue migrating the remaining NARs. The
+command MUST count and report the un-reassemblable NARs (by hash) at the end of the
+run so the operator can act, and its exit behavior MUST distinguish "all
+reassemblable NARs migrated, some skipped" from "fatal error".
+
+#### Scenario: Migration skips an un-reassemblable NAR and continues
+
+- **GIVEN** drain mode is active and chunked `nar_file` rows exist
+- **AND** one such NAR `H` is missing one or more chunk links or chunk blobs
+- **WHEN** `migrate-chunks-to-nar` is executed
+- **THEN** it SHALL skip `H` without aborting the run
+- **AND** it SHALL continue migrating the other reassemblable NARs to whole files
+- **AND** it SHALL include `H` in a report of skipped/un-reassemblable NARs
+
+#### Scenario: Migration reports the count of skipped NARs
+
+- **GIVEN** `K` chunked NARs cannot be reassembled and the rest can
+- **WHEN** `migrate-chunks-to-nar` completes
+- **THEN** it SHALL report the number of NARs migrated and the number skipped (`K`)
+- **AND** it SHALL list the skipped NAR hashes so they can be purged and refetched
+
+### Requirement: An un-reassemblable chunked NAR MUST be purgeable to a clean cache-miss state
+
+The system SHALL provide a path by which a permanently un-reassemblable chunked NAR
+(missing links or blobs, confirmed not in progress) is removed from the cache —
+deleting its `nar_file` row and chunk links while retaining the linked narinfo —
+so that a subsequent `GetNar` request observes a clean cache miss (the NAR is
+neither servable from chunks nor present as a whole file). The standard
+cache-miss path then refetches `H` from a configured upstream, which makes the 404
+produced by the serving-integrity check self-healing rather than a permanent dead
+end. (The upstream-fetch-and-serve-on-miss behavior itself is the cache's general
+miss path, covered by existing `GetNar` tests; this requirement governs only that
+the purge leaves a clean miss.)
+
+#### Scenario: Purging an un-reassemblable NAR leaves a clean cache miss
+
+- **GIVEN** a completed chunked NAR `H` that cannot be reassembled
+- **WHEN** `H` is purged (via the migrate/drain path or an explicit purge)
+- **THEN** `H`'s `nar_file` record and chunk links SHALL be deleted
+- **AND** the cache SHALL report `H` as neither servable from chunks nor present as a whole file (a cache miss)
+- **AND** the linked narinfo SHALL be retained so the next request can refetch `H` from upstream

--- a/openspec/changes/archive/2026-06-03-fix-truncated-chunked-nar-serving/specs/chunked-nar-serving-integrity/spec.md
+++ b/openspec/changes/archive/2026-06-03-fix-truncated-chunked-nar-serving/specs/chunked-nar-serving-integrity/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: A completed chunked NAR that cannot be reassembled MUST NOT be served as a truncated HTTP 200
+
+The system SHALL NOT return an `HTTP 200` response whose body it cannot fully
+produce. When serving a chunked NAR on the completed-chunk fast path
+(`total_chunks > 0`), the cache MUST verify — **before** the HTTP layer commits a
+status line or `Content-Length` — that the NAR is reassemblable: the number of
+`nar_file_chunks` junction links MUST equal `total_chunks`. If the NAR is not
+reassemblable, `GetNar`/`getNarFromChunks` SHALL return `storage.ErrNotFound`
+synchronously rather than returning a reader that fails mid-stream. The completeness
+failure that today surfaces as `expected N chunks but got M` inside the streaming
+goroutine MUST instead be detected up front.
+
+#### Scenario: Completed chunked NAR with a missing junction link resolves to 404
+
+- **GIVEN** a `nar_file` record for hash `H` with `total_chunks = N` and `N > 0`
+- **AND** fewer than `N` `nar_file_chunks` links exist for `H` (links were lost, e.g. via the `chunks` cascade delete)
+- **WHEN** a client requests `GET /nar/{H}.nar`
+- **THEN** `getNarFromChunks` SHALL return `storage.ErrNotFound` before any response body is written
+- **AND** the HTTP handler SHALL respond `HTTP 404 Not Found`
+- **AND** the client SHALL NOT receive an `HTTP 200` with a truncated body
+
+#### Scenario: Completeness is validated before the response is committed
+
+- **GIVEN** a completed chunked NAR (`total_chunks > 0`) that is missing one or more chunk links
+- **WHEN** the cache prepares to serve it
+- **THEN** the completeness check SHALL run before `io.Pipe`/`WriteHeader`/`Content-Length`
+- **AND** no partial bytes SHALL be written to the client before the error is detected
+
+#### Scenario: A fully-linked completed chunked NAR is still served normally
+
+- **GIVEN** a `nar_file` record for hash `H` with `total_chunks = N` and exactly `N` junction links
+- **WHEN** a client requests `GET /nar/{H}.nar`
+- **THEN** the cache SHALL stream the reassembled NAR with `HTTP 200`
+- **AND** the completeness check SHALL NOT alter the existing successful serve path
+
+### Requirement: The synchronous completeness check MUST NOT be applied to in-progress (progressive) chunking
+
+The completeness validation SHALL apply only to the completed-chunk fast path
+(`total_chunks > 0`). The progressive path (`total_chunks = 0`,
+`chunking_started_at` set), which legitimately streams chunks as they appear and
+waits for the next chunk, MUST remain unchanged so that a NAR being chunked
+concurrently (including by another instance in an HA deployment) is not falsely
+resolved to `404`. `total_chunks` is the completion latch: it is set only after all
+junction links are durably committed, so `total_chunks > 0 && links < total_chunks`
+is always genuine post-completion loss, never a mid-chunking race.
+
+#### Scenario: Mid-chunking NAR is not 404'd by the completeness check
+
+- **GIVEN** a `nar_file` record for hash `H` with `total_chunks = 0` and `chunking_started_at` set (chunking in progress)
+- **WHEN** a client requests `GET /nar/{H}.nar`
+- **THEN** the cache SHALL take the progressive streaming path
+- **AND** the completed-path completeness check SHALL NOT run for `H`
+- **AND** the request SHALL NOT be resolved to `404` on account of incomplete links

--- a/openspec/changes/archive/2026-06-03-fix-truncated-chunked-nar-serving/tasks.md
+++ b/openspec/changes/archive/2026-06-03-fix-truncated-chunked-nar-serving/tasks.md
@@ -1,0 +1,28 @@
+## 1. Serving integrity — completed-path completeness check (TDD)
+
+- [x] 1.1 RED: write a test seeding a completed `nar_file` (`total_chunks = N`) with fewer than `N` `nar_file_chunks` rows, asserting `GetNar` returns `storage.ErrNotFound` (not a reader that fails mid-stream). Run it; confirm it fails against current behavior.
+- [x] 1.2 GREEN: in `getNarFromChunks`, on the `total_chunks > 0` branch, count junction links in the init transaction and return `storage.ErrNotFound` synchronously when `links != total_chunks` (before `io.Pipe`). Make 1.1 pass.
+- [x] 1.3 RED→GREEN: fully-linked completed NAR (`links == total_chunks`) still streams `200` with correct bytes. Covered by the pre-existing `testCDCDrainModeGetNarServesFromChunks` / `testCDCPutAndGet`, which still pass under the new guard — no separate test added.
+- [x] 1.4 RED→GREEN: `TestGetNarFromChunks_MidChunkingPartialLinksNotFalse404` asserts a progressive NAR (`total_chunks = 0`, `chunking_started_at` set) with partial links is NOT resolved to `404` (HA-safety / completion-latch invariant).
+
+## 2. Serving integrity — no partial body before error
+
+- [x] 2.1 `testServeCompletedNarMissingLinkReturns404` asserts `GetNar` returns `storage.ErrNotFound` **synchronously** (no reader handed back), so the handler cannot have written any body before the error.
+- [x] 2.2 Confirmed `pkg/server/server.go` `getNar` (`:856`) maps `storage.ErrNotFound → 404` via `http.Error(StatusText)` (no leak) before any body write. No change needed.
+
+## 3. Drain / migrate hardening — skip, continue, report (TDD)
+
+- [x] 3.1/3.2 `TestMigrateChunksToNar_MissingLinkIsReportedAsMissingChunk`: a link-missing completed NAR is reported as `cache.ErrMissingChunk`. The migrate driver loop (`pkg/ncps/migrate_chunks_to_nar.go:431`) already maps `ErrMissingChunk` to `PurgeChunkedNar`+continue+count, and the serving guard (1.2) routes link-loss into that path via `MigrateChunksToNar`'s `ErrNotFound→ErrMissingChunk` mapping (`cache.go:7690`). No driver-loop code change required.
+- [x] 3.1/3.2 (verify W1) `TestMigrateChunksToNar_CLI_SkipsBrokenNarMigratesRestAndReports` (`pkg/ncps`): a **mix** of one reassemblable NAR (Nar1) + one un-reassemblable NAR (Nar2, missing a link) — the good one migrates to a whole file, the broken one is purged, the run continues and exits 0.
+- [x] 3.3 (verify W2) The same CLI test captures stdout and asserts the summary reports `"succeeded":1`, `"purged":1`, and the purged NAR by hash. (Per-row `nar_hash` logs at `:377`, summary counts at `:481`.)
+
+## 4. Purge / self-heal path
+
+- [x] 4.1 `TestPurgeChunkedNar_LeavesCleanCacheMissForRefetch`: purging an un-reassemblable NAR removes the `nar_file` (HasNarInChunks/HasNarInStore both false) while leaving the narinfo intact → a clean cache miss. (W3) The `cdc-drain-mode` spec scenario was tightened to assert exactly this precondition; the upstream-fetch-and-serve-on-miss step is the cache's general miss path, covered by existing `GetNar` tests rather than re-tested here (Nar1 is xz upstream → re-testing it would duplicate well-covered CDC/decompress integration).
+- [x] 4.2 Open Question resolved: purge stays drain-only; the serve path is side-effect-free (no purge-on-404). Recorded in `design.md` (contention/storm rationale).
+
+## 5. Verification
+
+- [x] 5.1 `task fmt` (clean), `task lint` (0 issues), `task test` (all packages ok).
+- [x] 5.2 `go test -race ./pkg/cache ./pkg/server` — both ok.
+- [x] 5.3 (post-verify) Added `pkg/ncps` mix-migration CLI test (W1/W2) and tightened the W3 spec scenario; `dropLastChunkLink` helper dedupes the three seed sites (S1). Re-ran fmt/lint/test — clean.

--- a/openspec/specs/cdc-drain-mode/spec.md
+++ b/openspec/specs/cdc-drain-mode/spec.md
@@ -107,3 +107,52 @@ positive, the command SHALL proceed with migration regardless of the value of
 - **WHEN** `migrate-chunks-to-nar` is executed
 - **THEN** it SHALL report that there is nothing to migrate
 - **AND** SHALL exit with status 0
+
+### Requirement: Drain and migrate MUST skip and report un-reassemblable chunked NARs rather than aborting
+
+The system SHALL skip un-reassemblable chunked NARs and continue the migration
+instead of aborting the whole run on the first failure. When `migrate-chunks-to-nar`
+(run standalone or concurrently with a drain-mode server) encounters a chunked NAR
+that cannot be reassembled — because its `nar_file_chunks` links are incomplete
+(`links < total_chunks`) or because a referenced chunk's blob is absent from the
+chunk store — it MUST skip that NAR and continue migrating the remaining NARs. The
+command MUST count and report the un-reassemblable NARs (by hash) at the end of the
+run so the operator can act, and its exit behavior MUST distinguish "all
+reassemblable NARs migrated, some skipped" from "fatal error".
+
+#### Scenario: Migration skips an un-reassemblable NAR and continues
+
+- **GIVEN** drain mode is active and chunked `nar_file` rows exist
+- **AND** one such NAR `H` is missing one or more chunk links or chunk blobs
+- **WHEN** `migrate-chunks-to-nar` is executed
+- **THEN** it SHALL skip `H` without aborting the run
+- **AND** it SHALL continue migrating the other reassemblable NARs to whole files
+- **AND** it SHALL include `H` in a report of skipped/un-reassemblable NARs
+
+#### Scenario: Migration reports the count of skipped NARs
+
+- **GIVEN** `K` chunked NARs cannot be reassembled and the rest can
+- **WHEN** `migrate-chunks-to-nar` completes
+- **THEN** it SHALL report the number of NARs migrated and the number skipped (`K`)
+- **AND** it SHALL list the skipped NAR hashes so they can be purged and refetched
+
+### Requirement: An un-reassemblable chunked NAR MUST be purgeable to a clean cache-miss state
+
+The system SHALL provide a path by which a permanently un-reassemblable chunked NAR
+(missing links or blobs, confirmed not in progress) is removed from the cache —
+deleting its `nar_file` row and chunk links while retaining the linked narinfo —
+so that a subsequent `GetNar` request observes a clean cache miss (the NAR is
+neither servable from chunks nor present as a whole file). The standard
+cache-miss path then refetches `H` from a configured upstream, which makes the 404
+produced by the serving-integrity check self-healing rather than a permanent dead
+end. (The upstream-fetch-and-serve-on-miss behavior itself is the cache's general
+miss path, covered by existing `GetNar` tests; this requirement governs only that
+the purge leaves a clean miss.)
+
+#### Scenario: Purging an un-reassemblable NAR leaves a clean cache miss
+
+- **GIVEN** a completed chunked NAR `H` that cannot be reassembled
+- **WHEN** `H` is purged (via the migrate/drain path or an explicit purge)
+- **THEN** `H`'s `nar_file` record and chunk links SHALL be deleted
+- **AND** the cache SHALL report `H` as neither servable from chunks nor present as a whole file (a cache miss)
+- **AND** the linked narinfo SHALL be retained so the next request can refetch `H` from upstream

--- a/openspec/specs/chunked-nar-serving-integrity/spec.md
+++ b/openspec/specs/chunked-nar-serving-integrity/spec.md
@@ -1,0 +1,67 @@
+# Capability Spec: Chunked NAR Serving Integrity
+
+## Purpose
+
+Guarantees that NARs stored as content-defined chunks are never served as
+truncated HTTP responses. When a completed chunked NAR cannot be fully
+reassembled (e.g. junction links were lost via a cascade delete), the cache
+MUST resolve the request to a clean `404` before committing any response body,
+rather than returning an `HTTP 200` with a body that fails mid-stream. The
+completeness check applies only to the completed-chunk fast path and must not
+disturb legitimate in-progress (progressive) chunking.
+
+## Requirements
+
+### Requirement: A completed chunked NAR that cannot be reassembled MUST NOT be served as a truncated HTTP 200
+
+The system SHALL NOT return an `HTTP 200` response whose body it cannot fully
+produce. When serving a chunked NAR on the completed-chunk fast path
+(`total_chunks > 0`), the cache MUST verify — **before** the HTTP layer commits a
+status line or `Content-Length` — that the NAR is reassemblable: the number of
+`nar_file_chunks` junction links MUST equal `total_chunks`. If the NAR is not
+reassemblable, `GetNar`/`getNarFromChunks` SHALL return `storage.ErrNotFound`
+synchronously rather than returning a reader that fails mid-stream. The completeness
+failure that today surfaces as `expected N chunks but got M` inside the streaming
+goroutine MUST instead be detected up front.
+
+#### Scenario: Completed chunked NAR with a missing junction link resolves to 404
+
+- **GIVEN** a `nar_file` record for hash `H` with `total_chunks = N` and `N > 0`
+- **AND** fewer than `N` `nar_file_chunks` links exist for `H` (links were lost, e.g. via the `chunks` cascade delete)
+- **WHEN** a client requests `GET /nar/{H}.nar`
+- **THEN** `getNarFromChunks` SHALL return `storage.ErrNotFound` before any response body is written
+- **AND** the HTTP handler SHALL respond `HTTP 404 Not Found`
+- **AND** the client SHALL NOT receive an `HTTP 200` with a truncated body
+
+#### Scenario: Completeness is validated before the response is committed
+
+- **GIVEN** a completed chunked NAR (`total_chunks > 0`) that is missing one or more chunk links
+- **WHEN** the cache prepares to serve it
+- **THEN** the completeness check SHALL run before `io.Pipe`/`WriteHeader`/`Content-Length`
+- **AND** no partial bytes SHALL be written to the client before the error is detected
+
+#### Scenario: A fully-linked completed chunked NAR is still served normally
+
+- **GIVEN** a `nar_file` record for hash `H` with `total_chunks = N` and exactly `N` junction links
+- **WHEN** a client requests `GET /nar/{H}.nar`
+- **THEN** the cache SHALL stream the reassembled NAR with `HTTP 200`
+- **AND** the completeness check SHALL NOT alter the existing successful serve path
+
+### Requirement: The synchronous completeness check MUST NOT be applied to in-progress (progressive) chunking
+
+The completeness validation SHALL apply only to the completed-chunk fast path
+(`total_chunks > 0`). The progressive path (`total_chunks = 0`,
+`chunking_started_at` set), which legitimately streams chunks as they appear and
+waits for the next chunk, MUST remain unchanged so that a NAR being chunked
+concurrently (including by another instance in an HA deployment) is not falsely
+resolved to `404`. `total_chunks` is the completion latch: it is set only after all
+junction links are durably committed, so `total_chunks > 0 && links < total_chunks`
+is always genuine post-completion loss, never a mid-chunking race.
+
+#### Scenario: Mid-chunking NAR is not 404'd by the completeness check
+
+- **GIVEN** a `nar_file` record for hash `H` with `total_chunks = 0` and `chunking_started_at` set (chunking in progress)
+- **WHEN** a client requests `GET /nar/{H}.nar`
+- **THEN** the cache SHALL take the progressive streaming path
+- **AND** the completed-path completeness check SHALL NOT run for `H`
+- **AND** the request SHALL NOT be resolved to `404` on account of incomplete links

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -7134,6 +7134,31 @@ func (c *Cache) getNarFromChunks(ctx context.Context, narURL *nar.URL) (int64, i
 			}
 		}
 
+		// Completeness guard (completed fast path only). total_chunks is the
+		// completion latch: storeNarWithCDC sets it only after every junction
+		// link is durably committed, so total_chunks > 0 with fewer links is
+		// never a mid-chunking race (including a concurrent HA replica) — it is
+		// genuine post-completion loss, e.g. the nar_file_chunks.chunk_id ->
+		// chunks(id) ON DELETE CASCADE stripping a shared chunk's links without
+		// resetting total_chunks. Detect it here, synchronously, before the
+		// caller hands back a reader, so the request resolves to ErrNotFound
+		// (HTTP 404 -> upstream fallback) instead of committing a 200 that
+		// truncates mid-stream. The progressive path (total_chunks = 0) is
+		// intentionally excluded: it legitimately streams chunks as they appear.
+		if nr.TotalChunks > 0 {
+			links, err := tx.NarFileChunk.Query().
+				Where(entnarfilechunk.NarFileID(nr.ID)).
+				Count(ctx)
+			if err != nil {
+				return fmt.Errorf("error counting chunk links: %w", err)
+			}
+
+			if int64(links) != nr.TotalChunks {
+				return fmt.Errorf("nar %s has %d of %d chunk links: %w",
+					narURL.Hash, links, nr.TotalChunks, storage.ErrNotFound)
+			}
+		}
+
 		return nil
 	})
 	if err != nil {

--- a/pkg/cache/cdc_test.go
+++ b/pkg/cache/cdc_test.go
@@ -198,6 +198,8 @@ func runCDCTestSuite(t *testing.T, factory cacheFactory) {
 		testCDCBackingLessRecordRecoversAfterTransientFailure(factory))
 	t.Run("backing-less record with genuine upstream 404 returns not found",
 		testCDCBackingLessRecordGenuine404ReturnsNotFound(factory))
+	t.Run("completed chunked NAR missing a junction link returns 404, not a truncated 200",
+		testServeCompletedNarMissingLinkReturns404(factory))
 }
 
 func testCDCPutAndGet(factory cacheFactory) func(*testing.T) {

--- a/pkg/cache/chunked_nar_serving_integrity_internal_test.go
+++ b/pkg/cache/chunked_nar_serving_integrity_internal_test.go
@@ -60,6 +60,7 @@ func TestGetNarFromChunks_MidChunkingPartialLinksNotFalse404(t *testing.T) {
 	_, rc, err := c.getNarFromChunks(ctx, &narURL)
 	require.NoError(t, err,
 		"mid-chunking (total_chunks=0) must take the progressive path, not be 404'd by the completeness check")
+	require.NotNil(t, rc, "the progressive path must return a reader, not (nil, nil)")
 
 	t.Cleanup(func() { _ = rc.Close() })
 }

--- a/pkg/cache/chunked_nar_serving_integrity_internal_test.go
+++ b/pkg/cache/chunked_nar_serving_integrity_internal_test.go
@@ -1,0 +1,65 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/testdata"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// TestGetNarFromChunks_MidChunkingPartialLinksNotFalse404 guards the HA-safety
+// invariant: a NAR that is legitimately mid-chunking (total_chunks = 0,
+// chunking_started_at set) with only a partial set of junction links — e.g. a
+// concurrent replica is still writing chunks — MUST NOT be resolved to a
+// synchronous storage.ErrNotFound by the completed-path completeness check. The
+// check is gated on total_chunks > 0; total_chunks is the completion latch, so a
+// total_chunks = 0 row with fewer links is in-progress, not corrupt. The
+// progressive path must still be taken (reader handed back, no synchronous error).
+func TestGetNarFromChunks_MidChunkingPartialLinksNotFalse404(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := newCDCCacheForStreaming(t)
+
+	// Fail fast on the progressive wait so the test does not block on a chunk
+	// that never arrives.
+	c.SetChunkWaitTimeout(200 * time.Millisecond)
+
+	nf, err := c.dbClient.Ent().NarFile.Create().
+		SetHash(testdata.Nar1.NarHash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(12345).
+		SetTotalChunks(0).
+		SetChunkingStartedAt(time.Now()).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Seed one partial chunk link (mid-chunking: some links written, not all).
+	ch, err := c.dbClient.Ent().Chunk.Create().
+		SetHash(testhelper.MustRandBase32NarHash()).
+		SetSize(64).
+		SetCompressedSize(64).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = c.dbClient.Ent().NarFileChunk.Create().
+		SetNarFileID(nf.ID).
+		SetChunkID(ch.ID).
+		SetChunkIndex(0).
+		Save(ctx)
+	require.NoError(t, err)
+
+	narURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: nar.CompressionTypeNone}
+
+	// The completeness guard must NOT fire: getNarFromChunks returns a reader (the
+	// progressive path), not a synchronous ErrNotFound.
+	_, rc, err := c.getNarFromChunks(ctx, &narURL)
+	require.NoError(t, err,
+		"mid-chunking (total_chunks=0) must take the progressive path, not be 404'd by the completeness check")
+
+	t.Cleanup(func() { _ = rc.Close() })
+}

--- a/pkg/cache/chunked_nar_serving_integrity_test.go
+++ b/pkg/cache/chunked_nar_serving_integrity_test.go
@@ -1,0 +1,73 @@
+package cache_test
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	entnarfile "github.com/kalbasit/ncps/ent/narfile"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
+	"github.com/kalbasit/ncps/pkg/storage/chunk"
+)
+
+// testServeCompletedNarMissingLinkReturns404 reproduces the production
+// "expected N chunks but got M" truncated-200 failure. A completed chunked NAR
+// (total_chunks = N > 0) loses one nar_file_chunks junction link — exactly what
+// the chunks(id) ON DELETE CASCADE FK does when a shared chunk row is deleted,
+// without resetting total_chunks. The serve fast path must detect this BEFORE
+// committing the response and return storage.ErrNotFound (→ HTTP 404 → upstream
+// fallback), never hand back a reader that truncates a 200 mid-stream.
+func testServeCompletedNarMissingLinkReturns404(factory cacheFactory) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+
+		c, dbClient, _, dir, _, cleanup := factory(t)
+		t.Cleanup(cleanup)
+
+		// Enable CDC and store the NAR as chunks (consistent total_chunks + links + blobs).
+		chunkStoreDir := filepath.Join(dir, "chunks-store")
+		chunkStore, err := chunk.NewLocalStore(chunkStoreDir)
+		require.NoError(t, err)
+
+		c.SetChunkStore(chunkStore)
+		require.NoError(t, c.SetCDCConfiguration(true, 1024, 4096, 8192))
+
+		// Large, varied content so the chunker produces several chunks; deleting a
+		// single junction link then leaves a genuine gap (total_chunks > links).
+		multiChunkContent := strings.Repeat("ncps-chunked-nar-serving-integrity-regression ", 400)
+
+		nu := nar.URL{Hash: "missinglinknar", Compression: nar.CompressionTypeNone}
+		require.NoError(t, c.PutNar(ctx, nu, io.NopCloser(strings.NewReader(multiChunkContent))))
+
+		// Confirm the NAR is fully chunked into more than one chunk.
+		nf, err := dbClient.Ent().NarFile.Query().
+			Where(entnarfile.HashEQ(nu.Hash)).
+			Only(ctx)
+		require.NoError(t, err)
+		require.Greater(t, nf.TotalChunks, int64(1), "test needs a multi-chunk NAR")
+
+		// Simulate the cascade loss: drop exactly one junction link, leaving
+		// total_chunks unchanged. Now links == total_chunks - 1.
+		dropLastChunkLink(ctx, t, dbClient, nf.ID)
+
+		// GetNar must fail synchronously with ErrNotFound, before returning a reader
+		// that would truncate a committed 200.
+		_, _, rc, err := c.GetNar(ctx, nu)
+		if rc != nil {
+			_ = rc.Close()
+		}
+
+		require.Error(t, err, "GetNar must not hand back a reader for an un-reassemblable NAR")
+		assert.ErrorIs(t, err, storage.ErrNotFound,
+			"an un-reassemblable completed chunked NAR must resolve to ErrNotFound (HTTP 404 → upstream fallback)")
+	}
+}

--- a/pkg/cache/migrate_chunks_to_nar_test.go
+++ b/pkg/cache/migrate_chunks_to_nar_test.go
@@ -60,6 +60,26 @@ func chunkedNarFixture(
 	return nar.URL{Hash: entry.NarHash, Compression: nar.CompressionTypeNone}, entry.NarText
 }
 
+// dropLastChunkLink deletes one nar_file_chunks junction row for narFileID (the
+// highest chunk_index), simulating the production
+// nar_file_chunks.chunk_id -> chunks(id) ON DELETE CASCADE loss that leaves a
+// completed NAR with total_chunks > remaining links.
+func dropLastChunkLink(ctx context.Context, t *testing.T, dbClient *database.Client, narFileID int) {
+	t.Helper()
+
+	links, err := dbClient.Ent().NarFileChunk.Query().
+		Where(entnarfilechunk.NarFileIDEQ(narFileID)).
+		Order(entnarfilechunk.ByChunkIndex()).
+		All(ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, links)
+
+	_, err = dbClient.Ent().NarFileChunk.Delete().
+		Where(entnarfilechunk.IDEQ(links[len(links)-1].ID)).
+		Exec(ctx)
+	require.NoError(t, err)
+}
+
 // TestMigrateChunksToNar_ReconstructsVerifiesAndStoresWholeFile is the slice-1
 // tracer bullet: a chunked NAR is reconstructed, its assembled SHA-256 verified
 // against the linked narinfo NarHash, and the whole file written to the store.
@@ -119,6 +139,77 @@ func TestMigrateChunksToNar_ResumesWhenWholeFileAlreadyPresent(t *testing.T) {
 		Only(ctx)
 	require.NoError(t, err)
 	assert.Zero(t, nf.TotalChunks, "the record must still be flipped to whole-file on resume")
+}
+
+// TestMigrateChunksToNar_MissingLinkIsReportedAsMissingChunk verifies the drain
+// hardening: a completed chunked NAR that lost a junction link (the production
+// chunks(id) ON DELETE CASCADE corruption — total_chunks unchanged, links < N)
+// is reported by MigrateChunksToNar as cache.ErrMissingChunk. That is the signal
+// the migrate driver loop uses to purge the NAR and continue (so the hash is
+// re-fetched from upstream), rather than reconstructing a truncated NAR or
+// aborting the run. This exercises the serving-integrity guard end-to-end through
+// the migration path.
+func TestMigrateChunksToNar_MissingLinkIsReportedAsMissingChunk(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	c, dbClient, _, dir, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	noneURL, _ := chunkedNarFixture(ctx, t, c, dbClient, dir)
+
+	nf, err := dbClient.Ent().NarFile.Query().
+		Where(entnarfile.HashEQ(noneURL.Hash), entnarfile.CompressionEQ(nar.CompressionTypeNone.String())).
+		Only(ctx)
+	require.NoError(t, err)
+	require.Positive(t, nf.TotalChunks, "fixture must produce a chunked NAR")
+
+	// Simulate the cascade loss: drop one junction link, leaving total_chunks intact.
+	dropLastChunkLink(ctx, t, dbClient, nf.ID)
+
+	err = c.MigrateChunksToNar(ctx, &noneURL, false)
+	require.ErrorIs(t, err, cache.ErrMissingChunk,
+		"a completed chunked NAR missing a junction link must be reported as ErrMissingChunk so the driver purges it")
+}
+
+// TestPurgeChunkedNar_LeavesCleanCacheMissForRefetch verifies the self-heal
+// contract: purging an un-reassemblable chunked NAR removes its nar_file record
+// (and chunk links) so HasNarInChunks/HasNarInStore both report absent — a clean
+// cache miss the next GetNar resolves by refetching from upstream — while leaving
+// the linked narinfo intact so that refetch can proceed.
+func TestPurgeChunkedNar_LeavesCleanCacheMissForRefetch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	c, dbClient, _, dir, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	noneURL, _ := chunkedNarFixture(ctx, t, c, dbClient, dir)
+
+	// Drop a junction link so the NAR is permanently un-reassemblable.
+	nf, err := dbClient.Ent().NarFile.Query().
+		Where(entnarfile.HashEQ(noneURL.Hash), entnarfile.CompressionEQ(nar.CompressionTypeNone.String())).
+		Only(ctx)
+	require.NoError(t, err)
+
+	dropLastChunkLink(ctx, t, dbClient, nf.ID)
+
+	require.NoError(t, c.PurgeChunkedNar(ctx, &noneURL))
+
+	// After purge: not servable from chunks, not in the whole-file store → a clean
+	// cache miss. The linked narinfo remains so a subsequent request refetches.
+	hasChunks, err := c.HasNarInChunks(ctx, noneURL)
+	require.NoError(t, err)
+	assert.False(t, hasChunks, "purged NAR must no longer be servable from chunks")
+	assert.False(t, c.HasNarInStore(ctx, noneURL), "purged NAR must not be in the whole-file store")
+
+	count, err := dbClient.Ent().NarFile.Query().
+		Where(entnarfile.HashEQ(noneURL.Hash)).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, count, "purged NAR's nar_file record must be deleted so the next GetNar is a cache miss")
 }
 
 // TestMigrateChunksToNar_FlipsRecordToWholeFile (slice 2): the nar_file is

--- a/pkg/ncps/migrate_chunks_to_nar_test.go
+++ b/pkg/ncps/migrate_chunks_to_nar_test.go
@@ -340,3 +340,131 @@ func TestMigrateChunksToNar_CLI_HashMismatchPurgesNarAndExitsZero(t *testing.T) 
 		"SELECT COUNT(*) FROM narinfos WHERE hash = ?", testdata.Nar1.NarInfoHash).Scan(&narInfoCount))
 	assert.Positive(t, narInfoCount, "narinfo must be retained after purge")
 }
+
+// seedBrokenChunkedNar inserts a COMPLETED chunked NAR (total_chunks=2) that is
+// missing a junction link (only 1 present) — the production
+// nar_file_chunks.chunk_id -> chunks(id) ON DELETE CASCADE corruption — with a
+// linked narinfo carrying a NarHash, so the reverse migration treats it as
+// un-reassemblable (ErrMissingChunk) and purges it rather than reconstructing a
+// truncated NAR. Uses testdata.Nar2's identifiers so it is distinct from the
+// Nar1 fixture.
+func seedBrokenChunkedNar(ctx context.Context, t *testing.T, dbClient *database.Client) {
+	t.Helper()
+
+	sum := sha256.Sum256([]byte(testdata.Nar2.NarText))
+	narHash := nixhash.MustNewHashWithEncoding(nixhash.SHA256, sum[:], nixhash.NixBase32, true).String()
+
+	ni, err := dbClient.Ent().NarInfo.Create().
+		SetHash(testdata.Nar2.NarInfoHash).
+		SetURL("nar/" + testdata.Nar2.NarHash + ".nar").
+		SetNarHash(narHash).
+		Save(ctx)
+	require.NoError(t, err)
+
+	nf, err := dbClient.Ent().NarFile.Create().
+		SetHash(testdata.Nar2.NarHash).
+		SetCompression("none").
+		SetQuery("").
+		SetFileSize(12345).
+		SetTotalChunks(2).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = dbClient.Ent().NarInfoNarFile.Create().
+		SetNarinfoID(ni.ID).
+		SetNarFileID(nf.ID).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Only ONE of the two declared chunk links — the gap that makes the NAR
+	// un-reassemblable. No physical blob is needed: the completeness guard fires
+	// on the link-count mismatch before any chunk is read.
+	ch, err := dbClient.Ent().Chunk.Create().
+		SetHash(testhelper.MustRandBase32NarHash()).
+		SetSize(64).
+		SetCompressedSize(64).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = dbClient.Ent().NarFileChunk.Create().
+		SetNarFileID(nf.ID).
+		SetChunkID(ch.ID).
+		SetChunkIndex(0).
+		Save(ctx)
+	require.NoError(t, err)
+}
+
+// TestMigrateChunksToNar_CLI_SkipsBrokenNarMigratesRestAndReports verifies the
+// drain-hardening contract end to end: with a mix of one reassemblable NAR (Nar1,
+// hash fixed up) and one un-reassemblable NAR (Nar2, missing a junction link), the
+// migrate command migrates the good one to a whole file, purges the broken one,
+// continues past the failure (exit 0), and reports the outcome — including the
+// purged NAR by hash — in its summary.
+//
+//nolint:paralleltest // redirects os.Stdout; cannot run in parallel
+func TestMigrateChunksToNar_CLI_SkipsBrokenNarMigratesRestAndReports(t *testing.T) {
+	ctx := context.Background()
+
+	dbClient, _, dir, dbURL, cleanup := setupNarToChunksMigrationSQLite(t)
+	t.Cleanup(cleanup)
+	configureCDCInDatabase(ctx, t, dbClient)
+
+	// Good NAR (Nar1): valid recorded hash → reconstructs, verifies, migrates.
+	app := setupChunkedNar(ctx, t, dbClient, dir, dbURL)
+	fixupNarHash(ctx, t, dbClient)
+
+	// Broken NAR (Nar2): completed chunked record missing a junction link → purged.
+	seedBrokenChunkedNar(ctx, t, dbClient)
+
+	// Capture the command's stdout logger (it writes JSON lines to os.Stdout).
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = w
+
+	t.Cleanup(func() {
+		os.Stdout = oldStdout
+		_ = r.Close()
+	})
+
+	var logBuf bytes.Buffer
+
+	readDone := make(chan struct{})
+
+	go func() {
+		_, _ = io.Copy(&logBuf, r)
+
+		close(readDone)
+	}()
+
+	runErr := app.Run(ctx, []string{
+		"ncps", "migrate-chunks-to-nar",
+		"--cache-database-url", dbURL,
+		"--cache-storage-local", dir,
+	})
+
+	require.NoError(t, w.Close())
+	<-readDone
+
+	require.NoError(t, runErr, "a broken NAR must be skipped/purged, not abort the run (exit 0)")
+
+	// The reassemblable NAR migrated: its record is flipped to whole-file.
+	var nar1Chunks int
+	require.NoError(t, dbClient.DB().QueryRowContext(ctx,
+		"SELECT total_chunks FROM nar_files WHERE hash = ?", testdata.Nar1.NarHash).Scan(&nar1Chunks))
+	assert.Zero(t, nar1Chunks, "the reassemblable NAR must still be migrated to a whole file")
+
+	// The un-reassemblable NAR was purged so its hash re-fetches from upstream later.
+	var nar2Rows int
+	require.NoError(t, dbClient.DB().QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM nar_files WHERE hash = ?", testdata.Nar2.NarHash).Scan(&nar2Rows))
+	assert.Zero(t, nar2Rows, "the un-reassemblable NAR's nar_file record must be purged")
+
+	// The run reports the outcome, including the purged NAR by hash.
+	logged := logBuf.String()
+	assert.Contains(t, logged, "migration completed", "must emit a final summary")
+	assert.Contains(t, logged, `"succeeded":1`, "summary must report one migrated NAR")
+	assert.Contains(t, logged, `"purged":1`, "summary must report one purged NAR")
+	assert.Contains(t, logged, testdata.Nar2.NarHash, "the purged NAR must be reported by hash")
+}


### PR DESCRIPTION
## Summary

Production Nix clients were getting **truncated NAR downloads** from ncps
(`unexpected end of nar`, `truncated input`, `SSL_read: SSL_ERROR_SYSCALL`) on
responses that started as `HTTP 200`. Root cause, confirmed against the live DB:

- `nar_file_chunks.chunk_id -> chunks(id)` is `ON DELETE CASCADE`. Deleting a
  shared `chunks` row strips its junction links from **completed** chunked NARs
  (`total_chunks > 0`) **without** resetting `total_chunks`. Nothing enforced
  `count(links) == total_chunks`.
- The serve fast path only detected the gap (`expected N chunks but got M`)
  **inside the streaming goroutine**, after `server.go` had already written
  `200 OK` + `Content-Length` — so the client got a body it couldn't fulfill and
  Nix could not fall back.
- This is **distinct from #1230/#1317** (those cover the `total_chunks = 0`
  mid-chunking orphans). Of 2499 completed chunked NARs in prod, 71 had
  `links < total_chunks`.

### Fix

`getNarFromChunks` now counts junction links in its init transaction on the
`total_chunks > 0` fast path and returns `storage.ErrNotFound` **synchronously**
when `links != total_chunks`, before the pipe/response are committed → handler
responds `404` → Nix refetches upstream. `total_chunks` is the completion latch
(written only after all links commit), so this is never a mid-chunking race; the
progressive `total_chunks = 0` path is left untouched and stays HA-safe.

The `migrate-chunks-to-nar` driver already maps `ErrMissingChunk` to
`PurgeChunkedNar` + continue + report; the guard routes link-loss into that path,
so the 71 broken NARs self-heal (purge → refetch) on the next drain.

Specs synced: new `chunked-nar-serving-integrity` capability + 2 added
requirements on `cdc-drain-mode`.

## Test plan

- [x] `task fmt` / `task lint` (0 issues) / `task test` (all packages ok)
- [x] `go test -race ./pkg/cache ./pkg/server` — ok
- [x] New tests: serving 404-not-truncated-200, HA-safety on progressive path,
      missing-link → `ErrMissingChunk`, purge → clean cache-miss, and a CLI
      mix-migration test (skip broken + migrate good + report by hash)