### PR TITLE
docs(spec): fix cdc-drain-mode SHALL validation

### DIFF
--- a/docs/docs/User Guide/Operations/Chunks to NAR Migration.md
+++ b/docs/docs/User Guide/Operations/Chunks to NAR Migration.md
@@ -109,7 +109,7 @@ After running `migrate-chunks-to-nar` to completion, disable CDC to stop storing
 
 **1. Confirm no chunked NARs remain** (optional but recommended):
 
-```sql
+```mariadb
 -- Should return 0 after a complete migration:
 SELECT count(*) FROM nar_files WHERE total_chunks > 0;
 ```
@@ -158,7 +158,7 @@ When OpenTelemetry is enabled (`--otel-enabled`), the process exports:
 
 ## Verification
 
-```mariadb
+```
 -- No chunked NARs should remain after a full migration:
 SELECT count(*) FROM nar_files WHERE total_chunks > 0;
 ```

--- a/openspec/specs/cdc-drain-mode/spec.md
+++ b/openspec/specs/cdc-drain-mode/spec.md
@@ -36,10 +36,10 @@ NARs are stored as chunks.
 
 ### Requirement: The server MUST enter drain mode when `cdc.enabled: false` but chunked NARs may exist
 
-When the server starts with `cdc.enabled: false` and the stored database configuration
-has `cdc_enabled=true` (indicating CDC was previously active and chunked NARs may
-remain), the server SHALL enter drain mode by initializing the chunk store for reads
-without enabling chunk writes. Drain mode SHALL:
+The server SHALL enter drain mode when it starts with `cdc.enabled: false` and the
+stored database configuration has `cdc_enabled=true` (indicating CDC was previously
+active and chunked NARs may remain): it initializes the chunk store for reads without
+enabling chunk writes. Drain mode SHALL:
 
 - Initialize the chunk store backend (local or S3) using the same storage flags as
   a CDC-enabled deployment.

--- a/openspec/specs/cdc-drain-mode/spec.md
+++ b/openspec/specs/cdc-drain-mode/spec.md
@@ -38,8 +38,8 @@ NARs are stored as chunks.
 
 The server SHALL enter drain mode when it starts with `cdc.enabled: false` and the
 stored database configuration has `cdc_enabled=true` (indicating CDC was previously
-active and chunked NARs may remain): it initializes the chunk store for reads without
-enabling chunk writes. Drain mode SHALL:
+active and chunked NARs may remain) by initializing the chunk store for reads
+without enabling chunk writes. Drain mode SHALL:
 
 - Initialize the chunk store backend (local or S3) using the same storage flags as
   a CDC-enabled deployment.


### PR DESCRIPTION
## Summary

- **`openspec/specs/cdc-drain-mode/spec.md`**: fix a pre-existing
  `openspec validate` failure (`requirements.1.text: Requirement must
  contain SHALL or MUST keyword`). The validator parses a requirement's
  text as only its **first physical line** and checks that line for
  `SHALL`/`MUST`. The "server MUST enter drain mode" requirement put its
  normative `SHALL` on the third wrapped line, so the validator never saw
  it. Reworded to open with `The server SHALL enter drain mode when it
  starts with …` — keyword now in the first line. Pure wording; meaning,
  scenarios, and behavior unchanged.
- **`docs/.../Chunks to NAR Migration.md`**: minor code-fence language-tag
  cleanup.

This is independent of #1319 (a pre-existing validation bug), branched off
`main` so it can merge on its own.

## Test plan

- [x] `openspec validate cdc-drain-mode` → valid
- [x] `task fmt` clean
- [x] No code changes; no test/lint impact