### PR TITLE
fix(cache): delete the stored variant on NAR eviction

### DIFF
--- a/openspec/changes/archive/2026-06-06-fix-deletenar-orphaned-bytes/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-06-fix-deletenar-orphaned-bytes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/archive/2026-06-06-fix-deletenar-orphaned-bytes/design.md
+++ b/openspec/changes/archive/2026-06-06-fix-deletenar-orphaned-bytes/design.md
@@ -1,0 +1,40 @@
+## Context
+
+`Cache.DeleteNar` (`pkg/cache/cache.go`) evicts a NAR: it deletes the store object and clears the durable `bytes_stored_at` marker on the matching `nar_file` row. The store, however, persists `Compression:none` NARs physically under the `.nar.zst` variant (whole-file zstd, served with transparent HTTP encoding). The codebase already encodes this asymmetry in two places:
+
+- `statNarInStore` checks the `.nar.zst` variant when asked about a `none` URL.
+- `deleteNarBytes` deletes the `.nar.zst` variant first, then the requested URL, "otherwise a reclaimed none NAR would leave its real object orphaned and invisible to normal cleanup/accounting."
+
+`DeleteNar` predates / bypasses that helper: it calls `c.narStore.DeleteNar(ctx, narURL)` directly. For a `none` URL that deletes `nar/<H>.nar` (which does not exist) and leaves the real `.nar.zst` blob, then clears `bytes_stored_at`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- After `DeleteNar`, no physical NAR object for that hash remains in the store, regardless of compression.
+- The cleared `bytes_stored_at` marker is truthful: `/upload` presence and on-disk state agree.
+
+**Non-Goals:**
+- Changing `deleteNarBytes`, `PutNar`, or the `/upload` read path.
+- Sweeping pre-existing orphaned `.nar.zst` blobs (separate GC/fsck task).
+
+## Decisions
+
+**1. Delete the actually-stored variant and track whether anything was removed.**
+For a `Compression:none` URL, delete the `.nar.zst` variant (the real object) as well as the bare none URL; for explicit compression, delete the URL itself. Tolerate `storage.ErrNotFound` on each individual delete but record whether **any** variant was present, and return `ErrNotFound` only when none was — mirroring `statNarInStore`, which reports a `none` NAR present if either the `.nar.zst` variant or the bare object exists. This preserves the established, tested contract ("`DeleteNar` of an absent NAR returns `ErrNotFound`") while removing the `.nar.zst` blob that the old single-URL delete orphaned.
+*Alternatives considered*: calling `deleteNarBytes` directly (rejected — for a `none` URL it also deletes the bare object that never exists, so it **always** returns `ErrNotFound` even after deleting the real `.nar.zst`, conflating the found-signal and breaking the contract); blanket-tolerating `ErrNotFound` (rejected — silently turns the "delete of an absent NAR errors" contract into a success and would clear the marker for a genuinely-absent NAR); deleting the marker before the object (rejected — widens the window where the marker lies).
+
+**2. Keep the ordering: delete bytes first, then clear the marker.**
+Return on any non-not-found failure (and on a confirmed full absence) before clearing `bytes_stored_at`, so the marker continues to reflect reality (present) rather than being cleared while bytes survive or while the state is in doubt.
+
+## Risks / Trade-offs
+
+- [The `.nar.zst` variant is genuinely absent for a real `none`-stored NAR] → each individual delete tolerates `storage.ErrNotFound`; the `deleted` flag and the final not-found return distinguish "one variant gone" from "nothing was there."
+- [Other `DeleteNar` call sites rely on the old single-variant behavior] → the public `Cache.DeleteNar` is the eviction entry point; deleting the stored variant is strictly more correct for every caller, and the `ErrNotFound`-on-absent contract is unchanged. Internal store-level `c.narStore.DeleteNar` calls elsewhere are untouched.
+
+## Migration Plan
+
+Pure code change; no schema or migration. Deployable immediately. Rollback is reverting the one-line change. Already-orphaned blobs from the prior behavior are unaffected (out of scope).
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-06-06-fix-deletenar-orphaned-bytes/proposal.md
+++ b/openspec/changes/archive/2026-06-06-fix-deletenar-orphaned-bytes/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+`Cache.DeleteNar` removes only the exact URL variant via `c.narStore.DeleteNar(ctx, narURL)`, then clears the `bytes_stored_at` marker. But for `Compression:none` NARs the physical object is stored under the `.nar.zst` variant (the same asymmetry `deleteNarBytes` already compensates for). So deleting a none NAR (`nar/<H>.nar`) leaves the real `.nar.zst` blob orphaned on disk **and** clears `bytes_stored_at` — leaking storage and making the cleared marker untruthful: the `/upload` presence check reports the NAR absent while its bytes are still physically present.
+
+## What Changes
+
+- `Cache.DeleteNar` SHALL remove the NAR's physical object under the variant it is actually stored as — for a `Compression:none` NAR that means the `.nar.zst` variant (mirroring `statNarInStore`) — **before** clearing the `bytes_stored_at` marker.
+- The established "deleting an absent NAR returns `ErrNotFound`" contract is preserved: a not-found error is returned (and the marker kept) only when **no** variant of the NAR was present.
+- After a successful deletion, no orphaned physical object remains and the cleared `bytes_stored_at` marker is truthful (the `/upload` presence check and the NAR's on-disk state agree).
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `upload-reference-presence`: add a requirement that NAR deletion removes the physical object for every compression variant before clearing the durable `bytes_stored_at` marker, so the marker never reports absent while bytes remain on disk.
+
+## Non-goals
+
+- No change to `deleteNarBytes` itself (it already handles the variant correctly).
+- No change to how `bytes_stored_at` is set by `PutNar` or read on the `/upload` path.
+- No retroactive sweep for already-orphaned `.nar.zst` blobs left by the current behavior; that would be a separate GC/fsck concern.
+
+## Impact
+
+- **Code**: `pkg/cache/cache.go` — `DeleteNar` (variant-aware delete: remove the `.nar.zst` variant for `none` NARs, track whether any variant was present, preserve the `ErrNotFound`-on-absent contract).
+- **Database**: none (no schema/migration change).
+- **I/O / network / memory**: negligible. At most one additional store `DeleteNar` call (the `.nar.zst` variant) per `Compression:none` eviction; `ErrNotFound` on a variant is tolerated. No change to the hot serve path.

--- a/openspec/changes/archive/2026-06-06-fix-deletenar-orphaned-bytes/specs/upload-reference-presence/spec.md
+++ b/openspec/changes/archive/2026-06-06-fix-deletenar-orphaned-bytes/specs/upload-reference-presence/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: NAR deletion MUST remove the stored compression variant before clearing the bytes-stored marker
+
+When the system deletes (evicts) a NAR, it SHALL remove the NAR's physical object under the variant it is actually stored as — in particular, for a `Compression:none` NAR it SHALL remove the `.nar.zst` variant under which `none` NARs are physically stored (mirroring how presence is determined) — **before** clearing the durable `bytes_stored_at` marker on the matching `nar_file` row. The deletion SHALL return a not-found error only when **no** variant of the NAR was present, preserving the established "deleting an absent NAR errors" contract; in that case the marker SHALL NOT be cleared. A non-not-found failure SHALL be returned and SHALL leave the marker intact (the NAR stays reported present). The marker SHALL be cleared only after at least one physical variant was successfully removed.
+
+#### Scenario: Deleting a Compression:none NAR removes the underlying .nar.zst object
+
+- **GIVEN** a `Compression:none` NAR whose physical object is stored under the `.nar.zst` variant with `bytes_stored_at` set
+- **WHEN** the NAR is deleted via `nar/<H>.nar`
+- **THEN** the `.nar.zst` object SHALL be removed from the store
+- **AND** the `bytes_stored_at` marker SHALL then be cleared
+- **AND** a subsequent `/upload` presence check SHALL report the NAR absent and find no orphaned object on disk
+
+#### Scenario: Deleting a NAR absent from the store returns not-found and keeps the marker
+
+- **GIVEN** a `Compression:none` `nar_file` row with `bytes_stored_at` set but no physical bytes (neither the `.nar.zst` variant nor the bare object) in the store
+- **WHEN** the NAR is deleted
+- **THEN** the deletion SHALL return a not-found error
+- **AND** the `bytes_stored_at` marker SHALL remain set
+
+#### Scenario: A real byte-deletion failure does not clear the marker
+
+- **WHEN** removing the NAR's physical bytes fails with a non-not-found error
+- **THEN** the deletion SHALL return that error
+- **AND** the `bytes_stored_at` marker SHALL remain set (the NAR is still reported present)

--- a/openspec/changes/archive/2026-06-06-fix-deletenar-orphaned-bytes/tasks.md
+++ b/openspec/changes/archive/2026-06-06-fix-deletenar-orphaned-bytes/tasks.md
@@ -1,0 +1,14 @@
+## 1. Reproduce (TDD red)
+
+- [x] 1.1 Write a failing test: store a `Compression:none` NAR (physical object under `.nar.zst`) with `bytes_stored_at` set, call `Cache.DeleteNar(nar/<H>.nar)`, then assert the `.nar.zst` object is gone from the store (currently it leaks / errors)
+- [x] 1.2 Assert that after deletion the `/upload` presence check reports absent AND no physical object remains (marker and disk agree)
+
+## 2. Fix (TDD green)
+
+- [x] 2.1 In `Cache.DeleteNar`, delete the actually-stored variant (the `.nar.zst` variant for `Compression:none`, mirroring `statNarInStore`) before clearing `bytes_stored_at`
+- [x] 2.2 Track whether any variant was present; return `ErrNotFound` only when none was (preserve the established contract), and return non-not-found errors without clearing the marker
+
+## 3. Verify
+
+- [x] 3.1 Add a test that an absent `none` NAR (no variant present) returns `ErrNotFound` and leaves the marker set (contract preserved); confirm the existing xz "absent → ErrNotFound" backend test still passes
+- [x] 3.2 `task fmt`, `task lint`, and `task test` all exit zero

--- a/openspec/specs/upload-reference-presence/spec.md
+++ b/openspec/specs/upload-reference-presence/spec.md
@@ -39,3 +39,28 @@ The marker SHALL be trusted only on the upload-only path. On the substituter pat
 - **THEN** the marker SHALL NOT be trusted as proof of local servability
 - **AND** the system SHALL fall back to upstream self-healing
 
+### Requirement: NAR deletion MUST remove the stored compression variant before clearing the bytes-stored marker
+
+When the system deletes (evicts) a NAR, it SHALL remove the NAR's physical object under the variant it is actually stored as — in particular, for a `Compression:none` NAR it SHALL remove the `.nar.zst` variant under which `none` NARs are physically stored (mirroring how presence is determined) — **before** clearing the durable `bytes_stored_at` marker on the matching `nar_file` row. The deletion SHALL return a not-found error only when **no** variant of the NAR was present, preserving the established "deleting an absent NAR errors" contract; in that case the marker SHALL NOT be cleared. A non-not-found failure SHALL be returned and SHALL leave the marker intact (the NAR stays reported present). The marker SHALL be cleared only after at least one physical variant was successfully removed.
+
+#### Scenario: Deleting a Compression:none NAR removes the underlying .nar.zst object
+
+- **GIVEN** a `Compression:none` NAR whose physical object is stored under the `.nar.zst` variant with `bytes_stored_at` set
+- **WHEN** the NAR is deleted via `nar/<H>.nar`
+- **THEN** the `.nar.zst` object SHALL be removed from the store
+- **AND** the `bytes_stored_at` marker SHALL then be cleared
+- **AND** a subsequent `/upload` presence check SHALL report the NAR absent and find no orphaned object on disk
+
+#### Scenario: Deleting a NAR absent from the store returns not-found and keeps the marker
+
+- **GIVEN** a `Compression:none` `nar_file` row with `bytes_stored_at` set but no physical bytes (neither the `.nar.zst` variant nor the bare object) in the store
+- **WHEN** the NAR is deleted
+- **THEN** the deletion SHALL return a not-found error
+- **AND** the `bytes_stored_at` marker SHALL remain set
+
+#### Scenario: A real byte-deletion failure does not clear the marker
+
+- **WHEN** removing the NAR's physical bytes fails with a non-not-found error
+- **THEN** the deletion SHALL return that error
+- **AND** the `bytes_stored_at` marker SHALL remain set (the NAR is still reported present)
+

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1746,8 +1746,36 @@ func (c *Cache) DeleteNar(ctx context.Context, narURL nar.URL) error {
 
 		zerolog.Ctx(ctx).Debug().Msg("deleting nar from store")
 
-		if err := c.narStore.DeleteNar(ctx, narURL); err != nil {
+		// Remove the physical bytes. A Compression:none NAR's real object is stored
+		// under the .nar.zst variant (statNarInStore mirrors this), so that variant
+		// must be deleted too — deleting only the bare none URL would orphan the
+		// blob while the marker below is cleared, making the /upload presence check
+		// lie. ErrNotFound is returned only when no variant was present, preserving
+		// the established "deleting an absent NAR errors" contract; a real failure
+		// is returned and leaves the marker intact (the NAR stays present).
+		deleted := false
+
+		if narURL.Compression == nar.CompressionTypeNone {
+			zstdURL := narURL
+			zstdURL.Compression = nar.CompressionTypeZstd
+
+			switch err := c.narStore.DeleteNar(ctx, zstdURL); {
+			case err == nil:
+				deleted = true
+			case !errors.Is(err, storage.ErrNotFound):
+				return err
+			}
+		}
+
+		switch err := c.narStore.DeleteNar(ctx, narURL); {
+		case err == nil:
+			deleted = true
+		case !errors.Is(err, storage.ErrNotFound):
 			return err
+		}
+
+		if !deleted {
+			return storage.ErrNotFound
 		}
 
 		// The bytes are gone; clear the durable bytes-stored marker for this variant

--- a/pkg/cache/nondestructive_narinfo_purge_internal_test.go
+++ b/pkg/cache/nondestructive_narinfo_purge_internal_test.go
@@ -16,6 +16,7 @@ import (
 	entnarinfo "github.com/kalbasit/ncps/ent/narinfo"
 
 	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
 	"github.com/kalbasit/ncps/pkg/storage/chunk"
 	"github.com/kalbasit/ncps/testdata"
 	"github.com/kalbasit/ncps/testhelper"
@@ -474,6 +475,79 @@ func TestDeleteNar_ClearsBytesStoredMarker(t *testing.T) {
 
 	assert.False(t, c.narFileBytesStored(ctx, narURL),
 		"deleting the NAR bytes must clear bytes_stored_at so /upload does not report it present")
+}
+
+// TestDeleteNar_RemovesNoneNarZstdVariant covers fix-deletenar-orphaned-bytes:
+// a Compression:none NAR's physical object lives under the .nar.zst variant, so
+// DeleteNar must remove that variant (not just the bare none URL) before clearing
+// bytes_stored_at. Otherwise the real blob is orphaned on disk while the marker
+// is cleared — leaking storage and making the /upload presence check lie (report
+// absent while bytes remain).
+func TestDeleteNar_RemovesNoneNarZstdVariant(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newUploadOnlyPurgeCacheNoSeed(t)
+
+	ctx := newContext()
+
+	narHash := testhelper.MustRandBase32NarHash()
+	noneURL := nar.URL{Hash: narHash, Compression: nar.CompressionTypeNone, Query: url.Values{}}
+	zstdURL := nar.URL{Hash: narHash, Compression: nar.CompressionTypeZstd, Query: url.Values{}}
+
+	// A Compression:none NAR is physically stored under the .nar.zst variant.
+	_, err := c.narStore.PutNar(ctx, zstdURL, strings.NewReader("dummy-nar-bytes!"), -1)
+	require.NoError(t, err)
+
+	_, err = c.dbClient.Ent().NarFile.Create().
+		SetHash(narHash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(16).
+		SetTotalChunks(0).
+		SetBytesStoredAt(time.Now()).
+		Save(ctx)
+	require.NoError(t, err)
+
+	require.True(t, c.narStore.HasNar(ctx, zstdURL), "precondition: .nar.zst variant present")
+
+	require.NoError(t, c.DeleteNar(ctx, noneURL))
+
+	assert.False(t, c.narStore.HasNar(ctx, zstdURL),
+		"deleting a Compression:none NAR must remove the underlying .nar.zst object, not orphan it")
+	assert.False(t, c.narFileBytesStored(ctx, noneURL),
+		"the bytes-stored marker must be cleared after deletion")
+}
+
+// TestDeleteNar_AbsentNoneNarReturnsNotFound covers the contract preservation of
+// fix-deletenar-orphaned-bytes: the variant-aware delete must still return
+// ErrNotFound (and leave the bytes-stored marker intact) when neither the
+// .nar.zst variant nor the bare none object is present — matching the established
+// "deleting an absent NAR errors" behavior for explicitly-compressed NARs.
+func TestDeleteNar_AbsentNoneNarReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	c, _ := newUploadOnlyPurgeCacheNoSeed(t)
+
+	ctx := newContext()
+
+	narHash := testhelper.MustRandBase32NarHash()
+	noneURL := nar.URL{Hash: narHash, Compression: nar.CompressionTypeNone, Query: url.Values{}}
+
+	// A nar_file row with a marker but NO physical bytes in the store.
+	_, err := c.dbClient.Ent().NarFile.Create().
+		SetHash(narHash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(16).
+		SetTotalChunks(0).
+		SetBytesStoredAt(time.Now()).
+		Save(ctx)
+	require.NoError(t, err)
+
+	require.ErrorIs(t, c.DeleteNar(ctx, noneURL), storage.ErrNotFound,
+		"deleting a none NAR whose bytes are absent must return ErrNotFound")
+	assert.True(t, c.narFileBytesStored(ctx, noneURL),
+		"the bytes-stored marker must remain set when nothing was deleted")
 }
 
 // TestCheckAndFixNarInfosForNar_ReconcilesMissingLink is Fix C (the creation-race


### PR DESCRIPTION
## Summary

`Cache.DeleteNar` removed only the exact URL variant via `narStore.DeleteNar`, but a `Compression:none` NAR's physical object is stored under the `.nar.zst` variant. Deleting `nar/<H>.nar` therefore left the real `.nar.zst` blob orphaned on disk while still clearing `bytes_stored_at` — leaking storage and making the `/upload` presence check lie (report absent while bytes remain). It also spuriously errored, since the bare none object never exists.

This deletes the actually-stored variant (the `.nar.zst` variant for `none`, mirroring `statNarInStore`) and tracks whether any variant was present, returning `ErrNotFound` only when none was — preserving the established "deleting an absent NAR errors" contract while no longer orphaning the blob.

Surfaced by a CodeRabbit "outside diff range" finding on #1331; scoped out of that PR as pre-existing, now fixed on its own.

Specs: adds a requirement to `upload-reference-presence` (deletion removes the stored variant before clearing the marker; not-found only when no variant was present).

## Test plan

- [x] `task fmt`, `task lint`, `task test` pass
- [x] New: `TestDeleteNar_RemovesNoneNarZstdVariant` (none NAR removes the `.nar.zst` object)
- [x] New: `TestDeleteNar_AbsentNoneNarReturnsNotFound` (contract: absent → `ErrNotFound`, marker kept)
- [x] Existing xz `DeleteNar` "absent → ErrNotFound" backend test still passes