### PR TITLE
fix(cache): don't route serve to chunks without a chunk store

### DIFF
--- a/openspec/changes/archive/2026-06-03-fix-flaky-pg-test/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-03-fix-flaky-pg-test/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/archive/2026-06-03-fix-flaky-pg-test/design.md
+++ b/openspec/changes/archive/2026-06-03-fix-flaky-pg-test/design.md
@@ -1,0 +1,118 @@
+## Context
+
+`GetNar` (`pkg/cache/cache.go`, ~line 1085) reads store presence into a local
+`hasNarInStore` once, then determines servability through `isServable`, which
+performs its **own** fresh `HasNarInStore` call. These are two distinct
+time-of-check observations of the same store:
+
+```go
+hasNarInStore := c.HasNarInStore(ctx, narURL)      // (1) may observe absent
+...
+hasNar, err := c.isServable(ctx, narURL)           // (2) calls HasNarInStore again — may observe present
+...
+if hasNar {
+    size, reader, err = c.serveNarFromStorageViaPipe(ctx, &narURL, hasNarInStore) // stale (1) passed in
+}
+```
+
+`isServable` short-circuits to `false` when `!c.isChunkStoreAvailable()` and the
+whole file is absent, so `hasNar=true` with `hasNarInStore=false` is only
+reachable when the whole file **landed between (1) and (2)** — `isServable`
+observed it present. The stale `hasNarInStore=false` is then handed to
+`serveNarFromStorageViaPipe`, where:
+
+```go
+serveFromChunks := !hasInStore        // = true (stale)
+...
+if serveFromChunks { c.getNarFromChunks(...) }   // → "chunk store not initialized" when no chunk store
+```
+
+`getNarFromChunks` guards on `isChunkStoreAvailable()` and returns
+`chunk store not initialized, cannot serve NAR from chunks: <ErrNotFound>`. In
+the flaky `RunLRUCleanupInconsistentNarInfoState` test (CDC-disabled variant,
+chunk store nil), this surfaces as `require.NoError` failing at idx 5.
+
+This is the inverse of #1324: that fix handled present-at-check then
+deleted-before-use (fall back store→chunks). This is absent-at-check then
+present-before-use, mis-routed to a non-existent chunk store.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `GetNar` serves a whole-file NAR that is present at serve time even when an
+  earlier check observed it absent.
+- The uncompressed serve path never calls `getNarFromChunks` when no chunk store
+  is configured.
+- Deterministic regression test for the stale-`hasInStore` race.
+- Fix passes under `-race`; no change to the chunk-store-present behavior.
+
+**Non-Goals:**
+- Reworking CDC serve/migration architecture or the #1324 fallback.
+- Changing LRU cleanup logic.
+- Touching the compressed-request chunk rules.
+
+## Decisions
+
+### Decision 1: Re-evaluate store presence inside `serveNarFromStorageViaPipe` instead of trusting the passed `hasInStore`
+
+The `hasInStore` parameter is a stale snapshot from `GetNar`. The most robust fix
+is to make the serve path's chunk-routing decision depend on currently-true
+conditions rather than the stale flag:
+
+- Default the chunk route on chunk-store availability: only set
+  `serveFromChunks := !hasInStore` to route to chunks when
+  `c.isChunkStoreAvailable()` is true. When no chunk store exists, an uncompressed
+  request resolves against the whole-file store regardless of the stale flag.
+- Because `getNarFromStore` returns `ErrNotFound` cleanly when the whole file is
+  truly absent, and the existing #1324 fallback already handles the
+  store-miss→chunks case **when a chunk store exists**, gating the chunk route on
+  `isChunkStoreAvailable()` is sufficient and symmetric with that fallback.
+
+**Alternatives considered:**
+- *Refresh `hasNarInStore` in `GetNar` right before the serve call.* Narrower, but
+  leaves `serveNarFromStorageViaPipe` trusting a caller-supplied flag that can
+  still go stale under the read lock; the serve function is the correct authority
+  for its own routing. Rejected in favor of fixing it at the routing site.
+- *Make `getNarFromChunks` fall back to the store on "chunk store unavailable".*
+  Inverts the layering (chunk path reaching back into store path) and muddies the
+  #1324 store→chunks fallback. Rejected.
+
+### Decision 2: Keep `storage.ErrNotFound` semantics intact
+
+When the whole file is genuinely absent and no chunk store exists, the serve path
+still returns `storage.ErrNotFound`, preserving cache-miss recovery (upstream
+re-download) for normal mode and the upload-only `ErrNotFound` contract. The fix
+only prevents the *spurious* `chunk store not initialized` error for a NAR whose
+whole file is actually present.
+
+### Decision 3: TDD with a deterministic race reproduction
+
+Following the #1324 precedent (`cdc_migration_race_internal_test.go`), reproduce
+the stale-`hasInStore` window deterministically rather than relying on timing.
+Options: a `narStore` wrapper whose `HasNar`/stat transitions from absent→present
+across calls, or driving `serveNarFromStorageViaPipe` directly with
+`hasInStore=false` while the whole file is present and chunk store is nil. The
+direct-serve approach is the tightest RED for the exact CI error.
+
+## Risks / Trade-offs
+
+- **[Masking a genuine chunk-only NAR served with stale flag]** → Not possible:
+  the chunk route is only skipped when `isChunkStoreAvailable()` is false; when a
+  chunk store exists, behavior (including the #1324 fallback) is unchanged.
+- **[Extra store stat on the racing path]** → Negligible; only on the narrow
+  `!hasInStore` uncompressed branch, and the whole-file stat is the same call the
+  store-serve path makes anyway.
+- **[Regression test flakiness]** → Mitigated by a deterministic wrapper/direct
+  call; assert under `-race` with repeated runs.
+
+## Migration Plan
+
+Pure in-process serve-path logic change. No schema, config, or API changes; no
+data migration. Rollback is reverting the commit. Safe under expand-contract (no
+DDL).
+
+## Open Questions
+
+- Final RED harness shape (store wrapper vs direct `serveNarFromStorageViaPipe`
+  call) — to be settled during TDD; the spec scenarios are the acceptance bar
+  either way.

--- a/openspec/changes/archive/2026-06-03-fix-flaky-pg-test/proposal.md
+++ b/openspec/changes/archive/2026-06-03-fix-flaky-pg-test/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+`TestCacheBackends/.../RunLRUCleanupInconsistentNarInfoState` flakes in CI
+([run 26929993682](https://github.com/kalbasit/ncps/actions/runs/26929993682/job/79447676107))
+with `chunk store not initialized, cannot serve NAR from chunks`. The root cause
+is a time-of-check/time-of-use (TOCTOU) race on the `hasInStore` flag in
+`GetNar`: the whole-file NAR is observed **absent** at one check, lands in the
+store moments later, and the now-stale "absent" flag makes the serve path route
+an uncompressed request to the chunk store — which hard-fails when no chunk store
+is configured. This is the inverse of the #1324 fix (present-at-check then
+deleted); here it is absent-at-check then present.
+
+## What Changes
+
+- `GetNar` (`pkg/cache/cache.go`) computes `hasNarInStore` once (line ~1090),
+  then `isServable` re-checks store presence with a fresh `HasNarInStore`. When
+  the whole-file lands between those two checks, `isServable` returns
+  `hasNar=true` while the stale `hasNarInStore=false` is passed into
+  `serveNarFromStorageViaPipe`.
+- In `serveNarFromStorageViaPipe`, `serveFromChunks := !hasInStore` then routes
+  to `getNarFromChunks`, which returns `chunk store not initialized` when no
+  chunk store exists.
+- **Fix**: the serve path MUST NOT route an uncompressed request to the chunk
+  store when no chunk store is available. When the whole file is in fact present
+  (or a chunk store is absent), it MUST (re)serve from the whole-file store; it
+  may only return `storage.ErrNotFound` when the whole file is genuinely absent.
+  Concretely, eliminate reliance on the stale `hasInStore` by re-evaluating store
+  presence at serve time (or gating the chunk route on chunk-store availability).
+- Add a deterministic regression test reproducing the stale-`hasInStore` race.
+- No **BREAKING** changes.
+
+## Capabilities
+
+- **New Capabilities**: none.
+- **Modified Capabilities**:
+  - `cdc-chunking` — adds a sibling to the existing "serving a whole-file NAR
+    MUST be resilient to a concurrent background migration" requirement, covering
+    the inverse TOCTOU: a whole-file observed absent then present MUST still be
+    served, and the serve path MUST NOT attempt a chunk serve when no chunk store
+    is configured.
+
+## Impact
+
+- **Code**: `pkg/cache/cache.go` (`serveNarFromStorageViaPipe` `serveFromChunks`
+  decision and/or the `hasNarInStore` value threaded from `GetNar`); new
+  regression coverage in `pkg/cache/*_internal_test.go`.
+- **Behavior**: A NAR whose whole-file lands during the serve decision is served
+  successfully instead of erroring with `chunk store not initialized`. Removes
+  the flaky CI failure. Non-CDC deployments are unaffected by chunk-store errors
+  on the read path.
+- **I/O / network / memory**: Negligible. At most one additional `HasNarInStore`
+  stat on a narrow, already-racing path; no new allocations, DB queries, or
+  network calls on the common (whole-file present at first check) path.
+
+## Non-goals
+
+- Reworking the broader CDC serve/migration architecture or the #1324
+  store→chunks migration-race fallback.
+- Changing chunked-serving behavior when a chunk store **is** configured.
+- Altering LRU cleanup logic — the failing test merely exposes the serve-path
+  race; the fix targets the serve path, not LRU.

--- a/openspec/changes/archive/2026-06-03-fix-flaky-pg-test/specs/cdc-chunking/spec.md
+++ b/openspec/changes/archive/2026-06-03-fix-flaky-pg-test/specs/cdc-chunking/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: Serving a whole-file NAR MUST be resilient to a stale time-of-check store-presence observation
+
+The system SHALL serve a NAR whose whole file is present at serve time even if an
+earlier time-of-check observed it absent. `GetNar` computes a store-presence flag
+(`hasNarInStore`) once and then re-evaluates servability via `isServable`, which
+performs its own fresh `HasNarInStore` check. When the whole file lands in the
+store between those two checks, the first flag is stale (`false`) while the NAR is
+in fact present and servable. The serve path MUST NOT treat that stale `false` as
+authoritative and route an uncompressed request to the chunk store.
+
+The system SHALL guarantee that an uncompressed serve request is routed to the
+chunk store ONLY when a chunk store is available. When no chunk store is
+configured, the serve path MUST serve from the whole-file store (re-evaluating
+store presence as needed) rather than calling the chunk-serve path. It MUST NOT
+surface `chunk store not initialized, cannot serve NAR from chunks` for a NAR
+whose whole file is present.
+
+`GetNar` MAY only return `storage.ErrNotFound` for such a request when the whole
+file is genuinely absent from the store AND (no chunk store is configured OR the
+chunks cannot be reassembled). A NAR that is observed servable but whose backing
+cannot actually produce bytes MUST fall through to the normal cache-miss recovery
+(re-download), not surface a chunk-store-unavailable error.
+
+This requirement is the inverse complement of "Serving a whole-file NAR MUST be
+resilient to a concurrent background migration": that requirement covers
+present-at-check / deleted-before-use (fall back store→chunks); this one covers
+absent-at-check / present-before-use (do not route to chunks; serve the present
+whole file). Both eliminate reliance on a single stale `hasInStore` observation.
+
+#### Scenario: Whole-file lands between time-of-check and serve, no chunk store
+
+- **GIVEN** CDC is disabled (no chunk store is configured)
+- **AND** a NAR for hash `H` is being downloaded so its whole file is briefly absent from the store
+- **WHEN** `GetNar(H)` observes `hasNarInStore = false`, then the whole file lands in the store, and `isServable` subsequently observes the whole file present
+- **THEN** `GetNar` serves `H` from the whole-file store and returns the complete NAR bytes with no error
+- **AND** the error `chunk store not initialized, cannot serve NAR from chunks` is NOT surfaced
+
+#### Scenario: Uncompressed serve never routes to chunks when no chunk store exists
+
+- **GIVEN** no chunk store is configured
+- **WHEN** the serve path handles an uncompressed (`Compression == none`) request whose stale `hasInStore` flag is `false`
+- **THEN** the serve path resolves against the whole-file store, not `getNarFromChunks`
+- **AND** no `chunk store not initialized` error is produced
+
+#### Scenario: Genuinely absent NAR with no chunk store still recovers via re-download
+
+- **GIVEN** no chunk store is configured
+- **AND** a hash `H` whose whole file is genuinely absent from the store but available upstream
+- **WHEN** `GetNar(H)` is called (not in upload-only mode)
+- **THEN** `GetNar` falls through to the upstream re-download path and serves `H` successfully
+- **AND** it does NOT return `chunk store not initialized`
+
+#### Scenario: Genuinely absent NAR in upload-only mode still returns not found
+
+- **GIVEN** no chunk store is configured
+- **AND** a hash `H` that has neither a whole file in the store nor any upstream source
+- **WHEN** `GetNar(H)` is called in upload-only mode
+- **THEN** `GetNar` returns `storage.ErrNotFound`
+- **AND** it does NOT return `chunk store not initialized`

--- a/openspec/changes/archive/2026-06-03-fix-flaky-pg-test/tasks.md
+++ b/openspec/changes/archive/2026-06-03-fix-flaky-pg-test/tasks.md
@@ -1,0 +1,26 @@
+## 1. Reproduce (RED)
+
+- [x] 1.1 Add a deterministic regression test in `pkg/cache/*_internal_test.go` that drives the stale-`hasInStore` race: whole file present + chunk store nil + `hasInStore=false`, asserting the current code fails with `chunk store not initialized, cannot serve NAR from chunks`.
+- [x] 1.2 Confirm the new test reproduces the exact CI error (RED) and matches the failing `RunLRUCleanupInconsistentNarInfoState` symptom.
+
+## 2. Fix the serve path (GREEN)
+
+- [x] 2.1 In `serveNarFromStorageViaPipe` (`pkg/cache/cache.go`), gate the `serveFromChunks := !hasInStore` chunk route on `c.isChunkStoreAvailable()` so an uncompressed request is never routed to `getNarFromChunks` when no chunk store is configured; resolve against the whole-file store instead.
+- [x] 2.2 Preserve `storage.ErrNotFound` semantics: a genuinely-absent whole file with no chunk store still returns `ErrNotFound` (cache-miss recovery / upload-only contract), and the #1324 store→chunks fallback remains unchanged when a chunk store exists.
+- [x] 2.3 Add a code comment explaining the inverse-TOCTOU rationale, referencing #1324 and the stale `hasInStore` flag.
+- [x] 2.4 Verify the RED test from 1.1 now passes (GREEN).
+
+## 3. Verify against spec scenarios
+
+- [x] 3.1 Cover "whole-file lands between time-of-check and serve, no chunk store" → serves successfully, no chunk-store error.
+- [x] 3.2 Cover "uncompressed serve never routes to chunks when no chunk store exists".
+- [x] 3.3 Cover "genuinely absent NAR with no chunk store recovers via re-download" (non-upload-only). _Covered by the now-passing `RunLRUCleanupInconsistentNarInfoState` integration test (GetNar re-download path); no duplicate unit test added._
+- [x] 3.4 Cover "genuinely absent NAR in upload-only mode returns `storage.ErrNotFound`". _GetNar returns `ErrNotFound` in the `IsUploadOnly` branch before the serve path; unaffected by this change and covered by existing upload-only tests._
+- [x] 3.5 Confirm no regression to chunk-store-present behavior (existing `TestCDCBackends` and `cdc_migration_race_internal_test.go` still pass).
+
+## 4. Validate
+
+- [x] 4.1 Run the targeted test under `-race` repeatedly to confirm the flake is gone.
+- [x] 4.2 Run `task fmt`, `task lint` (0 issues), and `task test` — all exit 0.
+- [x] 4.3 Run the integration suite for the postgres cohort (`task test:auto`) to confirm the original CI failure is resolved. _Full `task test:auto` passed (exit 0); `pkg/cache` ran 38s against real backends with 0 failures._
+- [x] 4.4 Update the `cdc-chunking` spec via `/opsx:sync` (or archive flow) once implementation is verified. _Synced at archive: the ADDED requirement + 4 scenarios appended to `openspec/specs/cdc-chunking/spec.md`._

--- a/openspec/specs/cdc-chunking/spec.md
+++ b/openspec/specs/cdc-chunking/spec.md
@@ -374,3 +374,63 @@ compressed stream (consistent with the existing chunked-serving rules).
 - **GIVEN** a NAR whose whole file has been migrated to (uncompressed) chunks
 - **WHEN** a request for the compressed NAR (`Compression != none`) is served
 - **THEN** the serve path returns `storage.ErrNotFound` rather than serving raw chunk bytes
+
+### Requirement: Serving a whole-file NAR MUST be resilient to a stale time-of-check store-presence observation
+
+The system SHALL serve a NAR whose whole file is present at serve time even if an
+earlier time-of-check observed it absent. `GetNar` computes a store-presence flag
+(`hasNarInStore`) once and then re-evaluates servability via `isServable`, which
+performs its own fresh `HasNarInStore` check. When the whole file lands in the
+store between those two checks, the first flag is stale (`false`) while the NAR is
+in fact present and servable. The serve path MUST NOT treat that stale `false` as
+authoritative and route an uncompressed request to the chunk store.
+
+The system SHALL guarantee that an uncompressed serve request is routed to the
+chunk store ONLY when a chunk store is available. When no chunk store is
+configured, the serve path MUST serve from the whole-file store (re-evaluating
+store presence as needed) rather than calling the chunk-serve path. It MUST NOT
+surface `chunk store not initialized, cannot serve NAR from chunks` for a NAR
+whose whole file is present.
+
+`GetNar` MAY only return `storage.ErrNotFound` for such a request when the whole
+file is genuinely absent from the store AND (no chunk store is configured OR the
+chunks cannot be reassembled). A NAR that is observed servable but whose backing
+cannot actually produce bytes MUST fall through to the normal cache-miss recovery
+(re-download), not surface a chunk-store-unavailable error.
+
+This requirement is the inverse complement of "Serving a whole-file NAR MUST be
+resilient to a concurrent background migration": that requirement covers
+present-at-check / deleted-before-use (fall back store→chunks); this one covers
+absent-at-check / present-before-use (do not route to chunks; serve the present
+whole file). Both eliminate reliance on a single stale `hasInStore` observation.
+
+#### Scenario: Whole-file lands between time-of-check and serve, no chunk store
+
+- **GIVEN** CDC is disabled (no chunk store is configured)
+- **AND** a NAR for hash `H` is being downloaded so its whole file is briefly absent from the store
+- **WHEN** `GetNar(H)` observes `hasNarInStore = false`, then the whole file lands in the store, and `isServable` subsequently observes the whole file present
+- **THEN** `GetNar` serves `H` from the whole-file store and returns the complete NAR bytes with no error
+- **AND** the error `chunk store not initialized, cannot serve NAR from chunks` is NOT surfaced
+
+#### Scenario: Uncompressed serve never routes to chunks when no chunk store exists
+
+- **GIVEN** no chunk store is configured
+- **WHEN** the serve path handles an uncompressed (`Compression == none`) request whose stale `hasInStore` flag is `false`
+- **THEN** the serve path resolves against the whole-file store, not `getNarFromChunks`
+- **AND** no `chunk store not initialized` error is produced
+
+#### Scenario: Genuinely absent NAR with no chunk store still recovers via re-download
+
+- **GIVEN** no chunk store is configured
+- **AND** a hash `H` whose whole file is genuinely absent from the store but available upstream
+- **WHEN** `GetNar(H)` is called (not in upload-only mode)
+- **THEN** `GetNar` falls through to the upstream re-download path and serves `H` successfully
+- **AND** it does NOT return `chunk store not initialized`
+
+#### Scenario: Genuinely absent NAR in upload-only mode still returns not found
+
+- **GIVEN** no chunk store is configured
+- **AND** a hash `H` that has neither a whole file in the store nor any upstream source
+- **WHEN** `GetNar(H)` is called in upload-only mode
+- **THEN** `GetNar` returns `storage.ErrNotFound`
+- **AND** it does NOT return `chunk store not initialized`

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -3043,7 +3043,20 @@ func (c *Cache) serveNarFromStorageViaPipe(
 	// - If hasInStore and not chunked (total_chunks=0): serve raw from store (lazy)
 	// - If hasInStore and chunked (total_chunks>0): serve from chunks (optimized)
 	// - If not in store: serve from chunks (standard CDC path)
-	serveFromChunks := !hasInStore
+	//
+	// The chunk route is gated on chunk-store availability. hasInStore is a stale
+	// time-of-check snapshot from GetNar: it reads HasNarInStore once, then
+	// re-evaluates servability via isServable (which performs its OWN fresh
+	// HasNarInStore). When the whole file lands between those two checks the flag
+	// is stale (false) while the NAR is in fact present. Without this gate the
+	// stale false would route an uncompressed request to getNarFromChunks, which
+	// hard-fails with "chunk store not initialized" when no chunk store exists.
+	// This is the inverse of the migration-race TOCTOU handled by the store->chunks
+	// fallback below (present-at-check, deleted-before-use); here it is
+	// absent-at-check, present-before-use. Gating on isChunkStoreAvailable() (not
+	// isCDCEnabled) keeps drain mode serving chunked NARs, consistent with
+	// getNarFromChunks' own guard.
+	serveFromChunks := !hasInStore && c.isChunkStoreAvailable()
 	if hasInStore && c.isCDCEnabled() {
 		// Check if the nar is chunked by looking at the nar_file record
 		nr, nrErr := c.getNarFileFromDB(ctx, c.dbClient.Ent().NarFile, *narURL)

--- a/pkg/cache/cdc_serve_stale_hasinstore_internal_test.go
+++ b/pkg/cache/cdc_serve_stale_hasinstore_internal_test.go
@@ -1,0 +1,118 @@
+package cache
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	locklocal "github.com/kalbasit/ncps/pkg/lock/local"
+
+	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
+	"github.com/kalbasit/ncps/pkg/storage/local"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// noChunkStoreTestCache builds a Cache backed by a real local store with NO chunk
+// store configured and CDC disabled — the configuration of a plain (non-CDC)
+// deployment. This is the environment in which the stale-hasInStore TOCTOU
+// surfaces as "chunk store not initialized".
+func noChunkStoreTestCache(t *testing.T) *Cache {
+	t.Helper()
+
+	ctx := newContext()
+
+	dir, err := os.MkdirTemp("", "cache-path-")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
+	dbClient, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dbClient.Close() })
+
+	localStore, err := local.New(ctx, dir)
+	require.NoError(t, err)
+
+	c, err := New(ctx, cacheName, dbClient, localStore, localStore, localStore, "",
+		locklocal.NewLocker(), locklocal.NewRWLocker(), downloadLockTTL, downloadPollTimeout, cacheLockTTL)
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	// Intentionally NO SetChunkStore / SetCDCConfiguration: chunk store stays nil,
+	// CDC stays disabled.
+	return c
+}
+
+// TestServeNarStaleHasInStoreServesWholeFile reproduces the flaky failure observed
+// in TestCacheBackends/.../RunLRUCleanupInconsistentNarInfoState
+// ("chunk store not initialized, cannot serve NAR from chunks").
+//
+// GetNar reads hasNarInStore once and then re-evaluates servability via
+// isServable, which performs its own fresh HasNarInStore check. When the
+// whole-file NAR lands in the store between those two checks, the first flag is
+// stale (false) while the NAR is in fact present. The stale flag is passed to
+// serveNarFromStorageViaPipe, where serveFromChunks := !hasInStore routes an
+// uncompressed request to getNarFromChunks — which hard-fails because no chunk
+// store is configured. The serve path MUST serve the present whole file instead.
+func TestServeNarStaleHasInStoreServesWholeFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := newContext()
+
+	const hash = "00ji9synj1r6h6sjw27wwv8fw98myxsg92q5ma1pvrbmh451kc28"
+
+	c := noChunkStoreTestCache(t)
+
+	content := strings.Repeat("stale has-in-store content; ", 256)
+	nu := nar.URL{Hash: hash, Compression: nar.CompressionTypeNone}
+	require.NoError(t, c.PutNar(ctx, nu, io.NopCloser(strings.NewReader(content))))
+	require.True(t, c.HasNarInStore(ctx, nu), "whole file must be present in the store")
+
+	// hasInStore=false models the stale time-of-check: the whole file was observed
+	// absent before it landed. With no chunk store, the serve path must NOT route
+	// to chunks; it must serve the now-present whole file.
+	size, rc, err := c.serveNarFromStorageViaPipe(ctx, &nu, false)
+	require.NoError(t, err,
+		"a stale not-in-store observation must not route an uncompressed serve to an absent chunk store")
+	require.NotNil(t, rc)
+
+	defer rc.Close()
+
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, content, string(got))
+	require.Equal(t, int64(len(content)), size)
+}
+
+// TestServeNarStaleHasInStoreGenuinelyAbsentReturnsNotFound asserts that gating
+// the chunk route on chunk-store availability preserves not-found semantics: with
+// no chunk store and no whole file, an uncompressed serve resolves against the
+// store and returns storage.ErrNotFound — never the "chunk store not initialized"
+// error — so the caller's cache-miss recovery (re-download) still engages.
+func TestServeNarStaleHasInStoreGenuinelyAbsentReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := newContext()
+
+	const hash = "11ji9synj1r6h6sjw27wwv8fw98myxsg92q5ma1pvrbmh451kc28"
+
+	c := noChunkStoreTestCache(t)
+
+	// No PutNar: neither a whole file nor chunks exist, and no chunk store is
+	// configured. hasInStore=false reflects the genuine absence here.
+	nu := nar.URL{Hash: hash, Compression: nar.CompressionTypeNone}
+
+	_, _, err := c.serveNarFromStorageViaPipe(ctx, &nu, false)
+	require.ErrorIs(t, err, storage.ErrNotFound,
+		"a genuinely absent NAR with no chunk store must return not-found, not a chunk-store error")
+	require.NotContains(t, err.Error(), "chunk store not initialized",
+		"the serve path must not route to chunks when no chunk store is configured")
+}


### PR DESCRIPTION
## Summary

Fixes the flaky `TestCacheBackends/.../RunLRUCleanupInconsistentNarInfoState`
failure in CI ([run 26929993682](https://github.com/kalbasit/ncps/actions/runs/26929993682/job/79447676107))
— `chunk store not initialized, cannot serve NAR from chunks`.

The root cause is a TOCTOU on `hasInStore` in `GetNar`. It reads
`HasNarInStore` once, then re-evaluates servability via `isServable`, which
performs its **own** fresh `HasNarInStore`. When the whole-file NAR lands in the
store between those two checks, the first flag is stale (`false`) while the NAR
is in fact present. `serveNarFromStorageViaPipe` then computed
`serveFromChunks := !hasInStore = true` and routed an uncompressed request to
`getNarFromChunks`, which hard-fails when no chunk store is configured.

This is the inverse of #1324 (present-at-check, deleted-before-use); here it is
absent-at-check, present-before-use.

## Fix

- Gate the chunk route on chunk-store availability:
  `serveFromChunks := !hasInStore && c.isChunkStoreAvailable()`.
- When no chunk store exists, an uncompressed request resolves against the
  whole-file store: a present whole file is served; a genuine absence returns a
  clean `storage.ErrNotFound`, preserving cache-miss recovery and the
  upload-only contract.
- When a chunk store **is** present the gate reduces to the original
  `!hasInStore`, so standard CDC and drain-mode serving are byte-identical
  (the #1324 store→chunks fallback is unchanged).

## Test plan

- [x] New deterministic regression test reproduces the exact CI error
  (RED → GREEN): `pkg/cache/cdc_serve_stale_hasinstore_internal_test.go`
- [x] Formerly-flaky `RunLRUCleanupInconsistentNarInfoState` passes 5× under `-race`
- [x] `#1324` migration-race tests still pass (no regression)
- [x] `task fmt`, `task lint` (0 issues), `task test`, and full `task test:auto`
  (real Postgres/MySQL/Redis/Garage) pass

## Spec

Adds the `cdc-chunking` requirement "Serving a whole-file NAR MUST be resilient
to a stale time-of-check store-presence observation" (4 scenarios), and archives
the OpenSpec change under
`openspec/changes/archive/2026-06-03-fix-flaky-pg-test/`.