### PR TITLE
fix(metrics): prime counters for startup exposure

### DIFF
--- a/openspec/changes/archive/2026-06-06-fix-prometheus-counter-priming/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-06-fix-prometheus-counter-priming/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/archive/2026-06-06-fix-prometheus-counter-priming/design.md
+++ b/openspec/changes/archive/2026-06-06-fix-prometheus-counter-priming/design.md
@@ -1,0 +1,65 @@
+## Context
+
+Counter instruments are created in package `init()` functions via the global OTel meter (`otel.Meter(...)`) in `pkg/cache/cache.go`, `pkg/lock/metrics.go`, and `pkg/ncps/metrics.go`. The global meter returns *delegating* instruments before `otel.SetMeterProvider` is called; once the provider is installed (by `prometheus.SetupPrometheusMetrics` and/or `otel.SetupOTelSDK` in `pkg/ncps/serve.go`), those instruments forward to the real SDK instruments.
+
+The OTel→Prometheus exporter materializes a counter series only after the counter records at least one measurement. Histograms behave the same; observable gauges export via callbacks and are unaffected. The counters in question are only incremented on real events:
+- `narServedCount` (`cache.go:1078`), `narInfoServedCount` (`cache.go:3559`)
+- LRU eviction counters, `backgroundMigrationObjectsTotal`, `downloadCoordinationFallbackTotal`
+- counters in `pkg/lock` and `pkg/ncps`
+
+So an idle/fresh instance scraping `/metrics` sees none of them — the bug in #1337.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Documented counters appear at `/metrics` with value `0` from startup.
+- Counting semantics unchanged (zero-add must not inflate totals).
+- Minimal, localized change; no new dependencies.
+
+**Non-Goals:**
+- Priming histograms (a synthetic observation would skew distributions) or gauges (already exported).
+- Adding/renaming metrics or changing attribute sets.
+- Resolving the dual meter-provider overwrite when both OTLP and Prometheus are enabled.
+
+## Decisions
+
+### Decision 1: Prime counters with `Add(ctx, 0)` rather than restructure instrument creation
+
+`Add(ctx, 0)` is the idiomatic OTel way to force a counter series to exist at zero. Alternatives considered:
+- *Per-handler lazy priming*: scatters logic and still misses untouched code paths — rejected.
+- *Switch counters to ObservableCounters with callbacks*: large refactor, changes the increment model everywhere — rejected.
+- *Custom Prometheus collector*: bypasses OTel, duplicates definitions — rejected.
+
+### Decision 2: One exported priming function per metrics-owning package
+
+Each of `pkg/cache`, `pkg/lock`, `pkg/ncps` exposes an exported function (e.g. `PrimeMetrics(ctx context.Context)`) that calls `Add(ctx, 0)` on each of its package-level counters. This keeps each package the owner of its own instrument list (no cross-package globals) and is trivially unit-testable.
+
+Signature (per package):
+```go
+// PrimeMetrics records a zero-valued measurement on every counter so the
+// series are exported from startup. Safe to call once after the global
+// meter provider is installed; a no-op effect on counting semantics.
+func PrimeMetrics(ctx context.Context)
+```
+
+### Decision 3: Call priming after the meter provider is installed, in `serve.go`
+
+Priming MUST run after `otel.SetMeterProvider` (inside `SetupPrometheusMetrics`/`SetupOTelSDK`); measurements recorded on the delegating instruments before a provider is set are dropped. Call sites go in `pkg/ncps/serve.go` immediately after the metrics-setup block, guarded so they run whenever a metrics exporter was configured. Calling with no provider installed is harmless (drops the zero-add), satisfying the "no-op when disabled" scenario.
+
+### Decision 4: Prime with the empty attribute set
+
+Real increments may carry attributes (e.g. per-cache). Priming emits a single attribute-less `{}` series at `0`. This is standard and harmless: PromQL aggregations (`rate(ncps_nar_served_total[5m])`) span all series and the `{}` series stays at `0`. Mirroring dynamic attributes at startup is impossible (values unknown) and unnecessary.
+
+## Risks / Trade-offs
+
+- [Extra `{}` zero series alongside attributed series] → Cosmetic; documented, standard OTel behavior; aggregations unaffected.
+- [Priming runs before provider set → silently dropped] → Mitigated by ordering the call after `SetupPrometheusMetrics` in `serve.go`; covered by the "no-op when disabled" scenario and an integration scrape test.
+- [Future counters added without priming] → Mitigated by colocating each package's prime list with its instrument declarations and a unit test that scrapes for zero series.
+
+## Migration Plan
+
+Pure additive code change; no DB migration, no config, no API change. Deploy normally. Rollback is a plain revert — counters simply return to appearing only after first use.
+
+## Open Questions
+
+- None blocking. (Out of scope: whether enabling both OTLP and Prometheus should compose meter providers instead of the second overwriting the first.)

--- a/openspec/changes/archive/2026-06-06-fix-prometheus-counter-priming/proposal.md
+++ b/openspec/changes/archive/2026-06-06-fix-prometheus-counter-priming/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+GitHub issue #1337: users scraping `/metrics` on a freshly-started or idle ncps instance do not see documented counters such as `ncps_nar_served_total` and `ncps_narinfo_served_total`. The OpenTelemetry Prometheus exporter only emits a counter time series after the counter records its first measurement, so until a NAR/narinfo is actually served (or an eviction/migration fires) these series are simply absent — contradicting the documentation that promises them and breaking dashboards/alerts that reference them from the start.
+
+## What Changes
+
+- Prime every OpenTelemetry `Int64Counter` instrument (in `pkg/cache`, `pkg/lock`, and `pkg/ncps`) with a zero-valued `Add(ctx, 0)` once the global meter provider is installed, so each documented counter appears in `/metrics` at value `0` from startup.
+- Each metrics-owning package exposes a small exported priming function; `pkg/ncps/serve.go` invokes them after metrics exporters are configured.
+- No new metrics, no renames, no behavioral change to counting semantics — only earlier visibility of already-defined counters.
+
+## Capabilities
+
+### New Capabilities
+- `metrics-exposure`: Defines that all documented counter metrics are exposed at `GET /metrics` from process startup (initialized to zero), independent of whether any traffic has been served yet.
+
+### Modified Capabilities
+<!-- None: no existing spec's requirements change. -->
+
+## Impact
+
+- **Code**: `pkg/cache`, `pkg/lock`, `pkg/ncps` (new priming functions + a call site in `serve.go`). Observable gauges and histograms are unaffected (gauges already export via callbacks).
+- **APIs**: `/metrics` output gains zero-valued counter series at startup; no schema/endpoint change.
+- **I/O / network / memory**: Negligible — a handful of one-time `Add(ctx, 0)` calls at boot; no steady-state overhead.
+
+## Non-goals
+
+- Not adding or renaming any metric.
+- Not changing histogram or observable-gauge exposure behavior.
+- Not reconciling the OTLP-vs-Prometheus dual-meter-provider interaction (separate concern).

--- a/openspec/changes/archive/2026-06-06-fix-prometheus-counter-priming/specs/metrics-exposure/spec.md
+++ b/openspec/changes/archive/2026-06-06-fix-prometheus-counter-priming/specs/metrics-exposure/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Counter metrics are exposed from startup
+
+All OpenTelemetry counter instruments that ncps defines (e.g. `ncps_nar_served_total`, `ncps_narinfo_served_total`, the LRU eviction counters, the background-migration counter, and the download-coordination fallback counter) SHALL be present in the `GET /metrics` output as soon as the Prometheus exporter is active, initialized to value `0`, regardless of whether any request, eviction, or migration has occurred yet.
+
+The system SHALL achieve this by recording a single zero-valued measurement (`Add(ctx, 0)`) on each counter after the global meter provider has been installed. Priming MUST NOT alter counting semantics: the first real event still advances the counter from `0` to `1`.
+
+Observable gauges and histograms are out of scope for this requirement: gauges already export via their registered callbacks, and histograms remain absent until their first genuine observation.
+
+#### Scenario: Documented counters present on an idle instance
+
+- **WHEN** ncps starts with Prometheus enabled and `GET /metrics` is scraped before any NAR or narinfo has been served
+- **THEN** the response includes `ncps_nar_served_total` and `ncps_narinfo_served_total` time series, each with value `0`
+
+#### Scenario: Priming preserves counting semantics
+
+- **WHEN** a counter has been primed to `0` at startup and ncps then serves exactly one NAR
+- **THEN** `ncps_nar_served_total` reports a total of `1`, not `2` (the zero-valued prime does not inflate the count)
+
+#### Scenario: All package counters are primed
+
+- **WHEN** ncps starts with Prometheus enabled and `GET /metrics` is scraped with no traffic
+- **THEN** every counter instrument defined in `pkg/cache`, `pkg/lock`, and `pkg/ncps` appears at value `0`
+
+#### Scenario: Priming is a no-op when metrics are disabled
+
+- **WHEN** ncps starts with Prometheus (and OTLP) metrics disabled
+- **THEN** priming the counters causes no error and no panic, and the process starts normally

--- a/openspec/changes/archive/2026-06-06-fix-prometheus-counter-priming/tasks.md
+++ b/openspec/changes/archive/2026-06-06-fix-prometheus-counter-priming/tasks.md
@@ -1,0 +1,20 @@
+## 1. Failing tests (TDD red)
+
+- [x] 1.1 In `pkg/cache`, add a test that installs a `sdkmetric.MeterProvider` with a manual/Prometheus reader via `otel.SetMeterProvider`, calls `cache.PrimeMetrics(ctx)`, gathers metrics, and asserts `ncps_nar_served_total` and `ncps_narinfo_served_total` (and the other cache counters) are present at value `0`. Confirm it fails (function undefined / series absent).
+- [x] 1.2 Add an analogous prime+scrape test in `pkg/lock` and `pkg/ncps` asserting each package's counters export at `0` after priming.
+- [x] 1.3 Add a semantics test: after priming, record one real increment and assert the counter total is `1` (prime did not inflate).
+- [x] 1.4 Add a no-op test: calling `PrimeMetrics(context.Background())` with no meter provider installed neither errors nor panics.
+
+## 2. Implementation (TDD green)
+
+- [x] 2.1 Add exported `func PrimeMetrics(ctx context.Context)` to `pkg/cache` that calls `Add(ctx, 0)` on every package-level `Int64Counter` (`narServedCount`, `narInfoServedCount`, `lruCleanupRunsTotal`, `lruNarInfosEvictedTotal`, `lruNarFilesEvictedTotal`, `lruChunksEvictedTotal`, `lruBytesFreedTotal`, `backgroundMigrationObjectsTotal`, `downloadCoordinationFallbackTotal`).
+- [x] 2.2 Add `PrimeMetrics(ctx)` to `pkg/lock` priming its counters.
+- [x] 2.3 Add `PrimeMetrics(ctx)` to `pkg/ncps` priming its counters (or fold the ncps-package counters in directly at the serve call site if cleaner).
+- [x] 2.4 In `pkg/ncps/serve.go`, after the Prometheus/OTel metrics setup block (once the global meter provider is installed), invoke `cache.PrimeMetrics(ctx)`, `lock.PrimeMetrics(ctx)`, and the ncps priming, guarded to run whenever a metrics exporter was configured.
+
+## 3. Verification (TDD refactor + gates)
+
+- [x] 3.1 Run `task test` (race detector) — all new and existing tests pass.
+- [x] 3.2 Manually (or via an integration-style test) start ncps with `--prometheus-enabled`, scrape `/metrics` with no traffic, and confirm `ncps_nar_served_total` / `ncps_narinfo_served_total` show `0`.
+- [x] 3.3 Run `task fmt` and `task lint` — both exit `0` (each new `//nolint`, if any, carries an explanatory comment).
+- [x] 3.4 Cross-check the priming list against the docs (`docs/.../Monitoring.md`, `Observability.md`, `Cache Management.md`); update docs only if any listed counter is intentionally not primed.

--- a/openspec/specs/metrics-exposure/spec.md
+++ b/openspec/specs/metrics-exposure/spec.md
@@ -1,0 +1,38 @@
+# metrics-exposure Specification
+
+## Purpose
+
+Define how ncps exposes its OpenTelemetry metrics so that monitoring systems can
+observe the proxy's behavior. In particular, this capability governs the
+availability and initial state of metric instruments in the `GET /metrics`
+Prometheus exposition.
+
+## Requirements
+
+### Requirement: Counter metrics are exposed from startup
+
+All OpenTelemetry counter instruments that ncps defines (e.g. `ncps_nar_served_total`, `ncps_narinfo_served_total`, the LRU eviction counters, the background-migration counter, and the download-coordination fallback counter) SHALL be present in the `GET /metrics` output as soon as the Prometheus exporter is active, initialized to value `0`, regardless of whether any request, eviction, or migration has occurred yet.
+
+The system SHALL achieve this by recording a single zero-valued measurement (`Add(ctx, 0)`) on each counter after the global meter provider has been installed. Priming MUST NOT alter counting semantics: the first real event still advances the counter from `0` to `1`.
+
+Observable gauges and histograms are out of scope for this requirement: gauges already export via their registered callbacks, and histograms remain absent until their first genuine observation.
+
+#### Scenario: Documented counters present on an idle instance
+
+- **WHEN** ncps starts with Prometheus enabled and `GET /metrics` is scraped before any NAR or narinfo has been served
+- **THEN** the response includes `ncps_nar_served_total` and `ncps_narinfo_served_total` time series, each with value `0`
+
+#### Scenario: Priming preserves counting semantics
+
+- **WHEN** a counter has been primed to `0` at startup and ncps then serves exactly one NAR
+- **THEN** `ncps_nar_served_total` reports a total of `1`, not `2` (the zero-valued prime does not inflate the count)
+
+#### Scenario: All package counters are primed
+
+- **WHEN** ncps starts with Prometheus enabled and `GET /metrics` is scraped with no traffic
+- **THEN** every counter instrument defined in `pkg/cache`, `pkg/lock`, and `pkg/ncps` appears at value `0`
+
+#### Scenario: Priming is a no-op when metrics are disabled
+
+- **WHEN** ncps starts with Prometheus (and OTLP) metrics disabled
+- **THEN** priming the counters causes no error and no panic, and the process starts normally

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -414,6 +414,38 @@ func init() {
 	}
 }
 
+// PrimeMetrics records a zero-valued measurement on every counter instrument in
+// this package so the corresponding time series are exported from startup,
+// rather than only appearing after the first real event. Without this, an idle
+// instance scraped at /metrics is missing documented counters such as
+// ncps_nar_served_total and ncps_narinfo_served_total (GitHub issue #1337).
+//
+// It must be called after the global OTel meter provider has been installed;
+// when no provider is configured the measurements are dropped, making this a
+// harmless no-op. Adding zero never inflates the counts: the first real event
+// still advances the counter from 0 to 1.
+func PrimeMetrics(ctx context.Context) {
+	counters := []metric.Int64Counter{
+		narServedCount,
+		narInfoServedCount,
+		lruCleanupRunsTotal,
+		lruNarInfosEvictedTotal,
+		lruNarFilesEvictedTotal,
+		lruChunksEvictedTotal,
+		lruBytesFreedTotal,
+		backgroundMigrationObjectsTotal,
+		downloadCoordinationFallbackTotal,
+	}
+
+	for _, c := range counters {
+		if c == nil {
+			continue
+		}
+
+		c.Add(ctx, 0)
+	}
+}
+
 // Cache represents the main cache service.
 type Cache struct {
 	hostName      string

--- a/pkg/cache/metrics_prime_test.go
+++ b/pkg/cache/metrics_prime_test.go
@@ -1,0 +1,19 @@
+package cache_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kalbasit/ncps/pkg/cache"
+)
+
+// TestPrimeMetricsNoProviderIsNoOp verifies that priming the counters is safe
+// when no OTel meter provider has been installed (metrics disabled). The
+// measurements are simply dropped; the call must not error or panic.
+func TestPrimeMetricsNoProviderIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	// Must not panic. No provider is configured in this test binary, so the
+	// zero-valued measurements are dropped.
+	cache.PrimeMetrics(context.Background())
+}

--- a/pkg/lock/metrics.go
+++ b/pkg/lock/metrics.go
@@ -98,6 +98,29 @@ func init() {
 	}
 }
 
+// PrimeMetrics records a zero-valued measurement on every counter instrument in
+// this package so the corresponding time series are exported from startup
+// rather than only appearing after the first real event (GitHub issue #1337).
+//
+// It must be called after the global OTel meter provider has been installed;
+// when no provider is configured the measurements are dropped, making this a
+// harmless no-op. Adding zero never inflates the counts.
+func PrimeMetrics(ctx context.Context) {
+	counters := []metric.Int64Counter{
+		lockAcquisitionsTotal,
+		lockFailuresTotal,
+		lockRetryAttemptsTotal,
+	}
+
+	for _, c := range counters {
+		if c == nil {
+			continue
+		}
+
+		c.Add(ctx, 0)
+	}
+}
+
 // RecordLockAcquisition records a lock acquisition attempt.
 // lockType should be one of LockType* constants.
 // mode should be one of LockMode* constants.

--- a/pkg/lock/metrics_prime_test.go
+++ b/pkg/lock/metrics_prime_test.go
@@ -1,0 +1,19 @@
+package lock_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kalbasit/ncps/pkg/lock"
+)
+
+// TestPrimeMetricsNoProviderIsNoOp verifies that priming the counters is safe
+// when no OTel meter provider has been installed (metrics disabled). The
+// measurements are simply dropped; the call must not error or panic.
+func TestPrimeMetricsNoProviderIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	// Must not panic. No provider is configured in this test binary, so the
+	// zero-valued measurements are dropped.
+	lock.PrimeMetrics(context.Background())
+}

--- a/pkg/ncps/metrics.go
+++ b/pkg/ncps/metrics.go
@@ -78,6 +78,21 @@ func init() {
 	}
 }
 
+// PrimeMetrics records a zero-valued measurement on every counter instrument in
+// this package so the corresponding time series are exported from startup
+// rather than only appearing after the first real event (GitHub issue #1337).
+//
+// It must be called after the global OTel meter provider has been installed;
+// when no provider is configured the measurements are dropped, making this a
+// harmless no-op. Adding zero never inflates the counts.
+func PrimeMetrics(ctx context.Context) {
+	if migrationObjectsTotal == nil {
+		return
+	}
+
+	migrationObjectsTotal.Add(ctx, 0)
+}
+
 // RecordMigrationObject records an object migration operation.
 // migrationType should be one of MigrationType* constants.
 // operation should be one of MigrationOperation* constants.

--- a/pkg/ncps/metrics_prime_test.go
+++ b/pkg/ncps/metrics_prime_test.go
@@ -1,0 +1,113 @@
+package ncps_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/resource"
+
+	"github.com/kalbasit/ncps/pkg/cache"
+	"github.com/kalbasit/ncps/pkg/lock"
+	"github.com/kalbasit/ncps/pkg/ncps"
+	"github.com/kalbasit/ncps/pkg/prometheus"
+)
+
+// TestPrimedCountersExposedAtZero verifies the fix for issue #1337: counter
+// metrics must appear at GET /metrics from startup (value 0), before any NAR or
+// narinfo has been served.
+//
+// This test is intentionally NOT parallel: it installs a global OTel meter
+// provider via SetupPrometheusMetrics. Running it during the sequential phase
+// (before t.Parallel() tests start) isolates it from other tests that record
+// into the same global instruments, which would otherwise make the zero-value
+// assertions flaky.
+//
+//nolint:paralleltest // sets global OTel meter provider; needs isolation for deterministic zero assertions.
+func TestPrimedCountersExposedAtZero(t *testing.T) {
+	ctx := context.Background()
+
+	gatherer, shutdown, err := prometheus.SetupPrometheusMetrics(resource.Default())
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		assert.NoError(t, shutdown(ctx))
+	})
+
+	// Prime every package's counters after the meter provider is installed.
+	cache.PrimeMetrics(ctx)
+	lock.PrimeMetrics(ctx)
+	ncps.PrimeMetrics(ctx)
+
+	families, err := gatherer.Gather()
+	require.NoError(t, err)
+
+	// Map each gathered family to the sum of its counter values so the
+	// assertions are robust to the empty-attribute series the prime emits.
+	values := make(map[string]float64, len(families))
+
+	for _, fam := range families {
+		var total float64
+
+		for _, m := range fam.GetMetric() {
+			total += m.GetCounter().GetValue()
+		}
+
+		values[fam.GetName()] = total
+	}
+
+	// The headline metrics from issue #1337 plus the rest of the counters that
+	// share the "not exported until first increment" problem.
+	wantZero := []string{
+		"ncps_nar_served_total",
+		"ncps_narinfo_served_total",
+		"ncps_lru_cleanup_runs_total",
+		"ncps_lru_narinfos_evicted_total",
+		"ncps_lru_nar_files_evicted_total",
+		"ncps_lru_chunks_evicted_total",
+		"ncps_lru_bytes_freed_total",
+		"ncps_background_migration_objects_total",
+		"ncps_download_coordination_fallback_total",
+		"ncps_lock_acquisitions_total",
+		"ncps_lock_failures_total",
+		"ncps_lock_retry_attempts_total",
+		"ncps_migration_objects_total",
+	}
+
+	for _, name := range wantZero {
+		got, ok := values[name]
+		assert.Truef(t, ok, "metric %q missing from /metrics at startup; got %v", name, names(values))
+		assert.Zerof(t, got, "primed metric %q must be exposed at value 0 (prime must not inflate the count)", name)
+	}
+
+	// Priming must not inflate the count: after one real event the total is 1,
+	// not 2. Drive a real increment through a public recording API and re-scrape.
+	lock.RecordLockRetryAttempt(ctx, lock.LockTypeRead)
+
+	families, err = gatherer.Gather()
+	require.NoError(t, err)
+
+	var retryTotal float64
+
+	for _, fam := range families {
+		if fam.GetName() != "ncps_lock_retry_attempts_total" {
+			continue
+		}
+
+		for _, m := range fam.GetMetric() {
+			retryTotal += m.GetCounter().GetValue()
+		}
+	}
+
+	assert.InDelta(t, float64(1), retryTotal, 0, "priming (0) plus one real event must total 1, not 2")
+}
+
+func names(m map[string]float64) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+
+	return out
+}

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -584,6 +584,17 @@ func serveAction(registerShutdown registerShutdownFn) cli.ActionFunc {
 				Msg("Prometheus metrics enabled at /metrics")
 		}
 
+		// Prime all counter instruments to zero now that the global meter
+		// provider is installed, so documented counters (e.g.
+		// ncps_nar_served_total) are exposed at /metrics from startup instead of
+		// only appearing after the first event (GitHub issue #1337). When no
+		// metrics exporter is configured this is a harmless no-op.
+		if cmd.Root().Bool("otel-enabled") || cmd.Root().Bool("prometheus-enabled") {
+			cache.PrimeMetrics(ctx)
+			lock.PrimeMetrics(ctx)
+			PrimeMetrics(ctx)
+		}
+
 		if pprofAddr := cmd.String("pprof-addr"); pprofAddr != "" {
 			pprofMux := http.NewServeMux()
 			pprofMux.HandleFunc("/debug/pprof/", netpprof.Index)


### PR DESCRIPTION
## Summary

Fixes #1337. Documented counters (`ncps_nar_served_total`,
`ncps_narinfo_served_total`, the LRU eviction counters, the lock
counters, and the migration counter) were absent from `GET /metrics`
on a freshly started or idle instance.

**Root cause:** the OpenTelemetry → Prometheus exporter only emits a
counter time series after the counter records its first measurement.
These counters only increment on real events, so until a NAR/narinfo
was served (or an eviction/migration fired) the series simply did not
exist — contradicting the docs that promise them and breaking
dashboards/alerts that reference them from the start.

**Fix:** add an exported `PrimeMetrics(ctx)` to `pkg/cache`,
`pkg/lock`, and `pkg/ncps` that records a zero-valued `Add(ctx, 0)` on
each `Int64Counter`, and call all three from `serve.go` once the global
meter provider is installed (when OTel or Prometheus is enabled).
Adding zero forces each series to export at value `0` without affecting
counts: the first real event still advances the counter from 0 to 1.
Observable gauges and histograms are unaffected (gauges already export
via callbacks).

## Test plan

- [x] `task fmt`, `task lint` (0 issues), `task test` (race detector) all pass
- [x] New `pkg/ncps/metrics_prime_test.go` drives the real Prometheus
      gatherer and asserts all 13 counters appear at `0` before any
      traffic, plus a 0→1 increment check proving priming does not inflate
- [x] `pkg/cache` and `pkg/lock` no-op-without-provider tests confirm
      priming is safe when metrics are disabled