### PR TITLE
docs(openspec): reconcile dechunk skip-vs-purge spec layering

### DIFF
--- a/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/design.md
+++ b/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/design.md
@@ -39,4 +39,4 @@ Spec-only; no migration, no deploy concern. Rollback is reverting the spec edit.
 
 ## Open Questions
 
-None — the authoritative policy was determined from the code (`pkg/cache/cache.go:8364-8377`, `pkg/ncps/migrate_chunks_to_nar.go:419-462`).
+None — the authoritative policy was determined from the code (`pkg/cache/cache.go:8398-8408`, `pkg/ncps/migrate_chunks_to_nar.go:419-462`).

--- a/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/design.md
+++ b/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/design.md
@@ -1,0 +1,42 @@
+## Context
+
+The `chunks-to-nar-migration` capability is implemented across two layers:
+
+1. **Single-NAR operation** — `Cache.MigrateChunksToNar(narURL, forceReclaim)` (`pkg/cache/cache.go`). It is verified-or-nothing: it resolves the expected NarHash from a referencing narinfo (join link, else hash-aware URL match), reconstructs the NAR, content-verifies it, and only then flips the record to whole-file. If it cannot resolve a NarHash it returns `ErrNoNarHashToVerify` and **leaves the NAR chunked** (it never deletes/truncates what it cannot verify). Other failure sentinels: `ErrMissingChunk`, `ErrNarHashMismatch`, `ErrNarAlreadyWholeFile`, `ErrMigrationInProgress`.
+
+2. **Batch pass** — `pkg/ncps/migrate_chunks_to_nar.go` iterates all chunked `nar_file` rows and calls the operation. Its error switch (lines 419-462) treats `ErrMigrationInProgress` / `ErrNarAlreadyWholeFile` as skips, context-cancellation as a non-purging failure, and **any other error** (including `ErrNoNarHashToVerify`, `ErrMissingChunk`, `ErrNarHashMismatch`) as a signal to `PurgeChunkedNar` — so the pass drives the chunked count to zero.
+
+The spec documents both layers but does not label which requirement governs which, so "skip … SHALL NOT delete" and "purge, not skipped" read as a contradiction.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the spec internally consistent by attributing "skip" to the single operation and "purge / drive-to-zero" to the pass.
+- Keep the spec faithful to the implemented behavior (verified at the cited lines).
+
+**Non-Goals:**
+- Any behavior change. The code is already consistent; only the wording is reconciled.
+- Re-litigating the verified-or-nothing or purge policies themselves.
+
+## Decisions
+
+**1. Reconcile by layering, not by picking skip XOR purge.**
+Both behaviors are correct and intended; they are not alternatives. The operation skips (refuses to de-chunk/delete an unverifiable NAR); the pass purges what the operation skipped. The spec will state this explicitly.
+*Alternative considered*: change the code so the operation itself purges (eliminating the layer distinction). Rejected — it would make `MigrateChunksToNar` destructive on a bare verification miss, removing the safety seam (e.g. a transient missing-narinfo race would delete a possibly-healthy NAR) and conflating "this run can't verify it" with "this NAR is permanently bad." The current two-layer design is deliberate and safer.
+
+**2. Edit the two requirements that read as conflicting.**
+- "De-chunk MUST resolve the verification NarHash via the narinfo URL when no join link exists" — its skip language and the "…is skipped" scenario are scoped to the single `MigrateChunksToNar` operation, and the scenario notes the batch pass subsequently purges (cross-referencing the drive-to-zero requirement).
+- "The de-chunk pass MUST always drive the chunked count to zero" — reaffirmed as the pass-level guarantee that purges whatever the operation skipped.
+
+## Risks / Trade-offs
+
+- [Wording implies a behavior the code does not have] → mitigated by citing exact files/lines during apply/verify; if a mismatch is found, it is surfaced, not papered over.
+- [Future readers re-introduce the contradiction] → the explicit "operation vs pass" framing in both requirements makes the layering self-documenting.
+
+## Migration Plan
+
+Spec-only; no migration, no deploy concern. Rollback is reverting the spec edit.
+
+## Open Questions
+
+None — the authoritative policy was determined from the code (`pkg/cache/cache.go:8364-8377`, `pkg/ncps/migrate_chunks_to_nar.go:419-462`).

--- a/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/proposal.md
+++ b/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/proposal.md
@@ -1,11 +1,11 @@
 ## Why
 
-The `chunks-to-nar-migration` spec reads as self-contradictory: one requirement says an un-verifiable chunked NAR (no linked/hash-matched narinfo NarHash) SHALL be **skipped** and SHALL NOT be deleted or truncated, while another says the de-chunk pass SHALL **purge** un-verifiable NARs and MUST drive the chunked count to zero. A reviewer (CodeRabbit, PR #1342) flagged this as ambiguous.
+The `chunks-to-nar-migration` spec reads as self-contradictory: one requirement says an unverifiable chunked NAR (no linked/hash-matched narinfo NarHash) SHALL be **skipped** and SHALL NOT be deleted or truncated, while another says the de-chunk pass SHALL **purge** unverifiable NARs and MUST drive the chunked count to zero. A reviewer (CodeRabbit, PR #1342) flagged this as ambiguous.
 
 Tracing the code shows there is **no behavioral conflict** — the two requirements describe two different layers, and the spec just fails to say so:
 
-- `Cache.MigrateChunksToNar` (the single-NAR operation) returns `ErrNoNarHashToVerify` and **leaves the NAR chunked**, never deleting what it cannot content-verify (`pkg/cache/cache.go:8371-8377`). That is the "skip" behavior — verified-or-nothing.
-- The batch pass (`pkg/ncps/migrate_chunks_to_nar.go:433-458`) catches that error and calls `PurgeChunkedNar`, so the **pass** drives the chunked count to zero. That is the "purge" behavior.
+- `Cache.MigrateChunksToNar` (the single-NAR operation) returns `ErrNoNarHashToVerify` and **leaves the NAR chunked**, never deleting what it cannot content-verify (`pkg/cache/cache.go:8398-8408`). That is the "skip" behavior — verified-or-nothing.
+- The batch pass (`pkg/ncps/migrate_chunks_to_nar.go:419-462`) catches that error and calls `PurgeChunkedNar`, so the **pass** drives the chunked count to zero. That is the "purge" behavior.
 
 ## What Changes
 

--- a/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/proposal.md
+++ b/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The `chunks-to-nar-migration` spec reads as self-contradictory: one requirement says an un-verifiable chunked NAR (no linked/hash-matched narinfo NarHash) SHALL be **skipped** and SHALL NOT be deleted or truncated, while another says the de-chunk pass SHALL **purge** un-verifiable NARs and MUST drive the chunked count to zero. A reviewer (CodeRabbit, PR #1342) flagged this as ambiguous.
+
+Tracing the code shows there is **no behavioral conflict** — the two requirements describe two different layers, and the spec just fails to say so:
+
+- `Cache.MigrateChunksToNar` (the single-NAR operation) returns `ErrNoNarHashToVerify` and **leaves the NAR chunked**, never deleting what it cannot content-verify (`pkg/cache/cache.go:8371-8377`). That is the "skip" behavior — verified-or-nothing.
+- The batch pass (`pkg/ncps/migrate_chunks_to_nar.go:433-458`) catches that error and calls `PurgeChunkedNar`, so the **pass** drives the chunked count to zero. That is the "purge" behavior.
+
+## What Changes
+
+- Clarify in the spec that **skip** is the single-`MigrateChunksToNar`-operation behavior (it refuses to de-chunk or delete a NAR it cannot verify; it returns `ErrNoNarHashToVerify` and leaves it chunked), and **purge / drive-to-zero** is the **batch-pass** behavior (the driver purges what the operation skipped so a later request re-fetches from upstream).
+- Reword the "NAR with neither a link nor a hash-matched narinfo is skipped" scenario to scope it to the single operation and note the pass subsequently purges it — removing the apparent contradiction.
+- No code change: the implementation already matches this layered policy.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `chunks-to-nar-migration`: clarify the layering between the single-operation "skip (verified-or-nothing)" behavior and the pass-level "purge / drive chunked count to zero" behavior so the requirements are mutually consistent.
+
+## Non-goals
+
+- No change to de-chunk behavior, purge behavior, or verified-or-nothing reconstruction — this is a documentation-consistency change only.
+- No change to the hash-aware narinfo matching introduced by `fix-dechunk-unlinked-narinfo-url-match` (that change stands; this only reconciles the skip-vs-purge wording).
+
+## Impact
+
+- **Code**: none. If verification during apply reveals the code does NOT match the documented layered policy, that divergence will be raised rather than silently "fixed" here.
+- **Spec**: `openspec/specs/chunks-to-nar-migration/spec.md` (two requirements reworded for layering clarity).
+- **I/O / network / memory**: none.

--- a/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/specs/chunks-to-nar-migration/spec.md
+++ b/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/specs/chunks-to-nar-migration/spec.md
@@ -1,0 +1,70 @@
+## MODIFIED Requirements
+
+### Requirement: De-chunk MUST resolve the verification NarHash via the narinfo URL when no join link exists
+
+When de-chunking a NAR, the system resolves the expected NarHash from the linked narinfo in order to content-verify the reconstruction (verified-or-nothing). When the `narinfo_nar_files` join link is absent — a known race leaves CDC-chunked `nar_file` rows unlinked — the system SHALL fall back to resolving the narinfo by the NAR's hash, matching **hash-aware** rather than by raw URL prefix: a candidate narinfo references the NAR when its URL, parsed and normalized (narinfo-hash prefix stripped), has the same NAR hash. This SHALL cover both canonical URLs (`nar/<hash>.nar[.<ext>]`) and nix-serve-style prefixed URLs (`nar/<narinfoHash>-<hash>.nar[.<ext>]`).
+
+This requirement governs the **single `MigrateChunksToNar` operation**. When no narinfo references the NAR by either the join link or a hash-matched URL, that operation SHALL NOT de-chunk and SHALL NOT delete or truncate the NAR (verified-or-nothing); it SHALL signal the unverifiable condition (`ErrNoNarHashToVerify`) and leave the NAR chunked. Driving the chunked count to zero is the responsibility of the **batch pass**, which purges such NARs (see "The de-chunk pass MUST always drive the chunked count to zero"); the two are layers of one policy, not alternatives.
+
+#### Scenario: Unlinked chunked NAR is de-chunked via the URL-resolved NarHash
+
+- **GIVEN** a `nar_file` for hash `H` with `total_chunks > 0` and intact chunk links
+- **AND** a narinfo with URL `nar/<H>.nar` carrying a recorded NarHash
+- **AND** NO `narinfo_nar_files` link between that narinfo and the `nar_file`
+- **WHEN** `MigrateChunksToNar` is invoked for `H`
+- **THEN** the system SHALL resolve the verification NarHash from the narinfo found by URL
+- **AND** SHALL reconstruct the whole NAR from its chunks
+- **AND** SHALL content-verify the reconstruction against that NarHash
+- **AND** SHALL flip the record to whole-file (`total_chunks = 0`)
+
+#### Scenario: Unlinked narinfo with a nix-serve-style prefixed URL is matched hash-aware
+
+- **GIVEN** a `nar_file` for hash `H` with `total_chunks > 0`
+- **AND** a narinfo with a prefixed URL `nar/<narinfoHash>-<H>.nar.xz` carrying a recorded NarHash
+- **AND** NO `narinfo_nar_files` link between that narinfo and the `nar_file`
+- **WHEN** `MigrateChunksToNar` is invoked for `H`
+- **THEN** the system SHALL recognize the narinfo as referencing `H` by its normalized embedded hash (not by a raw `nar/<H>.` prefix)
+- **AND** SHALL resolve the verification NarHash from it and de-chunk `H`
+
+#### Scenario: The single operation leaves an unverifiable NAR chunked (the pass purges it)
+
+- **GIVEN** a chunked `nar_file` for hash `H` with no `narinfo_nar_files` link
+- **AND** no narinfo whose URL normalizes to hash `H`
+- **WHEN** the single `MigrateChunksToNar` operation is invoked for `H`
+- **THEN** it SHALL NOT de-chunk `H` and SHALL NOT delete or truncate the NAR
+- **AND** it SHALL signal the unverifiable condition (`ErrNoNarHashToVerify`), leaving `H` chunked
+- **AND** the batch pass SHALL subsequently purge `H` to drive the chunked count to zero (per "The de-chunk pass MUST always drive the chunked count to zero")
+
+### Requirement: The de-chunk pass MUST always drive the chunked count to zero
+
+A full `migrate-chunks-to-nar` pass over all chunked `nar_file` rows SHALL leave no row with `total_chunks > 0`. For every chunked NAR the pass SHALL either de-chunk it to whole-file storage or purge it; it SHALL NOT leave a NAR chunked because it could not resolve a verification hash or could not reconstruct the NAR. This is the **pass-level** complement to the single-operation verified-or-nothing rule: when the single `MigrateChunksToNar` operation declines to de-chunk an unverifiable NAR (signalling `ErrNoNarHashToVerify`) or fails reconstruction, the pass SHALL purge that NAR (removing its chunk links so a later request re-fetches it from upstream) rather than leaving it chunked. An interruption (context cancellation) is NOT such a failure: the pass SHALL leave the NAR chunked for a later run rather than purge a possibly-healthy NAR.
+
+#### Scenario: NarHash is resolved by NAR hash from any referencing narinfo
+
+- **GIVEN** a chunked `nar_file` for hash `H` with no join link
+- **AND** the only narinfo carrying a `nar_hash` for `H` advertises a different-compression URL (e.g. `nar/<H>.nar.xz`), not the bare `nar/<H>.nar`
+- **WHEN** the de-chunk pass processes `H`
+- **THEN** it SHALL resolve the verification NarHash from that narinfo (matched by NAR hash, not by exact URL)
+- **AND** SHALL de-chunk `H` to whole-file storage
+
+#### Scenario: Un-verifiable NAR is purged by the pass, not left chunked
+
+- **GIVEN** a chunked `nar_file` for hash `H` with no narinfo carrying a resolvable `nar_hash`
+- **WHEN** the de-chunk pass processes `H` (the single operation signals `ErrNoNarHashToVerify`)
+- **THEN** the pass SHALL purge the chunked `nar_file` (removing its chunk links so a later request re-pulls from upstream)
+- **AND** SHALL NOT leave `H` chunked
+- **AND** SHALL NOT count `H` as a hard failure that aborts the run
+
+#### Scenario: Hard reconstruction failure is purged, not failed-and-left
+
+- **GIVEN** a chunked `nar_file` for hash `H` whose reconstruction fails (corrupt or missing chunks)
+- **WHEN** the de-chunk pass processes `H`
+- **THEN** it SHALL purge the chunked `nar_file`
+- **AND** SHALL NOT leave `H` chunked
+
+#### Scenario: An interrupted run leaves the NAR chunked rather than purging
+
+- **GIVEN** a chunked `nar_file` for hash `H`
+- **WHEN** the de-chunk pass is cancelled (context cancellation / deadline) while processing `H`
+- **THEN** the pass SHALL leave `H` chunked for a later run
+- **AND** SHALL NOT purge `H`

--- a/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/specs/chunks-to-nar-migration/spec.md
+++ b/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/specs/chunks-to-nar-migration/spec.md
@@ -47,7 +47,7 @@ A full `migrate-chunks-to-nar` pass over all chunked `nar_file` rows SHALL leave
 - **THEN** it SHALL resolve the verification NarHash from that narinfo (matched by NAR hash, not by exact URL)
 - **AND** SHALL de-chunk `H` to whole-file storage
 
-#### Scenario: Un-verifiable NAR is purged by the pass, not left chunked
+#### Scenario: Unverifiable NAR is purged by the pass, not left chunked
 
 - **GIVEN** a chunked `nar_file` for hash `H` with no narinfo carrying a resolvable `nar_hash`
 - **WHEN** the de-chunk pass processes `H` (the single operation signals `ErrNoNarHashToVerify`)

--- a/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/tasks.md
+++ b/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/tasks.md
@@ -1,0 +1,15 @@
+## 1. Confirm the authoritative behavior
+
+- [x] 1.1 Re-confirm the single operation `Cache.MigrateChunksToNar` returns `ErrNoNarHashToVerify` and leaves the NAR chunked (no delete/truncate) when no NarHash resolves (`pkg/cache/cache.go:8364-8377`)
+- [x] 1.2 Re-confirm the batch pass purges on `err != nil` (incl. `ErrNoNarHashToVerify`) and leaves the NAR chunked on context cancellation (`pkg/ncps/migrate_chunks_to_nar.go:419-462`)
+
+## 2. Reconcile the spec wording
+
+- [x] 2.1 Update "De-chunk MUST resolve the verification NarHash via the narinfo URL when no join link exists" to scope skip to the single operation (signals `ErrNoNarHashToVerify`, leaves chunked) and cross-reference the pass for purging
+- [x] 2.2 Update "The de-chunk pass MUST always drive the chunked count to zero" to state it purges what the single operation declined to de-chunk, and that context-cancellation leaves the NAR chunked
+- [x] 2.3 Reword the "…is skipped" scenario into "the single operation leaves an unverifiable NAR chunked (the pass purges it)" so it no longer contradicts the purge requirement
+
+## 3. Verify
+
+- [x] 3.1 `openspec validate clarify-dechunk-skip-vs-purge-layering` passes
+- [x] 3.2 No code change required (confirm the implementation already matches the documented layered policy); if a mismatch is found, raise it rather than silently editing code

--- a/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/tasks.md
+++ b/openspec/changes/archive/2026-06-06-clarify-dechunk-skip-vs-purge-layering/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Confirm the authoritative behavior
 
-- [x] 1.1 Re-confirm the single operation `Cache.MigrateChunksToNar` returns `ErrNoNarHashToVerify` and leaves the NAR chunked (no delete/truncate) when no NarHash resolves (`pkg/cache/cache.go:8364-8377`)
+- [x] 1.1 Re-confirm the single operation `Cache.MigrateChunksToNar` returns `ErrNoNarHashToVerify` and leaves the NAR chunked (no delete/truncate) when no NarHash resolves (`pkg/cache/cache.go:8398-8408`)
 - [x] 1.2 Re-confirm the batch pass purges on `err != nil` (incl. `ErrNoNarHashToVerify`) and leaves the NAR chunked on context cancellation (`pkg/ncps/migrate_chunks_to_nar.go:419-462`)
 
 ## 2. Reconcile the spec wording

--- a/openspec/specs/chunks-to-nar-migration/spec.md
+++ b/openspec/specs/chunks-to-nar-migration/spec.md
@@ -138,7 +138,9 @@ The Job rendered by `migrateChunksToNar.enabled: true` SHALL carry no `helm.sh/h
 
 ### Requirement: De-chunk MUST resolve the verification NarHash via the narinfo URL when no join link exists
 
-When de-chunking a NAR, the system resolves the expected NarHash from the linked narinfo in order to content-verify the reconstruction (verified-or-nothing). When the `narinfo_nar_files` join link is absent — a known race leaves CDC-chunked `nar_file` rows unlinked — the system SHALL fall back to resolving the narinfo by the NAR's hash, matching **hash-aware** rather than by raw URL prefix: a candidate narinfo references the NAR when its URL, parsed and normalized (narinfo-hash prefix stripped), has the same NAR hash. This SHALL cover both canonical URLs (`nar/<hash>.nar[.<ext>]`) and nix-serve-style prefixed URLs (`nar/<narinfoHash>-<hash>.nar[.<ext>]`). Only when no narinfo references the NAR by either the join link or a hash-matched URL SHALL the de-chunk be skipped for want of a verification hash.
+When de-chunking a NAR, the system resolves the expected NarHash from the linked narinfo in order to content-verify the reconstruction (verified-or-nothing). When the `narinfo_nar_files` join link is absent — a known race leaves CDC-chunked `nar_file` rows unlinked — the system SHALL fall back to resolving the narinfo by the NAR's hash, matching **hash-aware** rather than by raw URL prefix: a candidate narinfo references the NAR when its URL, parsed and normalized (narinfo-hash prefix stripped), has the same NAR hash. This SHALL cover both canonical URLs (`nar/<hash>.nar[.<ext>]`) and nix-serve-style prefixed URLs (`nar/<narinfoHash>-<hash>.nar[.<ext>]`).
+
+This requirement governs the **single `MigrateChunksToNar` operation**. When no narinfo references the NAR by either the join link or a hash-matched URL, that operation SHALL NOT de-chunk and SHALL NOT delete or truncate the NAR (verified-or-nothing); it SHALL signal the unverifiable condition (`ErrNoNarHashToVerify`) and leave the NAR chunked. Driving the chunked count to zero is the responsibility of the **batch pass**, which purges such NARs (see "The de-chunk pass MUST always drive the chunked count to zero"); the two are layers of one policy, not alternatives.
 
 #### Scenario: Unlinked chunked NAR is de-chunked via the URL-resolved NarHash
 
@@ -160,13 +162,14 @@ When de-chunking a NAR, the system resolves the expected NarHash from the linked
 - **THEN** the system SHALL recognize the narinfo as referencing `H` by its normalized embedded hash (not by a raw `nar/<H>.` prefix)
 - **AND** SHALL resolve the verification NarHash from it and de-chunk `H`
 
-#### Scenario: NAR with neither a link nor a hash-matched narinfo is skipped
+#### Scenario: The single operation leaves an unverifiable NAR chunked (the pass purges it)
 
 - **GIVEN** a chunked `nar_file` for hash `H` with no `narinfo_nar_files` link
 - **AND** no narinfo whose URL normalizes to hash `H`
-- **WHEN** `MigrateChunksToNar` is invoked for `H`
-- **THEN** the system SHALL skip de-chunking (no NarHash to verify against)
-- **AND** SHALL NOT delete or truncate the NAR
+- **WHEN** the single `MigrateChunksToNar` operation is invoked for `H`
+- **THEN** it SHALL NOT de-chunk `H` and SHALL NOT delete or truncate the NAR
+- **AND** it SHALL signal the unverifiable condition (`ErrNoNarHashToVerify`), leaving `H` chunked
+- **AND** the batch pass SHALL subsequently purge `H` to drive the chunked count to zero (per "The de-chunk pass MUST always drive the chunked count to zero")
 
 ### Requirement: De-chunk MUST content-verify the reconstructed NAR before committing
 
@@ -188,7 +191,7 @@ The de-chunk pass SHALL commit a NAR to whole-file storage only after it reconst
 
 ### Requirement: The de-chunk pass MUST always drive the chunked count to zero
 
-A full `migrate-chunks-to-nar` pass over all chunked `nar_file` rows SHALL leave no row with `total_chunks > 0`. For every chunked NAR the pass SHALL either de-chunk it to whole-file storage or purge it; it SHALL NOT leave a NAR chunked because it could not resolve a verification hash or could not reconstruct the NAR.
+A full `migrate-chunks-to-nar` pass over all chunked `nar_file` rows SHALL leave no row with `total_chunks > 0`. For every chunked NAR the pass SHALL either de-chunk it to whole-file storage or purge it; it SHALL NOT leave a NAR chunked because it could not resolve a verification hash or could not reconstruct the NAR. This is the **pass-level** complement to the single-operation verified-or-nothing rule: when the single `MigrateChunksToNar` operation declines to de-chunk an unverifiable NAR (signalling `ErrNoNarHashToVerify`) or fails reconstruction, the pass SHALL purge that NAR (removing its chunk links so a later request re-fetches it from upstream) rather than leaving it chunked. An interruption (context cancellation) is NOT such a failure: the pass SHALL leave the NAR chunked for a later run rather than purge a possibly-healthy NAR.
 
 #### Scenario: NarHash is resolved by NAR hash from any referencing narinfo
 
@@ -198,11 +201,11 @@ A full `migrate-chunks-to-nar` pass over all chunked `nar_file` rows SHALL leave
 - **THEN** it SHALL resolve the verification NarHash from that narinfo (matched by NAR hash, not by exact URL)
 - **AND** SHALL de-chunk `H` to whole-file storage
 
-#### Scenario: Un-verifiable NAR is purged, not skipped
+#### Scenario: Un-verifiable NAR is purged by the pass, not left chunked
 
 - **GIVEN** a chunked `nar_file` for hash `H` with no narinfo carrying a resolvable `nar_hash`
-- **WHEN** the de-chunk pass processes `H`
-- **THEN** it SHALL purge the chunked `nar_file` (removing its chunk links so a later request re-pulls from upstream)
+- **WHEN** the de-chunk pass processes `H` (the single operation signals `ErrNoNarHashToVerify`)
+- **THEN** the pass SHALL purge the chunked `nar_file` (removing its chunk links so a later request re-pulls from upstream)
 - **AND** SHALL NOT leave `H` chunked
 - **AND** SHALL NOT count `H` as a hard failure that aborts the run
 
@@ -212,6 +215,13 @@ A full `migrate-chunks-to-nar` pass over all chunked `nar_file` rows SHALL leave
 - **WHEN** the de-chunk pass processes `H`
 - **THEN** it SHALL purge the chunked `nar_file`
 - **AND** SHALL NOT leave `H` chunked
+
+#### Scenario: An interrupted run leaves the NAR chunked rather than purging
+
+- **GIVEN** a chunked `nar_file` for hash `H`
+- **WHEN** the de-chunk pass is cancelled (context cancellation / deadline) while processing `H`
+- **THEN** the pass SHALL leave `H` chunked for a later run
+- **AND** SHALL NOT purge `H`
 
 ### Requirement: De-chunking MUST normalize the narinfo URL to none
 

--- a/openspec/specs/chunks-to-nar-migration/spec.md
+++ b/openspec/specs/chunks-to-nar-migration/spec.md
@@ -201,7 +201,7 @@ A full `migrate-chunks-to-nar` pass over all chunked `nar_file` rows SHALL leave
 - **THEN** it SHALL resolve the verification NarHash from that narinfo (matched by NAR hash, not by exact URL)
 - **AND** SHALL de-chunk `H` to whole-file storage
 
-#### Scenario: Un-verifiable NAR is purged by the pass, not left chunked
+#### Scenario: Unverifiable NAR is purged by the pass, not left chunked
 
 - **GIVEN** a chunked `nar_file` for hash `H` with no narinfo carrying a resolvable `nar_hash`
 - **WHEN** the de-chunk pass processes `H` (the single operation signals `ErrNoNarHashToVerify`)


### PR DESCRIPTION
## Summary

The `chunks-to-nar-migration` spec read as self-contradictory: one requirement said an unverifiable chunked NAR is **skipped** and not deleted, while another said the de-chunk pass **purges** unverifiable NARs to drive the chunked count to zero. CodeRabbit flagged the ambiguity on #1342.

Tracing the code shows **no behavioral conflict** — only two layers the spec failed to distinguish:

- The single `MigrateChunksToNar` operation is verified-or-nothing: when it cannot resolve a NarHash it signals `ErrNoNarHashToVerify` and **leaves the NAR chunked**, never deleting it (`pkg/cache/cache.go:8398-8408`).
- The batch pass **purges** what the operation declined to de-chunk, driving the chunked count to zero — and leaves the NAR chunked only on context cancellation (`pkg/ncps/migrate_chunks_to_nar.go:419-462`).

This reconciles the spec by making the operation-vs-pass layering explicit in both requirements and the affected scenarios. **Spec-only — no code change** (the implementation already matches the documented policy).

## Test plan

- [x] `openspec validate chunks-to-nar-migration` passes
- [x] No code change; behavior unchanged (verified against `MigrateChunksToNar` and the batch driver)