### PR TITLE
fix(cache): NAR HEAD must verify bytes, not DB record

### DIFF
--- a/openspec/changes/archive/2026-06-03-fix-nar-head-verify-bytes/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-03-fix-nar-head-verify-bytes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/archive/2026-06-03-fix-nar-head-verify-bytes/design.md
+++ b/openspec/changes/archive/2026-06-03-fix-nar-head-verify-bytes/design.md
@@ -1,0 +1,111 @@
+## Context
+
+The NAR `HEAD` handler `getNar(false)` (pkg/server/server.go) has a fast-path
+optimization: it calls `c.GetNarFileSize(nu)` and, if that returns `size > 0`,
+writes `200` with `Content-Length` and returns — **without** confirming the NAR
+bytes exist. `GetNarFileSize` (pkg/cache/cache.go:1430) reads the `nar_file` row
+via `getNarFileFromDB`; it is a pure DB lookup.
+
+Every other path determines NAR existence from actual bytes:
+`statNarInStore` (cache.go:3989, tri-state present/absent/ambiguous) and
+`HasNarInChunks` (cache.go:7066). The `nar-cache-miss-recovery` capability already
+mandates that a bare `nar_file` row does not make a NAR servable — but only the
+`GetNar` path enforces it.
+
+So a phantom (`nar_file` row, no bytes) makes `HEAD` return `200`. During
+`nix copy --to .../upload`, nix HEADs each NAR before uploading; a false `200`
+makes nix skip the NAR upload (nix uploads NAR-first, narinfo-last), leaving a
+phantom, and a dependent's reference-verification `GET` then `404`s → Lix aborts.
+Confirmed deterministically at `replicas=1`.
+
+Exported helpers available to the server: `HasNarInStore(bool)` (swallows the
+ambiguous error → returns false) and `HasNarInChunks(bool, error)`. The tri-state
+`statNarInStore` is unexported.
+
+## Goals / Non-Goals
+
+**Goals:**
+- NAR `HEAD` reflects real servability, consistent with `GetNar`.
+- A record-without-bytes NAR HEADs `404` on `/upload` so nix re-uploads.
+- Honor the tri-state stat: an ambiguous storage error is neither a false `200`
+  nor a false `404`.
+- Keep the fast path for the common case (servable NAR → cheap stat → `200`).
+
+**Non-Goals:**
+- Write-path seed prevention (`storeInDatabase` creating byteless `nar_file`
+  rows) — separate follow-up.
+- Changing `GetNar`, the narinfo paths, schema, or routes.
+- Replica/topology concerns (irrelevant — repros at one replica).
+
+## Decisions
+
+### Decision: Gate the HEAD size-shortcut on actual servability via a new tri-state cache method
+
+Add an exported `Cache.IsNarServable(ctx, narURL) (bool, error)` that mirrors
+`GetNar`'s servability determination, tri-state:
+
+- whole-file present (`statNarInStore` → true) → `(true, nil)`
+- else chunks present (`HasNarInChunks` → true) → `(true, nil)`
+- both confirmed absent → `(false, nil)`
+- ambiguous storage error (stat returned an error) → `(false, err)`
+
+In `getNar(false)`, keep `GetNarFileSize` for the `Content-Length` value, but emit
+`200` only when `IsNarServable` returns `(true, nil)`:
+
+```go
+if !withBody {
+    nu.TransparentZstd = false
+    size, sErr := s.cache.GetNarFileSize(r.Context(), nu)
+    if sErr == nil && size > 0 {
+        if servable, _ := s.cache.IsNarServable(r.Context(), nu); servable {
+            // write 200 + Content-Length, return
+        }
+    }
+    // not servable / ambiguous / no record → fall through to GetNar
+}
+nu, size, reader, err := s.cache.GetNar(...)   // existing path
+```
+
+**Why fall through to `GetNar` for the non-servable case** instead of writing a
+bare `404`: `GetNar` already encodes the correct, divergent behavior the spec
+requires — on `cache.IsUploadOnly` it returns `storage.ErrNotFound` (→ `404`, so
+nix re-uploads), and on the substituter path it attempts upstream recovery. The
+HEAD handler already tolerates this path for HEAD (it writes headers only when
+`!withBody`), so HEAD stays consistent with GET by construction. The ambiguous
+case also falls through, where `GetNar` handles it without purging.
+
+**Alternatives considered:**
+- *Gate on `HasNarInStore || HasNarInChunks` (existing exported helpers).* Works,
+  but `HasNarInStore` collapses the ambiguous error to `false`, so an ambiguous
+  stat would drop out of the fast path into `GetNar` — acceptable, but a dedicated
+  tri-state method states intent and keeps the ambiguous decision explicit.
+- *Make `GetNarFileSize` verify bytes.* Rejected: it is used elsewhere purely for
+  the size value; overloading it with a presence check risks unrelated callers.
+- *Write `404` directly when not servable.* Rejected: it would diverge HEAD from
+  GET on the substituter path (no recovery) and duplicate the upload-only logic.
+
+## Risks / Trade-offs
+
+- **Extra cost on HEAD**: one storage `stat` (and a chunk check only when the
+  whole-file is absent) per HEAD, replacing a DB-only answer. Bounded, no NAR
+  bytes read; HEAD is an infrequent verb. Net work drops (no more failed-copy
+  retries / phantom churn). → Acceptable.
+- **Substituter HEAD on a missing NAR now falls through to `GetNar`**, which may
+  trigger upstream recovery to answer HEAD. This matches GET semantics (HEAD
+  should reflect availability) and is the documented behavior; the hot
+  `/upload` case returns `404` cheaply (no upstream). → Acceptable.
+- **Ambiguous storage error drops HEAD out of the fast path** into `GetNar`. Same
+  handling as GET; no purge, no false 404. → Acceptable.
+
+## Migration Plan
+
+- Pure behavioral change; no schema, migration, config, or route change.
+- Deploy: ship the image. Rollback: revert the commit.
+- Existing phantom rows need no special handling — once HEAD reports them absent,
+  nix re-uploads (or substituter recovery heals them).
+
+## Open Questions
+
+- None blocking. (Whether to also short-circuit `404` for ambiguous on the
+  upload-only path is deferred to `GetNar`'s existing behavior; revisit only if a
+  HEAD-specific ambiguous case proves problematic in practice.)

--- a/openspec/changes/archive/2026-06-03-fix-nar-head-verify-bytes/proposal.md
+++ b/openspec/changes/archive/2026-06-03-fix-nar-head-verify-bytes/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+`nix copy --to https://<host>/upload <closure>` still aborts with *"cannot add 'X' to the binary cache because the reference 'Y' does not exist"* even after the purge fix (#1321) and even with a single replica. Root cause: the NAR **HEAD** handler reports a NAR as present based solely on the `nar_file` **DB record** (`GetNarFileSize`), while every other path determines existence from **actual bytes**. When a `nar_file` row exists without backing bytes (a phantom), nix's pre-upload `HEAD /upload/nar/<h>.nar.zst` returns `200`, so nix **skips uploading the NAR** and writes only the narinfo (nix uploads NAR-first, narinfo-last). That leaves a phantom; a dependent path's reference-verification `GET` then `404`s and Lix aborts the whole copy. This directly contradicts the existing `nar-cache-miss-recovery` rule that "the mere existence of a `nar_file` row SHALL NOT by itself make a NAR servable" — which today is only enforced on the GET path, not HEAD.
+
+## What Changes
+
+- The NAR `HEAD` existence/size probe (`getNar(false)` in `pkg/server`) MUST confirm the NAR is actually **servable** (whole-file or chunks present, or chunking in progress) before returning `200` — it MUST NOT return `200` from the `nar_file` record's size alone.
+- A record-without-bytes NAR MUST `HEAD` `404` on `/upload` (so nix re-uploads it), and on the substituter path MUST behave consistently with `GET` (fall through to the normal recovery/serve path rather than a bare DB-size `200`).
+- The check MUST honor the tri-state stat: an **ambiguous** storage error MUST NOT be turned into a false `200` nor a false `404`.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `nar-cache-miss-recovery`: add a requirement that the NAR **HEAD/existence probe** reflects actual servability (not a bare `nar_file` row), consistent with `GetNar`. Existing GET-path requirements are unchanged.
+
+## Impact
+
+- **Code**: `pkg/server/server.go` (`getNar(false)` HEAD branch) and a `pkg/cache` existence check reused from the GET/phantom-guard path (`statNarInStore`/`HasNarInChunks`, tri-state aware). `pkg/server`/`pkg/cache` tests. No schema, migration, route, or write-path change.
+- **Behavior**: only NAR `HEAD` changes; `GET` and narinfo paths are untouched. Unblocks `nix copy --to .../upload`.
+- **I/O / latency / memory**: `HEAD` gains one cheap storage `stat` (and a chunk check when applicable) instead of a DB-only lookup — a small, bounded cost on an infrequent verb; it never reads NAR bytes. No change to the hot GET/serve path. Net effect is *less* work overall: it eliminates the failed-copy retries and the phantom churn.
+
+## Non-goals
+
+- Write-path seed prevention (`storeInDatabase`/`PutNarInfo` creating a `nar_file` record without durable bytes) — a separate follow-up. The HEAD fix alone breaks the failure chain because nix re-uploads the NAR once HEAD reports it absent.
+- Cross-replica / shared-storage consistency and replica count — confirmed irrelevant (the bug reproduces at one replica).
+- Cleanup of existing phantom `nar_file` rows (operational; they self-correct as NARs are re-uploaded or recovered from upstream).

--- a/openspec/changes/archive/2026-06-03-fix-nar-head-verify-bytes/specs/nar-cache-miss-recovery/spec.md
+++ b/openspec/changes/archive/2026-06-03-fix-nar-head-verify-bytes/specs/nar-cache-miss-recovery/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: A NAR HEAD/existence probe MUST reflect actual servability, not a bare nar_file record
+
+A NAR `HEAD` request (`HEAD /nar/<hash>.nar[.<compression>]`, including under `/upload`) MUST NOT report the NAR as present (HTTP 200) on the basis of the `nar_file` database record alone. The system SHALL apply the same servability determination used by `GetNar`: a NAR is "servable" only when a whole-file exists in the store, `total_chunks > 0`, or chunking is actively in progress within the lock TTL. A `nar_file` row's existence or its recorded `FileSize` (e.g. via a `GetNarFileSize`/`HasNarFileRecord`-style lookup) SHALL NOT by itself produce a `200`.
+
+When the NAR is not servable (a record exists but no backing bytes), the `HEAD` outcome MUST be consistent with `GetNar`:
+
+- On the upload path (`cache.IsUploadOnly`), `HEAD` SHALL resolve to `storage.ErrNotFound` (HTTP 404) so the client re-uploads the NAR.
+- On the substituter path, `HEAD` SHALL follow the same recovery path as `GetNar` (attempt upstream recovery) rather than returning a bare record-based `200`, and SHALL ultimately reflect whether the NAR could be made servable.
+
+The check MUST honor the tri-state storage stat: an ambiguous or transient storage error (not a confirmed absence) MUST NOT be turned into a false `200` nor a false `404`.
+
+#### Scenario: Upload-only HEAD of a backing-less NAR returns 404
+
+- **GIVEN** a `nar_file` row for hash `H` exists with a recorded `FileSize > 0`
+- **AND** neither a whole-file nor any chunks for `H` exist in storage, and chunking is not in progress
+- **WHEN** a client sends `HEAD /upload/nar/<H>.nar.zst`
+- **THEN** the system SHALL respond `404` (resolving to `storage.ErrNotFound`)
+- **AND** SHALL NOT respond `200` on the basis of the `nar_file` record or its `FileSize`
+
+#### Scenario: HEAD of a servable NAR returns 200
+
+- **GIVEN** a `nar_file` row for hash `H` whose backing bytes are present in the store (whole-file or `total_chunks > 0`)
+- **WHEN** a client sends `HEAD /nar/<H>.nar.zst` (or under `/upload`)
+- **THEN** the system SHALL respond `200`
+
+#### Scenario: nix re-uploads a NAR whose bytes are missing
+
+- **GIVEN** ncps holds a `nar_file` record for `H` with no backing bytes
+- **WHEN** `nix copy --to <host>/upload` evaluates `H` and sends `HEAD /upload/nar/<H>.nar.zst`
+- **THEN** the `404` response causes nix to upload the NAR bytes for `H` (`PUT /upload/nar/<H>.nar.zst`)
+- **AND** the path does not remain a phantom that fails a later reference-verification `GET`
+
+#### Scenario: Ambiguous storage error on HEAD is not a false present/absent
+
+- **GIVEN** a `nar_file` row for hash `H`
+- **AND** a storage stat for `H` fails transiently (timeout / stale-metadata read) rather than returning a definite not-found
+- **WHEN** the system evaluates NAR presence for a `HEAD` request
+- **THEN** it SHALL NOT report `200` solely from the record, and SHALL NOT treat the ambiguous error as a confirmed absence

--- a/openspec/changes/archive/2026-06-03-fix-nar-head-verify-bytes/tasks.md
+++ b/openspec/changes/archive/2026-06-03-fix-nar-head-verify-bytes/tasks.md
@@ -1,0 +1,33 @@
+## 1. Reconnaissance
+
+- [x] 1.1 Confirm the HEAD fast-path in `getNar(false)` (pkg/server/server.go) and that `GetNarFileSize` (pkg/cache/cache.go) is a DB-only lookup; note exact lines.
+- [x] 1.2 Confirm the servability helpers and signatures: `statNarInStore` (tri-state, unexported), `HasNarInChunks(bool,error)`, `HasNarInStore(bool)`; and how `GetNar` decides servability, so `IsNarServable` mirrors it.
+- [x] 1.3 Find existing HEAD/NAR server tests and cache existence tests to model new tests on (e.g. `pkg/server/server_test.go` HEAD cases, `pkg/cache` stat/chunk tests).
+
+## 2. TDD: Red — cache servability method
+
+- [x] 2.1 Add a `pkg/cache` test: `IsNarServable` returns `(true,nil)` when a whole-file is in the store; `(true,nil)` when chunks exist; `(false,nil)` when a `nar_file` row exists but neither bytes nor chunks are present; `(false,err)` when the store stat is ambiguous (model on `ambiguousNarStore` in `ambiguous_storage_purge_internal_test.go`).
+- [x] 2.2 Run and confirm RED (method does not exist yet / behavior absent).
+
+## 3. TDD: Green — cache servability method
+
+- [x] 3.1 Implement exported `Cache.IsNarServable(ctx, narURL) (bool, error)` mirroring `GetNar`'s determination: whole-file (`statNarInStore`) → true; else chunks (`HasNarInChunks`) → true; both confirmed absent → `(false,nil)`; ambiguous stat error → `(false,err)`.
+- [x] 3.2 Run section 2 tests → GREEN.
+
+## 4. TDD: Red — HEAD handler
+
+- [x] 4.1 Add a `pkg/server` test: `HEAD /upload/nar/<h>.nar.zst` for a NAR with a `nar_file` row but no backing bytes returns `404` (not `200`). Seed the byteless record the way production does (e.g. via narinfo PUT / direct ent create), no NAR in the store.
+- [x] 4.2 Add a `pkg/server` test: `HEAD` for a NAR whose bytes ARE present returns `200` with `Content-Length` (fast path preserved).
+- [x] 4.3 Run and confirm RED on 4.1 (today it returns `200` from the DB size).
+
+## 5. TDD: Green — HEAD handler
+
+- [x] 5.1 In `getNar(false)`, emit `200` from the `GetNarFileSize` size only when `IsNarServable` returns `(true,nil)`; otherwise fall through to `s.cache.GetNar(...)` (which handles upload-only `404` and substituter recovery, and writes no body for HEAD).
+- [x] 5.2 Run sections 4 and 2 tests → GREEN; confirm the servable-NAR fast path still returns `200`.
+
+## 6. Verification
+
+- [x] 6.1 `task fmt` exits 0.
+- [x] 6.2 `task lint` exits 0 (any `//nolint` carries a comment).
+- [x] 6.3 `task test` exits 0 (race on; all subtests call `t.Parallel()`).
+- [x] 6.4 Diff review against proposal/design scope: HEAD existence check + one new cache method only; no `GetNar`/narinfo/write-path/schema/route changes.

--- a/openspec/specs/nar-cache-miss-recovery/spec.md
+++ b/openspec/specs/nar-cache-miss-recovery/spec.md
@@ -121,3 +121,42 @@ written) — as distinct from a backing-less `nar_file` row with `total_chunks=0
   confirmed absence
 - **AND** SHALL NOT purge the narinfo on the basis of that ambiguous result
 
+### Requirement: A NAR HEAD/existence probe MUST reflect actual servability, not a bare nar_file record
+
+A NAR `HEAD` request (`HEAD /nar/<hash>.nar[.<compression>]`, including under `/upload`) MUST NOT report the NAR as present (HTTP 200) on the basis of the `nar_file` database record alone. The system SHALL apply the same servability determination used by `GetNar`: a NAR is "servable" only when a whole-file exists in the store, `total_chunks > 0`, or chunking is actively in progress within the lock TTL. A `nar_file` row's existence or its recorded `FileSize` (e.g. via a `GetNarFileSize`/`HasNarFileRecord`-style lookup) SHALL NOT by itself produce a `200`.
+
+When the NAR is not servable (a record exists but no backing bytes), the `HEAD` outcome MUST be consistent with `GetNar`:
+
+- On the upload path (`cache.IsUploadOnly`), `HEAD` SHALL resolve to `storage.ErrNotFound` (HTTP 404) so the client re-uploads the NAR.
+- On the substituter path, `HEAD` SHALL follow the same recovery path as `GetNar` (attempt upstream recovery) rather than returning a bare record-based `200`, and SHALL ultimately reflect whether the NAR could be made servable.
+
+The check MUST honor the tri-state storage stat: an ambiguous or transient storage error (not a confirmed absence) MUST NOT be turned into a false `200` nor a false `404`.
+
+#### Scenario: Upload-only HEAD of a backing-less NAR returns 404
+
+- **GIVEN** a `nar_file` row for hash `H` exists with a recorded `FileSize > 0`
+- **AND** neither a whole-file nor any chunks for `H` exist in storage, and chunking is not in progress
+- **WHEN** a client sends `HEAD /upload/nar/<H>.nar.zst`
+- **THEN** the system SHALL respond `404` (resolving to `storage.ErrNotFound`)
+- **AND** SHALL NOT respond `200` on the basis of the `nar_file` record or its `FileSize`
+
+#### Scenario: HEAD of a servable NAR returns 200
+
+- **GIVEN** a `nar_file` row for hash `H` whose backing bytes are present in the store (whole-file or `total_chunks > 0`)
+- **WHEN** a client sends `HEAD /nar/<H>.nar.zst` (or under `/upload`)
+- **THEN** the system SHALL respond `200`
+
+#### Scenario: nix re-uploads a NAR whose bytes are missing
+
+- **GIVEN** ncps holds a `nar_file` record for `H` with no backing bytes
+- **WHEN** `nix copy --to <host>/upload` evaluates `H` and sends `HEAD /upload/nar/<H>.nar.zst`
+- **THEN** the `404` response causes nix to upload the NAR bytes for `H` (`PUT /upload/nar/<H>.nar.zst`)
+- **AND** the path does not remain a phantom that fails a later reference-verification `GET`
+
+#### Scenario: Ambiguous storage error on HEAD is not a false present/absent
+
+- **GIVEN** a `nar_file` row for hash `H`
+- **AND** a storage stat for `H` fails transiently (timeout / stale-metadata read) rather than returning a definite not-found
+- **WHEN** the system evaluates NAR presence for a `HEAD` request
+- **THEN** it SHALL NOT report `200` solely from the record, and SHALL NOT treat the ambiguous error as a confirmed absence
+

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -3982,6 +3982,27 @@ func (c *Cache) HasNarInStore(ctx context.Context, narURL nar.URL) bool {
 	return present
 }
 
+// IsNarServable reports whether the NAR's actual bytes are present and therefore
+// servable, mirroring how GetNar determines existence — a whole-file in the store
+// or chunks present. It is tri-state, like statNarInStore: a confirmed absence is
+// (false, nil) while an ambiguous/transient storage error is (false, err) so
+// callers do NOT mistake an undeterminable result for "absent". The mere
+// existence of a nar_file row (e.g. GetNarFileSize/HasNarFileRecord) does NOT make
+// a NAR servable; callers gating an existence answer (e.g. the NAR HEAD handler)
+// MUST use this rather than the DB record alone.
+func (c *Cache) IsNarServable(ctx context.Context, narURL nar.URL) (bool, error) {
+	present, err := c.statNarInStore(ctx, narURL)
+	if err != nil {
+		return false, err
+	}
+
+	if present {
+		return true, nil
+	}
+
+	return c.HasNarInChunks(ctx, narURL)
+}
+
 // statNarInStore reports whether the NAR is in storage, distinguishing a
 // confirmed absence (false, nil) from an undeterminable result (false, err).
 // Decision paths that must not treat an ambiguous storage error as "absent"

--- a/pkg/cache/nar_servable_internal_test.go
+++ b/pkg/cache/nar_servable_internal_test.go
@@ -1,0 +1,95 @@
+package cache
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	locklocal "github.com/kalbasit/ncps/pkg/lock/local"
+
+	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
+	"github.com/kalbasit/ncps/pkg/storage/local"
+	"github.com/kalbasit/ncps/testdata"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// newServableTestCache builds a cache backed by the given NarStore (so tests can
+// inject an ambiguous store). The localStore also serves as config + narinfo store.
+func newServableTestCache(t *testing.T, makeNarStore func(*local.Store) storage.NarStore) *Cache {
+	t.Helper()
+
+	ctx := newContext()
+
+	dir, err := os.MkdirTemp("", "cache-path-")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
+	dbClient, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dbClient.Close() })
+
+	localStore, err := local.New(ctx, dir)
+	require.NoError(t, err)
+
+	narStore := makeNarStore(localStore)
+
+	c, err := New(ctx, cacheName, dbClient, localStore, localStore, narStore, "",
+		locklocal.NewLocker(), locklocal.NewRWLocker(), downloadLockTTL, downloadPollTimeout, cacheLockTTL)
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	return c
+}
+
+// TestIsNarServable_WholeFilePresent: bytes in the store → (true, nil).
+func TestIsNarServable_WholeFilePresent(t *testing.T) {
+	t.Parallel()
+
+	c := newServableTestCache(t, func(s *local.Store) storage.NarStore { return s })
+
+	narURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: testdata.Nar1.NarCompression}
+	require.NoError(t, c.PutNar(newContext(), narURL, io.NopCloser(strings.NewReader(testdata.Nar1.NarText))))
+
+	servable, err := c.IsNarServable(newContext(), narURL)
+	require.NoError(t, err)
+	require.True(t, servable, "a NAR whose bytes are in the store must be servable")
+}
+
+// TestIsNarServable_BytelessReturnsFalseNil: no bytes, no chunks → (false, nil),
+// a *confirmed* not-servable (distinct from an ambiguous error).
+func TestIsNarServable_BytelessReturnsFalseNil(t *testing.T) {
+	t.Parallel()
+
+	c := newServableTestCache(t, func(s *local.Store) storage.NarStore { return s })
+
+	narURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: testdata.Nar1.NarCompression}
+
+	servable, err := c.IsNarServable(newContext(), narURL)
+	require.NoError(t, err, "a confirmed absence must be (false, nil), not an error")
+	require.False(t, servable)
+}
+
+// TestIsNarServable_AmbiguousReturnsError: an undeterminable storage stat must
+// surface as (false, err) so callers don't treat it as a confirmed absence.
+func TestIsNarServable_AmbiguousReturnsError(t *testing.T) {
+	t.Parallel()
+
+	c := newServableTestCache(t, func(s *local.Store) storage.NarStore {
+		return &ambiguousNarStore{Store: s, failHash: testdata.Nar1.NarHash}
+	})
+
+	narURL := nar.URL{Hash: testdata.Nar1.NarHash, Compression: testdata.Nar1.NarCompression}
+
+	servable, err := c.IsNarServable(newContext(), narURL)
+	require.Error(t, err, "an ambiguous storage error must surface, not be reported as absent")
+	require.False(t, servable)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -840,14 +840,24 @@ func (s *Server) getNar(withBody bool) http.HandlerFunc {
 			// not an estimate of the compressed output.
 			nu.TransparentZstd = false
 
+			// Only answer 200 from the nar_file record's size when the NAR is
+			// actually servable (bytes present), not from the DB record alone.
+			// A record without backing bytes (a phantom) must NOT HEAD 200, or a
+			// client (e.g. `nix copy`) would skip uploading the NAR and leave a
+			// phantom whose later reference check 404s. When not servable (or the
+			// storage probe is ambiguous), fall through to GetNar, which resolves
+			// upload-only to 404 (so the client re-uploads) and the substituter
+			// path to upstream recovery — consistent with GET.
 			size, err := s.cache.GetNarFileSize(r.Context(), nu)
 			if err == nil && size > 0 {
-				h := w.Header()
-				h.Set(contentType, contentTypeNar)
-				h.Set(contentLength, strconv.FormatInt(size, 10))
-				w.WriteHeader(http.StatusOK)
+				if servable, sErr := s.cache.IsNarServable(r.Context(), nu); sErr == nil && servable {
+					h := w.Header()
+					h.Set(contentType, contentTypeNar)
+					h.Set(contentLength, strconv.FormatInt(size, 10))
+					w.WriteHeader(http.StatusOK)
 
-				return
+					return
+				}
 			}
 		}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -821,6 +821,7 @@ func TestGetNar_HeadAmbiguousStorageIsNotFalse200(t *testing.T) {
 
 	dbClient, err := database.Open("sqlite:"+dbFile, nil)
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = dbClient.Close() })
 
 	localStore, err := local.New(newContext(), dir)
 	require.NoError(t, err)
@@ -829,6 +830,7 @@ func TestGetNar_HeadAmbiguousStorageIsNotFalse200(t *testing.T) {
 
 	c, err := newTestCache(newContext(), dbClient, localStore, localStore, narStore)
 	require.NoError(t, err)
+	t.Cleanup(c.Close)
 
 	s := server.New(c)
 	s.SetPutPermitted(true)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"compress/gzip"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -704,7 +705,7 @@ func newContext() context.Context {
 		WithContext(context.Background())
 }
 
-func TestGetNar_HeadOptimization(t *testing.T) {
+func TestGetNar_HeadBytelessNarIs404(t *testing.T) {
 	t.Parallel()
 
 	// create a temporary directory for the cache
@@ -751,14 +752,110 @@ func TestGetNar_HeadOptimization(t *testing.T) {
 	storePath := filepath.Join(dir, "store", "nar", testdata.Nar1.NarPath)
 	assert.NoFileExists(t, storePath)
 
-	// 3. Make a HEAD request for the NAR. It should return 204 No Content and the correct size.
+	// 3. HEAD the NAR. The nar_file record exists (from the narinfo PUT) but the
+	//    NAR bytes are NOT in storage — a phantom. HEAD MUST NOT report 200 from
+	//    the DB record alone; on the upload path it must be 404 so the client
+	//    (re-)uploads the NAR rather than skipping it and leaving a phantom.
 	narURL := ts.URL + "/upload/nar/" + testdata.Nar1.NarHash + ".nar.xz"
+	req, err = http.NewRequestWithContext(newContext(), http.MethodHead, narURL, nil)
+	require.NoError(t, err)
+	resp, err = ts.Client().Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	resp.Body.Close()
+
+	// 4. Now upload the NAR bytes. HEAD must then report 200 with the size
+	//    (the fast path is preserved for a genuinely servable NAR).
+	putNar, err := http.NewRequestWithContext(newContext(), http.MethodPut,
+		narURL, strings.NewReader(testdata.Nar1.NarText))
+	require.NoError(t, err)
+	resp, err = ts.Client().Do(putNar)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	resp.Body.Close()
+
 	req, err = http.NewRequestWithContext(newContext(), http.MethodHead, narURL, nil)
 	require.NoError(t, err)
 	resp, err = ts.Client().Do(req)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, strconv.Itoa(len(testdata.Nar1.NarText)), resp.Header.Get("Content-Length"))
+	resp.Body.Close()
+}
+
+// errSimulatedAmbiguousStat models an undeterminable storage result (e.g. a
+// timed-out or stale stat on a network filesystem) rather than a clean absence.
+var errSimulatedAmbiguousStat = errors.New("simulated ambiguous storage error")
+
+// flakyStatNarStore wraps a real local store but reports an undeterminable
+// (false, err) result from StatNar for a chosen NAR hash, simulating a flaky
+// network-filesystem stat (timeout / stale handle) rather than a clean absence.
+type flakyStatNarStore struct {
+	*local.Store
+
+	failHash string
+}
+
+func (s *flakyStatNarStore) StatNar(ctx context.Context, narURL nar.URL) (bool, error) {
+	if narURL.Hash == s.failHash {
+		return false, errSimulatedAmbiguousStat
+	}
+
+	return s.Store.StatNar(ctx, narURL)
+}
+
+// TestGetNar_HeadAmbiguousStorageIsNotFalse200 verifies that when the storage
+// presence probe is ambiguous (not a confirmed absence), a NAR HEAD does NOT
+// report a bare 200 from the nar_file record — an ambiguous result must not be
+// mistaken for "present" (which would make a client skip uploading the NAR).
+func TestGetNar_HeadAmbiguousStorageIsNotFalse200(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "cache-path-amb-")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(dir)
+
+	dbFile := filepath.Join(dir, "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
+	dbClient, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+
+	localStore, err := local.New(newContext(), dir)
+	require.NoError(t, err)
+
+	narStore := &flakyStatNarStore{Store: localStore, failHash: testdata.Nar1.NarHash}
+
+	c, err := newTestCache(newContext(), dbClient, localStore, localStore, narStore)
+	require.NoError(t, err)
+
+	s := server.New(c)
+	s.SetPutPermitted(true)
+
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	// Put the narinfo so a nar_file record (size > 0) exists; the NAR bytes are
+	// absent and the store stat is ambiguous for this hash.
+	putURL := ts.URL + "/upload/" + testdata.Nar1.NarInfoHash + ".narinfo"
+	req, err := http.NewRequestWithContext(
+		newContext(), http.MethodPut, putURL, strings.NewReader(testdata.Nar1.NarInfoText),
+	)
+	require.NoError(t, err)
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	resp.Body.Close()
+
+	// HEAD must not produce a false 200 from the record under an ambiguous probe.
+	narURL := ts.URL + "/upload/nar/" + testdata.Nar1.NarHash + ".nar.xz"
+	req, err = http.NewRequestWithContext(newContext(), http.MethodHead, narURL, nil)
+	require.NoError(t, err)
+	resp, err = ts.Client().Do(req)
+	require.NoError(t, err)
+	assert.NotEqual(t, http.StatusOK, resp.StatusCode,
+		"an ambiguous storage probe must not yield a 200 from the nar_file record alone")
 	resp.Body.Close()
 }
 


### PR DESCRIPTION
## Summary

`nix copy --to https://<host>/upload <closure>` aborted with
`cannot add 'X' to the binary cache because the reference 'Y' does not exist`
even after the purge fix (#1321) and **even at a single replica** (so this is
not a cross-replica/NFS issue).

Root cause: the NAR `HEAD` handler (`getNar(false)`) returned `200` whenever
`GetNarFileSize` reported `size > 0`, and `GetNarFileSize` reads only the
`nar_file` **DB record** — it never checks that the NAR bytes exist. The
reference-check `GET` path, by contrast, decides existence from **actual bytes**
(`statNarInStore`). When a `nar_file` row exists without backing bytes (a
phantom), nix's pre-upload `HEAD /upload/nar/<h>.nar.zst` returns `200`, so nix
**skips uploading the NAR** (it uploads NAR-first, narinfo-last) and writes only
the narinfo → phantom → a dependent path's reference-verification `GET` `404`s →
Lix aborts. The mass `PutNar ... context canceled` errors are the *cascade* of
nix tearing down in-flight uploads at abort, not the cause.

## Fix

- Add `Cache.IsNarServable(ctx, narURL) (bool, error)` — tri-state servability
  from actual bytes (whole-file or chunks): `(true,nil)` present, `(false,nil)`
  confirmed absent, `(false,err)` ambiguous storage probe.
- Gate the HEAD size-shortcut on it: emit `200` only when the NAR is actually
  servable; otherwise fall through to `GetNar`, which resolves upload-only to
  `404` (so the client re-uploads) and the substituter path to upstream recovery
  — consistent with `GET`.

Scope is the HEAD existence check only. Write-path seed prevention
(`storeInDatabase` creating byteless `nar_file` rows) is a deliberate follow-up;
the HEAD fix alone breaks the failure chain. Follow-up to #1321.

## Test plan

- [x] `task fmt` / `task lint` / `task test` pass (race detector on)
- [x] `TestGetNar_HeadBytelessNarIs404` — byteless NAR HEAD → `404`, then `200`
  after the NAR is uploaded (fast path preserved). (Repurposed from the old
  `TestGetNar_HeadOptimization`, which had codified the buggy `200`.)
- [x] `TestGetNar_HeadAmbiguousStorageIsNotFalse200` — ambiguous storage probe
  must not yield a false `200`.
- [x] `IsNarServable` cache tests: whole-file present, byteless `(false,nil)`,
  ambiguous `(false,err)`.
- [x] `nar-cache-miss-recovery` spec synced (HEAD/servability requirement added).