### PR TITLE
fix(ent): stop sqlite phantom narinfos/nar_files rebuild

### DIFF
--- a/.claude/rules/ent-migrations.md
+++ b/.claude/rules/ent-migrations.md
@@ -87,6 +87,29 @@ This is enforced at the source level (AST check on the schema file) by
 `task uar:ent:lint`. The `Sensitive()` annotation is a schema-only metadata
 change; it does NOT alter the SQL column definition and requires no migration.
 
+### 6. `CURRENT_TIMESTAMP` DB defaults MUST use `entsql.Default(...)`, never `DefaultExpr`
+
+A DB-level `CURRENT_TIMESTAMP` default MUST be declared via
+`entsql.Default("CURRENT_TIMESTAMP")` (which Ent emits as a string default that
+Atlas's SQLite inspector round-trips exactly). It MUST NOT be declared via
+`entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"}`: Ent emits that form as a
+parenthesized Atlas `RawExpr`, but Atlas's SQLite inspector strips the parens on
+readback, so the desired (`(CURRENT_TIMESTAMP)`) and inspected
+(`CURRENT_TIMESTAMP`) values never compare equal. The result is a perpetual
+phantom `ModifyColumn` (ChangeDefault) that rebuilds the whole table on **every**
+generated SQLite migration (GitHub issue #1328).
+
+```go
+field.Time("last_accessed_at").
+    Optional().
+    Nillable().
+    Default(time.Now).
+    Annotations(entsql.Default("CURRENT_TIMESTAMP")), // NOT entsql.Annotation{DefaultExpr: ...}
+```
+
+This is enforced at the source level (AST check, invariant A6) by `cmd/ent-lint`.
+It is a schema-representation-only change; the emitted SQL DDL (`DEFAULT (CURRENT_TIMESTAMP)`) is unchanged, so it requires no migration.
+
 ## Snake_case enum types
 
 When a `field.Enum(...)` field generates a Postgres ENUM type, give it an

--- a/cmd/ent-lint/main.go
+++ b/cmd/ent-lint/main.go
@@ -11,6 +11,11 @@
 //   - A4: every edge.To declaration in any schema must have a reciprocal
 //     edge.From(...).Ref(...) on the target schema (otherwise Ent fabricates
 //     a phantom FK column on the target).
+//   - A6: a CURRENT_TIMESTAMP DB default declared via
+//     entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"} is forbidden (Ent
+//     emits a parenthesized RawExpr that Atlas's SQLite inspector does not
+//     round-trip, causing a perpetual phantom table rebuild — issue #1328);
+//     use entsql.Default("CURRENT_TIMESTAMP") instead.
 //
 // Future invariants enforced by this binary (tracked in the
 // ent-schema-lint spec but not yet implemented):
@@ -67,6 +72,7 @@ func main() {
 	results = append(results, checkA1(schemas)...)
 	results = append(results, checkA2(schemas)...)
 	results = append(results, checkA4(schemas)...)
+	results = append(results, checkA6(schemas)...)
 
 	sort.SliceStable(results, func(i, j int) bool {
 		if results[i].id != results[j].id {
@@ -248,7 +254,7 @@ func findFieldEntsqlCheck(sf schemaFile, fn *ast.FuncDecl) []int {
 			return true
 		}
 
-		if sel.Sel.Name != "Annotations" {
+		if sel.Sel.Name != annotationsMethod {
 			return true
 		}
 		// Found a `.Annotations(...)` call; if any argument is `entsql.Check(...)`,
@@ -281,7 +287,7 @@ func isEntsqlCheckCall(e ast.Expr) bool {
 		return false
 	}
 
-	return x.Name == "entsql" && sel.Sel.Name == "Check"
+	return x.Name == entsqlPkg && sel.Sel.Name == "Check"
 }
 
 // ---------- A2: entsql.OnDelete on edge.From is forbidden ----------
@@ -336,7 +342,7 @@ func findEdgeFromOnDelete(sf schemaFile, fn *ast.FuncDecl) []int {
 			return true
 		}
 
-		if sel.Sel.Name != "Annotations" {
+		if sel.Sel.Name != annotationsMethod {
 			return true
 		}
 		// Look at the receiver of .Annotations(...). If anywhere in the
@@ -397,7 +403,7 @@ func isEntsqlOnDeleteCall(e ast.Expr) bool {
 		return false
 	}
 
-	return x.Name == "entsql" && sel.Sel.Name == "OnDelete"
+	return x.Name == entsqlPkg && sel.Sel.Name == "OnDelete"
 }
 
 // ---------- A4: every edge.To needs a reciprocal edge.From().Ref() ----------
@@ -549,6 +555,130 @@ func findInnerEdgeFromTarget(e ast.Expr) string {
 	}
 }
 
+// ---------- A6: entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"} is forbidden ----------
+
+// checkA6 walks each schema's Fields() method body looking for a
+// `.Annotations(entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"})` chain.
+// Ent emits this form as a parenthesized Atlas RawExpr that Atlas's SQLite
+// inspector does not round-trip (it strips the parens), producing a
+// perpetual phantom ModifyColumn (ChangeDefault) and a destructive table
+// rebuild on every generated SQLite migration (issue #1328). The
+// round-trippable form is `entsql.Default("CURRENT_TIMESTAMP")`.
+func checkA6(schemas []schemaFile) []result {
+	var out []result
+
+	for _, sf := range schemas {
+		for _, m := range methodsByName(sf, "Fields") {
+			// Skip top-level helper functions named Fields — only method
+			// receivers can be Ent schema methods.
+			if receiverTypeName(m) == "" {
+				continue
+			}
+
+			violations := findDefaultExprCurrentTimestamp(sf, m)
+			if len(violations) == 0 {
+				out = append(out, result{
+					pass: true, id: "A6",
+					detail: fmt.Sprintf("%s: no DefaultExpr CURRENT_TIMESTAMP (use entsql.Default)", relPath(sf.path)),
+				})
+
+				continue
+			}
+
+			for _, v := range violations {
+				out = append(out, result{
+					pass: false, id: "A6",
+					detail: fmt.Sprintf(
+						"%s:%d entsql.Annotation{DefaultExpr: \"CURRENT_TIMESTAMP\"} is forbidden "+
+							"(use entsql.Default(\"CURRENT_TIMESTAMP\") — Atlas's SQLite inspector does not "+
+							"round-trip the parenthesized RawExpr; issue #1328)",
+						relPath(sf.path), v,
+					),
+				})
+			}
+		}
+	}
+
+	return out
+}
+
+func findDefaultExprCurrentTimestamp(sf schemaFile, fn *ast.FuncDecl) []int {
+	var lines []int
+
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+
+		if sel.Sel.Name != annotationsMethod {
+			return true
+		}
+
+		for _, arg := range call.Args {
+			if pos := entsqlAnnotationDefaultExpr(arg); pos != token.NoPos {
+				lines = append(lines, sf.fset.Position(pos).Line)
+			}
+		}
+
+		return true
+	})
+
+	return lines
+}
+
+// entsqlAnnotationDefaultExpr reports the position of a
+// `DefaultExpr: "CURRENT_TIMESTAMP"` field inside an `entsql.Annotation{...}`
+// composite literal, or token.NoPos if the expression is not such a literal.
+func entsqlAnnotationDefaultExpr(e ast.Expr) token.Pos {
+	lit, ok := e.(*ast.CompositeLit)
+	if !ok {
+		return token.NoPos
+	}
+
+	sel, ok := lit.Type.(*ast.SelectorExpr)
+	if !ok {
+		return token.NoPos
+	}
+
+	x, ok := sel.X.(*ast.Ident)
+	if !ok || x.Name != entsqlPkg || sel.Sel.Name != "Annotation" {
+		return token.NoPos
+	}
+
+	for _, el := range lit.Elts {
+		kv, ok := el.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok || key.Name != "DefaultExpr" {
+			continue
+		}
+
+		if isCurrentTimestampLit(kv.Value) {
+			return kv.Pos()
+		}
+	}
+
+	return token.NoPos
+}
+
+func isCurrentTimestampLit(e ast.Expr) bool {
+	bl, ok := e.(*ast.BasicLit)
+	if !ok || bl.Kind != token.STRING {
+		return false
+	}
+
+	return strings.EqualFold(stringLitValue(bl), "CURRENT_TIMESTAMP")
+}
+
 // ---------- helpers ----------
 
 func methodsByName(sf schemaFile, name string) []*ast.FuncDecl {
@@ -570,6 +700,13 @@ func methodsByName(sf schemaFile, name string) []*ast.FuncDecl {
 
 // edgePkg is the canonical Ent edge package import name.
 const edgePkg = "edge"
+
+// entsqlPkg is the canonical Ent entsql package import name; annotationsMethod
+// is the field/edge builder method that attaches schema annotations.
+const (
+	entsqlPkg         = "entsql"
+	annotationsMethod = "Annotations"
+)
 
 // receiverTypeName returns the bare type name of a method's receiver
 // (e.g. "Child" for `func (Child) Edges() ...` or `func (c Child) Edges() ...`).

--- a/cmd/ent-lint/main.go
+++ b/cmd/ent-lint/main.go
@@ -586,13 +586,18 @@ func checkA6(schemas []schemaFile) []result {
 			}
 
 			for _, v := range violations {
+				field := v.field
+				if field == "" {
+					field = "<unknown>"
+				}
+
 				out = append(out, result{
 					pass: false, id: "A6",
 					detail: fmt.Sprintf(
-						"%s:%d entsql.Annotation{DefaultExpr: \"CURRENT_TIMESTAMP\"} is forbidden "+
+						"%s:%d field %q: entsql.Annotation{DefaultExpr: \"CURRENT_TIMESTAMP\"} is forbidden "+
 							"(use entsql.Default(\"CURRENT_TIMESTAMP\") — Atlas's SQLite inspector does not "+
 							"round-trip the parenthesized RawExpr; issue #1328)",
-						relPath(sf.path), v,
+						relPath(sf.path), v.line, field,
 					),
 				})
 			}
@@ -602,8 +607,16 @@ func checkA6(schemas []schemaFile) []result {
 	return out
 }
 
-func findDefaultExprCurrentTimestamp(sf schemaFile, fn *ast.FuncDecl) []int {
-	var lines []int
+// a6Violation records one forbidden DefaultExpr annotation: the field it is
+// chained onto (for the diagnostic) and the source line of the offending
+// `DefaultExpr:` element.
+type a6Violation struct {
+	field string
+	line  int
+}
+
+func findDefaultExprCurrentTimestamp(sf schemaFile, fn *ast.FuncDecl) []a6Violation {
+	var violations []a6Violation
 
 	ast.Inspect(fn, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
@@ -622,20 +635,61 @@ func findDefaultExprCurrentTimestamp(sf schemaFile, fn *ast.FuncDecl) []int {
 
 		for _, arg := range call.Args {
 			if pos := entsqlAnnotationDefaultExpr(arg); pos != token.NoPos {
-				lines = append(lines, sf.fset.Position(pos).Line)
+				violations = append(violations, a6Violation{
+					field: fieldNameFromChain(sel.X),
+					line:  sf.fset.Position(pos).Line,
+				})
 			}
 		}
 
 		return true
 	})
 
-	return lines
+	return violations
+}
+
+// fieldPkg is the canonical Ent field package import name.
+const fieldPkg = "field"
+
+// fieldNameFromChain walks the receiver chain of a builder expression (the
+// "X" side of `.Annotations(...)`) inward looking for the originating
+// `field.<Type>("name", ...)` call, and returns that field's name (the first
+// string-literal argument). Returns "" if no such call is found.
+func fieldNameFromChain(e ast.Expr) string {
+	for {
+		call, ok := e.(*ast.CallExpr)
+		if !ok {
+			return ""
+		}
+
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return ""
+		}
+
+		if id, ok := sel.X.(*ast.Ident); ok && id.Name == fieldPkg {
+			if len(call.Args) >= 1 {
+				return stringLitValue(call.Args[0])
+			}
+
+			return ""
+		}
+
+		e = sel.X
+	}
 }
 
 // entsqlAnnotationDefaultExpr reports the position of a
 // `DefaultExpr: "CURRENT_TIMESTAMP"` field inside an `entsql.Annotation{...}`
 // composite literal, or token.NoPos if the expression is not such a literal.
+// The pointer form `&entsql.Annotation{...}` is also accepted by Ent (the
+// value-receiver Name() puts *entsql.Annotation in schema.Annotation's method
+// set), so the address-of operator is unwrapped first.
 func entsqlAnnotationDefaultExpr(e ast.Expr) token.Pos {
+	if unary, ok := e.(*ast.UnaryExpr); ok && unary.Op == token.AND {
+		e = unary.X
+	}
+
 	lit, ok := e.(*ast.CompositeLit)
 	if !ok {
 		return token.NoPos

--- a/cmd/ent-lint/main_test.go
+++ b/cmd/ent-lint/main_test.go
@@ -27,6 +27,9 @@ func TestEntLint(t *testing.T) {
 		invariant  string
 		wantFail   bool
 		wantInLine string
+		// wantField, when set, must appear on the [FAIL] line — the A6
+		// contract requires the message to name the offending field.
+		wantField string
 	}{
 		{fixture: "a1_good", invariant: "A1", wantFail: false},
 		{fixture: "a1_bad", invariant: "A1", wantFail: true, wantInLine: "entsql.Check"},
@@ -35,7 +38,9 @@ func TestEntLint(t *testing.T) {
 		{fixture: "a4_good", invariant: "A4", wantFail: false},
 		{fixture: "a4_bad", invariant: "A4", wantFail: true, wantInLine: "phantom FK"},
 		{fixture: "a6_good", invariant: "A6", wantFail: false},
-		{fixture: "a6_bad", invariant: "A6", wantFail: true, wantInLine: "entsql.Default"},
+		{fixture: "a6_bad", invariant: "A6", wantFail: true, wantInLine: "entsql.Default", wantField: "last_accessed_at"},
+		// Pointer form (&entsql.Annotation{...}) must also be flagged.
+		{fixture: "a6_bad_pointer", invariant: "A6", wantFail: true, wantField: "last_accessed_at"},
 	}
 
 	for _, tc := range cases {
@@ -54,8 +59,9 @@ func TestEntLint(t *testing.T) {
 			}
 
 			var (
-				sawFail bool
-				sawTok  bool
+				sawFail  bool
+				sawTok   bool
+				sawField bool
 			)
 
 			for _, line := range strings.Split(combined, "\n") {
@@ -69,6 +75,10 @@ func TestEntLint(t *testing.T) {
 
 				if strings.HasPrefix(line, "[FAIL]") {
 					sawFail = true
+
+					if tc.wantField != "" && strings.Contains(line, tc.wantField) {
+						sawField = true
+					}
 				}
 
 				if tc.wantInLine != "" && strings.Contains(line, tc.wantInLine) {
@@ -81,6 +91,11 @@ func TestEntLint(t *testing.T) {
 
 				if tc.wantInLine != "" {
 					assert.True(t, sawTok, "expected a [FAIL] line containing %q; output:\n%s", tc.wantInLine, combined)
+				}
+
+				if tc.wantField != "" {
+					assert.True(t, sawField,
+						"expected a [FAIL] %s line naming the field %q; output:\n%s", tc.invariant, tc.wantField, combined)
 				}
 			} else {
 				assert.False(t, sawFail, "expected no [FAIL] %s lines; output:\n%s", tc.invariant, combined)

--- a/cmd/ent-lint/main_test.go
+++ b/cmd/ent-lint/main_test.go
@@ -34,6 +34,8 @@ func TestEntLint(t *testing.T) {
 		{fixture: "a2_bad", invariant: "A2", wantFail: true, wantInLine: "OnDelete"},
 		{fixture: "a4_good", invariant: "A4", wantFail: false},
 		{fixture: "a4_bad", invariant: "A4", wantFail: true, wantInLine: "phantom FK"},
+		{fixture: "a6_good", invariant: "A6", wantFail: false},
+		{fixture: "a6_bad", invariant: "A6", wantFail: true, wantInLine: "entsql.Default"},
 	}
 
 	for _, tc := range cases {

--- a/cmd/ent-lint/testdata/a6_bad/schema.go
+++ b/cmd/ent-lint/testdata/a6_bad/schema.go
@@ -1,0 +1,29 @@
+// A6 bad fixture: a CURRENT_TIMESTAMP default declared via
+// entsql.Annotation{DefaultExpr: ...} is forbidden — Ent emits it as a
+// parenthesized RawExpr that Atlas's SQLite inspector does not round-trip,
+// producing a perpetual phantom table rebuild (issue #1328).
+package schema
+
+import (
+	"time"
+
+	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
+	"entgo.io/ent/schema/field"
+)
+
+type WithDefaultExpr struct {
+	ent.Schema
+}
+
+func (WithDefaultExpr) Fields() []ent.Field {
+	return []ent.Field{
+		field.Time("last_accessed_at").
+			Optional().
+			Nillable().
+			Default(time.Now).
+			Annotations(entsql.Annotation{
+				DefaultExpr: "CURRENT_TIMESTAMP",
+			}),
+	}
+}

--- a/cmd/ent-lint/testdata/a6_bad_pointer/schema.go
+++ b/cmd/ent-lint/testdata/a6_bad_pointer/schema.go
@@ -1,0 +1,30 @@
+// A6 bad fixture (pointer form): the forbidden DefaultExpr default is just
+// as broken when passed as a pointer to the composite literal
+// (&entsql.Annotation{...}) — entsql.Annotation has a value-receiver Name(),
+// so the pointer form also satisfies schema.Annotation and compiles. The
+// linter must unwrap the address-of operator and still flag it (issue #1328).
+package schema
+
+import (
+	"time"
+
+	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
+	"entgo.io/ent/schema/field"
+)
+
+type WithDefaultExprPointer struct {
+	ent.Schema
+}
+
+func (WithDefaultExprPointer) Fields() []ent.Field {
+	return []ent.Field{
+		field.Time("last_accessed_at").
+			Optional().
+			Nillable().
+			Default(time.Now).
+			Annotations(&entsql.Annotation{
+				DefaultExpr: "CURRENT_TIMESTAMP",
+			}),
+	}
+}

--- a/cmd/ent-lint/testdata/a6_good/schema.go
+++ b/cmd/ent-lint/testdata/a6_good/schema.go
@@ -1,0 +1,26 @@
+// A6 good fixture: a CURRENT_TIMESTAMP default declared via
+// entsql.Default(...) is OK — Ent emits a string default that Atlas's
+// SQLite inspector round-trips exactly (issue #1328).
+package schema
+
+import (
+	"time"
+
+	"entgo.io/ent"
+	"entgo.io/ent/dialect/entsql"
+	"entgo.io/ent/schema/field"
+)
+
+type WithEntsqlDefault struct {
+	ent.Schema
+}
+
+func (WithEntsqlDefault) Fields() []ent.Field {
+	return []ent.Field{
+		field.Time("last_accessed_at").
+			Optional().
+			Nillable().
+			Default(time.Now).
+			Annotations(entsql.Default("CURRENT_TIMESTAMP")),
+	}
+}

--- a/cmd/generate-migrations/main_test.go
+++ b/cmd/generate-migrations/main_test.go
@@ -55,6 +55,71 @@ func TestSQLOnlyEmitsThreeDialects(t *testing.T) {
 	assert.Equal(t, stamps[1], stamps[2], "timestamp prefixes must match across dialects")
 }
 
+// TestSQLiteNoPhantomDiff pins issue #1328: generating a SQLite migration
+// against the committed Ent schema with no field change MUST be a no-op.
+// Before the fix, `last_accessed_at`'s `entsql.Annotation{DefaultExpr:
+// "CURRENT_TIMESTAMP"}` made Atlas emit a perpetual ModifyColumn
+// (ChangeDefault) for narinfos and nar_files — a full table rebuild on
+// every migration. The diff must be empty, so no new .sql file is written.
+func TestSQLiteNoPhantomDiff(t *testing.T) {
+	t.Parallel()
+
+	binary := buildGenerateMigrations(t)
+
+	// Replay needs the real committed migration history; copy the SQLite
+	// dialect dir into an isolated root so the probe never pollutes the repo.
+	root := t.TempDir()
+	srcDir := filepath.Join("..", "..", "migrations", "sqlite")
+	dstDir := filepath.Join(root, "migrations", "sqlite")
+	require.NoError(t, copyDir(srcDir, dstDir))
+
+	before, err := filepath.Glob(filepath.Join(dstDir, "*.sql"))
+	require.NoError(t, err)
+
+	out, err := exec.CommandContext(t.Context(), binary,
+		"--name=phantom_probe", "--skip=postgres,mysql", "--root="+root).
+		CombinedOutput()
+	require.NoErrorf(t, err, "generate-migrations failed; output:\n%s", string(out))
+
+	after, err := filepath.Glob(filepath.Join(dstDir, "*.sql"))
+	require.NoError(t, err)
+
+	assert.Lenf(t, after, len(before),
+		"expected no new SQLite migration for an unchanged schema (issue #1328 phantom diff); "+
+			"before=%d after=%d; output:\n%s", len(before), len(after), string(out))
+}
+
+// copyDir copies every regular file directly under src into dst (one level;
+// the migration dirs are flat).
+func copyDir(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+
+		b, err := os.ReadFile(filepath.Join(src, e.Name()))
+		if err != nil {
+			return err
+		}
+
+		//nolint:gosec // G703: dst is a t.TempDir()-rooted, test-controlled path
+		if err := os.WriteFile(filepath.Join(dst, e.Name()), b, 0o600); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // TestNameValidation pins the placeholder-name rejection contract.
 func TestNameValidation(t *testing.T) {
 	t.Parallel()

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -121,7 +121,7 @@ var (
 		{Name: "chunking_started_at", Type: field.TypeTime, Nullable: true},
 		{Name: "verified_at", Type: field.TypeTime, Nullable: true},
 		{Name: "bytes_stored_at", Type: field.TypeTime, Nullable: true},
-		{Name: "last_accessed_at", Type: field.TypeTime, Nullable: true, Default: schema.Expr("CURRENT_TIMESTAMP")},
+		{Name: "last_accessed_at", Type: field.TypeTime, Nullable: true, Default: "CURRENT_TIMESTAMP"},
 	}
 	// NarFilesTable holds the schema information for the "nar_files" table.
 	NarFilesTable = &schema.Table{
@@ -196,7 +196,7 @@ var (
 		{Name: "deriver", Type: field.TypeString, Nullable: true},
 		{Name: "system", Type: field.TypeString, Nullable: true},
 		{Name: "ca", Type: field.TypeString, Nullable: true},
-		{Name: "last_accessed_at", Type: field.TypeTime, Nullable: true, Default: schema.Expr("CURRENT_TIMESTAMP")},
+		{Name: "last_accessed_at", Type: field.TypeTime, Nullable: true, Default: "CURRENT_TIMESTAMP"},
 	}
 	// NarinfosTable holds the schema information for the "narinfos" table.
 	NarinfosTable = &schema.Table{

--- a/ent/schema/nar_file.go
+++ b/ent/schema/nar_file.go
@@ -65,9 +65,12 @@ func (NarFile) Fields() []ent.Field {
 			Optional().
 			Nillable().
 			Default(time.Now).
-			Annotations(entsql.Annotation{
-				DefaultExpr: "CURRENT_TIMESTAMP",
-			}),
+			// DB default declared via entsql.Default (a string default Atlas's
+			// SQLite inspector round-trips exactly) rather than
+			// entsql.Annotation{DefaultExpr: ...} (a parenthesized RawExpr the
+			// inspector strips, producing a perpetual phantom table rebuild —
+			// issue #1328). Mirrors the Timestamps mixin's created_at.
+			Annotations(entsql.Default("CURRENT_TIMESTAMP")),
 	}
 }
 

--- a/ent/schema/narinfo.go
+++ b/ent/schema/narinfo.go
@@ -63,9 +63,12 @@ func (NarInfo) Fields() []ent.Field {
 			Optional().
 			Nillable().
 			Default(time.Now).
-			Annotations(entsql.Annotation{
-				DefaultExpr: "CURRENT_TIMESTAMP",
-			}),
+			// DB default declared via entsql.Default (a string default Atlas's
+			// SQLite inspector round-trips exactly) rather than
+			// entsql.Annotation{DefaultExpr: ...} (a parenthesized RawExpr the
+			// inspector strips, producing a perpetual phantom table rebuild —
+			// issue #1328). Mirrors the Timestamps mixin's created_at.
+			Annotations(entsql.Default("CURRENT_TIMESTAMP")),
 	}
 }
 

--- a/openspec/changes/archive/2026-06-06-fix-sqlite-default-expr-phantom-diff/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-06-fix-sqlite-default-expr-phantom-diff/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/archive/2026-06-06-fix-sqlite-default-expr-phantom-diff/design.md
+++ b/openspec/changes/archive/2026-06-06-fix-sqlite-default-expr-phantom-diff/design.md
@@ -1,0 +1,70 @@
+## Context
+
+GitHub issue #1328 reports that `task migrations:gen` rebuilds the unrelated `narinfos` table (a destructive create/copy/drop/rename swap) on **every** new SQLite migration. The issue hypothesized a CHECK-constraint normalization mismatch and suggested a one-time corrective migration.
+
+Direct investigation (replaying the committed SQLite migrations into an in-memory DB and intercepting Atlas's computed changes via Ent's `schema.WithDiffHook`) disproved that hypothesis and pinpointed the real cause:
+
+```
+ModifyTable narinfos:  ModifyColumn last_accessed_at  (ChangeKind=64 = ChangeDefault)
+ModifyTable nar_files: ModifyColumn last_accessed_at  (ChangeKind=64 = ChangeDefault)
+  current  (inspected from stored DDL): RawExpr{"CURRENT_TIMESTAMP"}
+  desired  (Ent):                       RawExpr{"(CURRENT_TIMESTAMP)"}
+```
+
+`last_accessed_at` (on `narinfos` and `nar_files` — the only two tables that have it, hence the only two rebuilt) declares its default via `entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"}`. Ent emits this as `schema.Expr("CURRENT_TIMESTAMP")` (Atlas `RawExpr`). Atlas's SQLite planner parenthesizes a `RawExpr` default → desired `(CURRENT_TIMESTAMP)`; Atlas's SQLite inspector strips the parens on readback → current `CURRENT_TIMESTAMP`. They never compare equal, so the diff is non-empty forever, and SQLite expresses a column-default change as a full table rebuild.
+
+`created_at` (and `updated_at`) escape this because the `Timestamps` mixin declares the default via `entsql.Default("CURRENT_TIMESTAMP")`, emitted as the plain string `"CURRENT_TIMESTAMP"`, which Atlas treats as a recognized literal/function default and round-trips exactly. Postgres and MySQL are unaffected because their inspectors normalize the parenthesization.
+
+Constraints: migrations are forward-only and existing files are immutable (`.claude/rules/ent-migrations.md`). The fix must not require editing or adding migration files, and must not change runtime default behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make SQLite `migrations:gen` produce an empty diff when no Ent field changed, and a table-scoped diff otherwise.
+- Eliminate the need to hand-trim SQLite migrations for `narinfos`/`nar_files`.
+- Prevent regression with a static lint guard.
+
+**Non-Goals:**
+- No corrective/data migration; no edits to existing migration files.
+- No change to Postgres/MySQL output (already clean).
+- No change to the runtime DB default of `last_accessed_at` (stays `CURRENT_TIMESTAMP`).
+- No broad sweep of unrelated `DefaultExpr` usages.
+
+## Decisions
+
+### Decision 1: Fix at the Ent schema layer, not via a migration
+
+Change `last_accessed_at` in `ent/schema/narinfo.go` and `ent/schema/nar_file.go` from `entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"}` to `entsql.Default("CURRENT_TIMESTAMP")`, then regenerate the Ent client.
+
+- **Why:** This makes Ent's *desired* schema use the same string-default representation that Atlas's SQLite inspector reports for the *current* schema, so the diff is empty. It mirrors the already-correct `created_at` in the `Timestamps` mixin.
+- **Key property:** the emitted on-disk DDL is byte-identical (`DEFAULT (CURRENT_TIMESTAMP)`). Verified by regenerating and confirming `migrations:gen` produces no new SQLite file. Because the DDL is unchanged, **existing databases need no migration**.
+- **Alternative — corrective migration (the issue's suggestion):** rejected. The stored DDL is already Atlas-canonical; rebuilding the table to the same DDL would not change what the inspector reads, so the phantom diff would persist. It also violates the forward-only/no-rebuild policy for no benefit.
+- **Alternative — set `DefaultExpr: "(CURRENT_TIMESTAMP)"` (pre-parenthesized):** rejected as fragile — it depends on Atlas's internal paren handling and risks diverging Postgres/MySQL output.
+- **Alternative — a diff-hook normalizer in `cmd/generate-migrations`** that drops paren-only `ChangeDefault` deltas: rejected as a heavier, less-obvious fix that masks the diff rather than making desired == current; the schema-layer fix is one line per table and self-documenting.
+
+### Decision 2: Add a static lint guard (A6) in `cmd/ent-lint`
+
+Add an AST check that fails on `entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"}` and recommends `entsql.Default("CURRENT_TIMESTAMP")`.
+
+- **Why:** the issue explicitly flags regression risk; this is the same class of guard `cmd/ent-lint` already provides for invariants A1/A2/A4, wired into `nix flake check`.
+- **Scope:** narrowly targets the `CURRENT_TIMESTAMP` literal in a `DefaultExpr` annotation — the proven phantom-diff trigger — not all `DefaultExpr` usages.
+
+## Risks / Trade-offs
+
+- [Regenerated `ent/` client churn could hide an unintended change] → Confirm `git diff` on `ent/migrate/schema.go` shows only `last_accessed_at` flipping from `schema.Expr("CURRENT_TIMESTAMP")` to `"CURRENT_TIMESTAMP"`; run `task ent:check`.
+- [Postgres/MySQL output might shift] → Run `task migrations:gen` for all three dialects (deps running) and confirm no new files are produced for any dialect.
+- [`entsql.Default` semantics differ for time fields] → Mitigated by precedent: `created_at` already uses this exact form across all three dialects with clean diffs.
+- [A6 lint false positives] → The check matches only the literal `CURRENT_TIMESTAMP` string inside a `DefaultExpr` annotation key, so other `DefaultExpr` uses are unaffected.
+
+## Migration Plan
+
+1. Edit the two schema files; `task ent:generate`.
+2. `task ent:check` (lint + drift) and `task migrations:gen NAME=verify_no_phantom_diff` across all dialects — expect **no** new migration files; delete the probe if any tooling created one and re-confirm clean.
+3. Implement and wire the A6 lint check; confirm it fails on the old form and passes on the new.
+4. `task fmt && task lint && task test`.
+
+Rollback: revert the schema annotation and regenerated client. No database state changes, so rollback is a pure code revert with no data implications.
+
+## Open Questions
+
+- None. Root cause, fix, and no-migration property are empirically confirmed.

--- a/openspec/changes/archive/2026-06-06-fix-sqlite-default-expr-phantom-diff/proposal.md
+++ b/openspec/changes/archive/2026-06-06-fix-sqlite-default-expr-phantom-diff/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+`task migrations:gen` emits, **for SQLite only**, a full destructive table-rebuild of `narinfos` and `nar_files` on *every* new migration — even when the schema change touches a different table (GitHub issue #1328). Each new SQLite migration must be hand-trimmed; a missed trim ships a spurious, destructive table swap. The root cause was traced precisely: it is **not** the `narinfos` CHECK constraints (as the issue hypothesized) and **cannot** be resolved by a corrective migration.
+
+The `last_accessed_at` columns on `narinfos` and `nar_files` declare their DB default via `entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"}`. Ent codegen emits this as `schema.Expr("CURRENT_TIMESTAMP")` (an Atlas `RawExpr`). Atlas's SQLite planner renders a `RawExpr` default parenthesized — desired default `(CURRENT_TIMESTAMP)` — but Atlas's SQLite **inspector** strips the parens when reading the stored DDL back, yielding current default `CURRENT_TIMESTAMP`. The two never compare equal, so Atlas emits a perpetual `ModifyColumn last_accessed_at` (ChangeDefault) for the only two tables carrying that column, which on SQLite forces a whole-table rebuild. `created_at` (via the `Timestamps` mixin's `entsql.Default("CURRENT_TIMESTAMP")`) is immune because the plain-string form round-trips cleanly.
+
+## What Changes
+
+- Change `last_accessed_at` in `ent/schema/narinfo.go` and `ent/schema/nar_file.go` from `entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"}` to `entsql.Default("CURRENT_TIMESTAMP")` (matching the `Timestamps` mixin's `created_at`), then regenerate the Ent client.
+- The emitted on-disk DDL is **identical** (`DEFAULT (CURRENT_TIMESTAMP)`), so **no migration file is produced or required** for any dialect. Existing databases are untouched.
+- Add a `cmd/ent-lint` static guard forbidding `entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"}` (the phantom-diff-producing form) and steering authors to `entsql.Default(...)`, preventing regression.
+- Verified empirically: after the change, `task migrations:gen` (SQLite) emits no spurious migration; the diff is clean.
+
+## Non-goals
+
+- No change to Postgres or MySQL migration output (already clean).
+- No corrective/data migration and no edit to any existing migration file (forbidden by the forward-only policy, and unnecessary here).
+- No change to runtime default-value behavior; `last_accessed_at` still defaults to `CURRENT_TIMESTAMP` at the DB level.
+- Not a general audit of every `DefaultExpr` usage beyond the `CURRENT_TIMESTAMP` phantom-diff case.
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `database-migrations`: add a requirement that SQLite migration generation produces minimal, table-scoped diffs (no spurious rebuild of unrelated tables), and that DB `CURRENT_TIMESTAMP` defaults are declared via the round-trippable `entsql.Default(...)` form.
+- `ent-schema-lint`: add a statically-enforced invariant rejecting `entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"}` in favor of `entsql.Default("CURRENT_TIMESTAMP")`.
+
+## Impact
+
+- Code: `ent/schema/narinfo.go`, `ent/schema/nar_file.go`, regenerated `ent/` client, `cmd/ent-lint`.
+- No runtime I/O, network-latency, or memory impact — the change is schema-representation only and alters no SQL DDL, query path, or stored data.
+- Developer-experience impact: future SQLite migrations are trustworthy and need no hand-trimming for these tables.

--- a/openspec/changes/archive/2026-06-06-fix-sqlite-default-expr-phantom-diff/specs/database-migrations/spec.md
+++ b/openspec/changes/archive/2026-06-06-fix-sqlite-default-expr-phantom-diff/specs/database-migrations/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Generated SQLite migrations are minimal and table-scoped
+
+The system SHALL generate SQLite migrations whose DDL touches only the tables whose Ent schema actually changed. A schema change to one table SHALL NOT cause `cmd/generate-migrations` to emit a rebuild (create-new / copy / drop / rename swap) of an unrelated table. In particular, the Atlas-computed diff between the replayed SQLite migration state and the Ent desired schema SHALL be empty when no Ent schema field has changed.
+
+To guarantee this, every DB-level `CURRENT_TIMESTAMP` column default SHALL be declared via `entsql.Default("CURRENT_TIMESTAMP")` (which Ent emits as a plain string default that Atlas's SQLite inspector round-trips exactly), and SHALL NOT be declared via `entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"}` (which Ent emits as a parenthesized `RawExpr` that Atlas's SQLite inspector reads back without parentheses, producing a perpetual phantom `ModifyColumn ... ChangeDefault`).
+
+#### Scenario: No-op generation when nothing changed
+
+- **WHEN** `cmd/generate-migrations --name=<x>` is run for the SQLite dialect against the committed Ent schema with no field changes
+- **THEN** no new `migrations/sqlite/*.sql` file SHALL be produced
+- **AND** the Atlas diff SHALL report zero changes (no `ModifyTable` for `narinfos` or `nar_files`)
+
+#### Scenario: Single-table change stays single-table
+
+- **WHEN** a developer adds a field to one table (e.g. `nar_files`) and runs `task migrations:gen NAME=add_widget`
+- **THEN** the generated `migrations/sqlite/<ts>_add_widget.sql` SHALL contain DDL only for `nar_files`
+- **AND** SHALL NOT contain a `new_narinfos` table rebuild or any DDL for the unrelated `narinfos` table
+
+#### Scenario: CURRENT_TIMESTAMP defaults round-trip cleanly
+
+- **WHEN** an Ent `field.Time(...)` column declares a DB default of `CURRENT_TIMESTAMP`
+- **THEN** it SHALL use `entsql.Default("CURRENT_TIMESTAMP")` so the generated `ent/migrate/schema.go` entry reads `Default: "CURRENT_TIMESTAMP"` (a string), not `Default: schema.Expr("CURRENT_TIMESTAMP")`
+- **AND** the on-disk SQLite DDL SHALL remain `DEFAULT (CURRENT_TIMESTAMP)`, requiring no migration to existing databases

--- a/openspec/changes/archive/2026-06-06-fix-sqlite-default-expr-phantom-diff/specs/ent-schema-lint/spec.md
+++ b/openspec/changes/archive/2026-06-06-fix-sqlite-default-expr-phantom-diff/specs/ent-schema-lint/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: `cmd/ent-lint` rejects the phantom-diff `DefaultExpr` form for CURRENT_TIMESTAMP
+
+The system SHALL add a statically-enforced invariant (A6) to `cmd/ent-lint` that fails when any `ent/schema/*.go` field declares its DB default as `entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"}`. This form is forbidden because Ent emits it as a parenthesized Atlas `RawExpr` that Atlas's SQLite inspector does not round-trip, producing a perpetual phantom table rebuild in generated SQLite migrations (GitHub issue #1328). Authors SHALL instead use `entsql.Default("CURRENT_TIMESTAMP")`, which round-trips cleanly. The check SHALL emit a checklist line with the `A6` identifier, the file, and the offending field, and SHALL exit non-zero on violation.
+
+#### Scenario: A6 — DefaultExpr CURRENT_TIMESTAMP is rejected
+
+- **WHEN** a schema declares `field.Time("last_accessed_at").Annotations(entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"})`
+- **THEN** `cmd/ent-lint` SHALL fail with a `[FAIL] A6` checklist message naming the file and field and recommending `entsql.Default("CURRENT_TIMESTAMP")`
+
+#### Scenario: A6 — entsql.Default form passes
+
+- **WHEN** every `CURRENT_TIMESTAMP` default in `ent/schema/*.go` is declared via `entsql.Default("CURRENT_TIMESTAMP")`
+- **THEN** `cmd/ent-lint` SHALL emit `[PASS] A6` and SHALL NOT fail on the A6 invariant

--- a/openspec/changes/archive/2026-06-06-fix-sqlite-default-expr-phantom-diff/tasks.md
+++ b/openspec/changes/archive/2026-06-06-fix-sqlite-default-expr-phantom-diff/tasks.md
@@ -1,0 +1,28 @@
+## 1. Schema fix
+
+- [x] 1.1 In `ent/schema/narinfo.go`, change `last_accessed_at`'s annotation from `entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"}` to `entsql.Default("CURRENT_TIMESTAMP")`.
+- [x] 1.2 In `ent/schema/nar_file.go`, apply the same change to `last_accessed_at`.
+- [x] 1.3 Run `task ent:generate` and confirm `git diff ent/migrate/schema.go` shows only the two `last_accessed_at` entries flipping from `Default: schema.Expr("CURRENT_TIMESTAMP")` to `Default: "CURRENT_TIMESTAMP"`.
+
+## 2. Verify no spurious diff (all dialects)
+
+- [x] 2.1 With dev DBs running, run `task migrations:gen NAME=verify_no_phantom_diff` and confirm **no** new `.sql` file is produced under `migrations/sqlite/`, `migrations/postgres/`, or `migrations/mysql/`. _Done: ran against live deps (PG+MySQL on random ports) into a temp root — 43→43 files, zero new for all three dialects._
+- [x] 2.2 If any tooling created a probe/`atlas.sum` change, revert it; re-run to confirm the diff is clean and the working tree shows no migration files. _N/A: ran in a temp root; repo `migrations/` untouched._
+- [x] 2.3 Add/confirm a generator-level test (extending `cmd/generate-migrations/main_test.go`) asserting the SQLite diff against the committed schema is empty — i.e. no `ModifyTable` for `narinfos`/`nar_files` when no field changed. Write it test-first (red) before relying on the fix (green). _Done: `TestSQLiteNoPhantomDiff` (RED 18→19 before fix, GREEN after)._
+
+## 3. Regression guard (A6 lint)
+
+- [x] 3.1 Write a failing `cmd/ent-lint` test (red): a schema fixture using `entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"}` MUST produce a `[FAIL] A6` line and non-zero exit. _Done: `testdata/a6_bad` + case (RED: exited 0 before impl)._
+- [x] 3.2 Implement the A6 AST check in `cmd/ent-lint`: flag any field whose annotation is `entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"}`, emit a checklist line naming file + field and recommending `entsql.Default("CURRENT_TIMESTAMP")`. _Done: `checkA6`._
+- [x] 3.3 Add a passing-case test: the fixed `ent/schema/*.go` tree emits `[PASS] A6` and the check exits zero. _Done: `testdata/a6_good` + `TestEntLintRealSchemas` passes._
+- [x] 3.4 Confirm A6 runs inside `nix flake check` via the existing `ent-lint-check` derivation (extend its output set/identifiers as needed). _Confirmed: derivation runs `ent-lint --root .` and greps `[FAIL]`; A6 auto-covered, no change needed._
+
+## 4. Documentation
+
+- [x] 4.1 Update `.claude/rules/ent-migrations.md` (or `CLAUDE.md`) to record the convention: DB `CURRENT_TIMESTAMP` defaults MUST use `entsql.Default("CURRENT_TIMESTAMP")`, never `DefaultExpr`, citing issue #1328. _Done: added invariant §6._
+
+## 5. Verification
+
+- [x] 5.1 Run `task ent:check` (generate + lint + drift) and confirm it exits zero. _Done: exit 0; all A6 lines PASS; ent drift clean._
+- [x] 5.2 Run `task fmt`, `task lint`, and `task test`; confirm each exits zero. _Done: fmt OK; lint 0 issues; test exit 0 (29 pkgs, 0 fail)._
+- [x] 5.3 Confirm `git status` shows no new or modified files under `migrations/` (proving the fix needs no migration). _Done: 0 changed files under migrations/._

--- a/openspec/specs/database-migrations/spec.md
+++ b/openspec/specs/database-migrations/spec.md
@@ -226,3 +226,27 @@ The runtime container image SHALL ship the `ncps` binary as the sole migration e
 - **WHEN** the runtime image (`.#docker`) is built
 - **THEN** the resulting image's filesystem SHALL NOT contain a `/bin/dbmate` (or any other path serving the dbmate binary)
 - **AND** `nix run .#docker | docker run --rm -it … which dbmate` SHALL exit non-zero
+
+### Requirement: Generated SQLite migrations are minimal and table-scoped
+
+The system SHALL generate SQLite migrations whose DDL touches only the tables whose Ent schema actually changed. A schema change to one table SHALL NOT cause `cmd/generate-migrations` to emit a rebuild (create-new / copy / drop / rename swap) of an unrelated table. In particular, the Atlas-computed diff between the replayed SQLite migration state and the Ent desired schema SHALL be empty when no Ent schema field has changed.
+
+To guarantee this, every DB-level `CURRENT_TIMESTAMP` column default SHALL be declared via `entsql.Default("CURRENT_TIMESTAMP")` (which Ent emits as a plain string default that Atlas's SQLite inspector round-trips exactly), and SHALL NOT be declared via `entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"}` (which Ent emits as a parenthesized `RawExpr` that Atlas's SQLite inspector reads back without parentheses, producing a perpetual phantom `ModifyColumn ... ChangeDefault`).
+
+#### Scenario: No-op generation when nothing changed
+
+- **WHEN** `cmd/generate-migrations --name=<x>` is run for the SQLite dialect against the committed Ent schema with no field changes
+- **THEN** no new `migrations/sqlite/*.sql` file SHALL be produced
+- **AND** the Atlas diff SHALL report zero changes (no `ModifyTable` for `narinfos` or `nar_files`)
+
+#### Scenario: Single-table change stays single-table
+
+- **WHEN** a developer adds a field to one table (e.g. `nar_files`) and runs `task migrations:gen NAME=add_widget`
+- **THEN** the generated `migrations/sqlite/<ts>_add_widget.sql` SHALL contain DDL only for `nar_files`
+- **AND** SHALL NOT contain a `new_narinfos` table rebuild or any DDL for the unrelated `narinfos` table
+
+#### Scenario: CURRENT_TIMESTAMP defaults round-trip cleanly
+
+- **WHEN** an Ent `field.Time(...)` column declares a DB default of `CURRENT_TIMESTAMP`
+- **THEN** it SHALL use `entsql.Default("CURRENT_TIMESTAMP")` so the generated `ent/migrate/schema.go` entry reads `Default: "CURRENT_TIMESTAMP"` (a string), not `Default: schema.Expr("CURRENT_TIMESTAMP")`
+- **AND** the on-disk SQLite DDL SHALL remain `DEFAULT (CURRENT_TIMESTAMP)`, requiring no migration to existing databases

--- a/openspec/specs/ent-schema-lint/spec.md
+++ b/openspec/specs/ent-schema-lint/spec.md
@@ -57,3 +57,17 @@ The system SHALL emit one line per check with a leading `[PASS]` or `[FAIL]` tok
 - **WHEN** `cmd/ent-lint --root .` is invoked
 - **THEN** stdout SHALL contain lines like `[PASS] A1 ent/schema/narinfo.go: no field-level entsql.Check` and (on failure) `[FAIL] A4 ent/schema/narinfo.go:<line> edge.To("references", Target.Type) has no reciprocal edge.From(NarInfo.Type).Ref("references") on Target — Ent will fabricate a phantom FK column`
 - **AND** the exit code SHALL be non-zero if and only if at least one `[FAIL]` line is emitted
+
+### Requirement: `cmd/ent-lint` rejects the phantom-diff `DefaultExpr` form for CURRENT_TIMESTAMP
+
+The system SHALL add a statically-enforced invariant (A6) to `cmd/ent-lint` that fails when any `ent/schema/*.go` field declares its DB default as `entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"}`. This form is forbidden because Ent emits it as a parenthesized Atlas `RawExpr` that Atlas's SQLite inspector does not round-trip, producing a perpetual phantom table rebuild in generated SQLite migrations (GitHub issue #1328). Authors SHALL instead use `entsql.Default("CURRENT_TIMESTAMP")`, which round-trips cleanly. The check SHALL emit a checklist line with the `A6` identifier, the file, and the offending field, and SHALL exit non-zero on violation.
+
+#### Scenario: A6 — DefaultExpr CURRENT_TIMESTAMP is rejected
+
+- **WHEN** a schema declares `field.Time("last_accessed_at").Annotations(entsql.Annotation{DefaultExpr: "CURRENT_TIMESTAMP"})`
+- **THEN** `cmd/ent-lint` SHALL fail with a `[FAIL] A6` checklist message naming the file and field and recommending `entsql.Default("CURRENT_TIMESTAMP")`
+
+#### Scenario: A6 — entsql.Default form passes
+
+- **WHEN** every `CURRENT_TIMESTAMP` default in `ent/schema/*.go` is declared via `entsql.Default("CURRENT_TIMESTAMP")`
+- **THEN** `cmd/ent-lint` SHALL emit `[PASS] A6` and SHALL NOT fail on the A6 invariant


### PR DESCRIPTION
## Summary

Fixes #1328.

`task migrations:gen` rebuilt the unrelated `narinfos` and `nar_files`
tables on **every** new sqlite migration, forcing each migration to be
hand-trimmed and risking a committed destructive table swap.

**Root cause** (traced via Ent's `WithDiffHook`): `last_accessed_at`
declared its DB default with `entsql.Annotation{DefaultExpr:
"CURRENT_TIMESTAMP"}`, which Ent emits as a parenthesized Atlas
`RawExpr`. Atlas's sqlite inspector strips the parens on readback, so
desired (`(CURRENT_TIMESTAMP)`) and inspected (`CURRENT_TIMESTAMP`)
never compare equal — a perpetual `ModifyColumn` (ChangeDefault) that
sqlite expresses as a full table rebuild. `created_at` was immune
because the `Timestamps` mixin already uses the string form
`entsql.Default("CURRENT_TIMESTAMP")`. The issue's suggested corrective
migration would **not** have worked: the stored DDL is already
atlas-canonical; the mismatch is in Ent's desired-schema representation.

## What changed

- `ent/schema/{narinfo,nar_file}.go`: `last_accessed_at` now uses
  `entsql.Default("CURRENT_TIMESTAMP")`; regenerated the Ent client.
  Emitted DDL (`DEFAULT (CURRENT_TIMESTAMP)`) is unchanged, so **no
  migration is needed** and existing databases are untouched.
- `cmd/ent-lint`: new invariant **A6** rejecting the `DefaultExpr`
  form, to prevent regression (wired into `nix flake check`).
- `cmd/generate-migrations`: `TestSQLiteNoPhantomDiff` pinning the
  empty-diff contract (RED before the fix, GREEN after).
- `.claude/rules/ent-migrations.md`: documented the convention (§6).
- Synced the `database-migrations` and `ent-schema-lint` specs.

## Test plan

- [x] `task fmt`, `task lint` (0 issues), `task test` (29 pkgs, 0 fail)
- [x] `task ent:check` exits 0 (A6 PASS on all schemas; ent drift clean)
- [x] `task migrations:gen` produces no spurious migration across
  **sqlite, postgres, and mysql** (verified against live dev DBs)
- [x] `git status` shows zero changed files under `migrations/`