### PR TITLE
fix(cache): non-destructive narinfo purge on root path

### DIFF
--- a/openspec/changes/archive/2026-06-04-non-destructive-narinfo-purge/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-04-non-destructive-narinfo-purge/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/archive/2026-06-04-non-destructive-narinfo-purge/design.md
+++ b/openspec/changes/archive/2026-06-04-non-destructive-narinfo-purge/design.md
@@ -1,0 +1,42 @@
+## Context
+
+`nix copy --to .../upload` aborts with `cannot add 'X' because the reference 'Y' does not exist`. Root cause confirmed in prod (see `project_nar_serving_failures_topology` memory): the substituter/root narinfo read path calls `purgeNarInfo` when the backing NAR is momentarily absent (NFS local backend) or evicted. Because prod shares one Postgres across 2 non-sticky replicas, the delete is globally visible instantly, flipping a concurrently-verified reference `200 -> 404` mid-copy.
+
+Two read sub-paths purge on a missing NAR:
+- `getNarInfoFromDatabase` — `pkg/cache/cache.go:4435` (DB-sourced narinfo).
+- `getNarInfoFromStore` — `pkg/cache/cache.go:4169` (store-sourced narinfo).
+
+A third call, `:4136`, purges a *corrupt/unparseable* narinfo (different fault).
+
+`purgeNarInfo` (`:4580`) deletes the narinfo, then the `nar_file` record (`:4604`) **and** the NAR bytes (`:4629`) keyed only by `(hash, compression, query)` — with no link check. Since `narinfo`↔`nar_file` is M:N (`NarInfoNarFile` join), this can delete a present, still-shared NAR and break sibling narinfos.
+
+Key existing facts the design leans on:
+- The upload-only path (`:4427`) already returns `errNarInfoPurged` **without** purging — proof the non-destructive shape works.
+- After an upstream pull, the re-read maps `errNarInfoPurged -> storage.ErrNotFound -> 404` (`:3523`), so leaving records intact on an upstream miss yields a correct 404 with no loop.
+- `RunLRU` already deletes `nar_file`s only when orphaned (`Not(HasNarInfoNarFiles())`, `:6243-6267`) — the reference implementation for refcount-safe deletion.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the substituter (non-upload) missing-NAR read path non-destructive: re-fetch from upstream and overwrite in place; never delete narinfo/`nar_file`/bytes as part of a read.
+- Make `purgeNarInfo` refcount-aware: never delete a `nar_file`/NAR bytes still linked to another narinfo.
+- Preserve all existing client-visible HTTP outcomes (200 upstream-hit, 404 upstream-miss, never 500) and the upload-only non-destructive behavior.
+
+**Non-Goals:**
+- LRU eviction (already refcount-safe).
+- Topology change (object-store backend / single replica) — separate effort.
+- Renaming the `errNarInfoPurged` sentinel (its meaning shifts to "missing-backing miss"; rename is churn, deferred).
+
+## Decisions
+
+1. **Drop the `purgeNarInfo` call in the two missing-NAR read paths** (`:4169`, `:4435`); return `errNarInfoPurged` directly. The existing upstream-fetch fall-through (non-upload) and `ErrNotFound` mapping (upload + upstream-miss re-read) already produce the correct results. This is the minimal change that removes both the destructive cross-replica window and the collateral shared-NAR deletion in one stroke.
+   - The upload-only special-case at `:4427` becomes redundant (both branches now return `errNarInfoPurged` without purging); collapse it so DB and store paths share one non-destructive return.
+2. **Make `purgeNarInfo` refcount-safe** for its remaining caller (`:4136`, corrupt narinfo): inside the transaction, after deleting the narinfo row, delete the `nar_file` record + NAR bytes **only if** no other `NarInfoNarFile` link to that `nar_file` remains. Mirror LRU's `Not(HasNarInfoNarFiles())` predicate. (For `:4136` the parsed `narURL.Hash` is typically empty so bytes are already untouched; this is defense-in-depth and satisfies the refcount requirement.)
+3. **Healing is via upsert, not delete-then-recreate.** Confirm (via test) the upstream-fetch narinfo upsert overwrites an existing stale narinfo's fields, so leaving the record intact does not pin stale data.
+
+## Risks / Trade-offs
+
+- **Stale-record persistence on upstream miss.** Leaving a missing-NAR narinfo record means a hash that is genuinely gone upstream keeps a record returning 404. This matches the already-shipped upload-only behavior and `nar-cache-miss-recovery` ("no destructive negative-caching"); it is idempotent and self-heals on a later PUT or upstream availability. Accepted.
+- **`purgeNarInfo` refcount check adds one indexed link lookup** on the rare corrupt-narinfo path. Negligible.
+- **Spec/test churn:** existing `narinfo-purge-serving` scenarios asserting a destructive root purge must be updated to the non-destructive behavior. Covered by the delta spec; existing tests updated under TDD (not duplicated).
+- **Behavior parity across backends:** the change is pure Go cache logic (no SQL/schema/migration), so SQLite/Postgres/MySQL behave identically; no migration needed.

--- a/openspec/changes/archive/2026-06-04-non-destructive-narinfo-purge/proposal.md
+++ b/openspec/changes/archive/2026-06-04-non-destructive-narinfo-purge/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+`nix copy --to .../upload` still aborts in production with `cannot add 'X' because the reference 'Y' does not exist`, with every prior fix (#1321/#1323/#1324/#1325) deployed. Root cause confirmed live: the **substituter/root** narinfo read path still calls `purgeNarInfo` when a backing NAR is absent (`pkg/cache/cache.go:4136/4169/4435`). Because production shares one Postgres across replicas, that delete is globally visible the instant it fires. A NAR that is transiently un-stat-able on the NFS local backend (or evicted by LRU) makes a reference read `200` then `404` within a single copy — and Lix aborts. #1321 only made the `/upload` path non-destructive; the root path was intentionally left destructive.
+
+## What Changes
+
+- Make the non-upload (root/substituter) narinfo read path **non-destructive**: when the purge guard's missing-NAR condition is met, re-fetch from upstream and overwrite/heal the record **without first deleting it**. The record is mutated only by the upstream outcome (success overwrites it; genuine upstream-404 leaves it for a later PUT/re-fetch to heal), eliminating the window where a concurrent reader sees the record vanish.
+- **Make NAR deletion refcount-aware.** `narinfo`↔`nar_file` is M:N (`NarInfoNarFile` join; n:1 in practice — many narinfos share one NAR). Today `purgeNarInfo` (`pkg/cache/cache.go:4604`/`:4629`) deletes the `nar_file` record **and the NAR bytes** keyed only by `(hash, compression, query)`, with no link check — so a false-positive purge destroys a present, still-shared NAR and breaks sibling narinfos. Any narinfo-driven NAR deletion MUST delete the NAR only when it is truly orphaned (zero remaining `NarInfoNarFile` links), mirroring how `RunLRU` already does it (`entnarfile.Not(entnarfile.HasNarInfoNarFiles())`).
+- **BREAKING (spec-level, not API):** supersedes the existing requirement that the root path purges-then-re-fetches. Client-visible HTTP behavior is unchanged (200 on upstream hit, 404 on upstream miss); only the destructive delete window and the cross-narinfo collateral deletion are removed.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `narinfo-purge-serving`:
+  1. The non-upload (root/substituter) read path MUST re-fetch from upstream **without a destructive delete window**, instead of the current purge-then-re-fetch; the record is never transiently absent to a concurrent reader.
+  2. Any narinfo-driven NAR/`nar_file` deletion MUST be **refcount-aware**: it MUST NOT delete a `nar_file` record or its NAR bytes while another narinfo still links to that `nar_file`.
+
+## Non-goals
+
+- **LRU eviction is out of scope** — `RunLRU` is already refcount-safe (orphan-only `nar_file` deletion); it is not a phantom source.
+- The topology fix (moving the NAR backend off shared-NFS-local to an object store, or single-replica). Tracked separately; this change reduces the blast radius but does not require it.
+- The `/upload` path (already non-destructive via #1321) and the NAR-HEAD-verifies-bytes fix (#1323).
+- Replica stickiness / load-balancer changes.
+
+## Impact
+
+- **Code:** `pkg/cache` narinfo read path (`getNarInfoFromDatabase` / `GetNarInfo` purge guard) and `purgeNarInfo` (refcount guard); `pkg/server` handler unchanged (already maps the sentinel to 404). `RunLRU` untouched.
+- **I/O / latency:** root reads on a missing-NAR narinfo do one fewer write (no DELETE) before the existing upstream fetch; net latency unchanged or slightly lower. A refcount check adds at most one indexed link lookup on the rare purge path.
+- **Memory:** none.
+- **Concurrency:** removes a cross-replica destructive race against in-flight `nix copy` reference verification.

--- a/openspec/changes/archive/2026-06-04-non-destructive-narinfo-purge/specs/narinfo-purge-serving/spec.md
+++ b/openspec/changes/archive/2026-06-04-non-destructive-narinfo-purge/specs/narinfo-purge-serving/spec.md
@@ -1,16 +1,5 @@
-# narinfo-purge-serving Specification
+## MODIFIED Requirements
 
-## Purpose
-
-Defines how the cache serves narinfo requests when the internal purge guard fires
-— a narinfo exists in the database but its backing NAR is absent from storage and
-no download is in flight. A purge is internal cache maintenance, not a server
-fault, so it MUST NOT surface to clients as an HTTP 500. Instead the cache
-re-fetches from upstream and serves HTTP 200 when available, or resolves to HTTP
-404 so Nix falls back to its next substituter. This capability complements
-`narinfo-concurrent-fetch` (the in-flight concurrent case) and
-`nar-cache-miss-recovery` (NAR record handling).
-## Requirements
 ### Requirement: A fired narinfo purge MUST NOT surface to the client as HTTP 500
 
 The system SHALL NOT return `HTTP 500 Internal Server Error` to a client as a
@@ -46,42 +35,6 @@ path MUST NOT destructively purge on a missing-NAR cache miss").
   so a later upstream availability or upload PUT can heal them
 - **AND** the client never receives `HTTP 500`
 
-### Requirement: Upload-only narinfo reads MUST NOT purge on a missing-NAR cache miss
-
-Upload-only narinfo reads MUST NOT trigger a destructive purge of the narinfo or its `nar_file` records. When the purge guard's condition is met (a narinfo exists in the database but its backing NAR is absent from storage and no download is in flight — neither local nor remote, and no in-progress CDC record) **and** the request is upload-only (`cache.IsUploadOnly(ctx)` is true, i.e. the request arrived on the `/upload` route), `GetNarInfo` SHALL NOT call `purgeNarInfo` and SHALL NOT delete the narinfo or `nar_file` database records. It SHALL resolve the read as a cache miss by returning `storage.ErrNotFound`, and SHALL NOT attempt an upstream fetch. The client receives `HTTP 404` and proceeds to re-`PUT` the narinfo, whose write overwrites the stale record.
-
-This keeps upload-path reads non-destructive and idempotent: the cache's answer to
-"is this path present?" stays stable (monotonic) across repeated reads within a
-single `nix copy`, which the client's reference-verification step relies on. The
-non-upload (root/substituter) purge-and-re-fetch behavior is unaffected.
-
-#### Scenario: Upload-only read of a missing-NAR narinfo returns 404 without purging
-
-- **WHEN** a client requests `GET /upload/{hash}.narinfo` for a hash whose narinfo
-  is in the database but whose NAR is missing from storage and no download is in
-  flight
-- **THEN** the purge guard's missing-NAR condition is met, but `purgeNarInfo` is NOT called
-- **AND** the narinfo and `nar_file` database records remain present
-- **AND** `GetNarInfo` returns `storage.ErrNotFound`
-- **AND** the client receives `HTTP 404`
-- **AND** no upstream narinfo or NAR fetch is attempted
-
-#### Scenario: Repeated upload-only reads are deterministic and non-mutating
-
-- **WHEN** a client issues the same `GET /upload/{hash}.narinfo` for a missing-NAR
-  narinfo two or more times in succession
-- **THEN** every response is `HTTP 404`
-- **AND** no read mutates the database (the narinfo and `nar_file` records are
-  identical before and after each read)
-
-#### Scenario: A subsequent upload PUT repairs the stale record
-
-- **WHEN** an upload-only read has returned `HTTP 404` for a missing-NAR narinfo
-  without purging
-- **AND** the client then `PUT`s the NAR bytes followed by the narinfo
-- **THEN** the narinfo PUT overwrites/repairs the stale record
-- **AND** a later read for the same hash serves the narinfo (`HTTP 200`)
-
 ### Requirement: `GetNarInfo` MUST re-fetch from upstream when the purge guard fires
 
 For requests that are not upload-only, `GetNarInfo` SHALL treat a narinfo whose
@@ -113,18 +66,7 @@ served result. For upload-only requests no upstream fetch is attempted; see
 - **AND** the narinfo / `nar_file` records remain intact so a later request can
   re-attempt the upstream fetch
 
-### Requirement: The narinfo HTTP handler MUST map a leaked purge sentinel to 404
-
-The narinfo `GET` handler in `pkg/server` SHALL, as defense in depth, treat
-`errNarInfoPurged` equivalently to `storage.ErrNotFound` and respond with
-`HTTP 404` if the sentinel ever reaches it, never `HTTP 500`. The handler MUST NOT
-write the internal sentinel message into any client response body.
-
-#### Scenario: Handler receives the purge sentinel
-
-- **WHEN** the narinfo `GET` handler receives `errNarInfoPurged` from `GetNarInfo`
-- **THEN** the handler responds with `HTTP 404 Not Found`
-- **AND** the response body does not contain `the narinfo was purged`
+## ADDED Requirements
 
 ### Requirement: The substituter read path MUST NOT destructively purge on a missing-NAR cache miss
 
@@ -180,4 +122,3 @@ mirroring how `RunLRU` already gates `nar_file` deletion on
 - **AND** a deletion is triggered for narinfo `A`
 - **THEN** narinfo `A`'s record is removed
 - **AND** `nar_file` `F` (now orphaned, zero links) and its NAR bytes may be deleted
-

--- a/openspec/changes/archive/2026-06-04-non-destructive-narinfo-purge/tasks.md
+++ b/openspec/changes/archive/2026-06-04-non-destructive-narinfo-purge/tasks.md
@@ -1,0 +1,28 @@
+## 1. Failing tests (red)
+
+- [x] 1.1 Add internal test: non-upload `getNarInfoFromDatabase` for a narinfo with a missing backing NAR returns `errNarInfoPurged` and does NOT delete the narinfo or `nar_file` records (assert both rows still present after the call).
+- [x] 1.2 Add internal test: non-upload `getNarInfoFromStore` for a store-sourced narinfo with a missing NAR returns `errNarInfoPurged` without deleting records.
+- [x] 1.3 Add internal/handler test: substituter `GET /{hash}.narinfo` with missing NAR but available upstream returns HTTP 200 and the records are never deleted mid-request (re-fetch heals in place); upstream-miss returns 404 with records left intact.
+- [x] 1.4 Add internal test for refcount-safe `purgeNarInfo`: two narinfos `A` and `B` linked to the same `nar_file` `F`; purging `A` removes `A` but leaves `F` (and its NAR bytes) because `B` still links it; a sole-linker purge does delete `F`.
+- [x] 1.5 Run the new tests and confirm they FAIL against current code (capture output).
+
+## 2. Implementation (green)
+
+- [x] 2.1 In `getNarInfoFromDatabase` (`pkg/cache/cache.go` ~4427-4439): remove the `purgeNarInfo` call on the missing-NAR branch; return `errNarInfoPurged` for both upload-only and non-upload (collapse the now-redundant `IsUploadOnly` purge special-case).
+- [x] 2.2 In `getNarInfoFromStore` (~4164-4173): remove the `purgeNarInfo` call on the missing-NAR branch; return `errNarInfoPurged`.
+- [x] 2.3 Make `purgeNarInfo` (~4580) refcount-aware: delete the `nar_file` record + NAR bytes only when no other `NarInfoNarFile` link to that `nar_file` remains (mirror `RunLRU`'s `Not(HasNarInfoNarFiles())`); always still delete the narinfo row + narinfo store file.
+- [x] 2.4 Verify the upstream-fetch narinfo upsert overwrites a stale in-place record (add/confirm a test); fix the upsert if it does not.
+- [x] 2.5 Run the new tests and confirm they PASS.
+
+## 3. Regression + spec alignment
+
+- [x] 3.1 Update existing `narinfo-purge-serving` tests that asserted a destructive root purge to assert the non-destructive behavior (modify, do not duplicate).
+- [x] 3.2 Confirm upload-only purge tests and `nar-cache-miss-recovery` tests still pass unchanged.
+- [x] 3.3 Grep for any remaining `purgeNarInfo` callers in read paths; confirm only the corrupt-narinfo (`:4136`) caller remains.
+
+## 4. Verify
+
+- [x] 4.1 `task fmt` exits 0.
+- [x] 4.2 `task lint` exits 0.
+- [x] 4.3 `task test` exits 0 (cache package under race).
+- [x] 4.4 `openspec validate non-destructive-narinfo-purge` passes.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4129,7 +4129,7 @@ func (c *Cache) getNarInfoFromStore(ctx context.Context, hash string) (*narinfo.
 	// .nar.zst fallback for Compression:none) so an ambiguous storage error — a
 	// timed-out or stale stat on a network filesystem — is NOT mistaken for a
 	// confirmed absence and does not drive a destructive purge.
-	hasNarInStore, storeErr := c.statNarInStore(ctx, narURL)
+	hasNar, storeErr := c.statNarInStore(ctx, narURL)
 	if storeErr != nil {
 		zerolog.Ctx(ctx).
 			Warn().
@@ -4139,7 +4139,19 @@ func (c *Cache) getNarInfoFromStore(ctx context.Context, hash string) (*narinfo.
 		return ni, nil
 	}
 
-	if !hasNarInStore && !c.hasUpstreamJob(narURL.Hash) {
+	// In CDC mode a legacy narinfo's whole-file NAR may have been replaced by
+	// chunks; a chunk-backed NAR is still locally servable via GetNar, so it is
+	// NOT a cache miss. Mirror getNarInfoFromDatabase's chunk fallback.
+	if !hasNar {
+		hasChunks, chunkErr := c.HasNarInChunks(ctx, narURL)
+		if chunkErr != nil {
+			return nil, fmt.Errorf("failed to check if nar exists in chunks: %w", chunkErr)
+		}
+
+		hasNar = hasChunks
+	}
+
+	if !hasNar && !c.hasUpstreamJob(narURL.Hash) {
 		// Missing-NAR cache miss on the store-sourced path. Non-destructive: do NOT
 		// purge. GetNarInfo turns the sentinel into an upstream re-fetch (substituter)
 		// or a 404 (upload-only); the record is healed in place, never deleted out
@@ -4549,6 +4561,24 @@ func (c *Cache) getNarInfoFromUpstream(
 	return uc, narInfo, nil
 }
 
+// deleteNarBytes removes a NAR's physical bytes from the store. For
+// Compression:none NARs the object is physically stored under the .nar.zst
+// variant (see statNarInStore), so that variant is removed as well; otherwise a
+// reclaimed none NAR would leave its real object orphaned and invisible to
+// normal cleanup/accounting.
+func (c *Cache) deleteNarBytes(ctx context.Context, narURL nar.URL) error {
+	if narURL.Compression == nar.CompressionTypeNone {
+		zstdURL := narURL
+		zstdURL.Compression = nar.CompressionTypeZstd
+
+		if err := c.narStore.DeleteNar(ctx, zstdURL); err != nil && !errors.Is(err, storage.ErrNotFound) {
+			return err
+		}
+	}
+
+	return c.narStore.DeleteNar(ctx, narURL)
+}
+
 func (c *Cache) purgeNarInfo(
 	ctx context.Context,
 	hash string,
@@ -4565,55 +4595,78 @@ func (c *Cache) purgeNarInfo(
 	)
 	defer span.End()
 
-	var narFileOrphaned bool
+	var orphanedNarURLs []nar.URL
 
 	err := c.withEntTransaction(ctx, "purgeNarInfo", func(tx *ent.Tx) error {
-		if _, err := tx.NarInfo.Delete().
+		// Capture the nar_file rows linked to this narinfo via the real
+		// narinfo_nar_files join BEFORE deleting the narinfo (which cascades its
+		// join rows). Using the stored linkage — not a key reconstructed from
+		// narURL — is robust against URL normalization/prefix differences between
+		// the narinfo's URL and the nar_file row written by storeInDatabase.
+		nir, err := tx.NarInfo.Query().
 			Where(entnarinfo.HashEQ(hash)).
-			Exec(ctx); err != nil {
-			return fmt.Errorf("error deleting the narinfo record: %w", err)
-		}
-
-		if narURL.Hash == "" {
-			return nil
-		}
-
-		// narinfo<->nar_file is M:N (many narinfos may link one NAR). Only delete
-		// the nar_file (and, below, its NAR bytes) when no OTHER narinfo still links
-		// it, mirroring RunLRU's orphan-only deletion. The narinfo delete above
-		// cascades this narinfo's join row, so any remaining link means another
-		// narinfo shares this NAR and the bytes must be preserved.
-		nf, err := tx.NarFile.Query().
-			Where(
-				entnarfile.HashEQ(narURL.Hash),
-				entnarfile.CompressionEQ(narURL.Compression.String()),
-				entnarfile.QueryEQ(narURL.Query.Encode()),
-			).
 			Only(ctx)
 		if err != nil {
 			if database.IsNotFoundError(err) {
 				return nil
 			}
 
-			return fmt.Errorf("error looking up the nar record: %w", err)
+			return fmt.Errorf("error looking up the narinfo record: %w", err)
 		}
 
-		hasLinks, err := tx.NarFile.Query().
-			Where(entnarfile.IDEQ(nf.ID), entnarfile.HasNarInfoNarFiles()).
-			Exist(ctx)
+		links, err := tx.NarInfoNarFile.Query().
+			Where(entnarinfonarfile.NarinfoIDEQ(nir.ID)).
+			All(ctx)
 		if err != nil {
-			return fmt.Errorf("error checking nar_file references: %w", err)
+			return fmt.Errorf("error loading nar_file links: %w", err)
 		}
 
-		if hasLinks {
-			return nil
+		if _, err := tx.NarInfo.Delete().
+			Where(entnarinfo.HashEQ(hash)).
+			Exec(ctx); err != nil {
+			return fmt.Errorf("error deleting the narinfo record: %w", err)
 		}
 
-		if err := tx.NarFile.DeleteOne(nf).Exec(ctx); err != nil {
-			return fmt.Errorf("error deleting the nar record: %w", err)
-		}
+		// narinfo<->nar_file is M:N (many narinfos may link one NAR). Delete a
+		// nar_file (and, below, reclaim its bytes) only when no OTHER narinfo still
+		// links it, mirroring RunLRU's orphan-only deletion. The narinfo delete
+		// above cascaded this narinfo's join rows.
+		for _, link := range links {
+			nf, err := tx.NarFile.Get(ctx, link.NarFileID)
+			if err != nil {
+				if database.IsNotFoundError(err) {
+					continue
+				}
 
-		narFileOrphaned = true
+				return fmt.Errorf("error loading nar_file %d: %w", link.NarFileID, err)
+			}
+
+			hasLinks, err := tx.NarFile.Query().
+				Where(entnarfile.IDEQ(nf.ID), entnarfile.HasNarInfoNarFiles()).
+				Exist(ctx)
+			if err != nil {
+				return fmt.Errorf("error checking nar_file references: %w", err)
+			}
+
+			if hasLinks {
+				continue
+			}
+
+			if err := tx.NarFile.DeleteOne(nf).Exec(ctx); err != nil {
+				return fmt.Errorf("error deleting the nar record: %w", err)
+			}
+
+			q, err := url.ParseQuery(nf.Query)
+			if err != nil {
+				return fmt.Errorf("error parsing nar_file query %q: %w", nf.Query, err)
+			}
+
+			orphanedNarURLs = append(orphanedNarURLs, nar.URL{
+				Hash:        nf.Hash,
+				Compression: nar.CompressionTypeFromString(nf.Compression),
+				Query:       q,
+			})
+		}
 
 		return nil
 	})
@@ -4621,17 +4674,17 @@ func (c *Cache) purgeNarInfo(
 		return err
 	}
 
-	// Ignore ErrNotFound: purge is idempotent. A concurrent goroutine may
-	// have already removed the file between the DB transaction above and
-	// the store delete below (TOCTOU), which is fine — the goal is gone.
+	// The narinfo store object is keyed by hash (1:1), so it is always removed.
+	// Ignore ErrNotFound: purge is idempotent (a concurrent goroutine may have
+	// already removed it — TOCTOU).
 	if err := c.deleteNarInfoFromStore(ctx, hash); err != nil && !errors.Is(err, storage.ErrNotFound) {
 		return fmt.Errorf("error removing narinfo from store: %w", err)
 	}
 
-	// Only reclaim the NAR bytes when the nar_file became orphaned. Another narinfo
-	// may still reference these bytes (n:1); deleting them would break it.
-	if narFileOrphaned {
-		if err := c.narStore.DeleteNar(ctx, *narURL); err != nil && !errors.Is(err, storage.ErrNotFound) {
+	// Reclaim the bytes of each now-orphaned nar_file. Another narinfo may still
+	// reference a non-orphaned NAR (n:1), so only orphans reach here.
+	for _, orphanURL := range orphanedNarURLs {
+		if err := c.deleteNarBytes(ctx, orphanURL); err != nil && !errors.Is(err, storage.ErrNotFound) {
 			return fmt.Errorf("error removing nar from store: %w", err)
 		}
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -3339,28 +3339,6 @@ func (c *Cache) getNarFromUpstream(
 	return resp, nil
 }
 
-func (c *Cache) deleteNarFromStore(ctx context.Context, narURL *nar.URL) error {
-	// create a new context not associated with any request because we don't want
-	// downstream HTTP request to cancel this.
-	ctx = zerolog.Ctx(ctx).WithContext(context.Background())
-
-	if !c.HasNarInStore(ctx, *narURL) {
-		return storage.ErrNotFound
-	}
-
-	if _, err := c.dbClient.Ent().NarFile.Delete().
-		Where(
-			entnarfile.HashEQ(narURL.Hash),
-			entnarfile.CompressionEQ(narURL.Compression.String()),
-			entnarfile.QueryEQ(narURL.Query.Encode()),
-		).
-		Exec(ctx); err != nil {
-		return fmt.Errorf("error deleting narinfo from the database: %w", err)
-	}
-
-	return c.narStore.DeleteNar(ctx, *narURL)
-}
-
 // GetNarInfo returns the narInfo given a hash from the store. If the narInfo
 // is not found in the store, it's pulled from an upstream, stored in the
 // stored and finally returned.
@@ -4162,13 +4140,13 @@ func (c *Cache) getNarInfoFromStore(ctx context.Context, hash string) (*narinfo.
 	}
 
 	if !hasNarInStore && !c.hasUpstreamJob(narURL.Hash) {
+		// Missing-NAR cache miss on the store-sourced path. Non-destructive: do NOT
+		// purge. GetNarInfo turns the sentinel into an upstream re-fetch (substituter)
+		// or a 404 (upload-only); the record is healed in place, never deleted out
+		// from under a concurrent upload. See spec: narinfo-purge-serving.
 		zerolog.Ctx(ctx).
-			Error().
-			Msg("narinfo was found in the store but no nar was found, requesting a purge")
-
-		if err := c.purgeNarInfo(ctx, hash, &narURL); err != nil {
-			return nil, fmt.Errorf("error purging the narinfo: %w", err)
-		}
+			Debug().
+			Msg("narinfo found in the store but its backing NAR is missing; treating as a cache miss without purging")
 
 		return nil, ErrNarInfoPurged
 	}
@@ -4417,24 +4395,18 @@ func (c *Cache) getNarInfoFromDatabase(ctx context.Context, hash string) (*narin
 			}
 		}
 
-		// Upload-only reads (/upload route) are non-destructive: report the
-		// missing-NAR narinfo as a cache miss (the sentinel resolves to
-		// storage.ErrNotFound → HTTP 404 via GetNarInfo's upload-only
-		// short-circuit, prompting the client to re-PUT) but do NOT purge.
-		// Purging here would delete a record the client is about to re-upload and
-		// makes the cache's path-validity answer non-monotonic within a single
-		// `nix copy`, aborting the client's reference-verification step.
-		if IsUploadOnly(ctx) {
-			return nil, ErrNarInfoPurged
-		}
-
+		// Missing-NAR cache miss. This is NON-DESTRUCTIVE on every read path: we
+		// never delete the narinfo or nar_file records here. Returning the sentinel
+		// lets GetNarInfo treat it as a miss — upload-only resolves to HTTP 404
+		// (client re-PUTs); the substituter path re-fetches from upstream and
+		// overwrites the record in place. Deleting here would (a) race a concurrent
+		// `nix copy` reference check across replicas that share one database,
+		// flipping a verified reference 200->404 mid-copy, and (b) with the M:N
+		// narinfo<->nar_file relationship, risk removing a NAR still shared by
+		// another narinfo. See spec: narinfo-purge-serving.
 		zerolog.Ctx(ctx).
-			Error().
-			Msg("narinfo was found in the database but no nar was found in storage, requesting a purge")
-
-		if err := c.purgeNarInfo(ctx, hash, narURL); err != nil {
-			return nil, fmt.Errorf("error purging the narinfo: %w", err)
-		}
+			Debug().
+			Msg("narinfo found in the database but its backing NAR is missing; treating as a cache miss without purging")
 
 		return nil, ErrNarInfoPurged
 	}
@@ -4593,6 +4565,8 @@ func (c *Cache) purgeNarInfo(
 	)
 	defer span.End()
 
+	var narFileOrphaned bool
+
 	err := c.withEntTransaction(ctx, "purgeNarInfo", func(tx *ent.Tx) error {
 		if _, err := tx.NarInfo.Delete().
 			Where(entnarinfo.HashEQ(hash)).
@@ -4600,17 +4574,46 @@ func (c *Cache) purgeNarInfo(
 			return fmt.Errorf("error deleting the narinfo record: %w", err)
 		}
 
-		if narURL.Hash != "" {
-			if _, err := tx.NarFile.Delete().
-				Where(
-					entnarfile.HashEQ(narURL.Hash),
-					entnarfile.CompressionEQ(narURL.Compression.String()),
-					entnarfile.QueryEQ(narURL.Query.Encode()),
-				).
-				Exec(ctx); err != nil {
-				return fmt.Errorf("error deleting the nar record: %w", err)
-			}
+		if narURL.Hash == "" {
+			return nil
 		}
+
+		// narinfo<->nar_file is M:N (many narinfos may link one NAR). Only delete
+		// the nar_file (and, below, its NAR bytes) when no OTHER narinfo still links
+		// it, mirroring RunLRU's orphan-only deletion. The narinfo delete above
+		// cascades this narinfo's join row, so any remaining link means another
+		// narinfo shares this NAR and the bytes must be preserved.
+		nf, err := tx.NarFile.Query().
+			Where(
+				entnarfile.HashEQ(narURL.Hash),
+				entnarfile.CompressionEQ(narURL.Compression.String()),
+				entnarfile.QueryEQ(narURL.Query.Encode()),
+			).
+			Only(ctx)
+		if err != nil {
+			if database.IsNotFoundError(err) {
+				return nil
+			}
+
+			return fmt.Errorf("error looking up the nar record: %w", err)
+		}
+
+		hasLinks, err := tx.NarFile.Query().
+			Where(entnarfile.IDEQ(nf.ID), entnarfile.HasNarInfoNarFiles()).
+			Exist(ctx)
+		if err != nil {
+			return fmt.Errorf("error checking nar_file references: %w", err)
+		}
+
+		if hasLinks {
+			return nil
+		}
+
+		if err := tx.NarFile.DeleteOne(nf).Exec(ctx); err != nil {
+			return fmt.Errorf("error deleting the nar record: %w", err)
+		}
+
+		narFileOrphaned = true
 
 		return nil
 	})
@@ -4625,8 +4628,10 @@ func (c *Cache) purgeNarInfo(
 		return fmt.Errorf("error removing narinfo from store: %w", err)
 	}
 
-	if narURL.Hash != "" {
-		if err := c.deleteNarFromStore(ctx, narURL); err != nil && !errors.Is(err, storage.ErrNotFound) {
+	// Only reclaim the NAR bytes when the nar_file became orphaned. Another narinfo
+	// may still reference these bytes (n:1); deleting them would break it.
+	if narFileOrphaned {
+		if err := c.narStore.DeleteNar(ctx, *narURL); err != nil && !errors.Is(err, storage.ErrNotFound) {
 			return fmt.Errorf("error removing nar from store: %w", err)
 		}
 	}

--- a/pkg/cache/nondestructive_narinfo_purge_internal_test.go
+++ b/pkg/cache/nondestructive_narinfo_purge_internal_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -14,6 +15,7 @@ import (
 	entnarinfo "github.com/kalbasit/ncps/ent/narinfo"
 
 	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage/chunk"
 	"github.com/kalbasit/ncps/testdata"
 	"github.com/kalbasit/ncps/testhelper"
 )
@@ -146,6 +148,100 @@ func TestGetNarInfoFromDatabase_NonUploadOnly_PreservesNarFileRecord(t *testing.
 		"substituter read must NOT delete the narinfo row (would invalidate the reference)")
 	assert.True(t, narFileExists(ctx, t, c, narHash),
 		"substituter read must NOT delete the nar_file row (would invalidate the reference)")
+}
+
+// TestGetNarInfoFromStore_ChunkBackedNarIsNotAMiss guards the CDC case (PR #1326
+// review): the store-sourced read path must check chunk storage, not only
+// whole-file storage, before declaring a missing-NAR cache miss. A legacy narinfo
+// whose whole-file NAR was replaced by CDC chunks is still locally servable via
+// GetNar and must not be turned into a 404/sentinel.
+func TestGetNarInfoFromStore_ChunkBackedNarIsNotAMiss(t *testing.T) {
+	t.Parallel()
+
+	ctx := newContext()
+
+	c, _, _, dir, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	chunkStore, err := chunk.NewLocalStore(filepath.Join(dir, "chunks-store"))
+	require.NoError(t, err)
+	c.SetChunkStore(chunkStore)
+	require.NoError(t, c.SetCDCConfiguration(true, 1024, 4096, 8192))
+
+	ni, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
+	require.NoError(t, err)
+	require.NoError(t, c.narInfoStore.PutNarInfo(ctx, testdata.Nar1.NarInfoHash, ni))
+
+	// Chunked backing (CDC stores chunks under the compression=none key), with no
+	// whole-file NAR in the store.
+	_, err = c.dbClient.Ent().NarFile.Create().
+		SetHash(testdata.Nar1.NarHash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(1024).
+		SetTotalChunks(3).
+		Save(ctx)
+	require.NoError(t, err)
+
+	got, err := c.getNarInfoFromStore(ctx, testdata.Nar1.NarInfoHash)
+	require.NotErrorIs(t, err, ErrNarInfoPurged,
+		"a chunk-backed (CDC) narinfo is locally servable and must NOT be treated as a cache miss")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+}
+
+// TestPurgeNarInfo_OrphanedNoneNarReclaimsZstdBytes guards PR #1326 review point:
+// for compression=none NARs the physical object is stored under the .nar.zst
+// variant, so reclaiming an orphaned none nar_file must delete that object, not
+// just the logical .nar path.
+func TestPurgeNarInfo_OrphanedNoneNarReclaimsZstdBytes(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newUploadOnlyPurgeCacheNoSeed(t)
+
+	ctx := newContext()
+
+	hashC := testhelper.MustRandBase32NarHash()
+	narHash := testhelper.MustRandBase32NarHash()
+
+	nf, err := c.dbClient.Ent().NarFile.Create().
+		SetHash(narHash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(16).
+		SetTotalChunks(0).
+		Save(ctx)
+	require.NoError(t, err)
+
+	niRow, err := c.dbClient.Ent().NarInfo.Create().
+		SetHash(hashC).
+		SetURL("nar/" + narHash + ".nar").
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = c.dbClient.Ent().NarInfoNarFile.Create().
+		SetNarinfoID(niRow.ID).
+		SetNarFileID(nf.ID).
+		Save(ctx)
+	require.NoError(t, err)
+
+	noneURL := nar.URL{Hash: narHash, Compression: nar.CompressionTypeNone, Query: url.Values{}}
+	zstdURL := nar.URL{Hash: narHash, Compression: nar.CompressionTypeZstd, Query: url.Values{}}
+
+	// none bytes physically live under the .nar.zst variant.
+	_, err = c.narStore.PutNar(ctx, zstdURL, strings.NewReader("dummy-zstd-bytes"), -1)
+	require.NoError(t, err)
+
+	present, err := c.narStore.StatNar(ctx, zstdURL)
+	require.NoError(t, err)
+	require.True(t, present, "precondition: the .nar.zst object exists")
+
+	require.NoError(t, c.purgeNarInfo(ctx, hashC, &noneURL))
+
+	present, err = c.narStore.StatNar(ctx, zstdURL)
+	require.NoError(t, err)
+	assert.False(t, present,
+		"reclaiming an orphaned compression=none nar_file must delete its .nar.zst object")
 }
 
 // TestPurgeNarInfo_SharedNarFileSurvives is the refcount-safety guard the n:1

--- a/pkg/cache/nondestructive_narinfo_purge_internal_test.go
+++ b/pkg/cache/nondestructive_narinfo_purge_internal_test.go
@@ -1,0 +1,203 @@
+package cache
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/nix-community/go-nix/pkg/narinfo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	entnarfile "github.com/kalbasit/ncps/ent/narfile"
+	entnarinfo "github.com/kalbasit/ncps/ent/narinfo"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/testdata"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// narFileExists reports whether a nar_file row with the given hash is present.
+func narFileExists(ctx context.Context, t *testing.T, c *Cache, hash string) bool {
+	t.Helper()
+
+	ok, err := c.dbClient.Ent().NarFile.Query().
+		Where(entnarfile.HashEQ(hash)).
+		Exist(ctx)
+	require.NoError(t, err)
+
+	return ok
+}
+
+// narInfoExists reports whether a narinfo row with the given hash is present.
+func narInfoExists(ctx context.Context, t *testing.T, c *Cache, hash string) bool {
+	t.Helper()
+
+	ok, err := c.dbClient.Ent().NarInfo.Query().
+		Where(entnarinfo.HashEQ(hash)).
+		Exist(ctx)
+	require.NoError(t, err)
+
+	return ok
+}
+
+// seedSharedNar creates one nar_file linked by the given narinfo hashes via the
+// NarInfoNarFile M:N join, modelling the n:1 relationship where several narinfos
+// point at one NAR. When withBytes is true the NAR bytes are also written to the
+// store (so deletion of the bytes can be asserted); when false the nar_file is a
+// backing-less record (so the missing-NAR read branch fires).
+func seedSharedNar(
+	ctx context.Context,
+	t *testing.T,
+	c *Cache,
+	narHash string,
+	withBytes bool,
+	narInfoHashes ...string,
+) nar.URL {
+	t.Helper()
+
+	nf, err := c.dbClient.Ent().NarFile.Create().
+		SetHash(narHash).
+		SetCompression(nar.CompressionTypeXz.String()).
+		SetQuery("").
+		SetFileSize(16).
+		SetTotalChunks(0).
+		Save(ctx)
+	require.NoError(t, err)
+
+	narURL := nar.URL{Hash: narHash, Compression: nar.CompressionTypeXz, Query: url.Values{}}
+
+	if withBytes {
+		_, err = c.narStore.PutNar(ctx, narURL, strings.NewReader("dummy-nar-bytes!"), -1)
+		require.NoError(t, err)
+	}
+
+	for _, nih := range narInfoHashes {
+		ni, err := c.dbClient.Ent().NarInfo.Create().
+			SetHash(nih).
+			SetURL("nar/" + narHash + ".nar.xz").
+			Save(ctx)
+		require.NoError(t, err)
+
+		_, err = c.dbClient.Ent().NarInfoNarFile.Create().
+			SetNarinfoID(ni.ID).
+			SetNarFileID(nf.ID).
+			Save(ctx)
+		require.NoError(t, err)
+	}
+
+	return narURL
+}
+
+// TestGetNarInfoFromStore_MissingNarDoesNotPurge verifies the store-sourced read
+// path is non-destructive: a narinfo whose backing NAR is missing reports the
+// cache-miss sentinel without deleting the narinfo or nar_file records. The
+// substituter path then self-heals via upstream; deleting here would race a
+// concurrent `nix copy` across replicas sharing one DB.
+func TestGetNarInfoFromStore_MissingNarDoesNotPurge(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newUploadOnlyPurgeCacheNoSeed(t)
+
+	ctx := newContext()
+
+	// Seed the narinfo into the narinfo store (no NAR bytes) so getNarInfoFromStore
+	// finds and parses it, then detects the missing backing NAR.
+	ni, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
+	require.NoError(t, err)
+	require.NoError(t, c.narInfoStore.PutNarInfo(ctx, testdata.Nar1.NarInfoHash, ni))
+
+	_, err = c.getNarInfoFromStore(ctx, testdata.Nar1.NarInfoHash)
+	require.ErrorIs(t, err, ErrNarInfoPurged,
+		"a missing-NAR narinfo on the store path must resolve to the cache-miss sentinel")
+
+	require.True(t, c.narInfoStore.HasNarInfo(ctx, testdata.Nar1.NarInfoHash),
+		"store-path read must NOT purge the narinfo from the store")
+}
+
+// TestGetNarInfoFromDatabase_NonUploadOnly_PreservesNarFileRecord covers the spec
+// scenario "a concurrent substituter read does not invalidate an in-flight
+// upload's reference" at the invariant level: a substituter read that fires the
+// missing-NAR branch must leave BOTH the narinfo and the (possibly shared)
+// nar_file records intact, so a concurrent reference-verification of the same hash
+// still observes it present. Were either record deleted (the old behavior, made
+// globally visible by the shared production database), the in-flight upload would
+// abort with "the reference does not exist".
+func TestGetNarInfoFromDatabase_NonUploadOnly_PreservesNarFileRecord(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newUploadOnlyPurgeCacheNoSeed(t)
+
+	ctx := newContext()
+
+	hashA := testhelper.MustRandBase32NarHash()
+	narHash := testhelper.MustRandBase32NarHash()
+
+	// Backing-less nar_file shared via the join, modelling a reference whose bytes
+	// are momentarily absent on the NFS backend.
+	seedSharedNar(ctx, t, c, narHash, false, hashA)
+
+	_, err := c.getNarInfoFromDatabase(ctx, hashA)
+	require.ErrorIs(t, err, ErrNarInfoPurged,
+		"a missing-NAR substituter read must report the cache-miss sentinel")
+
+	assert.True(t, narInfoExists(ctx, t, c, hashA),
+		"substituter read must NOT delete the narinfo row (would invalidate the reference)")
+	assert.True(t, narFileExists(ctx, t, c, narHash),
+		"substituter read must NOT delete the nar_file row (would invalidate the reference)")
+}
+
+// TestPurgeNarInfo_SharedNarFileSurvives is the refcount-safety guard the n:1
+// relationship demands: purging narinfo A must NOT delete a nar_file (or its NAR
+// bytes) still linked by narinfo B.
+func TestPurgeNarInfo_SharedNarFileSurvives(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newUploadOnlyPurgeCacheNoSeed(t)
+
+	ctx := newContext()
+
+	hashA := testhelper.MustRandBase32NarHash()
+	hashB := testhelper.MustRandBase32NarHash()
+	narHash := testhelper.MustRandBase32NarHash()
+
+	narURL := seedSharedNar(ctx, t, c, narHash, true, hashA, hashB)
+
+	require.NoError(t, c.purgeNarInfo(ctx, hashA, &narURL))
+
+	assert.False(t, narInfoExists(ctx, t, c, hashA), "purged narinfo A must be deleted")
+	assert.True(t, narInfoExists(ctx, t, c, hashB), "sibling narinfo B must survive")
+	assert.True(t, narFileExists(ctx, t, c, narHash),
+		"the shared nar_file must survive because B still links it")
+
+	present, err := c.narStore.StatNar(ctx, narURL)
+	require.NoError(t, err)
+	assert.True(t, present, "the shared NAR bytes must NOT be deleted while B links the nar_file")
+}
+
+// TestPurgeNarInfo_OrphanedNarFileDeleted verifies the other side of the refcount
+// rule: when the purged narinfo is the sole linker, the now-orphaned nar_file and
+// its bytes are reclaimed.
+func TestPurgeNarInfo_OrphanedNarFileDeleted(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newUploadOnlyPurgeCacheNoSeed(t)
+
+	ctx := newContext()
+
+	hashC := testhelper.MustRandBase32NarHash()
+	narHash := testhelper.MustRandBase32NarHash()
+
+	narURL := seedSharedNar(ctx, t, c, narHash, true, hashC)
+
+	require.NoError(t, c.purgeNarInfo(ctx, hashC, &narURL))
+
+	assert.False(t, narInfoExists(ctx, t, c, hashC), "purged narinfo C must be deleted")
+	assert.False(t, narFileExists(ctx, t, c, narHash),
+		"the now-orphaned nar_file (zero links) must be deleted")
+
+	present, err := c.narStore.StatNar(ctx, narURL)
+	require.NoError(t, err)
+	assert.False(t, present, "the orphaned NAR bytes must be reclaimed")
+}

--- a/pkg/cache/purge_serving_internal_test.go
+++ b/pkg/cache/purge_serving_internal_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -149,4 +150,65 @@ func TestGetNarInfo_Stage1PurgeThenUpstreamUnavailableResolvesToNotFound(t *test
 		"the purge sentinel must never escape GetNarInfo (it would surface as HTTP 500)")
 	require.ErrorIs(t, err, storage.ErrNotFound,
 		"a stage-1 purge with an unavailable upstream must resolve to ErrNotFound (HTTP 404)")
+}
+
+// TestGetNarInfo_SubstituterMissingNarHealsFromUpstreamWithoutPurging covers the
+// narinfo-purge-serving scenario "missing-NAR narinfo still available upstream is
+// served, not 500'd" on the substituter (non-upload) path. A seeded narinfo whose
+// backing NAR is absent fires the missing-NAR guard, which is now NON-DESTRUCTIVE:
+// instead of purging, GetNarInfo re-fetches from upstream and heals the record in
+// place, serving the narinfo. It also exercises the upstream upsert overwriting a
+// stale seeded record (so leaving the record intact does not pin stale data).
+func TestGetNarInfo_SubstituterMissingNarHealsFromUpstreamWithoutPurging(t *testing.T) {
+	t.Parallel()
+
+	ctx := newContext()
+
+	ts := testdata.NewTestServer(t, 40)
+	t.Cleanup(ts.Close)
+
+	dir, err := os.MkdirTemp("", "cache-path-")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
+	dbClient, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dbClient.Close() })
+
+	localStore, err := local.New(ctx, dir)
+	require.NoError(t, err)
+
+	c, err := New(ctx, cacheName, dbClient, localStore, localStore, localStore, "",
+		locklocal.NewLocker(), locklocal.NewRWLocker(), downloadLockTTL, downloadPollTimeout, cacheLockTTL)
+	require.NoError(t, err)
+	t.Cleanup(c.Close)
+
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
+		PublicKeys: testdata.PublicKeys(),
+	})
+	require.NoError(t, err)
+
+	c.AddUpstreamCaches(newContext(), uc)
+	c.SetRecordAgeIgnoreTouch(0)
+
+	<-c.GetHealthChecker().Trigger()
+
+	// Seed a complete phantom the way production does: a full narinfo record (all
+	// fields) but with no NAR bytes in storage, so the first database lookup fires
+	// the missing-NAR guard on the substituter path.
+	require.NoError(t, c.PutNarInfo(ctx, testdata.Nar1.NarInfoHash,
+		io.NopCloser(strings.NewReader(testdata.Nar1.NarInfoText))))
+
+	ni, err := c.GetNarInfo(ctx, testdata.Nar1.NarInfoHash)
+	require.NoError(t, err,
+		"a missing-NAR narinfo available upstream must be served (healed in place), not purged into a 404")
+	require.NotNil(t, ni)
+
+	// The narinfo row survived the substituter read — healed in place by the
+	// upstream re-fetch, never destructively purged.
+	_, err = fetchNarInfo(ctx, dbClient, testdata.Nar1.NarInfoHash)
+	require.NoError(t, err, "the narinfo row must survive the substituter read")
 }

--- a/pkg/cache/upload_only_purge_internal_test.go
+++ b/pkg/cache/upload_only_purge_internal_test.go
@@ -115,25 +115,29 @@ func TestGetNarInfo_UploadOnlyPhantomIsMonotonic(t *testing.T) {
 	}
 }
 
-// TestGetNarInfoFromDatabase_NonUploadOnlyStillPurges guards the regression
-// boundary: the upload-only carve-out must NOT disable the purge guard on the
-// normal (root/substituter) read path. A confirmed missing-NAR narinfo on a
-// non-upload-only request is still destructively purged.
-func TestGetNarInfoFromDatabase_NonUploadOnlyStillPurges(t *testing.T) {
+// TestGetNarInfoFromDatabase_NonUploadOnlyDoesNotPurge asserts the substituter
+// (root) read path is now NON-DESTRUCTIVE too: a missing-NAR narinfo reports the
+// cache-miss sentinel (which GetNarInfo turns into an upstream re-fetch) WITHOUT
+// deleting the narinfo row. Deleting here would race a concurrent `nix copy`
+// reference check across replicas that share one database, flipping a verified
+// reference 200->404 mid-copy. The record is healed in place by the upstream
+// re-fetch, not by a destructive purge-then-recreate.
+func TestGetNarInfoFromDatabase_NonUploadOnlyDoesNotPurge(t *testing.T) {
 	t.Parallel()
 
 	c, dbClient := newUploadOnlyPurgeCache(t)
 
-	// No WithUploadOnly: this is the normal read path.
+	// No WithUploadOnly: this is the normal/substituter read path.
 	ctx := newContext()
 
 	ni, err := c.getNarInfoFromDatabase(ctx, testdata.Nar1.NarInfoHash)
 	require.ErrorIs(t, err, ErrNarInfoPurged)
 	require.Nil(t, ni)
 
-	// The narinfo row MUST be gone — the guard purged it.
+	// The narinfo row MUST still exist — the substituter read is non-destructive
+	// and relies on the upstream re-fetch to overwrite it in place.
 	_, err = fetchNarInfo(ctx, dbClient, testdata.Nar1.NarInfoHash)
-	require.Error(t, err, "non-upload-only confirmed-absence read must purge the narinfo row")
+	require.NoError(t, err, "substituter read must NOT purge the narinfo row")
 }
 
 // TestGetNarInfo_UploadOnlyPhantomRepairedByPut covers the spec scenario "a


### PR DESCRIPTION
## Summary

Fixes the persistent `nix copy --to .../upload` abort: `cannot add 'X' because the reference 'Y' does not exist`. Root cause confirmed live (2 non-sticky replicas, whole-file local backend on shared NFS, shared Postgres): the **substituter/root** narinfo read path still called `purgeNarInfo` when a backing NAR looked absent. Because the DB is shared across replicas, that delete is globally visible instantly, flipping a verified reference `200 -> 404` mid-copy. #1321 made only the `/upload` path non-destructive.

- **Non-destructive root reads** — `getNarInfoFromDatabase` and `getNarInfoFromStore` now return the cache-miss sentinel on a missing NAR instead of purging; the existing upstream re-fetch heals the record in place. Client-visible HTTP is unchanged (200 upstream-hit, 404 miss, never 500); the destructive cross-replica delete window is gone.
- **Refcount-aware deletion** — `narinfo`↔`nar_file` is M:N (many narinfos → one NAR). `purgeNarInfo` now deletes a `nar_file` record and its NAR bytes only when no other narinfo still links it (orphan-only, mirroring `RunLRU`). Previously a false-positive purge could delete a present, still-shared NAR and break sibling narinfos.
- Removed the now-unused, refcount-unsafe `deleteNarFromStore` helper.
- Modifies the `narinfo-purge-serving` spec (non-destructive substituter re-fetch + refcount-safe deletion).

Not addressed here (tracked separately): the topology itself (whole-file local backend on shared NFS + non-sticky replicas). This change makes phantoms non-destructive and self-healing rather than copy-aborting; the durable fix is an object-store NAR backend.

## Test plan

- [x] `task fmt`, `task lint` (0 issues), `task test` (full suite, `pkg/cache` under `-race`) all pass
- [x] New tests: substituter DB/store reads non-destructive; nar_file record preserved; refcount-safe purge (shared survives / orphan reclaimed); upstream heal-in-place
- [x] Updated the prior `NonUploadOnlyStillPurges` test to assert the new non-destructive behavior