### PR TITLE
fix(cache): fall back to chunks when migration races serve

### DIFF
--- a/openspec/changes/archive/2026-06-03-fix-flaky-cdc-mixed-mode-test/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-03-fix-flaky-cdc-mixed-mode-test/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/archive/2026-06-03-fix-flaky-cdc-mixed-mode-test/design.md
+++ b/openspec/changes/archive/2026-06-03-fix-flaky-cdc-mixed-mode-test/design.md
@@ -1,0 +1,94 @@
+## Context
+
+`TestCDCBackends/.../Mixed_Mode` (`pkg/cache/cdc_test.go:284`) intermittently fails at line
+316 with `error fetching the nar from the store: not found`. The test stores a whole-file
+NAR with CDC disabled, enables CDC, stores a second (chunked) NAR, then retrieves both.
+
+Root cause is a TOCTOU race in the read path (`pkg/cache/cache.go`):
+
+1. `GetNar` computes `hasNarInStore = true` for the whole-file blob, then at
+   `cache.go:1118-1123` calls `maybeBackgroundMigrateNarToChunks` — which spawns a
+   **detached background goroutine** (`BackgroundMigrateNarToChunks`) that chunks the NAR
+   and, once chunks are committed, **deletes the whole file** from `narStore`
+   (`migrateNarToChunksCleanup`, `cache.go:8112`).
+2. `GetNar` then *synchronously* calls `serveNarFromStorageViaPipe(narURL, hasInStore=true)`.
+3. That function (`cache.go:3047-3076`) decides store-vs-chunks from `nar_file.total_chunks`.
+   In the race window the DB still reports `total_chunks = 0`, so it picks the **store**
+   branch and calls `getNarFromStore` → `narStore.GetNar` → `storage.ErrNotFound`
+   (`cache.go:3152`), which is wrapped as the observed error.
+
+Key ordering fact (verified at `cache.go:8040-8044`): the whole-file deletion happens
+**after** the chunk data and `nar_file` records are committed. Therefore, whenever the whole
+file is missing due to migration, the chunks are guaranteed to exist and be reassemblable.
+
+This is a real production defect (spurious 404s on freshly-migrated NARs under concurrent
+reads), not merely a test artifact; the test simply exposes it reliably under load.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Eliminate the spurious `not found` when a concurrent background migration deletes the
+  whole file mid-serve, for the uncompressed serve path.
+- Make `testCDCMixedMode` deterministic by exercising and asserting the corrected behavior.
+- Preserve genuine `ErrNotFound` for NARs that truly have neither whole file nor chunks, and
+  preserve `ErrNotFound` for compressed requests whose whole file is gone.
+
+**Non-Goals:**
+- Redesigning the background NAR→chunks migration or its scheduling/drain semantics.
+- Changing lazy-chunking deletion behavior (delayed deletion is already race-free).
+- Touching the compressed/`.nar.xz` serving contract.
+
+## Decisions
+
+### Decision 1 — Fall back to chunks on a whole-file store miss (uncompressed, CDC on)
+
+In `serveNarFromStorageViaPipe`, when the store branch was chosen (`serveFromChunks == false`)
+but `getNarFromStore` returns `storage.ErrNotFound`, **and** CDC is enabled **and** the
+request is for the uncompressed NAR (`Compression == none`), retry via `getNarFromChunks`.
+If the chunk read also misses, return the original `ErrNotFound`.
+
+Rationale: the migration-ordering guarantee (chunks committed before whole-file delete)
+makes the fallback safe and deterministic — if the whole file vanished, the chunks are
+present. This closes the window regardless of how `total_chunks` is observed, with no locking
+or synchronization added to the hot path.
+
+- **Alternative A — order/serialize migration vs. serve (e.g. read-lock the whole file
+  during delete):** rejected; adds contention to the serve path and still needs a fallback
+  for cross-process races.
+- **Alternative B — re-read `total_chunks` in a retry loop until it flips > 0:** rejected;
+  busy-waiting with unclear bound; the direct fallback is simpler and bounded.
+- **Alternative C — don't trigger background migration before serving:** rejected; the
+  background migration is intentional and desirable; only its interaction with the serve is
+  buggy.
+- **Alternative D — fix the test only (await migration / disable it):** rejected; masks a
+  real production 404 and contradicts the proposal.
+
+### Decision 2 — Regression test drives the actual race window
+
+Following TDD, first add a failing test that constructs the exact failing state — a NAR whose
+chunks are committed (reassemblable) but whose whole file has been removed while
+`total_chunks` is observed as `0` on the store branch — and asserts `GetNar` returns the full
+original bytes via the chunk fallback. The hardened `testCDCMixedMode` then asserts mixed-mode
+retrieval succeeds regardless of background-migration timing.
+
+## Risks / Trade-offs
+
+- **[Fallback masks a genuinely corrupt/missing NAR]** → The fallback only engages on
+  `ErrNotFound` from the store and still returns `ErrNotFound` when chunks are also absent or
+  not reassemblable (the existing `chunked-nar-serving-integrity` completeness check governs
+  reassembly), so no truncated 200 is introduced.
+- **[Extra store-read miss in the race]** → One additional metadata/store lookup only in the
+  rare race; steady-state path is unchanged.
+- **[Compressed-request regression]** → Guarded: fallback is gated on `Compression == none`;
+  compressed requests keep returning `ErrNotFound` so clients fall back upstream.
+
+## Migration Plan
+
+Pure code change; no schema or data migration. Deploy normally. Rollback is a straight
+revert — behavior reverts to the pre-fix race (no data-format change to undo).
+
+## Open Questions
+
+- None blocking. The exact placement of the fallback (`serveNarFromStorageViaPipe` vs. a thin
+  wrapper around `getNarFromStore`) is an implementation detail to settle during TDD; the
+  spec requirement is layer-agnostic.

--- a/openspec/changes/archive/2026-06-03-fix-flaky-cdc-mixed-mode-test/proposal.md
+++ b/openspec/changes/archive/2026-06-03-fix-flaky-cdc-mixed-mode-test/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+`TestCDCBackends/.../Mixed_Mode` (`pkg/cache/cdc_test.go:316`) fails intermittently in CI
+with `error fetching the nar from the store: not found` and the failure rate is rising. The
+flake exposes a real **time-of-check/time-of-use race** in the NAR read path, not merely a
+brittle test: when a whole-file NAR is served while CDC is enabled, `GetNar` spawns a
+**background** NAR→chunks migration that deletes the whole file from the store, then
+*synchronously* serves from that same store. If the background delete wins the race before
+`getNarFromStore` opens the file — while `nar_file.total_chunks` is still `0`, so the serve
+path chose the store branch — the read 404s. In production this surfaces as spurious
+`not found` errors on freshly-migrated NARs.
+
+## What Changes
+
+- **Fix the read-path race** so a `GetNar` that observed the whole file in the store never
+  returns `not found` when a concurrent background migration removed it. The serve path
+  (`serveNarFromStorageViaPipe` / `getNarFromStore`) MUST fall back to serving from chunks
+  when the whole-file read misses while CDC is enabled, instead of surfacing
+  `storage.ErrNotFound` to the caller.
+- **Make the test deterministic** by asserting the corrected behavior (mixed-mode retrieval
+  of a blob stored before CDC was enabled always succeeds), covering the race window rather
+  than depending on background-goroutine timing.
+- No change to the on-disk format, the migration semantics, or the chunk store.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `cdc-chunking`: Add a requirement that the whole-file serve path is resilient to a
+  concurrent background NAR→chunks migration — a store read that misses (because migration
+  deleted the whole file) MUST fall back to chunk reassembly rather than returning
+  `not found`, so serving a NAR observed as present never races to a 404.
+
+## Impact
+
+- **Code**: `pkg/cache/cache.go` — `GetNar` / `serveNarFromStorageViaPipe` / `getNarFromStore`
+  fallback logic; `pkg/cache/cdc_test.go` — `testCDCMixedMode` assertions.
+- **APIs**: none. HTTP/storage interfaces unchanged.
+- **I/O**: in the rare race, one extra store-read miss before falling back to chunks (a few
+  metadata lookups). No additional network calls; memory unchanged (chunk reassembly already
+  streams). Steady-state latency unaffected.
+
+## Non-goals
+
+- Not redesigning the background NAR→chunks migration or the "migrate chunks" topology
+  (tracked separately as `migrate-chunks-to-nar`).
+- Not changing when migration is triggered, drain mode, or CDC enable/disable semantics.
+- Not addressing other flaky tests or unrelated backends; scope is this one race and its
+  regression coverage.

--- a/openspec/changes/archive/2026-06-03-fix-flaky-cdc-mixed-mode-test/specs/cdc-chunking/spec.md
+++ b/openspec/changes/archive/2026-06-03-fix-flaky-cdc-mixed-mode-test/specs/cdc-chunking/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Serving a whole-file NAR MUST be resilient to a concurrent background migration
+
+The system SHALL serve a NAR that it observed as present even if a concurrent background
+NAR→chunks migration removes the whole file mid-serve.
+
+When `GetNar` observes a NAR present as a whole file in the store while CDC is enabled, it
+MAY trigger a background NAR→chunks migration that, on completion, deletes the whole file
+from the store. The synchronous serve that follows MUST NOT surface
+`storage.ErrNotFound` to the caller solely because that background migration removed the
+whole file between the time-of-check (`HasNarInStore`) and the time-of-use
+(`getNarFromStore`).
+
+The system SHALL treat a whole-file store read that misses, while CDC is enabled and the
+request is for the uncompressed NAR (`Compression == none`), as a signal that the NAR has
+been migrated, and SHALL fall back to serving the NAR by reassembling it from chunks. Only
+when neither the whole file nor a reassemblable set of chunks exists MAY `GetNar` return
+`storage.ErrNotFound`.
+
+This fallback applies exclusively to the uncompressed serve path. A request for a
+compressed NAR (e.g. `.nar.xz`) whose whole file is gone MUST continue to resolve to
+`storage.ErrNotFound`, because chunks are stored uncompressed and cannot reconstruct a
+compressed stream (consistent with the existing chunked-serving rules).
+
+#### Scenario: Whole-file deleted by background migration mid-serve falls back to chunks
+
+- **GIVEN** a NAR for hash `H` stored as a whole file while CDC was disabled
+- **AND** CDC is subsequently enabled
+- **WHEN** `GetNar(H)` is called and the triggered background migration deletes the whole
+  file from the store before the synchronous `getNarFromStore` opens it
+- **THEN** the serve path detects the store miss and reassembles `H` from its chunks
+- **AND** `GetNar` returns the complete NAR bytes with no error
+- **AND** `storage.ErrNotFound` is NOT surfaced to the caller
+
+#### Scenario: Mixed-mode retrieval after enabling CDC always succeeds
+
+- **GIVEN** a blob NAR stored with CDC disabled and a separate NAR stored with CDC enabled
+- **WHEN** both NARs are retrieved via `GetNar` after CDC is enabled
+- **THEN** each retrieval returns its exact original content
+- **AND** neither retrieval fails with `error fetching the nar from the store: not found`,
+  regardless of background-migration timing
+
+#### Scenario: Genuinely absent NAR still returns not found
+
+- **GIVEN** a hash `H` that has neither a whole file in the store nor any chunks
+- **WHEN** `GetNar(H)` is called in upload-only mode (no upstream pull)
+- **THEN** `GetNar` returns `storage.ErrNotFound`
+
+#### Scenario: Compressed request after migration still returns not found
+
+- **GIVEN** a NAR whose whole file has been migrated to (uncompressed) chunks
+- **WHEN** a request for the compressed NAR (`Compression != none`) is served
+- **THEN** the serve path returns `storage.ErrNotFound` rather than serving raw chunk bytes

--- a/openspec/changes/archive/2026-06-03-fix-flaky-cdc-mixed-mode-test/tasks.md
+++ b/openspec/changes/archive/2026-06-03-fix-flaky-cdc-mixed-mode-test/tasks.md
@@ -1,0 +1,27 @@
+## 1. Reproduce the race with a failing test (TDD red)
+
+- [x] 1.1 Add a focused test in `pkg/cache/cdc_test.go` that constructs the failing state: a NAR whose chunks are committed and reassemblable, but whose whole file has been removed from `narStore` while `nar_file.total_chunks` is observed as `0` (the store-branch decision in `serveNarFromStorageViaPipe`). Assert `GetNar` returns the full original bytes.
+- [x] 1.2 Run the new test and confirm it fails with `error fetching the nar from the store: not found` (verifies it captures the real defect, not a tautology).
+
+## 2. Implement the chunk fallback (TDD green)
+
+- [x] 2.1 In `serveNarFromStorageViaPipe` (`pkg/cache/cache.go`), when the store branch was chosen (`serveFromChunks == false`) and `getNarFromStore` returns `storage.ErrNotFound`, **and** CDC is enabled, **and** the request is uncompressed (`narURL.Compression == nar.CompressionTypeNone`), retry via `getNarFromChunks`.
+- [x] 2.2 If the chunk fallback also misses, return the original `storage.ErrNotFound` (preserve genuine not-found semantics).
+- [x] 2.3 Ensure the fallback does NOT engage for compressed requests (`Compression != none`) — those keep returning `ErrNotFound` so clients fall back upstream.
+- [x] 2.4 Run the test from task 1 and confirm it now passes.
+
+## 3. Harden the existing flaky test
+
+- [x] 3.1 Update `testCDCMixedMode` so it deterministically asserts mixed-mode retrieval succeeds regardless of background-migration timing (no reliance on goroutine scheduling).
+- [x] 3.2 Run `TestCDCBackends` repeatedly with the race detector (e.g. `go test -race -run TestCDCBackends -count=20 ./pkg/cache/`) and confirm zero failures.
+
+## 4. Verify requirement coverage
+
+- [x] 4.1 Confirm each scenario in `specs/cdc-chunking/spec.md` is covered by a test: migration-mid-serve fallback, mixed-mode retrieval, genuinely-absent not-found, and compressed-request not-found.
+- [x] 4.2 Add/adjust assertions for any uncovered scenario.
+
+## 5. Final verification
+
+- [x] 5.1 Run `task fmt` and confirm it exits clean.
+- [x] 5.2 Run `task lint` and confirm it exits clean.
+- [x] 5.3 Run `task test` (and the Postgres integration cohort via `task test:auto` where the flake originally surfaced) and confirm all pass.

--- a/openspec/specs/cdc-chunking/spec.md
+++ b/openspec/specs/cdc-chunking/spec.md
@@ -306,3 +306,56 @@ created placeholder for an in-flight download.
 - **WHEN** the recovery process evaluates `H`
 - **THEN** the placeholder row SHALL NOT be removed
 - **AND** `H` SHALL remain eligible for a future re-evaluation
+
+### Requirement: Serving a whole-file NAR MUST be resilient to a concurrent background migration
+
+The system SHALL serve a NAR that it observed as present even if a concurrent background
+NAR→chunks migration removes the whole file mid-serve.
+
+When `GetNar` observes a NAR present as a whole file in the store while CDC is enabled, it
+MAY trigger a background NAR→chunks migration that, on completion, deletes the whole file
+from the store. The synchronous serve that follows MUST NOT surface
+`storage.ErrNotFound` to the caller solely because that background migration removed the
+whole file between the time-of-check (`HasNarInStore`) and the time-of-use
+(`getNarFromStore`).
+
+The system SHALL treat a whole-file store read that misses, while CDC is enabled and the
+request is for the uncompressed NAR (`Compression == none`), as a signal that the NAR has
+been migrated, and SHALL fall back to serving the NAR by reassembling it from chunks. Only
+when neither the whole file nor a reassemblable set of chunks exists MAY `GetNar` return
+`storage.ErrNotFound`.
+
+This fallback applies exclusively to the uncompressed serve path. A request for a
+compressed NAR (e.g. `.nar.xz`) whose whole file is gone MUST continue to resolve to
+`storage.ErrNotFound`, because chunks are stored uncompressed and cannot reconstruct a
+compressed stream (consistent with the existing chunked-serving rules).
+
+#### Scenario: Whole-file deleted by background migration mid-serve falls back to chunks
+
+- **GIVEN** a NAR for hash `H` stored as a whole file while CDC was disabled
+- **AND** CDC is subsequently enabled
+- **WHEN** `GetNar(H)` is called and the triggered background migration deletes the whole
+  file from the store before the synchronous `getNarFromStore` opens it
+- **THEN** the serve path detects the store miss and reassembles `H` from its chunks
+- **AND** `GetNar` returns the complete NAR bytes with no error
+- **AND** `storage.ErrNotFound` is NOT surfaced to the caller
+
+#### Scenario: Mixed-mode retrieval after enabling CDC always succeeds
+
+- **GIVEN** a blob NAR stored with CDC disabled and a separate NAR stored with CDC enabled
+- **WHEN** both NARs are retrieved via `GetNar` after CDC is enabled
+- **THEN** each retrieval returns its exact original content
+- **AND** neither retrieval fails with `error fetching the nar from the store: not found`,
+  regardless of background-migration timing
+
+#### Scenario: Genuinely absent NAR still returns not found
+
+- **GIVEN** a hash `H` that has neither a whole file in the store nor any chunks
+- **WHEN** `GetNar(H)` is called in upload-only mode (no upstream pull)
+- **THEN** `GetNar` returns `storage.ErrNotFound`
+
+#### Scenario: Compressed request after migration still returns not found
+
+- **GIVEN** a NAR whose whole file has been migrated to (uncompressed) chunks
+- **WHEN** a request for the compressed NAR (`Compression != none`) is served
+- **THEN** the serve path returns `storage.ErrNotFound` rather than serving raw chunk bytes

--- a/openspec/specs/cdc-chunking/spec.md
+++ b/openspec/specs/cdc-chunking/spec.md
@@ -319,11 +319,18 @@ from the store. The synchronous serve that follows MUST NOT surface
 whole file between the time-of-check (`HasNarInStore`) and the time-of-use
 (`getNarFromStore`).
 
-The system SHALL treat a whole-file store read that misses, while CDC is enabled and the
-request is for the uncompressed NAR (`Compression == none`), as a signal that the NAR has
-been migrated, and SHALL fall back to serving the NAR by reassembling it from chunks. Only
-when neither the whole file nor a reassemblable set of chunks exists MAY `GetNar` return
-`storage.ErrNotFound`.
+The system SHALL treat a whole-file store read that misses, whenever a chunk store is
+available (CDC enabled OR drain mode) and the request is for the uncompressed NAR
+(`Compression == none`), as a signal that the NAR has been migrated, and SHALL fall back to
+serving the NAR by reassembling it from chunks. Gating on chunk-store availability rather
+than on CDC writes being enabled ensures the fallback also protects reads during drain mode,
+where chunked NARs remain servable. Only when neither the whole file nor a reassemblable set
+of chunks exists MAY `GetNar` return `storage.ErrNotFound`.
+
+A chunk-path failure that is NOT a not-found result (e.g. a database or storage error) MUST
+be surfaced to the caller rather than masked as the original store not-found, matching how
+the direct chunk-serve path propagates its errors. Both `storage.ErrNotFound` and an ent
+not-found result count as "the NAR is absent" and preserve the original store not-found.
 
 This fallback applies exclusively to the uncompressed serve path. A request for a
 compressed NAR (e.g. `.nar.xz`) whose whole file is gone MUST continue to resolve to
@@ -338,6 +345,14 @@ compressed stream (consistent with the existing chunked-serving rules).
   file from the store before the synchronous `getNarFromStore` opens it
 - **THEN** the serve path detects the store miss and reassembles `H` from its chunks
 - **AND** `GetNar` returns the complete NAR bytes with no error
+- **AND** `storage.ErrNotFound` is NOT surfaced to the caller
+
+#### Scenario: Whole-file store miss in drain mode falls back to chunks
+
+- **GIVEN** a NAR for hash `H` whose chunks are committed and reassemblable
+- **AND** the cache is in drain mode (CDC writes disabled, chunk store still configured)
+- **WHEN** the whole-file store read for `H` misses
+- **THEN** the serve path falls back to reassembling `H` from its chunks
 - **AND** `storage.ErrNotFound` is NOT surfaced to the caller
 
 #### Scenario: Mixed-mode retrieval after enabling CDC always succeeds

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -3082,15 +3082,28 @@ func (c *Cache) serveNarFromStorageViaPipe(
 		// stored uncompressed, so a compressed request keeps returning ErrNotFound
 		// (the client then falls back to an upstream that still has the .nar.xz).
 		//
-		// Only adopt the chunk result on success: if chunks are also absent (the
-		// NAR is genuinely gone), keep the original store ErrNotFound so callers
-		// see the same not-found sentinel they always have.
+		// Gated on chunk-store availability (not isCDCEnabled) so the fallback also
+		// applies during drain mode, where CDC writes are disabled but chunked NARs
+		// remain servable — consistent with getNarFromChunks' own guard.
 		if err != nil &&
 			errors.Is(err, storage.ErrNotFound) &&
-			c.isCDCEnabled() &&
+			c.isChunkStoreAvailable() &&
 			narURL.Compression == nar.CompressionTypeNone {
-			if chunkSize, chunkReader, chunkErr := c.getNarFromChunks(ctx, narURL); chunkErr == nil {
+			chunkSize, chunkReader, chunkErr := c.getNarFromChunks(ctx, narURL)
+
+			switch {
+			case chunkErr == nil:
+				// Chunks served the NAR: adopt the chunk result.
 				storageSize, storageReader, err = chunkSize, chunkReader, nil
+			case errors.Is(chunkErr, storage.ErrNotFound) || database.IsNotFoundError(chunkErr):
+				// Chunks are also absent: the NAR is genuinely gone. Keep the
+				// original store ErrNotFound so callers see the same not-found
+				// sentinel they always have.
+			default:
+				// A real chunk-path failure (e.g. DB/storage error). Surface it
+				// instead of masking it as a cache miss — matching how the direct
+				// chunk-serve path above propagates its errors.
+				return 0, nil, fmt.Errorf("fallback to chunk serve failed: %w", chunkErr)
 			}
 		}
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -3073,6 +3073,26 @@ func (c *Cache) serveNarFromStorageViaPipe(
 		storageSize, storageReader, err = c.getNarFromChunks(ctx, narURL)
 	} else {
 		storageSize, storageReader, err = c.getNarFromStore(ctx, narURL)
+
+		// A concurrent background NAR->chunks migration can delete the whole-file
+		// NAR between the total_chunks check above and this store read (TOCTOU).
+		// Because migration commits the chunks before deleting the whole file, the
+		// NAR is still retrievable from chunks. Fall back instead of surfacing a
+		// spurious not-found. Restricted to the uncompressed serve path: chunks are
+		// stored uncompressed, so a compressed request keeps returning ErrNotFound
+		// (the client then falls back to an upstream that still has the .nar.xz).
+		//
+		// Only adopt the chunk result on success: if chunks are also absent (the
+		// NAR is genuinely gone), keep the original store ErrNotFound so callers
+		// see the same not-found sentinel they always have.
+		if err != nil &&
+			errors.Is(err, storage.ErrNotFound) &&
+			c.isCDCEnabled() &&
+			narURL.Compression == nar.CompressionTypeNone {
+			if chunkSize, chunkReader, chunkErr := c.getNarFromChunks(ctx, narURL); chunkErr == nil {
+				storageSize, storageReader, err = chunkSize, chunkReader, nil
+			}
+		}
 	}
 
 	if err != nil {

--- a/pkg/cache/cdc_migration_race_internal_test.go
+++ b/pkg/cache/cdc_migration_race_internal_test.go
@@ -1,0 +1,203 @@
+package cache
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	entnarfile "github.com/kalbasit/ncps/ent/narfile"
+	locklocal "github.com/kalbasit/ncps/pkg/lock/local"
+
+	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
+	"github.com/kalbasit/ncps/pkg/storage/chunk"
+	"github.com/kalbasit/ncps/pkg/storage/local"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// migrationRaceNarStore wraps a real local store and, for a chosen NAR hash,
+// reports the whole file as present (HasNar -> true) but reports it as absent
+// when actually read (GetNar -> ErrNotFound). This models the TOCTOU window in
+// the read path: a concurrent background NAR->chunks migration deletes the
+// whole-file NAR between serveNarFromStorageViaPipe's total_chunks check and its
+// store read. The first GetNar for failHash invokes onFirstGet, used to flip the
+// DB into its post-migration state (total_chunks committed), exactly as the real
+// migration does immediately before deleting the file.
+type migrationRaceNarStore struct {
+	*local.Store
+
+	failHash   string
+	onFirstGet func()
+	once       sync.Once
+}
+
+func (s *migrationRaceNarStore) HasNar(ctx context.Context, narURL nar.URL) bool {
+	if narURL.Hash == s.failHash {
+		return true
+	}
+
+	return s.Store.HasNar(ctx, narURL)
+}
+
+func (s *migrationRaceNarStore) GetNar(ctx context.Context, narURL nar.URL) (int64, io.ReadCloser, error) {
+	if narURL.Hash == s.failHash {
+		s.once.Do(func() {
+			if s.onFirstGet != nil {
+				s.onFirstGet()
+			}
+		})
+
+		return 0, nil, storage.ErrNotFound
+	}
+
+	return s.Store.GetNar(ctx, narURL)
+}
+
+// raceTestCache builds a Cache whose narStore is a migrationRaceNarStore for the
+// given hash, with CDC enabled and a chunk store initialized.
+func raceTestCache(t *testing.T, hash string) (*Cache, *database.Client, *migrationRaceNarStore) {
+	t.Helper()
+
+	ctx := newContext()
+
+	dir, err := os.MkdirTemp("", "cache-path-")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
+	dbClient, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dbClient.Close() })
+
+	localStore, err := local.New(ctx, dir)
+	require.NoError(t, err)
+
+	narStore := &migrationRaceNarStore{Store: localStore, failHash: hash}
+
+	c, err := New(ctx, cacheName, dbClient, localStore, localStore, narStore, "",
+		locklocal.NewLocker(), locklocal.NewRWLocker(), downloadLockTTL, downloadPollTimeout, cacheLockTTL)
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	chunkStore, err := chunk.NewLocalStore(filepath.Join(dir, "chunks-store"))
+	require.NoError(t, err)
+
+	c.SetChunkStore(chunkStore)
+	require.NoError(t, c.SetCDCConfiguration(true, 1024, 4096, 8192))
+
+	return c, dbClient, narStore
+}
+
+// TestServeNarFromStorageRaceWithMigrationFallsBackToChunks reproduces the flaky
+// failure observed in TestCDCBackends/.../Mixed_Mode
+// ("error fetching the nar from the store: not found"). When the whole-file NAR
+// is removed by a concurrent background migration after the serve path decided to
+// read from the store (total_chunks still observed as 0) but before the actual
+// store read, the cache MUST fall back to reassembling the NAR from chunks rather
+// than surfacing a spurious not-found error.
+func TestServeNarFromStorageRaceWithMigrationFallsBackToChunks(t *testing.T) {
+	t.Parallel()
+
+	ctx := newContext()
+
+	const hash = "00ji9synj1r6h6sjw27wwv8fw98myxsg92q5ma1pvrbmh451kc27"
+
+	c, dbClient, narStore := raceTestCache(t, hash)
+
+	// Store the NAR via CDC: this writes chunks + junction links and commits
+	// total_chunks > 0. No whole file is written to the narStore.
+	content := strings.Repeat("mixed-mode race content; ", 256)
+	nu := nar.URL{Hash: hash, Compression: nar.CompressionTypeNone}
+	require.NoError(t, c.PutNar(ctx, nu, io.NopCloser(strings.NewReader(content))))
+
+	committed, err := dbClient.Ent().NarFile.Query().Where(entnarfile.HashEQ(hash)).Only(ctx)
+	require.NoError(t, err)
+	require.Positive(t, committed.TotalChunks, "NAR must be chunked for this test")
+
+	totalChunks := committed.TotalChunks
+
+	// Model the stale read: at the moment the serve path decides store-vs-chunks,
+	// the migration has not yet committed, so total_chunks is observed as 0.
+	_, err = dbClient.Ent().NarFile.Update().Where(entnarfile.HashEQ(hash)).SetTotalChunks(0).Save(ctx)
+	require.NoError(t, err)
+
+	// The migration completes exactly when the store read happens: total_chunks is
+	// committed (>0) and the whole file is deleted (GetNar returns ErrNotFound).
+	narStore.onFirstGet = func() {
+		_, uerr := dbClient.Ent().NarFile.Update().Where(entnarfile.HashEQ(hash)).SetTotalChunks(totalChunks).Save(ctx)
+		require.NoError(t, uerr)
+	}
+
+	// hasInStore=true: the serve path observed the whole file as present.
+	size, rc, err := c.serveNarFromStorageViaPipe(ctx, &nu, true)
+	require.NoError(t, err,
+		"a whole-file store miss caused by a concurrent migration must fall back to chunks, not surface not-found")
+	require.NotNil(t, rc)
+
+	defer rc.Close()
+
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, content, string(got))
+	require.Equal(t, int64(len(content)), size)
+}
+
+// TestServeNarFromStorageRaceCompressedRequestStillNotFound asserts the chunk
+// fallback does NOT engage for a compressed request. Chunks are stored
+// uncompressed, so a missing whole file for a .nar.xz request must still resolve
+// to ErrNotFound (the client then falls back to an upstream with the original
+// compressed file) rather than serving raw chunk bytes.
+func TestServeNarFromStorageRaceCompressedRequestStillNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := newContext()
+
+	const hash = "1s8p1kgdms8rmxkq24q51wc7zpn0aqcwgzvc473v9cii7z2qyxq0"
+
+	c, dbClient, _ := raceTestCache(t, hash)
+
+	content := strings.Repeat("compressed request race content; ", 256)
+	nu := nar.URL{Hash: hash, Compression: nar.CompressionTypeNone}
+	require.NoError(t, c.PutNar(ctx, nu, io.NopCloser(strings.NewReader(content))))
+
+	// Force the store branch for the (compressed) request.
+	_, err := dbClient.Ent().NarFile.Update().Where(entnarfile.HashEQ(hash)).SetTotalChunks(0).Save(ctx)
+	require.NoError(t, err)
+
+	xzURL := nar.URL{Hash: hash, Compression: nar.CompressionTypeXz}
+
+	_, _, err = c.serveNarFromStorageViaPipe(ctx, &xzURL, true)
+	require.ErrorIs(t, err, storage.ErrNotFound,
+		"a compressed request whose whole file is gone must not fall back to uncompressed chunks")
+}
+
+// TestServeNarFromStorageRaceGenuinelyAbsentReturnsNotFound asserts that when the
+// whole file is gone AND there are no chunks, the fallback preserves not-found
+// semantics rather than masking a genuinely absent NAR.
+func TestServeNarFromStorageRaceGenuinelyAbsentReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := newContext()
+
+	const hash = "abcdghij2k3l4m5n6o7p8q9r0s1t2u3v4w5x6y7z8a9b0c1d2e3f"
+
+	c, _, _ := raceTestCache(t, hash)
+
+	// No PutNar: neither a whole file nor chunks exist for this hash. The narStore
+	// wrapper still reports the whole file as present at check time but absent on
+	// read, exercising the fallback with nothing to fall back to.
+	nu := nar.URL{Hash: hash, Compression: nar.CompressionTypeNone}
+
+	_, _, err := c.serveNarFromStorageViaPipe(ctx, &nu, true)
+	require.ErrorIs(t, err, storage.ErrNotFound,
+		"a genuinely absent NAR (no whole file, no chunks) must still return not-found")
+}

--- a/pkg/cache/cdc_migration_race_internal_test.go
+++ b/pkg/cache/cdc_migration_race_internal_test.go
@@ -201,3 +201,41 @@ func TestServeNarFromStorageRaceGenuinelyAbsentReturnsNotFound(t *testing.T) {
 	require.ErrorIs(t, err, storage.ErrNotFound,
 		"a genuinely absent NAR (no whole file, no chunks) must still return not-found")
 }
+
+// TestServeNarFromStorageRaceDrainModeFallsBackToChunks asserts the fallback is
+// gated on chunk-store availability, not on CDC writes being enabled. In drain
+// mode (CDC disabled, chunk store still configured) a whole-file store miss MUST
+// still fall back to chunks, since chunked NARs remain servable throughout drain.
+func TestServeNarFromStorageRaceDrainModeFallsBackToChunks(t *testing.T) {
+	t.Parallel()
+
+	ctx := newContext()
+
+	const hash = "33ji9synj1r6h6sjw27wwv8fw98myxsg92q5ma1pvrbmh451kc27"
+
+	c, dbClient, _ := raceTestCache(t, hash)
+
+	content := strings.Repeat("drain mode race content; ", 256)
+	nu := nar.URL{Hash: hash, Compression: nar.CompressionTypeNone}
+	require.NoError(t, c.PutNar(ctx, nu, io.NopCloser(strings.NewReader(content))))
+
+	committed, err := dbClient.Ent().NarFile.Query().Where(entnarfile.HashEQ(hash)).Only(ctx)
+	require.NoError(t, err)
+	require.Positive(t, committed.TotalChunks, "NAR must be chunked for this test")
+
+	// Enter drain mode: CDC writes disabled, chunk store still available.
+	require.NoError(t, c.SetCDCConfiguration(false, 0, 0, 0))
+
+	// The whole-file read misses (wrapper) but chunks remain reassemblable.
+	size, rc, err := c.serveNarFromStorageViaPipe(ctx, &nu, true)
+	require.NoError(t, err,
+		"drain mode must still fall back to chunks when the whole file is missing")
+	require.NotNil(t, rc)
+
+	defer rc.Close()
+
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, content, string(got))
+	require.Equal(t, int64(len(content)), size)
+}

--- a/pkg/cache/cdc_test.go
+++ b/pkg/cache/cdc_test.go
@@ -311,7 +311,15 @@ func testCDCMixedMode(factory cacheFactory) func(*testing.T) {
 		nuChunk := nar.URL{Hash: "00ji9synj1r6h6sjw27wwv8fw98myxsg92q5ma1pvrbmh451kc27", Compression: nar.CompressionTypeNone}
 		require.NoError(t, c.PutNar(ctx, nuChunk, io.NopCloser(strings.NewReader(chunkContent))))
 
-		// 3. Retrieve both
+		// 3. Retrieve both.
+		//
+		// Retrieving nuBlob races a background NAR->chunks migration that GetNar
+		// triggers because the whole file is in the store and CDC is now enabled:
+		// the migration deletes the whole file while the serve path may still be
+		// reading it. This retrieval MUST succeed regardless of that timing — see
+		// TestServeNarFromStorageRaceWithMigrationFallsBackToChunks for the
+		// deterministic regression. Historically this flaked as
+		// "error fetching the nar from the store: not found".
 		_, _, rc1, err := c.GetNar(ctx, nuBlob)
 		require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

Fixes the flaky `TestCDCBackends/.../Mixed_Mode` failure seen in CI
(e.g. on #1322) — `error fetching the nar from the store: not found`.

The root cause is a TOCTOU race in the NAR read path. When a whole-file
NAR is served while CDC is enabled, `GetNar` triggers a **background**
NAR→chunks migration that deletes the whole file, then *synchronously*
serves from that same store. If the delete wins the race after
`serveNarFromStorageViaPipe` chose the store branch (`total_chunks`
still observed as `0`) but before `getNarFromStore` opens the file, the
read 404s — even though the NAR is fully available as chunks. In
production this surfaces as spurious 404s on freshly-migrated NARs.

Because the migration commits the chunks **before** deleting the whole
file, the NAR is always retrievable from chunks at that point. The fix:
when a store read returns `ErrNotFound` while CDC is enabled and the
request is uncompressed, fall back to `getNarFromChunks`.

- The chunk result is adopted **only on success**; if chunks are also
  absent, the original store `ErrNotFound` is preserved (genuine
  not-found semantics unchanged).
- Compressed requests are excluded — chunks are stored uncompressed, so
  a `.nar.xz` request keeps returning `ErrNotFound` and falls back
  upstream.

## Test plan

- [x] New deterministic regression test reproduces the race via a
  `narStore` wrapper (RED → GREEN; RED reproduced the exact CI error)
- [x] Added coverage for the compressed-request and genuinely-absent
  edges; documented the race in `testCDCMixedMode`
- [x] `TestCDCBackends` + new tests pass under `-race` (repeated runs)
- [x] `task fmt`, `task lint` (0 issues), `task test`, and full
  integration suite (`task test:auto`, real Postgres/MySQL/Redis) pass

## Spec

Adds the `cdc-chunking` requirement "Serving a whole-file NAR MUST be
resilient to a concurrent background migration" (4 scenarios), and
archives the OpenSpec change under
`openspec/changes/archive/2026-06-03-fix-flaky-cdc-mixed-mode-test/`.