### PR TITLE
fix(cache): no purge on upload-only narinfo reads

### DIFF
--- a/openspec/changes/archive/2026-06-03-fix-upload-read-no-purge/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-03-fix-upload-read-no-purge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/archive/2026-06-03-fix-upload-read-no-purge/design.md
+++ b/openspec/changes/archive/2026-06-03-fix-upload-read-no-purge/design.md
@@ -1,0 +1,96 @@
+## Context
+
+`GetNarInfo` (pkg/cache/cache.go) has a "purge guard": when a narinfo row exists
+but its backing NAR is absent from storage and no download is in flight, it calls
+`purgeNarInfo` (cache.go:~4357) — a destructive DB delete of the narinfo +
+`nar_file` rows plus store deletes — and returns the internal `errNarInfoPurged`
+sentinel. `GetNarInfo` then routes that sentinel: on the root/substituter path it
+falls through to an upstream re-fetch; on the `/upload` path
+(`cache.IsUploadOnly(ctx)`) the short-circuit at cache.go:~3432 returns
+`storage.ErrNotFound` (HTTP 404).
+
+The destructive purge runs on **both** paths. On the upload path this makes the
+cache's "is path X present?" answer non-monotonic within a single `nix copy`: the
+narinfo is present when the client runs `queryValidPaths`, then deleted by a
+purge-on-read before the per-reference verification step, so Lix's
+`BinaryCacheStore::addToStore` aborts with "the reference does not exist". Each
+retry re-`PUT`s the narinfo (re-seeding a phantom) which is purged again — a churn
+loop (244 purge events in one production run).
+
+Constraints: the project mandates TDD; the change must be additive/behavioral only
+(no schema or migration); root-path self-healing behavior must be preserved.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `/upload` narinfo reads non-destructive so `nix copy --to .../upload`
+  succeeds against a cache containing phantom narinfos.
+- Preserve identical root/substituter purge-and-re-fetch behavior.
+- Keep the diff surgical and well-covered by tests.
+
+**Non-Goals:**
+- Preventing phantom *seeds* at write time (`PutNarInfo`/`storeInDatabase` creating
+  a `nar_file` record without verifying NAR bytes) — separate change.
+- Bulk cleanup of existing phantom narinfos (fsck/operational).
+- Any change to CDC chunk handling or replica/storage topology.
+
+## Decisions
+
+### Decision: Skip only the `purgeNarInfo` call under upload-only; reuse the existing sentinel routing
+
+In the purge-guard block of `getNarInfoFromDatabase`, branch on
+`IsUploadOnly(ctx)` immediately **before** the `purgeNarInfo` call. When
+upload-only, return the existing `errNarInfoPurged` sentinel **without** purging:
+
+```go
+if IsUploadOnly(ctx) {
+    // Upload-only reads are non-destructive. Report the missing-NAR narinfo as a
+    // cache miss so the client re-uploads, but do NOT purge — a purge here makes
+    // the cache's path-validity answer non-monotonic within a single `nix copy`
+    // and aborts the client's reference-verification step.
+    return nil, ErrNarInfoPurged
+}
+// existing: log "...requesting a purge" + purgeNarInfo(...) + return ErrNarInfoPurged
+```
+
+**Why:** `GetNarInfo` already maps `errNarInfoPurged` to `storage.ErrNotFound`
+(HTTP 404) on the upload-only path (cache.go:~3432) and to upstream re-fetch on the
+root path. Returning the same sentinel from the upload-only branch yields the
+desired 404 with the smallest possible change and no new control flow in
+`GetNarInfo`. The sentinel is internal and never reaches the client (defense-in-
+depth handler mapping already covers a leak).
+
+**Alternatives considered:**
+- *Return `storage.ErrNotFound` directly from the guard.* Rejected: it would enter
+  the `!errors.Is(err, ErrNarInfoPurged)` branch (cache.go:~3416) and
+  `handleStorageFetchError`, a different code path with its own retry semantics —
+  more surface area and behavior to reason about than reusing the established
+  sentinel route.
+- *Gate the purge at the HTTP/server layer.* Rejected: `IsUploadOnly` is a cache
+  context concern and the guard lives in the cache; the server handler has no
+  visibility into the guard firing.
+
+## Risks / Trade-offs
+
+- **Stale phantom narinfo persists on the upload path** → Acceptable and intended:
+  the immediately following client `PUT` overwrites it (`storeInDatabase` upserts).
+  Root-path reads still purge-and-re-fetch, so substituter consumers self-heal.
+- **`errNarInfoPurged` returned without an actual purge is mildly misleading** →
+  Mitigated by a clear comment at the branch; the sentinel is internal-only and the
+  routing it triggers (→ 404) is exactly what's wanted.
+- **A concurrent root-path read could still purge the same hash mid-copy** →
+  Out of this change's control and unchanged by it; the upload path no longer
+  *contributes* to the churn, which removes the dominant cause observed in prod.
+
+## Migration Plan
+
+- Pure behavioral change; no DB migration, no config, no API/route change.
+- Deploy: ship the new image; both replicas pick it up on rollout.
+- Rollback: revert the commit / redeploy the prior image — no state to undo.
+- Existing phantoms need no special handling: upload reads stop deleting them,
+  root reads continue to self-heal them, and re-uploads repair them.
+
+## Open Questions
+
+- None blocking. (Phantom-seed prevention at write time is acknowledged as a
+  separate follow-up, not required for this fix to resolve the `nix copy` abort.)

--- a/openspec/changes/archive/2026-06-03-fix-upload-read-no-purge/proposal.md
+++ b/openspec/changes/archive/2026-06-03-fix-upload-read-no-purge/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+`nix copy --to https://<host>/upload <closure>` aborts with *"cannot add 'X' to the binary cache because the reference 'Y' does not exist"* whenever the closure contains a phantom narinfo (narinfo row present, backing NAR bytes absent). On the upload path the purge guard **destructively deletes** the narinfo on read, so the destination's view of "is path Y valid?" flips from present (Nix's `queryValidPaths` phase) to absent (Nix's per-reference verification phase). Lix's `BinaryCacheStore::addToStore` reference check turns that non-monotonic answer into a fatal abort. Retrying re-`PUT`s the narinfo, which re-seeds the phantom, which is purged again — observed churn of 244 purge events in a single production run.
+
+## What Changes
+
+- When the narinfo purge guard fires **and** the request context is `cache.IsUploadOnly` (the `/upload` route), `GetNarInfo` MUST NOT call `purgeNarInfo`. It returns `storage.ErrNotFound` instead, so the client receives `HTTP 404` and proceeds to `PUT` (which overwrites the stale record).
+- Purge-on-read behavior on the root/substituter path is **unchanged** — it still purges and re-fetches/falls back as today. Self-healing only matters where reads are substituter lookups; on `/upload` the client is the source of truth and is about to re-upload.
+- Net effect: upload-path reads become **non-destructive and idempotent**, restoring the monotonic path-validity that `nix copy` relies on.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `narinfo-purge-serving`: add a requirement that the purge guard MUST skip the destructive purge and resolve to `404` (not delete, not upstream-fetch) when the request is upload-only. The existing root-path purge+re-fetch requirements are retained unchanged.
+
+## Impact
+
+- **Code**: `pkg/cache/cache.go` — the purge-guard block in `GetNarInfo` (~`cache.go:4300`, `purgeNarInfo` call at ~`4357`) gains an `IsUploadOnly(ctx)` branch. `pkg/cache` tests. No HTTP handler, schema, migration, or storage-layer changes.
+- **Behavior**: only the `/upload` read path changes; root path identical. No API/route changes.
+- **I/O / network / memory**: strictly reduces work on the upload path — eliminates a DB delete transaction and store-delete per phantom read, and avoids the re-PUT→re-purge churn. No new allocations on the hot NAR-streaming path. No measurable latency or memory change to normal serving.
+
+## Non-goals
+
+- Preventing phantom seeds at write time (`PutNarInfo`/`storeInDatabase` creating a `nar_file` record without verifying NAR bytes) — deliberately out of scope; tracked separately.
+- Cleaning up the existing population of phantom narinfos (an fsck/purge pass) — operational, not part of this change.
+- Any change to root/substituter purge-on-read, CDC chunk reassembly, or replica/storage topology.

--- a/openspec/changes/archive/2026-06-03-fix-upload-read-no-purge/specs/narinfo-purge-serving/spec.md
+++ b/openspec/changes/archive/2026-06-03-fix-upload-read-no-purge/specs/narinfo-purge-serving/spec.md
@@ -1,47 +1,4 @@
-# narinfo-purge-serving Specification
-
-## Purpose
-
-Defines how the cache serves narinfo requests when the internal purge guard fires
-— a narinfo exists in the database but its backing NAR is absent from storage and
-no download is in flight. A purge is internal cache maintenance, not a server
-fault, so it MUST NOT surface to clients as an HTTP 500. Instead the cache
-re-fetches from upstream and serves HTTP 200 when available, or resolves to HTTP
-404 so Nix falls back to its next substituter. This capability complements
-`narinfo-concurrent-fetch` (the in-flight concurrent case) and
-`nar-cache-miss-recovery` (NAR record handling).
-
-## Requirements
-### Requirement: A fired narinfo purge MUST NOT surface to the client as HTTP 500
-
-The system SHALL NOT return `HTTP 500 Internal Server Error` to a client as a
-result of the narinfo purge guard firing. When `GetNarInfo` determines a narinfo
-exists in the database but its backing NAR is absent from storage and no download
-job is in flight (neither local nor remote, and no in-progress CDC record), the
-purge guard purges the narinfo and internally signals `errNarInfoPurged`. This
-sentinel is an internal cache-maintenance signal and MUST NOT propagate to the
-HTTP client. The request that triggered the purge SHALL instead resolve to a
-served narinfo (HTTP 200) or a not-found response (HTTP 404), never a 500.
-
-#### Scenario: Purged narinfo still available upstream is served, not 500'd
-
-- **WHEN** a client requests `GET /{hash}.narinfo` for a hash whose narinfo is in
-  the database but whose NAR is missing from storage and no download is in flight
-- **AND** the narinfo is still available from a configured upstream cache
-- **THEN** the purge guard fires and purges the stale database record
-- **AND** `GetNarInfo` re-fetches the narinfo from upstream
-- **AND** the client receives `HTTP 200` with a valid signed narinfo
-- **AND** the client never receives `HTTP 500` or the body `the narinfo was purged`
-
-#### Scenario: Purged narinfo absent upstream resolves to 404 fallback
-
-- **WHEN** a client requests `GET /{hash}.narinfo` for a hash whose narinfo is in
-  the database but whose NAR is missing from storage and no download is in flight
-- **AND** the narinfo is not available from any configured upstream cache
-- **THEN** the purge guard fires and purges the stale database record
-- **AND** `GetNarInfo` resolves to `storage.ErrNotFound`
-- **AND** the client receives `HTTP 404` so Nix falls back to its next substituter
-- **AND** the client never receives `HTTP 500`
+## ADDED Requirements
 
 ### Requirement: Upload-only narinfo reads MUST NOT purge on a missing-NAR cache miss
 
@@ -79,6 +36,8 @@ non-upload (root/substituter) purge-and-re-fetch behavior is unaffected.
 - **THEN** the narinfo PUT overwrites/repairs the stale record
 - **AND** a later read for the same hash serves the narinfo (`HTTP 200`)
 
+## MODIFIED Requirements
+
 ### Requirement: `GetNarInfo` MUST re-fetch from upstream when the purge guard fires
 
 For requests that are not upload-only, `GetNarInfo` SHALL treat a fired purge guard during the initial database lookup as a cache miss and proceed through the existing upstream-fetch path (the same path taken when a narinfo is absent from both database and store), rather than returning the `errNarInfoPurged` sentinel to its caller. The upstream fetch outcome — success or `storage.ErrNotFound` — determines the served result. For upload-only requests the purge guard does not fire and no upstream fetch is attempted; see "Upload-only narinfo reads MUST NOT purge on a missing-NAR cache miss".
@@ -100,17 +59,3 @@ For requests that are not upload-only, `GetNarInfo` SHALL treat a fired purge gu
 - **THEN** `GetNarInfo` returns the upstream fetch error
 - **AND** the returned error is never `errNarInfoPurged`
 - **AND** a later request for the same hash is able to re-attempt the upstream fetch
-
-### Requirement: The narinfo HTTP handler MUST map a leaked purge sentinel to 404
-
-The narinfo `GET` handler in `pkg/server` SHALL, as defense in depth, treat
-`errNarInfoPurged` equivalently to `storage.ErrNotFound` and respond with
-`HTTP 404` if the sentinel ever reaches it, never `HTTP 500`. The handler MUST NOT
-write the internal sentinel message into any client response body.
-
-#### Scenario: Handler receives the purge sentinel
-
-- **WHEN** the narinfo `GET` handler receives `errNarInfoPurged` from `GetNarInfo`
-- **THEN** the handler responds with `HTTP 404 Not Found`
-- **AND** the response body does not contain `the narinfo was purged`
-

--- a/openspec/changes/archive/2026-06-03-fix-upload-read-no-purge/specs/narinfo-purge-serving/spec.md
+++ b/openspec/changes/archive/2026-06-03-fix-upload-read-no-purge/specs/narinfo-purge-serving/spec.md
@@ -14,7 +14,7 @@ non-upload (root/substituter) purge-and-re-fetch behavior is unaffected.
 - **WHEN** a client requests `GET /upload/{hash}.narinfo` for a hash whose narinfo
   is in the database but whose NAR is missing from storage and no download is in
   flight
-- **THEN** the purge guard does NOT fire and `purgeNarInfo` is NOT called
+- **THEN** the purge guard's missing-NAR condition is met, but `purgeNarInfo` is NOT called
 - **AND** the narinfo and `nar_file` database records remain present
 - **AND** `GetNarInfo` returns `storage.ErrNotFound`
 - **AND** the client receives `HTTP 404`

--- a/openspec/changes/archive/2026-06-03-fix-upload-read-no-purge/tasks.md
+++ b/openspec/changes/archive/2026-06-03-fix-upload-read-no-purge/tasks.md
@@ -1,0 +1,24 @@
+## 1. Reconnaissance
+
+- [x] 1.1 Confirm the purge-guard block in `getNarInfoFromDatabase` (pkg/cache/cache.go, the `purgeNarInfo` call ~cache.go:4357) and the upload-only short-circuit in `GetNarInfo` (~cache.go:3432) still match the design; note exact line numbers.
+- [x] 1.2 Locate existing purge-guard tests (`pkg/cache/cache_internal_test.go`, `pkg/server/purge_serving_test.go`, `narinfo-purge-serving` coverage) to model the new tests on, and confirm `WithUploadOnly`/`IsUploadOnly` helpers are reachable from the test package.
+
+## 2. TDD: Red — failing tests
+
+- [x] 2.1 Add a cache-level test: with a narinfo in the DB but its NAR absent and no download in flight, calling `GetNarInfo` with an upload-only context returns a not-found result (HTTP-404-equivalent) **and** leaves the narinfo + `nar_file` rows intact (assert `purgeNarInfo` did NOT run — rows still present after the call).
+- [x] 2.2 Add a test asserting repeated upload-only reads of the same missing-NAR narinfo are deterministic (every call → not-found) and non-mutating (DB rows identical before/after), and that no upstream fetch is attempted.
+- [x] 2.3 Add/confirm a regression test that the **non-upload-only** path is unchanged: the purge guard still fires (rows deleted) and still falls through to upstream re-fetch.
+- [x] 2.4 Run the new tests and confirm they FAIL against current code (red), for the expected reason (rows are deleted under upload-only today).
+
+## 3. TDD: Green — implementation
+
+- [x] 3.1 In the purge-guard block of `getNarInfoFromDatabase`, add an `if IsUploadOnly(ctx) { return nil, ErrNarInfoPurged }` branch immediately before the "requesting a purge" log + `purgeNarInfo` call, with an explanatory comment (per `nolint`/comment conventions and the design rationale).
+- [x] 3.2 Verify the returned sentinel routes through `GetNarInfo`'s upload-only short-circuit (~cache.go:3432) to `storage.ErrNotFound` → HTTP 404, with no upstream fetch and no destructive delete.
+- [x] 3.3 Run the tests from section 2 and confirm they now PASS (green), and that the non-upload-only regression test still passes.
+
+## 4. Verification
+
+- [x] 4.1 `task fmt` exits 0.
+- [x] 4.2 `task lint` exits 0 (any `//nolint` carries an explanatory comment).
+- [x] 4.3 `task test` exits 0 (race detector on; all subtests call `t.Parallel()`).
+- [x] 4.4 Re-read the diff against `proposal.md`/`design.md` scope: read-path only, no write-path/`PutNarInfo` change, no schema/migration, root path untouched.

--- a/openspec/specs/narinfo-purge-serving/spec.md
+++ b/openspec/specs/narinfo-purge-serving/spec.md
@@ -57,7 +57,7 @@ non-upload (root/substituter) purge-and-re-fetch behavior is unaffected.
 - **WHEN** a client requests `GET /upload/{hash}.narinfo` for a hash whose narinfo
   is in the database but whose NAR is missing from storage and no download is in
   flight
-- **THEN** the purge guard does NOT fire and `purgeNarInfo` is NOT called
+- **THEN** the purge guard's missing-NAR condition is met, but `purgeNarInfo` is NOT called
 - **AND** the narinfo and `nar_file` database records remain present
 - **AND** `GetNarInfo` returns `storage.ErrNotFound`
 - **AND** the client receives `HTTP 404`

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4350,6 +4350,17 @@ func (c *Cache) getNarInfoFromDatabase(ctx context.Context, hash string) (*narin
 			}
 		}
 
+		// Upload-only reads (/upload route) are non-destructive: report the
+		// missing-NAR narinfo as a cache miss (the sentinel resolves to
+		// storage.ErrNotFound → HTTP 404 via GetNarInfo's upload-only
+		// short-circuit, prompting the client to re-PUT) but do NOT purge.
+		// Purging here would delete a record the client is about to re-upload and
+		// makes the cache's path-validity answer non-monotonic within a single
+		// `nix copy`, aborting the client's reference-verification step.
+		if IsUploadOnly(ctx) {
+			return nil, ErrNarInfoPurged
+		}
+
 		zerolog.Ctx(ctx).
 			Error().
 			Msg("narinfo was found in the database but no nar was found in storage, requesting a purge")

--- a/pkg/cache/upload_only_purge_internal_test.go
+++ b/pkg/cache/upload_only_purge_internal_test.go
@@ -1,0 +1,176 @@
+package cache
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	locklocal "github.com/kalbasit/ncps/pkg/lock/local"
+
+	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
+	"github.com/kalbasit/ncps/pkg/storage/local"
+	"github.com/kalbasit/ncps/testdata"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// newUploadOnlyPurgeCacheNoSeed wires a cache backed by a plain local store (so
+// a missing NAR is a *confirmed* absence, not an ambiguous storage error) with
+// no narinfo seeded.
+func newUploadOnlyPurgeCacheNoSeed(t *testing.T) (*Cache, *database.Client) {
+	t.Helper()
+
+	ctx := newContext()
+
+	dir, err := os.MkdirTemp("", "cache-path-")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
+	dbClient, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dbClient.Close() })
+
+	localStore, err := local.New(ctx, dir)
+	require.NoError(t, err)
+
+	c, err := New(ctx, cacheName, dbClient, localStore, localStore, localStore, "",
+		locklocal.NewLocker(), locklocal.NewRWLocker(), downloadLockTTL, downloadPollTimeout, cacheLockTTL)
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	return c, dbClient
+}
+
+// newUploadOnlyPurgeCache returns a cache seeded with an orphan narinfo: a DB row
+// whose backing NAR is absent from storage. This is the phantom-narinfo state
+// that the purge guard reacts to.
+func newUploadOnlyPurgeCache(t *testing.T) (*Cache, *database.Client) {
+	t.Helper()
+
+	c, dbClient := newUploadOnlyPurgeCacheNoSeed(t)
+
+	_, err := dbClient.Ent().NarInfo.Create().
+		SetHash(testdata.Nar1.NarInfoHash).
+		SetURL("nar/" + testdata.Nar1.NarHash + ".nar").
+		Save(newContext())
+	require.NoError(t, err)
+
+	return c, dbClient
+}
+
+// TestGetNarInfoFromDatabase_UploadOnlyDoesNotPurge verifies that on the
+// upload-only (/upload) read path, a missing-NAR narinfo is reported as a cache
+// miss (the internal ErrNarInfoPurged sentinel, which GetNarInfo maps to
+// storage.ErrNotFound → HTTP 404) WITHOUT destructively purging the DB row. The
+// client is about to re-PUT the narinfo; purging here makes the cache's
+// path-validity answer non-monotonic within a single `nix copy` and aborts the
+// client's reference-verification step.
+func TestGetNarInfoFromDatabase_UploadOnlyDoesNotPurge(t *testing.T) {
+	t.Parallel()
+
+	c, dbClient := newUploadOnlyPurgeCache(t)
+
+	ctx := WithUploadOnly(newContext())
+
+	ni, err := c.getNarInfoFromDatabase(ctx, testdata.Nar1.NarInfoHash)
+	require.ErrorIs(t, err, ErrNarInfoPurged,
+		"a missing-NAR narinfo on the upload-only path must resolve to the purge sentinel (→ 404)")
+	require.Nil(t, ni)
+
+	// The narinfo row MUST still exist — the upload-only read must be
+	// non-destructive so the subsequent client PUT can overwrite it.
+	_, err = fetchNarInfo(ctx, dbClient, testdata.Nar1.NarInfoHash)
+	require.NoError(t, err, "upload-only read must NOT purge the narinfo row")
+}
+
+// TestGetNarInfo_UploadOnlyPhantomIsMonotonic exercises the public GetNarInfo
+// entry point: an upload-only read of a phantom narinfo (DB row present, NAR
+// absent) resolves to storage.ErrNotFound (→ HTTP 404) and never leaks the purge
+// sentinel. Repeating the read yields the same answer and never mutates the DB —
+// the path-validity answer is monotonic, which is what `nix copy`'s
+// reference-verification step relies on.
+func TestGetNarInfo_UploadOnlyPhantomIsMonotonic(t *testing.T) {
+	t.Parallel()
+
+	c, dbClient := newUploadOnlyPurgeCache(t)
+
+	ctx := WithUploadOnly(newContext())
+
+	for i := range 2 {
+		ni, err := c.GetNarInfo(ctx, testdata.Nar1.NarInfoHash)
+		require.ErrorIs(t, err, storage.ErrNotFound,
+			"read %d: upload-only phantom narinfo must resolve to ErrNotFound (HTTP 404)", i)
+		require.NotErrorIs(t, err, ErrNarInfoPurged,
+			"read %d: the purge sentinel must never escape GetNarInfo", i)
+		require.Nil(t, ni)
+
+		// Every read leaves the narinfo row intact — reads are non-mutating.
+		_, err = fetchNarInfo(ctx, dbClient, testdata.Nar1.NarInfoHash)
+		require.NoError(t, err, "read %d: upload-only read must not purge the narinfo row", i)
+	}
+}
+
+// TestGetNarInfoFromDatabase_NonUploadOnlyStillPurges guards the regression
+// boundary: the upload-only carve-out must NOT disable the purge guard on the
+// normal (root/substituter) read path. A confirmed missing-NAR narinfo on a
+// non-upload-only request is still destructively purged.
+func TestGetNarInfoFromDatabase_NonUploadOnlyStillPurges(t *testing.T) {
+	t.Parallel()
+
+	c, dbClient := newUploadOnlyPurgeCache(t)
+
+	// No WithUploadOnly: this is the normal read path.
+	ctx := newContext()
+
+	ni, err := c.getNarInfoFromDatabase(ctx, testdata.Nar1.NarInfoHash)
+	require.ErrorIs(t, err, ErrNarInfoPurged)
+	require.Nil(t, ni)
+
+	// The narinfo row MUST be gone — the guard purged it.
+	_, err = fetchNarInfo(ctx, dbClient, testdata.Nar1.NarInfoHash)
+	require.Error(t, err, "non-upload-only confirmed-absence read must purge the narinfo row")
+}
+
+// TestGetNarInfo_UploadOnlyPhantomRepairedByPut covers the spec scenario "a
+// subsequent upload PUT repairs the stale record": because the upload-only read
+// left the narinfo row in place (instead of purging it), uploading the missing
+// NAR bytes repairs the phantom, and a later read serves the narinfo. This is the
+// payoff of the non-destructive behavior — the path becomes valid again rather
+// than churning.
+func TestGetNarInfo_UploadOnlyPhantomRepairedByPut(t *testing.T) {
+	t.Parallel()
+
+	c, dbClient := newUploadOnlyPurgeCacheNoSeed(t)
+
+	// Seed a complete phantom the way production does: a full narinfo record (all
+	// fields) created by an upload PUT, but with no NAR bytes in storage.
+	require.NoError(t, c.PutNarInfo(newContext(), testdata.Nar1.NarInfoHash,
+		io.NopCloser(strings.NewReader(testdata.Nar1.NarInfoText))))
+
+	ctx := WithUploadOnly(newContext())
+
+	// 1. Phantom read: the upload-only read reports a miss without purging.
+	_, err := c.GetNarInfo(ctx, testdata.Nar1.NarInfoHash)
+	require.ErrorIs(t, err, storage.ErrNotFound)
+
+	_, err = fetchNarInfo(ctx, dbClient, testdata.Nar1.NarInfoHash)
+	require.NoError(t, err, "the narinfo row must survive the upload-only read")
+
+	// 2. The client re-uploads the missing NAR bytes at the URL the narinfo points
+	//    to. Because the narinfo row was left intact, this repairs the record.
+	narURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: testdata.Nar1.NarCompression}
+	require.NoError(t, c.PutNar(newContext(), narURL, io.NopCloser(strings.NewReader(testdata.Nar1.NarText))))
+
+	// 3. The narinfo is now served — the phantom was repaired, not stuck in a churn.
+	ni, err := c.GetNarInfo(newContext(), testdata.Nar1.NarInfoHash)
+	require.NoError(t, err)
+	require.NotNil(t, ni)
+}

--- a/pkg/cache/upload_only_purge_internal_test.go
+++ b/pkg/cache/upload_only_purge_internal_test.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"io"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -27,9 +26,7 @@ func newUploadOnlyPurgeCacheNoSeed(t *testing.T) (*Cache, *database.Client) {
 
 	ctx := newContext()
 
-	dir, err := os.MkdirTemp("", "cache-path-")
-	require.NoError(t, err)
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	dir := t.TempDir()
 
 	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
 	testhelper.CreateMigrateDatabase(t, dbFile)


### PR DESCRIPTION
## Summary

`nix copy --to https://<host>/upload <closure>` aborted with
`cannot add 'X' to the binary cache because the reference 'Y' does not exist`
whenever the closure contained a **phantom narinfo** (DB row present, backing
NAR bytes absent).

The read-path purge guard destructively purged such narinfos on **every** read,
including on the `/upload` route. That made the destination's path-validity
answer **non-monotonic** within a single `nix copy`: a path was present at the
client's `queryValidPaths` phase, then purged before its reference was verified,
so Lix's `BinaryCacheStore::addToStore` reference check aborted the whole copy.
Each retry re-`PUT` the narinfo, which re-seeded the phantom and was purged again
— observed churn of 244 purge events in one production run.

## Fix

`getNarInfoFromDatabase` now skips `purgeNarInfo` when the request is upload-only
(`cache.IsUploadOnly`), returning the existing `ErrNarInfoPurged` sentinel that
`GetNarInfo` already maps to `storage.ErrNotFound` (HTTP 404) on that path. The
client receives 404 and re-uploads; the `PUT` overwrites the stale record.
Root/substituter purge-and-re-fetch behavior is unchanged.

Scope is the read path only — phantom *seed* prevention at write time
(`PutNarInfo` creating a `nar_file` record without bytes) is deliberately a
separate follow-up.

## Test plan

- [x] `task fmt` / `task lint` / `task test` pass (race detector on)
- [x] New `pkg/cache/upload_only_purge_internal_test.go`:
  - upload-only read → 404, narinfo row **not** purged
  - repeated upload-only reads → deterministic 404, non-mutating (monotonic)
  - non-upload-only read → still purges (regression boundary)
  - post-404 re-upload repairs the record (served `200`)
- [x] `narinfo-purge-serving` spec synced (added upload-only requirement; scoped the upstream-refetch requirement to non-upload-only)