### PR TITLE
fix(cache): match unlinked prefixed narinfo URLs hash-aware

### DIFF
--- a/openspec/changes/archive/2026-06-06-fix-dechunk-unlinked-narinfo-url-match/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-06-fix-dechunk-unlinked-narinfo-url-match/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/archive/2026-06-06-fix-dechunk-unlinked-narinfo-url-match/design.md
+++ b/openspec/changes/archive/2026-06-06-fix-dechunk-unlinked-narinfo-url-match/design.md
@@ -1,0 +1,55 @@
+## Context
+
+When a NAR is de-chunked to whole-file (`Compression:none`) storage, the de-chunk path must (a) resolve the verification NarHash from a referencing narinfo and (b) rewrite every referencing narinfo's URL to `nar/<H>.nar`. Both depend on locating the narinfos that reference the NAR. Three sites in `pkg/cache/cache.go` do this with the same predicate:
+
+```go
+entnarinfo.Or(
+    entnarinfo.HasNarInfoNarFilesWith(entnarinfonarfile.NarFileIDEQ(nr.ID)), // join link (primary)
+    entnarinfo.URLHasPrefix("nar/"+narURL.Hash+"."),                          // URL fallback
+)
+```
+
+- `MigrateChunksToNar` (the flip transaction — normalizes URLs)
+- `NormalizeChunkedNarInfoURL`
+- `LinkedNarinfoNarHash` (resolves the verification NarHash)
+
+The URL fallback exists to cover **unlinked** rows (a known race drops the `narinfo_nar_files` link). But `URLHasPrefix("nar/"+H+".")` only matches URLs whose path component immediately after `nar/` is the NAR hash. A nix-serve-style prefixed URL embeds a narinfo-hash prefix: `nar/<narinfoHash>-<H>.nar.xz`. That string starts with `nar/<narinfoHash>-`, so the `nar/<H>.` prefix never matches. Unlinked + prefixed therefore falls through both branches.
+
+The project already has URL parsing/normalization that strips the narinfo-hash prefix: `nar.URL.Normalize()` (and `ParseURL`) reduce `nar/<narinfoHash>-<H>.nar.xz` to hash `H`. The fix is to use that, hash-aware, instead of a textual prefix.
+
+## Goals / Non-Goals
+
+**Goals:**
+- An unlinked narinfo with a nix-serve-style prefixed URL is recognized as referencing the NAR.
+- All three sites share one hash-aware identification, so they cannot drift.
+- Join-link and canonical-URL matches keep working.
+
+**Non-Goals:**
+- Changing the join-link primary path or verified-or-nothing reconstruction.
+- A repair migration for already-stranded narinfos (the corrected pass fixes them on next run).
+
+## Decisions
+
+**1. Match by normalized embedded hash, not by URL prefix.**
+Replace the `URLHasPrefix` branch with a hash-aware match: identify a candidate narinfo as referencing the NAR when `Normalize(ParseURL(narinfo.URL)).Hash == narURL.Hash`. Because a prefixed URL cannot be reduced to its hash in pure SQL, the fallback fetches candidate narinfos and evaluates the embedded hash in Go, then operates on the matched set.
+*Alternatives considered*: a broader SQL `LIKE %<H>.%` (rejected — can match unrelated hashes / different NARs, losing the "trailing dot anchors the fixed-length hash" safety the current code relies on); a generated normalized-hash column on `narinfos` (rejected — schema/migration cost for a narrow race-recovery path).
+
+**2. One shared helper for all three sites.**
+Extract the hash-aware "does this narinfo reference NAR H" logic into a single helper so `MigrateChunksToNar`, `NormalizeChunkedNarInfoURL`, and `LinkedNarinfoNarHash` use identical semantics.
+
+**3. Keep the join link as the primary, cheap path.**
+Try the join link first; only fall back to the hash-aware URL scan when no link exists, preserving today's fast path and only paying the scan for the unlinked race.
+
+## Risks / Trade-offs
+
+- [Fetching + parsing candidate narinfos costs more than a prefix `UPDATE`] → bounded by the few narinfos referencing one hash, and only on the unlinked fallback; the hot path (join link) is unchanged.
+- [A malformed/unparseable narinfo URL] → treated as non-matching (same as today's prefix miss), never as a false match; reconstruction stays verified-or-nothing.
+- [Behavioral overlap with the existing "resolved by NAR hash from any referencing narinfo" scenario] → that scenario covers canonical different-compression URLs (`nar/<H>.nar.xz`); this change additionally covers the prefixed form (`nar/<narinfoHash>-<H>...`). The hash-aware helper subsumes both.
+
+## Migration Plan
+
+Pure code change; no schema or migration. Deployable immediately. Rollback is reverting the helper + three call sites. Stranded narinfos from the old behavior self-correct the next time the de-chunk pass processes their hash.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-06-06-fix-dechunk-unlinked-narinfo-url-match/proposal.md
+++ b/openspec/changes/archive/2026-06-06-fix-dechunk-unlinked-narinfo-url-match/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The de-chunk path identifies the narinfos that reference a NAR with a raw SQL predicate: `Or(HasNarInfoNarFilesWith(join), URLHasPrefix("nar/"+hash+"."))`. The prefix branch only matches **canonical** `nar/<hash>...` URLs. A nix-serve-style **prefixed** URL — `nar/<narinfoHash>-<hash>.nar.xz` — starts with `nar/<narinfoHash>-`, so the `nar/<hash>.` prefix never matches it. When such a narinfo is also **unlinked** (a known race drops the `narinfo_nar_files` join row), neither branch matches, so:
+
+- `MigrateChunksToNar` / `NormalizeChunkedNarInfoURL` leave the narinfo advertising a stale `.nar.xz` URL after the NAR is de-chunked to whole-file → a later serve 404s (serve-time normalization only rewrites while chunks exist).
+- `LinkedNarinfoNarHash` wrongly concludes there is no `NarHash` to verify against.
+
+This is reachable: `checkAndFixNarInfosForNar` already documents that CDC row replacement can drop the join row.
+
+## What Changes
+
+- The three de-chunk sites that locate referencing narinfos (`MigrateChunksToNar`, `NormalizeChunkedNarInfoURL`, `LinkedNarinfoNarHash`) SHALL identify a referencing narinfo **hash-aware**: parse/normalize each candidate URL's embedded NAR hash and match it against the target hash, instead of a raw `URLHasPrefix` match.
+- As a result, an unlinked narinfo with a nix-serve-style prefixed URL (`nar/<narinfoHash>-<hash>.nar.xz`) SHALL be found — so its verification NarHash is resolved and its URL is normalized to `none` on de-chunk.
+- The join-link branch and canonical-URL matches continue to work unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `chunks-to-nar-migration`: strengthen the "resolve verification NarHash via the narinfo URL when no join link exists" and "de-chunking MUST normalize the narinfo URL to none" requirements so the URL-based narinfo lookup is hash-aware and covers unlinked nix-serve-style prefixed URLs.
+
+## Non-goals
+
+- No change to the join-link (primary) match path or to verified-or-nothing reconstruction.
+- No change to how prefixed URLs are produced by nix-serve-style upstreams.
+- No backfill/repair migration for already-stranded narinfos; the corrected de-chunk pass fixes them on its next run over the affected hash.
+
+## Impact
+
+- **Code**: `pkg/cache/cache.go` — the three `URLHasPrefix("nar/"+narURL.Hash+".")` sites (in `MigrateChunksToNar`, `NormalizeChunkedNarInfoURL`, `LinkedNarinfoNarHash`) replaced with a hash-aware match (a shared predicate/helper reusing the existing URL parse/normalize logic).
+- **Database**: none (no schema/migration change).
+- **I/O / network / memory**: negligible. The hash-aware match may require fetching candidate narinfo rows and parsing their URLs in Go rather than a single prefix-filtered `UPDATE`; bounded by the small number of narinfos referencing one hash. No change to the hot serve path.

--- a/openspec/changes/archive/2026-06-06-fix-dechunk-unlinked-narinfo-url-match/specs/chunks-to-nar-migration/spec.md
+++ b/openspec/changes/archive/2026-06-06-fix-dechunk-unlinked-narinfo-url-match/specs/chunks-to-nar-migration/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: De-chunk MUST resolve the verification NarHash via the narinfo URL when no join link exists
+
+When de-chunking a NAR, the system resolves the expected NarHash from the linked narinfo in order to content-verify the reconstruction (verified-or-nothing). When the `narinfo_nar_files` join link is absent — a known race leaves CDC-chunked `nar_file` rows unlinked — the system SHALL fall back to resolving the narinfo by the NAR's hash, matching **hash-aware** rather than by raw URL prefix: a candidate narinfo references the NAR when its URL, parsed and normalized (narinfo-hash prefix stripped), has the same NAR hash. This SHALL cover both canonical URLs (`nar/<hash>.nar[.<ext>]`) and nix-serve-style prefixed URLs (`nar/<narinfoHash>-<hash>.nar[.<ext>]`). Only when no narinfo references the NAR by either the join link or a hash-matched URL SHALL the de-chunk be skipped for want of a verification hash.
+
+#### Scenario: Unlinked chunked NAR is de-chunked via the URL-resolved NarHash
+
+- **GIVEN** a `nar_file` for hash `H` with `total_chunks > 0` and intact chunk links
+- **AND** a narinfo with URL `nar/<H>.nar` carrying a recorded NarHash
+- **AND** NO `narinfo_nar_files` link between that narinfo and the `nar_file`
+- **WHEN** `MigrateChunksToNar` is invoked for `H`
+- **THEN** the system SHALL resolve the verification NarHash from the narinfo found by URL
+- **AND** SHALL reconstruct the whole NAR from its chunks
+- **AND** SHALL content-verify the reconstruction against that NarHash
+- **AND** SHALL flip the record to whole-file (`total_chunks = 0`)
+
+#### Scenario: Unlinked narinfo with a nix-serve-style prefixed URL is matched hash-aware
+
+- **GIVEN** a `nar_file` for hash `H` with `total_chunks > 0`
+- **AND** a narinfo with a prefixed URL `nar/<narinfoHash>-<H>.nar.xz` carrying a recorded NarHash
+- **AND** NO `narinfo_nar_files` link between that narinfo and the `nar_file`
+- **WHEN** `MigrateChunksToNar` is invoked for `H`
+- **THEN** the system SHALL recognize the narinfo as referencing `H` by its normalized embedded hash (not by a raw `nar/<H>.` prefix)
+- **AND** SHALL resolve the verification NarHash from it and de-chunk `H`
+
+#### Scenario: NAR with neither a link nor a hash-matched narinfo is skipped
+
+- **GIVEN** a chunked `nar_file` for hash `H` with no `narinfo_nar_files` link
+- **AND** no narinfo whose URL normalizes to hash `H`
+- **WHEN** `MigrateChunksToNar` is invoked for `H`
+- **THEN** the system SHALL skip de-chunking (no NarHash to verify against)
+- **AND** SHALL NOT delete or truncate the NAR
+
+### Requirement: De-chunking MUST normalize the narinfo URL to none
+
+When the de-chunk pass converts a NAR to whole-file (`Compression:none`) storage, it SHALL update every narinfo referencing that NAR to advertise the Compression:none URL (`nar/<H>.nar`, FileHash null, FileSize null), so the persisted narinfo is consistent with the whole-file storage and does not depend on serve-time chunk-based normalization. "Every narinfo referencing that NAR" SHALL be identified by the `narinfo_nar_files` join link OR, for unlinked rows, by a **hash-aware** URL match (the candidate URL parsed and normalized to the same NAR hash) — covering both canonical and nix-serve-style prefixed URLs — not by a raw URL prefix that would miss prefixed URLs.
+
+#### Scenario: A de-chunked NAR's narinfo advertises none
+
+- **GIVEN** a chunked NAR whose narinfo advertises `nar/<H>.nar.xz`
+- **WHEN** the de-chunk pass de-chunks it to `none/whole`
+- **THEN** the narinfo SHALL be updated to URL `nar/<H>.nar` and Compression none
+- **AND** a subsequent serve of that narinfo SHALL NOT 404 the NAR
+
+#### Scenario: An unlinked, prefixed-URL narinfo is normalized on de-chunk
+
+- **GIVEN** a de-chunked NAR for hash `H`
+- **AND** a narinfo with a prefixed URL `nar/<narinfoHash>-<H>.nar.xz` and NO join link to the `nar_file`
+- **WHEN** the de-chunk pass normalizes referencing narinfos
+- **THEN** the prefixed-URL narinfo SHALL be updated to URL `nar/<H>.nar` and Compression none
+- **AND** a subsequent serve of that narinfo SHALL NOT 404 the NAR

--- a/openspec/changes/archive/2026-06-06-fix-dechunk-unlinked-narinfo-url-match/tasks.md
+++ b/openspec/changes/archive/2026-06-06-fix-dechunk-unlinked-narinfo-url-match/tasks.md
@@ -1,0 +1,21 @@
+## 1. Reproduce (TDD red)
+
+- [x] 1.1 Write a failing test: a chunked `nar_file` for `H`, an **unlinked** narinfo with a nix-serve-style prefixed URL `nar/<narinfoHash>-<H>.nar.xz` carrying a NarHash; invoke `MigrateChunksToNar(H)` and assert it resolves the verification NarHash (currently it can't — `LinkedNarinfoNarHash` misses the prefixed URL)
+- [x] 1.2 Write a failing test: after de-chunk, the prefixed-URL unlinked narinfo's URL is normalized to `nar/<H>.nar` / Compression none (currently left as `.nar.xz`, so a later serve 404s)
+
+## 2. Hash-aware match helper (TDD green)
+
+- [x] 2.1 Add a shared helper that decides whether a narinfo references a NAR hash by parsing+normalizing its URL (`Normalize(ParseURL(url)).Hash == H`), covering canonical and prefixed URLs; treat unparseable URLs as non-matching
+- [x] 2.2 Use the join link as the primary path; fall back to the hash-aware scan only when no link exists
+
+## 3. Apply at all three sites
+
+- [x] 3.1 `LinkedNarinfoNarHash` — resolve the verification NarHash via the hash-aware match
+- [x] 3.2 `MigrateChunksToNar` (flip transaction) — normalize the URLs of hash-aware-matched referencing narinfos
+- [x] 3.3 `NormalizeChunkedNarInfoURL` — same hash-aware match
+- [x] 3.4 Confirm the join-link primary path and canonical-URL matches still behave identically (no regression in existing de-chunk tests)
+
+## 4. Verify
+
+- [x] 4.1 The red tests from section 1 now pass
+- [x] 4.2 `task fmt`, `task lint`, and `task test` all exit zero

--- a/openspec/specs/chunks-to-nar-migration/spec.md
+++ b/openspec/specs/chunks-to-nar-migration/spec.md
@@ -215,7 +215,7 @@ A full `migrate-chunks-to-nar` pass over all chunked `nar_file` rows SHALL leave
 
 ### Requirement: De-chunking MUST normalize the narinfo URL to none
 
-When the de-chunk pass converts a NAR to whole-file (`Compression:none`) storage, it SHALL update every narinfo referencing that NAR to advertise the Compression:none URL (`nar/<H>.nar`, FileHash null, FileSize null), so the persisted narinfo is consistent with the whole-file storage and does not depend on serve-time chunk-based normalization. "Every narinfo referencing that NAR" SHALL be identified by the `narinfo_nar_files` join link OR, for unlinked rows, by a **hash-aware** URL match (the candidate URL parsed and normalized to the same NAR hash) — covering both canonical and nix-serve-style prefixed URLs — not by a raw URL prefix that would miss prefixed URLs.
+When the de-chunk pass converts a NAR to whole-file (`Compression:none`) storage, it SHALL update every narinfo referencing that NAR to advertise the Compression:none URL (`nar/<H>.nar`, FileHash null, FileSize null), so the persisted narinfo is consistent with the whole-file storage and does not depend on serve-time chunk-based normalization. "Every narinfo referencing that NAR" SHALL be identified by the `narinfo_nar_files` join link OR, for unlinked rows, by a **hash-aware** URL match (the candidate URL parsed and normalized to the same NAR hash **and query**) — covering both canonical and nix-serve-style prefixed URLs — not by a raw URL prefix that would miss prefixed URLs. Because `nar_file` rows are keyed by `(hash, compression, query)`, a narinfo whose URL normalizes to the same hash but a **different query** is a distinct variant and SHALL NOT be rewritten by this normalization.
 
 #### Scenario: A de-chunked NAR's narinfo advertises none
 
@@ -231,4 +231,11 @@ When the de-chunk pass converts a NAR to whole-file (`Compression:none`) storage
 - **WHEN** the de-chunk pass normalizes referencing narinfos
 - **THEN** the prefixed-URL narinfo SHALL be updated to URL `nar/<H>.nar` and Compression none
 - **AND** a subsequent serve of that narinfo SHALL NOT 404 the NAR
+
+#### Scenario: A same-hash, different-query narinfo is not rewritten
+
+- **GIVEN** a de-chunked NAR for hash `H` with query `""`
+- **AND** a narinfo for the same hash but a different query (URL `nar/<H>.nar.xz?foo=bar`), referencing a distinct `nar_file` variant
+- **WHEN** the de-chunk pass normalizes referencing narinfos
+- **THEN** the different-query narinfo's URL SHALL be left unchanged (its query SHALL NOT be clobbered)
 

--- a/openspec/specs/chunks-to-nar-migration/spec.md
+++ b/openspec/specs/chunks-to-nar-migration/spec.md
@@ -138,7 +138,7 @@ The Job rendered by `migrateChunksToNar.enabled: true` SHALL carry no `helm.sh/h
 
 ### Requirement: De-chunk MUST resolve the verification NarHash via the narinfo URL when no join link exists
 
-When de-chunking a NAR, the system resolves the expected NarHash from the linked narinfo in order to content-verify the reconstruction (verified-or-nothing). When the `narinfo_nar_files` join link is absent — a known race leaves CDC-chunked `nar_file` rows unlinked — the system SHALL fall back to resolving the narinfo by the NAR's `Compression:none` URL (`nar/<hash>.nar`) instead of treating the NAR as un-verifiable and skipping it. Only when no narinfo references the NAR by either the join link or its URL SHALL the de-chunk be skipped for want of a verification hash.
+When de-chunking a NAR, the system resolves the expected NarHash from the linked narinfo in order to content-verify the reconstruction (verified-or-nothing). When the `narinfo_nar_files` join link is absent — a known race leaves CDC-chunked `nar_file` rows unlinked — the system SHALL fall back to resolving the narinfo by the NAR's hash, matching **hash-aware** rather than by raw URL prefix: a candidate narinfo references the NAR when its URL, parsed and normalized (narinfo-hash prefix stripped), has the same NAR hash. This SHALL cover both canonical URLs (`nar/<hash>.nar[.<ext>]`) and nix-serve-style prefixed URLs (`nar/<narinfoHash>-<hash>.nar[.<ext>]`). Only when no narinfo references the NAR by either the join link or a hash-matched URL SHALL the de-chunk be skipped for want of a verification hash.
 
 #### Scenario: Unlinked chunked NAR is de-chunked via the URL-resolved NarHash
 
@@ -151,10 +151,19 @@ When de-chunking a NAR, the system resolves the expected NarHash from the linked
 - **AND** SHALL content-verify the reconstruction against that NarHash
 - **AND** SHALL flip the record to whole-file (`total_chunks = 0`)
 
-#### Scenario: NAR with neither a link nor a URL-matched narinfo is skipped
+#### Scenario: Unlinked narinfo with a nix-serve-style prefixed URL is matched hash-aware
+
+- **GIVEN** a `nar_file` for hash `H` with `total_chunks > 0`
+- **AND** a narinfo with a prefixed URL `nar/<narinfoHash>-<H>.nar.xz` carrying a recorded NarHash
+- **AND** NO `narinfo_nar_files` link between that narinfo and the `nar_file`
+- **WHEN** `MigrateChunksToNar` is invoked for `H`
+- **THEN** the system SHALL recognize the narinfo as referencing `H` by its normalized embedded hash (not by a raw `nar/<H>.` prefix)
+- **AND** SHALL resolve the verification NarHash from it and de-chunk `H`
+
+#### Scenario: NAR with neither a link nor a hash-matched narinfo is skipped
 
 - **GIVEN** a chunked `nar_file` for hash `H` with no `narinfo_nar_files` link
-- **AND** no narinfo whose URL is `nar/<H>.nar`
+- **AND** no narinfo whose URL normalizes to hash `H`
 - **WHEN** `MigrateChunksToNar` is invoked for `H`
 - **THEN** the system SHALL skip de-chunking (no NarHash to verify against)
 - **AND** SHALL NOT delete or truncate the NAR
@@ -206,12 +215,20 @@ A full `migrate-chunks-to-nar` pass over all chunked `nar_file` rows SHALL leave
 
 ### Requirement: De-chunking MUST normalize the narinfo URL to none
 
-When the de-chunk pass converts a NAR to whole-file (`Compression:none`) storage, it SHALL update every narinfo referencing that NAR to advertise the Compression:none URL (`nar/<H>.nar`, FileHash null, FileSize null), so the persisted narinfo is consistent with the whole-file storage and does not depend on serve-time chunk-based normalization.
+When the de-chunk pass converts a NAR to whole-file (`Compression:none`) storage, it SHALL update every narinfo referencing that NAR to advertise the Compression:none URL (`nar/<H>.nar`, FileHash null, FileSize null), so the persisted narinfo is consistent with the whole-file storage and does not depend on serve-time chunk-based normalization. "Every narinfo referencing that NAR" SHALL be identified by the `narinfo_nar_files` join link OR, for unlinked rows, by a **hash-aware** URL match (the candidate URL parsed and normalized to the same NAR hash) — covering both canonical and nix-serve-style prefixed URLs — not by a raw URL prefix that would miss prefixed URLs.
 
 #### Scenario: A de-chunked NAR's narinfo advertises none
 
 - **GIVEN** a chunked NAR whose narinfo advertises `nar/<H>.nar.xz`
 - **WHEN** the de-chunk pass de-chunks it to `none/whole`
 - **THEN** the narinfo SHALL be updated to URL `nar/<H>.nar` and Compression none
+- **AND** a subsequent serve of that narinfo SHALL NOT 404 the NAR
+
+#### Scenario: An unlinked, prefixed-URL narinfo is normalized on de-chunk
+
+- **GIVEN** a de-chunked NAR for hash `H`
+- **AND** a narinfo with a prefixed URL `nar/<narinfoHash>-<H>.nar.xz` and NO join link to the `nar_file`
+- **WHEN** the de-chunk pass normalizes referencing narinfos
+- **THEN** the prefixed-URL narinfo SHALL be updated to URL `nar/<H>.nar` and Compression none
 - **AND** a subsequent serve of that narinfo SHALL NOT 404 the NAR
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -8479,7 +8479,7 @@ func (c *Cache) MigrateChunksToNar(ctx context.Context, narURL *nar.URL, forceRe
 		// while chunks exist. Match by the join link (primary) OR a hash-aware URL
 		// match (covers unlinked rows, including nix-serve-style prefixed URLs that a
 		// raw "nar/<hash>." prefix would miss).
-		ids, err := narInfoIDsByNormalizedHash(ctx, tx.NarInfo, narURL.Hash)
+		ids, err := narInfoIDsByNormalizedURL(ctx, tx.NarInfo, noneURL)
 		if err != nil {
 			return err
 		}
@@ -8632,7 +8632,7 @@ func (c *Cache) NormalizeChunkedNarInfoURL(ctx context.Context, narURL *nar.URL)
 		// Match by the join link (primary) OR a hash-aware URL match (covers unlinked
 		// rows, including nix-serve-style prefixed URLs that a raw "nar/<hash>."
 		// prefix would miss).
-		ids, err := narInfoIDsByNormalizedHash(ctx, tx.NarInfo, narURL.Hash)
+		ids, err := narInfoIDsByNormalizedURL(ctx, tx.NarInfo, noneURL)
 		if err != nil {
 			return err
 		}
@@ -8723,8 +8723,15 @@ func LinkedNarinfoNarHash(
 		return nil, fmt.Errorf("error resolving narinfo by hash for nar_file %d: %w", narFileID, err)
 	}
 
+	// The verification NarHash is the uncompressed NAR content hash, identical
+	// across every narinfo referencing the NAR regardless of the query its URL
+	// carries — so match by hash only here (de-chunk still content-verifies).
 	for _, cand := range cands {
-		if cand.URL != nil && normalizedURLHash(*cand.URL) == narURL.Hash {
+		if cand.URL == nil {
+			continue
+		}
+
+		if n, ok := normalizedURL(*cand.URL); ok && n.Hash == narURL.Hash {
 			return parseNarinfoNarHash(cand)
 		}
 	}
@@ -8747,38 +8754,43 @@ func parseNarinfoNarHash(ni *ent.NarInfo) (*nixhash.HashWithEncoding, error) {
 	return expected, nil
 }
 
-// normalizedURLHash returns the normalized NAR hash embedded in a narinfo URL, or
-// "" when the URL cannot be parsed/normalized (treated as non-matching). Unlike a
-// raw "nar/<hash>." prefix test, this recognizes both canonical URLs and
-// nix-serve-style prefixed URLs (nar/<narinfoHash>-<hash>.nar.xz) because
-// URL.Normalize strips the optional narinfo-hash prefix.
-func normalizedURLHash(rawURL string) string {
+// normalizedURL returns the normalized form of a narinfo URL (narinfo-hash prefix
+// stripped), and false when the URL cannot be parsed/normalized (treated as
+// non-matching). Unlike a raw "nar/<hash>." prefix test, this recognizes both
+// canonical URLs and nix-serve-style prefixed URLs (nar/<narinfoHash>-<hash>.nar.xz)
+// because URL.Normalize strips the optional narinfo-hash prefix.
+func normalizedURL(rawURL string) (nar.URL, bool) {
 	u, err := nar.ParseURL(rawURL)
 	if err != nil {
-		return ""
+		return nar.URL{}, false
 	}
 
 	normalized, err := u.Normalize()
 	if err != nil {
-		return ""
+		return nar.URL{}, false
 	}
 
-	return normalized.Hash
+	return normalized, true
 }
 
-// narInfoIDsByNormalizedHash returns the IDs of narinfos whose URL normalizes to
-// narHash. The candidate set is narrowed in SQL by URLContains(narHash) — the
-// 52/64-char hash is highly selective — and confirmed in Go via normalizedURLHash,
-// so it matches unlinked nix-serve-style prefixed URLs that a raw URLHasPrefix
-// match would miss. q may be a *ent.Tx's NarInfo client or the cache's.
-func narInfoIDsByNormalizedHash(ctx context.Context, q *ent.NarInfoClient, narHash string) ([]int, error) {
+// narInfoIDsByNormalizedURL returns the IDs of narinfos whose URL normalizes to
+// the same (hash, query) as target. The candidate set is narrowed in SQL by
+// URLContains(target.Hash) — the 52/64-char hash is highly selective — and
+// confirmed in Go via normalizedURL, so it matches unlinked nix-serve-style
+// prefixed URLs that a raw URLHasPrefix match would miss. The query is matched too
+// because nar_file rows are keyed by (hash, compression, query): a same-hash but
+// different-query narinfo is a distinct variant and MUST NOT be rewritten here.
+// q may be a *ent.Tx's NarInfo client or the cache's.
+func narInfoIDsByNormalizedURL(ctx context.Context, q *ent.NarInfoClient, target nar.URL) ([]int, error) {
 	cands, err := q.Query().
-		Where(entnarinfo.URLContains(narHash)).
+		Where(entnarinfo.URLContains(target.Hash)).
 		Select(entnarinfo.FieldID, entnarinfo.FieldURL).
 		All(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error querying candidate narinfos for hash %q: %w", narHash, err)
+		return nil, fmt.Errorf("error querying candidate narinfos for hash %q: %w", target.Hash, err)
 	}
+
+	wantQuery := target.Query.Encode()
 
 	ids := make([]int, 0, len(cands))
 
@@ -8787,7 +8799,7 @@ func narInfoIDsByNormalizedHash(ctx context.Context, q *ent.NarInfoClient, narHa
 			continue
 		}
 
-		if normalizedURLHash(*ni.URL) == narHash {
+		if n, ok := normalizedURL(*ni.URL); ok && n.Hash == target.Hash && n.Query.Encode() == wantQuery {
 			ids = append(ids, ni.ID)
 		}
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -8476,15 +8476,21 @@ func (c *Cache) MigrateChunksToNar(ctx context.Context, narURL *nar.URL, forceRe
 		// the persisted narinfo matches the new whole-file storage. Without this a
 		// narinfo advertising a different-compression URL (e.g. .nar.xz) would 404
 		// once the NAR is no longer chunked — serve-time normalization only rewrites
-		// while chunks exist. Match by the join link (primary — covers nix-serve-style
-		// prefixed URLs the URL prefix would miss) OR the Compression:none URL prefix
-		// (covers unlinked rows); the trailing "." anchors the fixed-length hash so the
-		// prefix cannot match a different NAR.
+		// while chunks exist. Match by the join link (primary) OR a hash-aware URL
+		// match (covers unlinked rows, including nix-serve-style prefixed URLs that a
+		// raw "nar/<hash>." prefix would miss).
+		ids, err := narInfoIDsByNormalizedHash(ctx, tx.NarInfo, narURL.Hash)
+		if err != nil {
+			return err
+		}
+
+		match := entnarinfo.HasNarInfoNarFilesWith(entnarinfonarfile.NarFileIDEQ(nr.ID))
+		if len(ids) > 0 {
+			match = entnarinfo.Or(match, entnarinfo.IDIn(ids...))
+		}
+
 		if _, err := tx.NarInfo.Update().
-			Where(entnarinfo.Or(
-				entnarinfo.HasNarInfoNarFilesWith(entnarinfonarfile.NarFileIDEQ(nr.ID)),
-				entnarinfo.URLHasPrefix("nar/"+narURL.Hash+"."),
-			)).
+			Where(match).
 			SetURL(noneURL.String()).
 			SetCompression(nar.CompressionTypeNone.String()).
 			ClearFileHash().
@@ -8623,15 +8629,21 @@ func (c *Cache) NormalizeChunkedNarInfoURL(ctx context.Context, narURL *nar.URL)
 
 	return c.withEntTransaction(ctx, "NormalizeChunkedNarInfoURL", func(tx *ent.Tx) error {
 		// Normalize every narinfo referencing this NAR to the Compression:none URL.
-		// Match by the join link (covers nix-serve-style prefixed URLs the prefix
-		// would miss) OR the Compression:none URL prefix (covers unlinked rows); the
-		// trailing "." anchors the fixed-length hash so the prefix cannot match a
-		// different NAR.
+		// Match by the join link (primary) OR a hash-aware URL match (covers unlinked
+		// rows, including nix-serve-style prefixed URLs that a raw "nar/<hash>."
+		// prefix would miss).
+		ids, err := narInfoIDsByNormalizedHash(ctx, tx.NarInfo, narURL.Hash)
+		if err != nil {
+			return err
+		}
+
+		match := entnarinfo.HasNarInfoNarFilesWith(entnarinfonarfile.NarFileIDEQ(nr.ID))
+		if len(ids) > 0 {
+			match = entnarinfo.Or(match, entnarinfo.IDIn(ids...))
+		}
+
 		if _, err := tx.NarInfo.Update().
-			Where(entnarinfo.Or(
-				entnarinfo.HasNarInfoNarFilesWith(entnarinfonarfile.NarFileIDEQ(nr.ID)),
-				entnarinfo.URLHasPrefix("nar/"+narURL.Hash+"."),
-			)).
+			Where(match).
 			SetURL(noneURL.String()).
 			SetCompression(nar.CompressionTypeNone.String()).
 			ClearFileHash().
@@ -8698,23 +8710,26 @@ func LinkedNarinfoNarHash(
 
 	// No NarHash-bearing join-linked narinfo (the link may be missing, or the linked
 	// narinfo may lack a NarHash). Fall back to any narinfo referencing the NAR by
-	// hash, at any compression URL. The trailing "." anchors the fixed-length hash so
-	// the prefix cannot match a different NAR.
-	ni, err = dbClient.Ent().NarInfo.Query().
+	// hash, at any compression URL. The match is hash-aware (URL normalized to the
+	// NAR hash) so it also covers nix-serve-style prefixed URLs
+	// (nar/<narinfoHash>-<hash>.nar.xz) that a raw "nar/<hash>." prefix would miss.
+	cands, err := dbClient.Ent().NarInfo.Query().
 		Where(
-			entnarinfo.URLHasPrefix("nar/"+narURL.Hash+"."),
+			entnarinfo.URLContains(narURL.Hash),
 			entnarinfo.NarHashNotNil(),
 		).
-		First(ctx)
+		All(ctx)
 	if err != nil {
-		if database.IsNotFoundError(err) {
-			return nil, nil //nolint:nilnil // no narinfo carries a NarHash == nothing to verify against
-		}
-
 		return nil, fmt.Errorf("error resolving narinfo by hash for nar_file %d: %w", narFileID, err)
 	}
 
-	return parseNarinfoNarHash(ni)
+	for _, cand := range cands {
+		if cand.URL != nil && normalizedURLHash(*cand.URL) == narURL.Hash {
+			return parseNarinfoNarHash(cand)
+		}
+	}
+
+	return nil, nil //nolint:nilnil // no narinfo carries a NarHash == nothing to verify against
 }
 
 // parseNarinfoNarHash parses a narinfo's recorded NarHash, returning (nil, nil) when
@@ -8730,6 +8745,54 @@ func parseNarinfoNarHash(ni *ent.NarInfo) (*nixhash.HashWithEncoding, error) {
 	}
 
 	return expected, nil
+}
+
+// normalizedURLHash returns the normalized NAR hash embedded in a narinfo URL, or
+// "" when the URL cannot be parsed/normalized (treated as non-matching). Unlike a
+// raw "nar/<hash>." prefix test, this recognizes both canonical URLs and
+// nix-serve-style prefixed URLs (nar/<narinfoHash>-<hash>.nar.xz) because
+// URL.Normalize strips the optional narinfo-hash prefix.
+func normalizedURLHash(rawURL string) string {
+	u, err := nar.ParseURL(rawURL)
+	if err != nil {
+		return ""
+	}
+
+	normalized, err := u.Normalize()
+	if err != nil {
+		return ""
+	}
+
+	return normalized.Hash
+}
+
+// narInfoIDsByNormalizedHash returns the IDs of narinfos whose URL normalizes to
+// narHash. The candidate set is narrowed in SQL by URLContains(narHash) — the
+// 52/64-char hash is highly selective — and confirmed in Go via normalizedURLHash,
+// so it matches unlinked nix-serve-style prefixed URLs that a raw URLHasPrefix
+// match would miss. q may be a *ent.Tx's NarInfo client or the cache's.
+func narInfoIDsByNormalizedHash(ctx context.Context, q *ent.NarInfoClient, narHash string) ([]int, error) {
+	cands, err := q.Query().
+		Where(entnarinfo.URLContains(narHash)).
+		Select(entnarinfo.FieldID, entnarinfo.FieldURL).
+		All(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error querying candidate narinfos for hash %q: %w", narHash, err)
+	}
+
+	ids := make([]int, 0, len(cands))
+
+	for _, ni := range cands {
+		if ni.URL == nil || *ni.URL == "" {
+			continue
+		}
+
+		if normalizedURLHash(*ni.URL) == narHash {
+			ids = append(ids, ni.ID)
+		}
+	}
+
+	return ids, nil
 }
 
 // MigrateNarToChunks migrates a traditional NAR blob to content-defined chunks.

--- a/pkg/cache/migrate_chunks_to_nar_test.go
+++ b/pkg/cache/migrate_chunks_to_nar_test.go
@@ -231,6 +231,101 @@ func TestMigrateChunksToNar_DeChunksUnlinkedNarViaURLFallback(t *testing.T) {
 	assert.Equal(t, content, string(data), "reconstruction of the unlinked NAR must be correct")
 }
 
+// TestMigrateChunksToNar_DeChunksUnlinkedPrefixedNarinfoURL covers
+// fix-dechunk-unlinked-narinfo-url-match: an unlinked narinfo whose URL is the
+// nix-serve-style prefixed form (nar/<narinfoHash>-<H>.nar.xz) must be matched
+// hash-aware. The old raw URLHasPrefix("nar/"+H+".") fallback missed it, so the
+// verify NarHash could not be resolved (NAR purged / drain stuck) and the narinfo
+// URL was left unnormalized (→ later 404). The hash-aware match normalizes the
+// candidate URL's embedded hash and recognizes it as referencing the NAR.
+func TestMigrateChunksToNar_DeChunksUnlinkedPrefixedNarinfoURL(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	c, dbClient, _, dir, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	noneURL, content := chunkedNarFixture(ctx, t, c, dbClient, dir)
+
+	// The only NarHash-bearing narinfo advertises a nix-serve-style PREFIXED URL
+	// (narinfoHash prepended to the nar hash), and there is no join link — the
+	// stranded class the raw prefix match misses.
+	prefixedURL := "nar/" + testdata.Nar1.NarInfoHash + "-" + noneURL.Hash + ".nar.xz"
+
+	_, err := dbClient.Ent().NarInfo.Update().
+		Where(entnarinfo.HashEQ(testdata.Nar1.NarInfoHash)).
+		SetURL(prefixedURL).
+		SetCompression(nar.CompressionTypeXz.String()).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = dbClient.Ent().NarInfoNarFile.Delete().Exec(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, c.MigrateChunksToNar(ctx, &noneURL, false),
+		"an unlinked prefixed-URL narinfo must be matched hash-aware and the NAR de-chunked")
+
+	assert.True(t, c.HasNarInStore(ctx, noneURL),
+		"the whole NAR must be present after de-chunking via the hash-aware match")
+
+	row, err := dbClient.Ent().NarInfo.Query().Where(entnarinfo.HashEQ(testdata.Nar1.NarInfoHash)).Only(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, row.URL)
+	assert.Equal(t, "nar/"+noneURL.Hash+".nar", *row.URL,
+		"the prefixed-URL narinfo must be normalized to the Compression:none URL on de-chunk")
+	require.NotNil(t, row.Compression)
+	assert.Equal(t, nar.CompressionTypeNone.String(), *row.Compression)
+
+	_, _, rc, err := c.GetNar(ctx, noneURL)
+	require.NoError(t, err)
+
+	defer rc.Close()
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(data), "reconstruction of the unlinked prefixed-URL NAR must be correct")
+}
+
+// TestNormalizeChunkedNarInfoURL_MatchesUnlinkedPrefixedURL covers the
+// NormalizeChunkedNarInfoURL site of fix-dechunk-unlinked-narinfo-url-match: the
+// fsck residue repair must normalize an unlinked narinfo with a nix-serve-style
+// prefixed URL via the hash-aware match (leaving the NAR chunked), where the old
+// raw URLHasPrefix fallback left it stranded.
+func TestNormalizeChunkedNarInfoURL_MatchesUnlinkedPrefixedURL(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	c, dbClient, _, dir, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	noneURL, _ := chunkedNarFixture(ctx, t, c, dbClient, dir)
+
+	prefixedURL := "nar/" + testdata.Nar1.NarInfoHash + "-" + noneURL.Hash + ".nar.xz"
+
+	_, err := dbClient.Ent().NarInfo.Update().
+		Where(entnarinfo.HashEQ(testdata.Nar1.NarInfoHash)).
+		SetURL(prefixedURL).
+		SetCompression(nar.CompressionTypeXz.String()).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = dbClient.Ent().NarInfoNarFile.Delete().Exec(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, c.NormalizeChunkedNarInfoURL(ctx, &noneURL),
+		"an unlinked prefixed-URL narinfo must be matched hash-aware and normalized")
+
+	row, err := dbClient.Ent().NarInfo.Query().Where(entnarinfo.HashEQ(testdata.Nar1.NarInfoHash)).Only(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, row.URL)
+	assert.Equal(t, "nar/"+noneURL.Hash+".nar", *row.URL,
+		"NormalizeChunkedNarInfoURL must normalize an unlinked prefixed-URL narinfo to none")
+	require.NotNil(t, row.Compression)
+	assert.Equal(t, nar.CompressionTypeNone.String(), *row.Compression)
+}
+
 // TestMigrateChunksToNar_ResumesWhenWholeFileAlreadyPresent: an interrupted
 // prior run may have written the (verified) whole file but crashed before the
 // record flip. Re-running must treat the already-present object as resumable —

--- a/pkg/cache/migrate_chunks_to_nar_test.go
+++ b/pkg/cache/migrate_chunks_to_nar_test.go
@@ -326,6 +326,46 @@ func TestNormalizeChunkedNarInfoURL_MatchesUnlinkedPrefixedURL(t *testing.T) {
 	assert.Equal(t, nar.CompressionTypeNone.String(), *row.Compression)
 }
 
+// TestMigrateChunksToNar_DoesNotRewriteDifferentQueryVariant covers the
+// query-scoping fix (CodeRabbit, PR #1342): nar_file rows are keyed by
+// (hash, compression, query), so de-chunking the (H, query="") variant MUST NOT
+// rewrite the URL of a narinfo for the SAME hash but a DIFFERENT query — that is
+// a distinct variant, and a hash-only match would clobber its query.
+func TestMigrateChunksToNar_DoesNotRewriteDifferentQueryVariant(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	c, dbClient, _, dir, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	noneURL, _ := chunkedNarFixture(ctx, t, c, dbClient, dir)
+
+	// A separate, unlinked narinfo for the SAME nar hash but a DIFFERENT query.
+	const otherNarInfoHash = "0123456789abcdfghijklmnpqrsvwxyz"
+
+	otherURL := "nar/" + noneURL.Hash + ".nar.xz?foo=bar"
+
+	sum := sha256.Sum256([]byte("other-variant"))
+	otherNarHash := nixhash.MustNewHashWithEncoding(nixhash.SHA256, sum[:], nixhash.NixBase32, true).String()
+
+	_, err := dbClient.Ent().NarInfo.Create().
+		SetHash(otherNarInfoHash).
+		SetURL(otherURL).
+		SetCompression(nar.CompressionTypeXz.String()).
+		SetNarHash(otherNarHash).
+		Save(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, c.MigrateChunksToNar(ctx, &noneURL, false))
+
+	row, err := dbClient.Ent().NarInfo.Query().Where(entnarinfo.HashEQ(otherNarInfoHash)).Only(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, row.URL)
+	assert.Equal(t, otherURL, *row.URL,
+		"de-chunking the empty-query variant must not rewrite a different-query variant's narinfo URL")
+}
+
 // TestMigrateChunksToNar_ResumesWhenWholeFileAlreadyPresent: an interrupted
 // prior run may have written the (verified) whole file but crashed before the
 // record flip. Re-running must treat the already-present object as resumable —


### PR DESCRIPTION
## Summary

The de-chunk path located narinfos referencing a NAR with a raw `URLHasPrefix("nar/"+hash+".")` fallback. That only matches canonical `nar/<hash>...` URLs, so a nix-serve-style prefixed URL (`nar/<narinfoHash>-<hash>.nar.xz`) on an **unlinked** narinfo (a known race drops the `narinfo_nar_files` join row) matched neither the join link nor the prefix. Such narinfos were left unnormalized after de-chunk (a later serve 404s) and their verification `NarHash` could not be resolved (NAR purged / drain stuck).

This matches **hash-aware** instead: narrow candidates in SQL via `URLContains(hash)`, then confirm in Go with `ParseURL`+`Normalize` so the embedded hash (narinfo-hash prefix stripped) equals the target. A shared `normalizedURLHash` helper backs all three sites — `LinkedNarinfoNarHash`, `MigrateChunksToNar`, `NormalizeChunkedNarInfoURL` — and the join link stays the primary match.

Surfaced by a CodeRabbit "outside diff range" finding on #1331; scoped out of that PR as pre-existing, now fixed on its own.

Specs: updates two `chunks-to-nar-migration` requirements (URL-based narinfo lookup is hash-aware, covering unlinked nix-serve-style prefixed URLs).

## Test plan

- [x] `task fmt`, `task lint`, `task test` pass
- [x] New: `TestMigrateChunksToNar_DeChunksUnlinkedPrefixedNarinfoURL` (de-chunk + normalize via hash-aware match)
- [x] New: `TestNormalizeChunkedNarInfoURL_MatchesUnlinkedPrefixedURL` (first direct test of that entry point)
- [x] Existing canonical/unlinked/different-compression de-chunk tests still pass (join-link path unchanged)