### PR TITLE
ci(openspec): validate canonical specs and fix existing breakage

### DIFF
--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -449,14 +449,25 @@
             fileset = ../../openspec;
             root = ../..;
           };
+          dontUnpack = false;
           dontConfigure = true;
-          dontBuild = true;
+          dontBuild = false;
           nativeBuildInputs = [ pkgs.openspec ];
-          doCheck = true;
-          checkPhase = ''
-            runHook preCheck
-            openspec validate --specs
-            runHook postCheck
+          # --no-interactive is mandatory here. `openspec validate --specs`
+          # otherwise starts an `ora` progress spinner, and that interactive
+          # code path blocks forever inside the Nix build sandbox (stdout is a
+          # pipe, not a TTY) — the build hangs until CI cancels the job rather
+          # than ever running the validation. --no-interactive disables the
+          # spinner and the command exits cleanly. OPENSPEC_TELEMETRY=0 keeps
+          # the build hermetic (no telemetry POST to edge.openspec.dev, which is
+          # unreachable in the sandbox), and HOME points at a writable temp dir
+          # because the sandbox HOME is read-only.
+          OPENSPEC_TELEMETRY = "0";
+          buildPhase = ''
+            runHook preBuild
+            export HOME="$TMPDIR"
+            openspec validate --specs --no-interactive
+            runHook postBuild
           '';
           installPhase = ''
             runHook preInstall

--- a/nix/checks/flake-module.nix
+++ b/nix/checks/flake-module.nix
@@ -434,6 +434,37 @@
           '';
         };
 
+        # openspec-validate-check runs `openspec validate --specs` against the
+        # committed openspec/ tree and fails the build if any capability spec is
+        # malformed (missing Purpose/Requirements, a requirement without a
+        # SHALL/MUST statement, or a requirement with no scenario). This is the
+        # spec-health counterpart to the change-archival guard: it keeps the
+        # canonical specs under openspec/specs/ structurally valid so they remain
+        # machine-checkable. Narrow src (only the openspec/ tree); openspec is a
+        # standalone CLI from nixpkgs, so no Go toolchain is needed at check time.
+        # See the flake-check-topology spec, "Canonical specs are validated in CI".
+        openspec-validate-check = pkgs.stdenvNoCC.mkDerivation {
+          name = "openspec-validate-check";
+          src = lib.fileset.toSource {
+            fileset = ../../openspec;
+            root = ../..;
+          };
+          dontConfigure = true;
+          dontBuild = true;
+          nativeBuildInputs = [ pkgs.openspec ];
+          doCheck = true;
+          checkPhase = ''
+            runHook preCheck
+            openspec validate --specs
+            runHook postCheck
+          '';
+          installPhase = ''
+            runHook preInstall
+            touch $out
+            runHook postInstall
+          '';
+        };
+
         # Helm chart unit tests via helm-unittest.
         # Skipped on all platforms: the helm-unittest plugin in nixpkgs-26.05
         # ships neither untt-linux-amd64 nor untt-linux-arm64, so the check

--- a/openspec/specs/api-surface/spec.md
+++ b/openspec/specs/api-surface/spec.md
@@ -1,18 +1,16 @@
 # API Surface Specification
 
-## Overview
+## Purpose
 
-The public API of ncps consists of three layers:
+This specification documents the public API of ncps. The API consists of three layers: (1) the Nix-protocol-compatible HTTP endpoints served by `pkg/server`, (2) the `pkg/cache.Cache` domain methods called by the server handlers, and (3) the pluggable storage and chunk backend interfaces in `pkg/storage` and `pkg/storage/chunk`. It also documents the central artifact type `narinfo.NarInfo`, the `pkg/nar` URL type, and the known edge cases and failure modes that the system must handle.
 
-1. **HTTP endpoints** — the Nix-protocol-compatible REST API served by `pkg/server`.
-2. **`pkg/cache.Cache` methods** — the core domain interface called by the server handlers.
-3. **Storage and chunk interfaces** — the pluggable backend contracts in `pkg/storage` and `pkg/storage/chunk`.
+## Requirements
 
----
+### Requirement: NarInfo Data Structure
 
-## Core Data Structure: `narinfo.NarInfo`
+The system SHALL represent every narinfo as the `narinfo.NarInfo` struct from `github.com/nix-community/go-nix/pkg/narinfo`, and all narinfo operations SHALL revolve around this struct.
 
-The central artifact type is `narinfo.NarInfo` from `github.com/nix-community/go-nix/pkg/narinfo`. All narinfo operations revolve around this struct:
+The central artifact type is `narinfo.NarInfo`:
 
 ```go
 // NarInfo represents a Nix narinfo file — the metadata record for a single
@@ -38,24 +36,36 @@ Key invariants:
 - `References` elements are bare base names (no `/nix/store/` prefix), stored one-per-row in `narinfo_references`.
 - `Signatures` are stored one-per-row in `narinfo_signatures` and re-attached on read.
 
----
+#### Scenario: URL normalization on serve
+- **WHEN** a narinfo is read for serving
+- **THEN** the system SHALL normalize the `URL` field via `nar.URL.Normalize()`, stripping any narinfo-hash prefix
 
-## HTTP Endpoints
+#### Scenario: References and signatures persisted per-row
+- **WHEN** a narinfo is stored
+- **THEN** the system SHALL store `References` as bare base names one-per-row in `narinfo_references` and `Signatures` one-per-row in `narinfo_signatures`, re-attaching the signatures on read
 
-All endpoints are registered on a `chi.Mux` router in `pkg/server.Server.createRouter()`.
+### Requirement: Infrastructure Routes
 
-### Infrastructure Routes
+The system SHALL register infrastructure routes on a `chi.Mux` router in `pkg/server.Server.createRouter()`.
 
 | Method | Path | Handler | Notes |
 |---|---|---|---|
 | `GET` | `/healthz` | chi `middleware.Heartbeat` | Returns `200 OK` with body `"."`. Never traced. |
 | `GET` | `/metrics` | `promhttp.HandlerFor` | Only registered when a Prometheus gatherer is configured. Never traced. |
 
-### Nix Cache Protocol Routes
+#### Scenario: Health check
+- **WHEN** a client sends `GET /healthz`
+- **THEN** the system SHALL return `200 OK` with body `"."` and SHALL NOT emit a trace
 
-#### `GET /nix-cache-info`
+#### Scenario: Metrics endpoint
+- **WHEN** a Prometheus gatherer is configured and a client sends `GET /metrics`
+- **THEN** the system SHALL serve the Prometheus metrics via `promhttp.HandlerFor` and SHALL NOT emit a trace
+- **WHEN** no Prometheus gatherer is configured
+- **THEN** the system SHALL NOT register the `/metrics` route
 
-Returns the Nix cache configuration text.
+### Requirement: GET /nix-cache-info
+
+The system SHALL return the Nix cache configuration text at `GET /nix-cache-info`.
 
 **Response:** `200 OK`, `Content-Type: text/plain`
 
@@ -65,19 +75,23 @@ WantMassQuery: 1
 Priority: 10
 ```
 
-#### `GET /pubkey`
+#### Scenario: Cache info served
+- **WHEN** a client sends `GET /nix-cache-info`
+- **THEN** the system SHALL return `200 OK` with `Content-Type: text/plain` and a body declaring `StoreDir: /nix/store`, `WantMassQuery: 1`, and `Priority: 10`
 
-Returns the cache's Ed25519 public key (used for narinfo signature verification by Nix clients).
+### Requirement: GET /pubkey
+
+The system SHALL return the cache's Ed25519 public key at `GET /pubkey`, used for narinfo signature verification by Nix clients.
 
 **Response:** `200 OK`, `Content-Type: text/plain`, body is the base64-encoded public key.
 
----
+#### Scenario: Public key served
+- **WHEN** a client sends `GET /pubkey`
+- **THEN** the system SHALL return `200 OK` with `Content-Type: text/plain` and a body containing the base64-encoded Ed25519 public key
 
-#### `HEAD /{hash}.narinfo`
+### Requirement: HEAD and GET /{hash}.narinfo
 
-#### `GET /{hash}.narinfo`
-
-Fetch narinfo metadata for a store path hash.
+The system SHALL serve narinfo metadata for a store path hash at `HEAD /{hash}.narinfo` and `GET /{hash}.narinfo`.
 
 - `hash` must match `narinfo.HashPattern` (Nix base32).
 - `HEAD` returns headers only (no body).
@@ -91,11 +105,25 @@ The NAR URL in the returned narinfo is always normalized (any narinfo-hash prefi
 - `404 Not Found` — hash not in database, storage, or any upstream cache.
 - `500 Internal Server Error` — database error or signature validation failure.
 
----
+#### Scenario: Successful narinfo fetch
+- **WHEN** a client sends `GET /{hash}.narinfo` for a hash matching `narinfo.HashPattern` that is available in database, storage, or an upstream cache
+- **THEN** the system SHALL return `200 OK` with `Content-Type: text/x-nix-narinfo` and the full narinfo text, with the NAR URL normalized
 
-#### `PUT /upload/{hash}.narinfo`
+#### Scenario: HEAD returns headers only
+- **WHEN** a client sends `HEAD /{hash}.narinfo` for an available narinfo
+- **THEN** the system SHALL return `200 OK` with the narinfo headers and no body
 
-Store a narinfo pushed by the client. Only available under `/upload` prefix.
+#### Scenario: Narinfo not found
+- **WHEN** the hash is not present in the database, storage, or any upstream cache
+- **THEN** the system SHALL return `404 Not Found`
+
+#### Scenario: Narinfo server error
+- **WHEN** a database error or signature validation failure occurs
+- **THEN** the system SHALL return `500 Internal Server Error`
+
+### Requirement: PUT /upload/{hash}.narinfo
+
+The system SHALL store a narinfo pushed by the client at `PUT /upload/{hash}.narinfo`, available only under the `/upload` prefix.
 
 **Request:** `Content-Type: text/x-nix-narinfo`, body is narinfo text.
 
@@ -107,11 +135,21 @@ Store a narinfo pushed by the client. Only available under `/upload` prefix.
 - `403 Forbidden` — PUT not permitted (`putPermitted == false`).
 - `500 Internal Server Error` — parse or storage error.
 
----
+#### Scenario: Successful narinfo upload
+- **WHEN** `putPermitted == true` and the client sends a valid narinfo body to `PUT /upload/{hash}.narinfo`
+- **THEN** the system SHALL store the narinfo and return `200 OK`
 
-#### `DELETE /{hash}.narinfo`
+#### Scenario: Narinfo upload not permitted
+- **WHEN** `putPermitted == false` (the default)
+- **THEN** the system SHALL return `403 Forbidden` before any body is read
 
-Delete a cached narinfo and its associated nar_file records.
+#### Scenario: Narinfo upload error
+- **WHEN** a parse or storage error occurs
+- **THEN** the system SHALL return `500 Internal Server Error`
+
+### Requirement: DELETE /{hash}.narinfo
+
+The system SHALL delete a cached narinfo and its associated nar_file records at `DELETE /{hash}.narinfo`.
 
 **Response:** `200 OK` on success.
 
@@ -122,17 +160,25 @@ Delete a cached narinfo and its associated nar_file records.
 - `404 Not Found` — hash not found.
 - `500 Internal Server Error` — database or storage error.
 
----
+#### Scenario: Successful narinfo deletion
+- **WHEN** `deletePermitted == true` and the narinfo exists
+- **THEN** the system SHALL delete the narinfo and its associated nar_file records and return `200 OK`
 
-#### `HEAD /nar/{hash}.nar`
+#### Scenario: Narinfo deletion not permitted
+- **WHEN** `deletePermitted == false`
+- **THEN** the system SHALL return `403 Forbidden` immediately
 
-#### `GET /nar/{hash}.nar`
+#### Scenario: Narinfo deletion not found
+- **WHEN** the hash is not found
+- **THEN** the system SHALL return `404 Not Found`
 
-#### `HEAD /nar/{hash}.nar.{compression}`
+#### Scenario: Narinfo deletion error
+- **WHEN** a database or storage error occurs
+- **THEN** the system SHALL return `500 Internal Server Error`
 
-#### `GET /nar/{hash}.nar.{compression}`
+### Requirement: HEAD and GET /nar/{hash}.nar[.{compression}]
 
-Fetch a NAR archive. Supports uncompressed (`.nar`) and compressed (`.nar.xz`, `.nar.zst`, etc.) variants.
+The system SHALL serve a NAR archive at `HEAD`/`GET /nar/{hash}.nar` and `HEAD`/`GET /nar/{hash}.nar.{compression}`, supporting uncompressed (`.nar`) and compressed (`.nar.xz`, `.nar.zst`, etc.) variants.
 
 - `hash` must match `nar.NormalizedHashPattern`.
 - `compression` is optional; omitting it serves the raw NAR stream.
@@ -155,11 +201,41 @@ Fetch a NAR archive. Supports uncompressed (`.nar`) and compressed (`.nar.xz`, `
 - `500 Internal Server Error` — I/O error, upstream failure, or hash mismatch.
 - Connection reset / partial response — client disconnected; upstream fetch aborted (see above).
 
----
+#### Scenario: Serve NAR from chunks
+- **WHEN** CDC is enabled and the NAR is stored as chunks
+- **THEN** the system SHALL return `200 OK` with `Content-Type: application/x-nix-nar`, streaming chunks progressively as they become available, with `Content-Length` from the `nar_files.file_size` record
 
-#### `PUT /upload/nar/{hash}.nar[.{compression}]`
+#### Scenario: Serve NAR from whole file
+- **WHEN** the NAR is stored as a whole file
+- **THEN** the system SHALL return `200 OK` with `Content-Type: application/x-nix-nar`, piping directly from storage, with `Content-Length` from the `nar_files.file_size` record
 
-Store a NAR pushed by the client.
+#### Scenario: Transparent zstd re-compression
+- **WHEN** the client sends `Accept-Encoding: zstd` and the stored NAR is uncompressed
+- **THEN** the system SHALL transparently zstd-compress the response on the fly using a pooled `zstd.Writer`
+
+#### Scenario: Client disconnects while serving from storage or chunks
+- **WHEN** the client drops the connection while the system is serving from storage or chunks
+- **THEN** the system SHALL abort the pipe/stream immediately and SHALL NOT continue any background work
+
+#### Scenario: Client disconnects during upstream fetch
+- **WHEN** the client drops the connection while an upstream fetch is in progress
+- **THEN** the system SHALL exit the download loop on `ctx` cancellation, discard the partial temp file, write no DB record or storage file, and not cache the NAR
+
+#### Scenario: Client disconnects after lazy CDC dispatch
+- **WHEN** the client disconnects after the whole-file NAR was written to `narStore` and the lazy CDC background goroutine was already dispatched
+- **THEN** the background goroutine SHALL run to completion using a detached `context.Background()`, fully chunking and caching the NAR despite the cancelled triggering request
+
+#### Scenario: NAR not found
+- **WHEN** the NAR is not in storage, chunks, or any upstream
+- **THEN** the system SHALL return `404 Not Found`
+
+#### Scenario: NAR serving error
+- **WHEN** an I/O error, upstream failure, or hash mismatch occurs
+- **THEN** the system SHALL return `500 Internal Server Error`
+
+### Requirement: PUT /upload/nar/{hash}.nar[.{compression}]
+
+The system SHALL store a NAR pushed by the client at `PUT /upload/nar/{hash}.nar[.{compression}]`.
 
 **Request:** `Content-Type: application/x-nix-nar`, body is raw NAR bytes.
 
@@ -169,11 +245,21 @@ Store a NAR pushed by the client.
 - `403 Forbidden` — PUT not permitted.
 - `500 Internal Server Error` — storage error.
 
----
+#### Scenario: Successful NAR upload
+- **WHEN** PUT is permitted and the client sends raw NAR bytes
+- **THEN** the system SHALL store the NAR and return `200 OK`
 
-#### `DELETE /nar/{hash}.nar[.{compression}]`
+#### Scenario: NAR upload not permitted
+- **WHEN** PUT is not permitted
+- **THEN** the system SHALL return `403 Forbidden`
 
-Delete a cached NAR from storage and the database.
+#### Scenario: NAR upload error
+- **WHEN** a storage error occurs
+- **THEN** the system SHALL return `500 Internal Server Error`
+
+### Requirement: DELETE /nar/{hash}.nar[.{compression}]
+
+The system SHALL delete a cached NAR from storage and the database at `DELETE /nar/{hash}.nar[.{compression}]`.
 
 **Response:** `200 OK` on success.
 
@@ -182,25 +268,37 @@ Delete a cached NAR from storage and the database.
 - `404 Not Found`.
 - `500 Internal Server Error`.
 
----
+#### Scenario: Successful NAR deletion
+- **WHEN** DELETE is permitted and the NAR exists
+- **THEN** the system SHALL delete the NAR from storage and the database and return `200 OK`
 
-#### `HEAD /build-trace-v2/{drvName}/{outputName}.doi`
+#### Scenario: NAR deletion not permitted
+- **WHEN** DELETE is not permitted
+- **THEN** the system SHALL return `403 Forbidden`
 
-Returns `200 OK` if the build trace entry exists or `404 Not Found` if it does not. No body is returned.
+#### Scenario: NAR deletion not found
+- **WHEN** the NAR does not exist
+- **THEN** the system SHALL return `404 Not Found`
 
-##### Scenario: Entry exists
+#### Scenario: NAR deletion error
+- **WHEN** a storage or database error occurs
+- **THEN** the system SHALL return `500 Internal Server Error`
+
+### Requirement: HEAD /build-trace-v2/{drvName}/{outputName}.doi
+
+The system SHALL return `200 OK` if the build trace entry exists or `404 Not Found` if it does not at `HEAD /build-trace-v2/{drvName}/{outputName}.doi`. No body is returned.
+
+#### Scenario: Entry exists
 - **WHEN** a client sends `HEAD /build-trace-v2/{drvName}/{outputName}.doi` for a stored entry
 - **THEN** the system SHALL return `200 OK` with no body
 
-##### Scenario: Entry does not exist
+#### Scenario: Entry does not exist
 - **WHEN** a client sends `HEAD /build-trace-v2/{drvName}/{outputName}.doi` for an unknown entry
 - **THEN** the system SHALL return `404 Not Found`
 
----
+### Requirement: GET /build-trace-v2/{drvName}/{outputName}.doi
 
-#### `GET /build-trace-v2/{drvName}/{outputName}.doi`
-
-Returns the stored build trace entry as JSON.
+The system SHALL return the stored build trace entry as JSON at `GET /build-trace-v2/{drvName}/{outputName}.doi`.
 
 **Response:** `Content-Type: application/json`, body is the build trace v3 JSON object with `key` and `value` fields, `value.signatures` containing all stored signatures including ncps's own.
 
@@ -208,19 +306,21 @@ Returns the stored build trace entry as JSON.
 - `404 Not Found` — entry not found.
 - `500 Internal Server Error` — database error.
 
-##### Scenario: Successful GET
+#### Scenario: Successful GET
 - **WHEN** a client sends `GET /build-trace-v2/{drvName}/{outputName}.doi` and the entry exists
 - **THEN** the system SHALL return `200 OK` with a JSON body containing `key` and `value` fields
 
-##### Scenario: Not found
+#### Scenario: Not found
 - **WHEN** a client sends `GET /build-trace-v2/{drvName}/{outputName}.doi` for an unknown entry
 - **THEN** the system SHALL return `404 Not Found`
 
----
+#### Scenario: Build trace GET error
+- **WHEN** a database error occurs
+- **THEN** the system SHALL return `500 Internal Server Error`
 
-#### `PUT /upload/build-trace-v2/{drvName}/{outputName}.doi`
+### Requirement: PUT /upload/build-trace-v2/{drvName}/{outputName}.doi
 
-Stores a build trace entry. Only available under the `/upload` prefix. Authorization follows the same `putPermitted` boolean gate used by narinfo and NAR uploads.
+The system SHALL store a build trace entry at `PUT /upload/build-trace-v2/{drvName}/{outputName}.doi`, available only under the `/upload` prefix. Authorization follows the same `putPermitted` boolean gate used by narinfo and NAR uploads.
 
 **Request:** `Content-Type: application/json`, body is a build trace v3 JSON object.
 
@@ -233,23 +333,21 @@ Stores a build trace entry. Only available under the `/upload` prefix. Authoriza
 - `405 Method Not Allowed` — PUT not permitted.
 - `500 Internal Server Error` — database error.
 
-##### Scenario: Successful PUT
+#### Scenario: Successful PUT
 - **WHEN** `putPermitted == true` and the client sends a valid build trace JSON body
 - **THEN** the system SHALL return `204 No Content`
 
-##### Scenario: PUT not permitted
+#### Scenario: PUT not permitted
 - **WHEN** `putPermitted == false`
 - **THEN** the system SHALL return `405 Method Not Allowed`
 
-##### Scenario: Invalid body
+#### Scenario: Invalid body
 - **WHEN** the body is not valid JSON or missing required fields
 - **THEN** the system SHALL return `400 Bad Request`
 
----
+### Requirement: Cache NarInfo Operations
 
-## `pkg/cache.Cache` — Core Methods
-
-### NarInfo Operations
+The `pkg/cache.Cache` type SHALL expose the core narinfo domain methods called by the server handlers.
 
 ```go
 // GetNarInfo returns narinfo for the given hash.
@@ -267,7 +365,25 @@ func (c *Cache) PutNarInfo(ctx context.Context, hash string, r io.ReadCloser) er
 func (c *Cache) DeleteNarInfo(ctx context.Context, hash string) error
 ```
 
-### NAR Operations
+#### Scenario: GetNarInfo lookup order
+- **WHEN** `GetNarInfo` is called for a hash
+- **THEN** the system SHALL look up the narinfo in order database → storage (legacy) → upstream
+- **WHEN** the database misses but storage hits
+- **THEN** the system SHALL spawn a background DB migration goroutine
+- **WHEN** the database hits and the NAR is CDC eligible
+- **THEN** the system SHALL spawn `maybeBackgroundMigrateNarToChunks`
+
+#### Scenario: PutNarInfo persistence
+- **WHEN** `PutNarInfo` is called with a narinfo reader
+- **THEN** the system SHALL parse and validate the narinfo and store it in the database (narinfos + references + signatures + narinfo_nar_files)
+
+#### Scenario: DeleteNarInfo removal
+- **WHEN** `DeleteNarInfo` is called for a hash
+- **THEN** the system SHALL remove the narinfo from the database and storage
+
+### Requirement: Cache NAR Operations
+
+The `pkg/cache.Cache` type SHALL expose the core NAR domain methods called by the server handlers.
 
 ```go
 // GetNar streams a NAR to the provided writer.
@@ -287,7 +403,29 @@ func (c *Cache) DeleteNar(ctx context.Context, narURL nar.URL) error
 func (c *Cache) HasNarInChunks(ctx context.Context, narURL nar.URL) (bool, error)
 ```
 
-### CDC Configuration
+#### Scenario: GetNar lookup order
+- **WHEN** `GetNar` is called with CDC disabled
+- **THEN** the system SHALL look up the NAR in order storage → upstream
+- **WHEN** `GetNar` is called with CDC enabled
+- **THEN** the system SHALL look up the NAR in order chunks (DB) → storage → upstream
+
+#### Scenario: GetNar upstream fetch
+- **WHEN** `GetNar` must fetch from upstream
+- **THEN** the system SHALL download to a temp file, atomically move it to storage, write the DB record, and optionally trigger CDC chunking
+
+#### Scenario: PutNar and DeleteNar
+- **WHEN** `PutNar` is called
+- **THEN** the system SHALL store the NAR from the reader
+- **WHEN** `DeleteNar` is called
+- **THEN** the system SHALL remove the NAR from storage and the database
+
+#### Scenario: HasNarInChunks check
+- **WHEN** `HasNarInChunks` is called
+- **THEN** the system SHALL check the database for CDC chunk records and return whether they exist
+
+### Requirement: Cache CDC Configuration
+
+The `pkg/cache.Cache` type SHALL expose methods to configure Content-Defined Chunking (CDC).
 
 ```go
 // SetCDCConfiguration enables CDC and sets chunker parameters.
@@ -305,7 +443,21 @@ func (c *Cache) SetCDCLazyChunking(enabled bool, workers int)
 func (c *Cache) SetCDCDeleteDelay(delay time.Duration)
 ```
 
-### Lifecycle
+#### Scenario: Configure CDC parameters
+- **WHEN** `SetCDCConfiguration` is called
+- **THEN** the system SHALL enable CDC and set the chunker `minSize`, `avgSize`, and `maxSize` parameters in bytes
+
+#### Scenario: Inject chunk store and lazy chunking
+- **WHEN** `SetChunkStore` is called
+- **THEN** the system SHALL inject the chunk storage backend
+- **WHEN** `SetCDCLazyChunking` is called
+- **THEN** the system SHALL toggle lazy background chunking with the given worker pool size
+- **WHEN** `SetCDCDeleteDelay` is called
+- **THEN** the system SHALL set the delay before deleting whole-file NARs after chunking
+
+### Requirement: Cache Lifecycle Operations
+
+The `pkg/cache.Cache` type SHALL expose lifecycle methods for cron scheduling, sizing, and upstream registration.
 
 ```go
 // SetupCron initializes the cron runner with the given timezone.
@@ -324,9 +476,23 @@ func (c *Cache) SetMaxSize(maxSize uint64)
 func (c *Cache) AddUpstreamCaches(...)
 ```
 
----
+#### Scenario: Cron setup and jobs
+- **WHEN** `SetupCron` is called with a timezone
+- **THEN** the system SHALL initialize the cron runner with that timezone
+- **WHEN** `AddLRUCronJob` is called
+- **THEN** the system SHALL register an LRU eviction job on the given schedule
+- **WHEN** `AddCDCDeletedCleanupCronJob` is called
+- **THEN** the system SHALL register a CDC orphan-cleanup job on the given schedule
 
-## `pkg/storage` — Storage Interfaces
+#### Scenario: Sizing and upstream registration
+- **WHEN** `SetMaxSize` is called
+- **THEN** the system SHALL set the maximum cache size in bytes for LRU eviction
+- **WHEN** `AddUpstreamCaches` is called
+- **THEN** the system SHALL register the given upstream caches and their trusted public keys
+
+### Requirement: Storage Interfaces
+
+The `pkg/storage` package SHALL define the pluggable backend contracts implemented by the filesystem and S3 backends.
 
 ```go
 // NarInfoStore — narinfo metadata storage (filesystem or S3).
@@ -359,9 +525,19 @@ Sentinel errors:
 - `storage.ErrNotFound` — returned when a narinfo or NAR does not exist.
 - `storage.ErrAlreadyExists` — returned when attempting to overwrite an existing file.
 
----
+#### Scenario: Backends implement storage interfaces
+- **WHEN** a storage backend is selected (filesystem or S3)
+- **THEN** the backend SHALL implement `NarInfoStore` and `NarStore` (and the deprecated `ConfigStore`)
 
-## `pkg/storage/chunk` — Chunk Store Interface
+#### Scenario: Storage sentinel errors
+- **WHEN** a narinfo or NAR does not exist
+- **THEN** the store SHALL return `storage.ErrNotFound`
+- **WHEN** an attempt is made to overwrite an existing file
+- **THEN** the store SHALL return `storage.ErrAlreadyExists`
+
+### Requirement: Chunk Store Interface
+
+The `pkg/storage/chunk` package SHALL define the `Store` interface for CDC chunk storage, implemented by `chunk.NewLocalStore(baseDir)` and `chunk.NewS3Store(ctx, cfg, locker)`.
 
 ```go
 type Store interface {
@@ -377,11 +553,23 @@ type Store interface {
 }
 ```
 
-Implementations: `chunk.NewLocalStore(baseDir)`, `chunk.NewS3Store(ctx, cfg, locker)`.
+#### Scenario: Chunk retrieval variants
+- **WHEN** `GetChunk` is called
+- **THEN** the store SHALL decompress the chunk before returning it
+- **WHEN** `GetRawChunk` is called
+- **THEN** the store SHALL return the compressed bytes without decompression
 
----
+#### Scenario: Chunk storage result
+- **WHEN** `PutChunk` is called
+- **THEN** the store SHALL store the chunk and return `(isNew, compressedSize, error)`
 
-## `pkg/nar` — NAR URL Type
+#### Scenario: Chunk store implementations
+- **WHEN** a chunk store is constructed via `chunk.NewLocalStore(baseDir)` or `chunk.NewS3Store(ctx, cfg, locker)`
+- **THEN** the resulting value SHALL implement the `Store` interface
+
+### Requirement: NAR URL Type
+
+The `pkg/nar` package SHALL define the `URL` type and parsing functions that represent and normalize narinfo URL fields.
 
 ```go
 type URL struct {
@@ -400,9 +588,17 @@ func ParseURL(u string) (URL, error)
 func (u URL) Normalize() URL
 ```
 
----
+#### Scenario: ParseURL validation and prefix stripping
+- **WHEN** `ParseURL` is called with a narinfo URL field
+- **THEN** the system SHALL validate the hash against `nar.NormalizedHashPattern` and strip any narinfo-hash prefix (e.g., `"prefix-actualhash"` → `"actualhash"`)
 
-## Known Edge Cases and Failure Modes
+#### Scenario: Normalize strips embedded prefix
+- **WHEN** `Normalize` is called on a `URL`
+- **THEN** the system SHALL return a `URL` with any embedded narinfo-hash prefix stripped
+
+### Requirement: Known Edge Cases and Failure Modes
+
+The system SHALL handle the following edge cases and failure modes with the documented behavior.
 
 | Scenario | Behavior |
 |---|---|
@@ -419,3 +615,47 @@ func (u URL) Normalize() URL
 | SQLite write contention | WAL mode + `busy_timeout=10s` retries; `MaxOpenConns=1` serializes writes. |
 | Storage `ErrAlreadyExists` on `PutNarInfo` | Treated as a no-op success (idempotent). |
 | Upload-only context (`/upload` prefix) | `cache.WithUploadOnly(ctx)` is set; cache layer skips upstream fetch for PUTs. |
+
+#### Scenario: Upstream cache miss
+- **WHEN** all upstream caches return 404
+- **THEN** `GetNarInfo` / `GetNar` SHALL return `storage.ErrNotFound` and the server SHALL respond `404`
+
+#### Scenario: Upstream fetch failure
+- **WHEN** an upstream fetch times out, errors on the network, or the NAR hash mismatches after download
+- **THEN** the system SHALL propagate the error (discarding any partial download) and the server SHALL respond `500`
+
+#### Scenario: Concurrent narinfo writes
+- **WHEN** a `PutNarInfo` races with a background migration for the same hash
+- **THEN** the system SHALL handle the duplicate key error gracefully, the first commit SHALL win, and the second SHALL receive `storage.ErrAlreadyExists`
+
+#### Scenario: Thundering herd on GetNarInfo
+- **WHEN** multiple concurrent `GetNarInfo` calls target the same hash
+- **THEN** `downloadState` SHALL serialize them so only the first goroutine fetches from upstream and the others wait and receive the result via broadcast
+
+#### Scenario: CDC chunking in progress
+- **WHEN** a client requests a NAR while CDC chunking is in progress for it
+- **THEN** the system SHALL serve the client from whole-file storage during chunking, and the background goroutine SHALL be unaffected by the client's context
+
+#### Scenario: Stale CDC lock recovery
+- **WHEN** `chunking_started_at` age is ≥ 1h after a process crash mid-chunk
+- **THEN** the system SHALL trigger stale-lock recovery: `DeleteNarFileChunksByNarFileID` removes junction records, `cleanupStaleLockChunks` removes orphaned chunk files and records, and chunking restarts
+
+#### Scenario: NarInfo present but NAR missing
+- **WHEN** a narinfo exists in the database but the NAR is not in storage or chunks
+- **THEN** `GetNar` SHALL fall through to an upstream fetch, re-downloading and re-storing the NAR
+
+#### Scenario: NarInfo url field is NULL
+- **WHEN** the narinfo `url` field is `NULL` in the database
+- **THEN** `getNarInfoFromDatabase` SHALL treat the record as incomplete and fall through to storage lookup
+
+#### Scenario: SQLite write contention
+- **WHEN** concurrent writes contend on SQLite
+- **THEN** the system SHALL use WAL mode with `busy_timeout=10s` retries and `MaxOpenConns=1` to serialize writes
+
+#### Scenario: Idempotent PutNarInfo
+- **WHEN** `PutNarInfo` receives `storage.ErrAlreadyExists`
+- **THEN** the system SHALL treat it as a no-op success (idempotent)
+
+#### Scenario: Upload-only context skips upstream
+- **WHEN** a request is served under the `/upload` prefix with `cache.WithUploadOnly(ctx)` set
+- **THEN** the cache layer SHALL skip the upstream fetch for PUTs

--- a/openspec/specs/api-surface/spec.md
+++ b/openspec/specs/api-surface/spec.md
@@ -127,21 +127,21 @@ The system SHALL store a narinfo pushed by the client at `PUT /upload/{hash}.nar
 
 **Request:** `Content-Type: text/x-nix-narinfo`, body is narinfo text.
 
-**Response:** `200 OK` on success.
+**Response:** `204 No Content` on success.
 
-**Authorization:** `403 Forbidden` is evaluated by a strict configuration boolean — there is no auth middleware or token validation. `Server.SetPutPermitted(false)` (the default) causes the handler to immediately return `403` before any body is read. There is no per-request authentication.
+**Authorization:** `405 Method Not Allowed` is evaluated by a strict configuration boolean — there is no auth middleware or token validation. `Server.SetPutPermitted(false)` (the default) causes the handler to immediately return `405` before any body is read. There is no per-request authentication.
 
 **Failure modes:**
-- `403 Forbidden` — PUT not permitted (`putPermitted == false`).
+- `405 Method Not Allowed` — PUT not permitted (`putPermitted == false`).
 - `500 Internal Server Error` — parse or storage error.
 
 #### Scenario: Successful narinfo upload
 - **WHEN** `putPermitted == true` and the client sends a valid narinfo body to `PUT /upload/{hash}.narinfo`
-- **THEN** the system SHALL store the narinfo and return `200 OK`
+- **THEN** the system SHALL store the narinfo and return `204 No Content`
 
 #### Scenario: Narinfo upload not permitted
 - **WHEN** `putPermitted == false` (the default)
-- **THEN** the system SHALL return `403 Forbidden` before any body is read
+- **THEN** the system SHALL return `405 Method Not Allowed` before any body is read
 
 #### Scenario: Narinfo upload error
 - **WHEN** a parse or storage error occurs
@@ -151,22 +151,22 @@ The system SHALL store a narinfo pushed by the client at `PUT /upload/{hash}.nar
 
 The system SHALL delete a cached narinfo and its associated nar_file records at `DELETE /{hash}.narinfo`.
 
-**Response:** `200 OK` on success.
+**Response:** `204 No Content` on success.
 
-**Authorization:** Same as PUT — `deletePermitted` is a strict boolean set at startup via `Server.SetDeletePermitted`. No middleware or token evaluation occurs; a `false` value causes an immediate `403` response.
+**Authorization:** Same as PUT — `deletePermitted` is a strict boolean set at startup via `Server.SetDeletePermitted`. No middleware or token evaluation occurs; a `false` value causes an immediate `405` response.
 
 **Failure modes:**
-- `403 Forbidden` — DELETE not permitted (`deletePermitted == false`).
+- `405 Method Not Allowed` — DELETE not permitted (`deletePermitted == false`).
 - `404 Not Found` — hash not found.
 - `500 Internal Server Error` — database or storage error.
 
 #### Scenario: Successful narinfo deletion
 - **WHEN** `deletePermitted == true` and the narinfo exists
-- **THEN** the system SHALL delete the narinfo and its associated nar_file records and return `200 OK`
+- **THEN** the system SHALL delete the narinfo and its associated nar_file records and return `204 No Content`
 
 #### Scenario: Narinfo deletion not permitted
 - **WHEN** `deletePermitted == false`
-- **THEN** the system SHALL return `403 Forbidden` immediately
+- **THEN** the system SHALL return `405 Method Not Allowed` immediately
 
 #### Scenario: Narinfo deletion not found
 - **WHEN** the hash is not found
@@ -239,19 +239,19 @@ The system SHALL store a NAR pushed by the client at `PUT /upload/nar/{hash}.nar
 
 **Request:** `Content-Type: application/x-nix-nar`, body is raw NAR bytes.
 
-**Response:** `200 OK` on success.
+**Response:** `204 No Content` on success.
 
 **Failure modes:**
-- `403 Forbidden` — PUT not permitted.
+- `405 Method Not Allowed` — PUT not permitted.
 - `500 Internal Server Error` — storage error.
 
 #### Scenario: Successful NAR upload
 - **WHEN** PUT is permitted and the client sends raw NAR bytes
-- **THEN** the system SHALL store the NAR and return `200 OK`
+- **THEN** the system SHALL store the NAR and return `204 No Content`
 
 #### Scenario: NAR upload not permitted
 - **WHEN** PUT is not permitted
-- **THEN** the system SHALL return `403 Forbidden`
+- **THEN** the system SHALL return `405 Method Not Allowed`
 
 #### Scenario: NAR upload error
 - **WHEN** a storage error occurs
@@ -261,20 +261,20 @@ The system SHALL store a NAR pushed by the client at `PUT /upload/nar/{hash}.nar
 
 The system SHALL delete a cached NAR from storage and the database at `DELETE /nar/{hash}.nar[.{compression}]`.
 
-**Response:** `200 OK` on success.
+**Response:** `204 No Content` on success.
 
 **Failure modes:**
-- `403 Forbidden` — DELETE not permitted.
+- `405 Method Not Allowed` — DELETE not permitted.
 - `404 Not Found`.
 - `500 Internal Server Error`.
 
 #### Scenario: Successful NAR deletion
 - **WHEN** DELETE is permitted and the NAR exists
-- **THEN** the system SHALL delete the NAR from storage and the database and return `200 OK`
+- **THEN** the system SHALL delete the NAR from storage and the database and return `204 No Content`
 
 #### Scenario: NAR deletion not permitted
 - **WHEN** DELETE is not permitted
-- **THEN** the system SHALL return `403 Forbidden`
+- **THEN** the system SHALL return `405 Method Not Allowed`
 
 #### Scenario: NAR deletion not found
 - **WHEN** the NAR does not exist

--- a/openspec/specs/architecture/spec.md
+++ b/openspec/specs/architecture/spec.md
@@ -1,12 +1,14 @@
 # Architecture Specification
 
-## Overview
+## Purpose
 
-ncps (Nix Cache Proxy Server) is a Go HTTP proxy that sits between Nix clients and upstream binary caches (e.g., `cache.nixos.org`). It intercepts `.narinfo` and `.nar` requests, caches artifacts locally, and re-serves them—reducing external bandwidth and download latency.
+ncps (Nix Cache Proxy Server) is a Go HTTP proxy that sits between Nix clients and upstream binary caches (e.g., `cache.nixos.org`). It intercepts `.narinfo` and `.nar` requests, caches artifacts locally, and re-serves them—reducing external bandwidth and download latency. This specification describes the system's package structure, request lifecycle, concurrency model, database architecture, eviction strategy, background migration behavior, configuration entry points, and observability surface.
 
----
+## Requirements
 
-## Package Structure
+### Requirement: Package structure
+
+The system SHALL be organized into the following packages, with each package owning a single, well-defined responsibility:
 
 ```
 cmd/                        CLI entrypoints (serve, migrate-narinfo, global flags, OTel bootstrap)
@@ -38,11 +40,14 @@ db/
   schema/{sqlite,postgres,mysql}.sql    Derived schema snapshots (via migrate-up)
 ```
 
----
+#### Scenario: Locating a responsibility by package
 
-## Request Lifecycle
+- **WHEN** a developer needs to find where a given responsibility lives (e.g., upstream HTTP fetching, S3 storage, or CDC chunking)
+- **THEN** that responsibility resides in exactly one package as documented above (e.g., `pkg/cache/upstream`, `pkg/storage/s3`, `pkg/chunker` respectively)
 
-### Standard Proxy Flow (CDC disabled)
+### Requirement: Standard proxy request lifecycle (CDC disabled)
+
+The system SHALL serve `.narinfo` and `.nar` requests through the chi router into the core cache, resolving each request via a cache-hit, legacy-hit, or upstream-miss path in that priority order.
 
 ```
 Nix client
@@ -64,9 +69,21 @@ pkg/cache.Cache.GetNar(ctx, narURL)
   3. Upstream fetch → MISS: pull into temp file, move to storage, store DB record
 ```
 
-### CDC Enabled, Lazy Disabled (synchronous chunking)
+#### Scenario: NarInfo request resolution
 
-When CDC is enabled and `cdcLazyChunkingEnabled == false`:
+- **WHEN** a client issues `HEAD`/`GET /{hash}.narinfo`
+- **THEN** `Cache.GetNarInfo` checks the `narinfos` table first (cache HIT returns immediately), then the storage backend via `NarInfoStore.HasNarInfo` (legacy HIT returns and triggers a background DB migration), and otherwise fetches from upstream, validates the signature, stores it in both the DB and storage, and returns it
+
+#### Scenario: NAR request resolution
+
+- **WHEN** a client issues `HEAD`/`GET /nar/{hash}.nar[.{compression}]`
+- **THEN** `Cache.GetNar` checks the storage backend via `NarStore.HasNar` (HIT streams from storage), then the DB for CDC chunks via `HasNarInChunks` (HIT streams chunks progressively), and otherwise pulls from upstream into a temp file, moves it to storage, and stores a DB record
+
+### Requirement: CDC enabled with lazy chunking disabled (synchronous chunking)
+
+When CDC is enabled and `cdcLazyChunkingEnabled == false`, the system SHALL chunk a downloaded NAR synchronously before returning to the client, persist chunk records in progressive batches, and signal CDC storage by rewriting the narinfo URL.
+
+The behavior is:
 
 1. NAR is downloaded from upstream into a temp file (via `pullNarIntoStore`).
 2. `storeNarWithCDC` is called **synchronously** before returning to the client.
@@ -76,9 +93,16 @@ When CDC is enabled and `cdcLazyChunkingEnabled == false`:
 6. Once all chunks are recorded, the whole-file NAR is deleted from `narStore` after `cdcDeleteDelay`.
 7. `narinfo.URL` is rewritten to `{hash}.nar` (no compression extension) to signal CDC storage.
 
-### CDC Enabled, Lazy Enabled (background chunking)
+#### Scenario: Synchronous chunking on cache miss
 
-When `cdcLazyChunkingEnabled == true`:
+- **WHEN** CDC is enabled, `cdcLazyChunkingEnabled == false`, and a NAR is fetched from upstream into a temp file
+- **THEN** `storeNarWithCDC` runs synchronously before the client response: the NAR is split by `chunker.CDCChunker`, each chunk is zstd-compressed and written to `chunk.Store`, chunk and `nar_file_chunks` records are committed in progressive batches (first after 100ms, then every 500ms, max 100 chunks/batch), the whole-file NAR is deleted from `narStore` after `cdcDeleteDelay`, and `narinfo.URL` is rewritten to `{hash}.nar`
+
+### Requirement: CDC enabled with lazy chunking enabled (background chunking)
+
+When `cdcLazyChunkingEnabled == true`, the system SHALL store the NAR as a whole file, return to the client immediately, and chunk the NAR asynchronously in a bounded background worker pool while serving concurrent requests from the whole-file copy.
+
+The behavior is:
 
 1. NAR is downloaded and stored as a whole file in `narStore` first.
 2. The handler returns to the client immediately.
@@ -86,9 +110,14 @@ When `cdcLazyChunkingEnabled == true`:
 4. Concurrent requests for the same NAR during chunking are streamed from the whole-file storage until chunking completes.
 5. A distributed lock (`TryLock`) prevents thundering-herd duplicate chunking of the same NAR across multiple processes.
 
----
+#### Scenario: Background chunking with concurrent reads
 
-## Concurrency Model
+- **WHEN** CDC is enabled, `cdcLazyChunkingEnabled == true`, and a NAR is fetched and stored as a whole file
+- **THEN** the handler returns immediately, a background goroutine bounded by `cdcBackgroundWorkers` calls `storeNarWithCDC` asynchronously, concurrent requests for the same NAR are streamed from whole-file storage until chunking completes, and a distributed `TryLock` prevents duplicate chunking across processes
+
+### Requirement: Concurrency model
+
+The system SHALL coordinate concurrent work using the following mechanisms, each addressing a specific concern:
 
 | Concern | Mechanism |
 |---|---|
@@ -102,15 +131,37 @@ When `cdcLazyChunkingEnabled == true`:
 | OTel tracing | Every public cache and server method starts a child span |
 | Metrics | OpenTelemetry `metric.Meter` for counters/histograms; Prometheus gatherer at `/metrics` |
 
-### Memory Efficiency: Pooled zstd Readers/Writers
+#### Scenario: Deduplicating concurrent downloads of the same narinfo
+
+- **WHEN** multiple concurrent requests target the same narinfo hash that is being downloaded
+- **THEN** a per-hash `downloadState` guarded by `sync.Mutex` + `sync.Cond` broadcast deduplicates the download so only one upstream fetch occurs and waiters are notified on completion
+
+#### Scenario: Recovering a stale CDC lock
+
+- **WHEN** a CDC chunking lock's `chunking_started_at` timestamp is older than 1 hour
+- **THEN** the lock is considered stale and cleaned up so chunking can proceed
+
+### Requirement: Pooled zstd readers/writers
+
+To keep GC pauses predictable under concurrent load, the system SHALL reuse zstd encoders and decoders via `sync.Pool`-backed pooled types rather than allocating a fresh encoder/decoder per request.
 
 NAR files are large binary streams (often hundreds of MB). When a client requests a NAR with `Accept-Encoding: zstd` but the cached copy is stored uncompressed, the server must re-compress on the fly. Naively allocating a new `zstd.Writer` per request would cause severe GC pressure at high throughput — each encoder allocates large internal dictionaries and buffers.
 
 To address this, `pkg/zstd` provides pooled `PooledReader` and `PooledWriter` types backed by `sync.Pool`. Encoders and decoders are reset and returned to the pool after each use rather than being garbage-collected. This dramatically reduces allocations-per-request and keeps GC pauses predictable under concurrent load. The same pooling applies when decompressing chunks in CDC streaming (`GetChunk` via `chunk.Store`).
 
----
+#### Scenario: Re-compressing an uncompressed NAR on the fly
 
-## Database Architecture
+- **WHEN** a client requests a NAR with `Accept-Encoding: zstd` but the cached copy is stored uncompressed
+- **THEN** the server obtains a `PooledWriter` from `pkg/zstd`'s `sync.Pool`, re-compresses the stream, and resets and returns the encoder to the pool after use rather than garbage-collecting it
+
+#### Scenario: Decompressing CDC chunks
+
+- **WHEN** CDC chunks are streamed via `GetChunk` on `chunk.Store`
+- **THEN** the same pooled `PooledReader` decoders are reused from `sync.Pool` to decompress each chunk
+
+### Requirement: Database architecture
+
+The system SHALL avoid ORMs and access the database exclusively through hand-written, engine-specific SQL compiled by sqlc into three independent querier implementations selected at runtime by URL scheme, with schema migrations managed by dbmate via a URL-aware wrapper.
 
 ncps deliberately avoids ORMs. All database access goes through hand-written SQL queries stored in `db/query.{sqlite,postgres,mysql}.sql`. This keeps queries explicit, auditable, and engine-specific — we use the right SQL dialect per engine rather than a lowest-common-denominator abstraction.
 
@@ -124,9 +175,19 @@ The three packages are never mixed at runtime. `database.Open()` inspects the UR
 
 **dbmate** manages schema migrations. The `dbmate` binary in dev and Docker is actually a thin Go wrapper (`nix/dbmate-wrapper/`) that reads the `--url` flag, auto-selects the migrations directory (`db/migrations/{sqlite,postgres,mysql}`) and schema output path (`db/schema/{engine}.sql`) from the URL scheme, and then delegates to the real `dbmate` binary. This means developers never need to specify `--migrations-dir` manually, and the same `dbmate` command works correctly across all three engines.
 
----
+#### Scenario: Selecting the engine-specific querier at runtime
 
-## LRU Eviction
+- **WHEN** `database.Open()` is called with a database URL
+- **THEN** it inspects the URL scheme and returns the matching engine wrapper (`sqlitedb`, `postgresdb`, or `mysqldb`) as the shared `database.Querier` interface, never mixing the three engine packages at runtime
+
+#### Scenario: Running dbmate against any engine
+
+- **WHEN** the dbmate wrapper is invoked with a `--url` flag
+- **THEN** it auto-selects the migrations directory (`db/migrations/{sqlite,postgres,mysql}`) and schema output path (`db/schema/{engine}.sql`) from the URL scheme and delegates to the real `dbmate` binary, without requiring a manual `--migrations-dir`
+
+### Requirement: LRU eviction
+
+The system SHALL bound on-disk cache size via a scheduled least-recently-used eviction job that deletes the least-used NARs (chunks or whole files) and their orphaned narinfos, and SHALL emit eviction counters.
 
 - Controlled by `Cache.SetMaxSize(bytes)`.
 - Scheduled via `Cache.AddLRUCronJob(ctx, schedule)` using an internal cron runner.
@@ -135,20 +196,28 @@ The three packages are never mixed at runtime. `database.Open()` inspects the UR
 - `narinfos` orphaned after nar_file deletion are cascade-deleted via FK constraints.
 - OTel counters: `ncps_lru_narinfos_evicted_total`, `ncps_lru_nar_files_evicted_total`, `ncps_lru_chunks_evicted_total`, `ncps_lru_bytes_freed_total`.
 
----
+#### Scenario: Evicting least-recently-used entries
 
-## NarInfo Background Migration (Storage → Database)
+- **WHEN** the LRU cron job scheduled by `Cache.AddLRUCronJob` runs and the cache exceeds the `Cache.SetMaxSize` limit
+- **THEN** `runLRU` queries `GetLeastUsedNarInfos` ordered by `last_accessed_at`, deletes each evicted `nar_file`'s chunks (CDC) or whole file (non-CDC) and its DB records, cascade-deletes orphaned `narinfos` via FK constraints, and increments the `ncps_lru_*_evicted_total` and `ncps_lru_bytes_freed_total` counters
 
-Narinfos stored in the legacy storage backend (pre-0.8.0) are automatically migrated to the database:
+### Requirement: NarInfo background migration (storage to database)
+
+Narinfos stored in the legacy storage backend (pre-0.8.0) SHALL be automatically migrated to the database without blocking the client response, using a distributed lock to avoid duplicate migration across processes.
 
 1. `GetNarInfo` finds the narinfo in `narInfoStore` but not in the database.
 2. It returns the narinfo to the client immediately.
 3. A background goroutine acquires a distributed lock and writes the narinfo to the database.
 4. If the lock is already held (another process migrating the same hash), the goroutine exits silently.
 
----
+#### Scenario: Migrating a legacy narinfo on read
 
-## Configuration Entry Points
+- **WHEN** `GetNarInfo` finds a narinfo in `narInfoStore` but not in the database
+- **THEN** it returns the narinfo to the client immediately and a background goroutine acquires a distributed lock to write it to the database, exiting silently if the lock is already held by another process migrating the same hash
+
+### Requirement: Configuration entry points
+
+The system SHALL expose the following methods as the supported entry points for configuring cache and server behavior:
 
 | Method | Purpose |
 |---|---|
@@ -161,9 +230,19 @@ Narinfos stored in the legacy storage backend (pre-0.8.0) are automatically migr
 | `Server.SetPutPermitted(bool)` | Allow/deny PUT requests |
 | `Server.SetDeletePermitted(bool)` | Allow/deny DELETE requests |
 
----
+#### Scenario: Enabling CDC with lazy chunking
 
-## Observability
+- **WHEN** an operator calls `Cache.SetCDCConfiguration(...)`, `Cache.SetChunkStore(...)`, and `Cache.SetCDCLazyChunking(enabled, workers)`
+- **THEN** CDC is enabled with the configured chunker parameters, the chunk storage backend is injected, and lazy background chunking is toggled with the specified worker count
+
+#### Scenario: Controlling write verbs on the server
+
+- **WHEN** an operator calls `Server.SetPutPermitted(bool)` and `Server.SetDeletePermitted(bool)`
+- **THEN** the server allows or denies `PUT` and `DELETE` requests accordingly
+
+### Requirement: Observability
+
+The system SHALL emit OpenTelemetry traces and metrics, expose a Prometheus endpoint, use context-propagated structured logging, and expose a health endpoint.
 
 - **Tracing**: OpenTelemetry spans on every cache and server operation.
 - **Metrics**: OTel meter with Prometheus export at `GET /metrics`.
@@ -178,3 +257,13 @@ Narinfos stored in the legacy storage backend (pre-0.8.0) are automatically migr
   - `ncps_background_migration_objects_total`
 - **Logging**: zerolog, context-propagated logger (`zerolog.Ctx(ctx)`).
 - **Health**: `GET /healthz` via chi `middleware.Heartbeat`.
+
+#### Scenario: Scraping metrics
+
+- **WHEN** a Prometheus scraper issues `GET /metrics`
+- **THEN** the OTel meter exports the documented counters, histograms, and gauges (e.g., `ncps_narinfo_served_total`, `ncps_nar_served_total`, `ncps_lru_*_evicted_total`, `ncps_cache_utilization_ratio`, `ncps_upstream_nar_fetch_duration`)
+
+#### Scenario: Health check
+
+- **WHEN** a client issues `GET /healthz`
+- **THEN** the chi `middleware.Heartbeat` responds indicating the server is healthy

--- a/openspec/specs/cdc-chunking/spec.md
+++ b/openspec/specs/cdc-chunking/spec.md
@@ -40,7 +40,7 @@ If `fileSize == 0`, the validation MUST be skipped (narinfo with unknown declare
 
 ### Requirement: GetNarInfo MUST normalize compression in-memory during lazy-chunking transition
 
-When lazy CDC chunking is enabled, narinfos are initially stored in the DB with the
+When lazy CDC chunking is enabled, `GetNarInfo` MUST normalize the narinfo in-memory. Narinfos are initially stored in the DB with the
 upstream compression (e.g., `Compression: xz`) while the NAR is chunked in the
 background. After chunking completes, the DB update is asynchronous. During this window,
 `GetNarInfo` MUST normalize the narinfo in-memory before returning so that clients
@@ -82,7 +82,7 @@ The normalization SHALL:
 
 ### Requirement: GetNar MUST return 404 for compressed URL when NAR exists only as chunks
 
-When CDC is enabled and a client requests a NAR by its compressed URL (e.g.,
+The system SHALL return 404 for a compressed URL when the NAR exists only as chunks. When CDC is enabled and a client requests a NAR by its compressed URL (e.g.,
 `nar/hash.nar.xz`), but the NAR exists only as CDC chunks (no whole-file in storage),
 the system SHALL return `storage.ErrNotFound` rather than attempting to serve
 uncompressed chunk data as compressed content. Serving chunk data with mismatched
@@ -107,7 +107,7 @@ compression would cause Nix to fail with "input compression not recognized".
 
 ### Requirement: CDC chunk insert MUST use ignore-on-conflict, not upsert
 
-When recording a batch of chunks in `recordChunkBatch`, each chunk insert
+CDC chunk inserts SHALL use ignore-on-conflict, not upsert. When recording a batch of chunks in `recordChunkBatch`, each chunk insert
 into the `chunks` table SHALL use `ON CONFLICT (hash) DO NOTHING` (not
 `DO UPDATE`). Chunks are content-addressed immutable blobs; an existing
 chunk with the same hash is already correct and MUST NOT be touched.
@@ -141,7 +141,7 @@ pre-existed.
 
 ### Requirement: Transaction failure MUST NOT leave connections in aborted state
 
-After any transaction in `withEntTransactionRetry` fails (whether immediately
+A transaction failure MUST NOT leave connections in an aborted state. After any transaction in `withEntTransactionRetry` fails (whether immediately
 or after all retry attempts are exhausted), the system SHALL ensure the
 database connection is returned to the pool in a clean, non-aborted state.
 
@@ -200,7 +200,7 @@ simple-path copy.
 
 ### Requirement: Placeholder nar_file records MUST NOT be treated as servable
 
-A `nar_file` row with `total_chunks = 0` and `chunking_started_at` NULL is a **placeholder**
+Placeholder `nar_file` records MUST NOT be treated as servable. A `nar_file` row with `total_chunks = 0` and `chunking_started_at` NULL is a **placeholder**
 created by `storeInDatabase` at narinfo-fetch time before any NAR bytes have been downloaded or
 chunked. Such a placeholder SHALL NOT be considered servable by any read path. Specifically:
 
@@ -264,7 +264,7 @@ eligible for recovery.
 
 ### Requirement: CDC startup validation MUST allow enabled→disabled transition
 
-When CDC configuration is validated at startup via `ValidateOrStoreCDCConfig`, the
+CDC startup validation MUST allow the enabled→disabled transition. When CDC configuration is validated at startup via `ValidateOrStoreCDCConfig`, the
 system SHALL permit the transition from a stored `cdc_enabled=true` to a current
 `enabled=false`. The system SHALL return nil without modifying any stored configuration
 keys. The four stored CDC config keys (`cdc_enabled`, `cdc_min`, `cdc_avg`, `cdc_max`)

--- a/openspec/specs/cdc-disable/spec.md
+++ b/openspec/specs/cdc-disable/spec.md
@@ -44,7 +44,7 @@ When this transition is detected at startup, the system SHALL:
 
 ### Requirement: Chunked NARs are served from the chunk store during drain, not treated as cache misses
 
-**Replaces**: "Chunked NARs become cache misses when CDC is disabled" (removed).
+This requirement SHALL replace "Chunked NARs become cache misses when CDC is disabled" (removed).
 
 After CDC is disabled with chunked NARs remaining, those NARs SHALL be served from the
 chunk store until they are migrated to whole files by `migrate-chunks-to-nar`. The chunk

--- a/openspec/specs/dynamic-test-ports/spec.md
+++ b/openspec/specs/dynamic-test-ports/spec.md
@@ -53,9 +53,10 @@ sequential runs.
 ---
 
 ### Requirement: `enable-s3-tests` emits endpoint URL using current `NCPS_TEST_S3_PORT`
-When `eval "$(enable-s3-tests)"` is called in a shell where `NCPS_TEST_S3_PORT` is already
-exported, the script SHALL emit `export NCPS_TEST_S3_ENDPOINT="http://127.0.0.1:$NCPS_TEST_S3_PORT"`.
-When `NCPS_TEST_S3_PORT` is not set, it SHALL fall back to port 9000.
+The `enable-s3-tests` script SHALL emit
+`export NCPS_TEST_S3_ENDPOINT="http://127.0.0.1:$NCPS_TEST_S3_PORT"` when
+`eval "$(enable-s3-tests)"` is called in a shell where `NCPS_TEST_S3_PORT` is already
+exported. When `NCPS_TEST_S3_PORT` is not set, it SHALL fall back to port 9000.
 
 #### Scenario: Dynamic port already exported
 - **WHEN** `NCPS_TEST_S3_PORT=19000` is set in the shell and `eval "$(enable-s3-tests)"` is run
@@ -68,9 +69,9 @@ When `NCPS_TEST_S3_PORT` is not set, it SHALL fall back to port 9000.
 ---
 
 ### Requirement: `enable-postgres-tests` emits connection URL using current `PGPORT`
-When `eval "$(enable-postgres-tests)"` is called in a shell where `PGPORT` is already
-exported, the script SHALL emit a connection URL referencing that port.
-When `PGPORT` is not set, it SHALL fall back to port 5432.
+The `enable-postgres-tests` script SHALL emit a connection URL referencing `PGPORT` when
+`eval "$(enable-postgres-tests)"` is called in a shell where `PGPORT` is already
+exported. When `PGPORT` is not set, it SHALL fall back to port 5432.
 
 #### Scenario: Dynamic port already exported
 - **WHEN** `PGPORT=15432` is set in the shell and `eval "$(enable-postgres-tests)"` is run
@@ -83,9 +84,9 @@ When `PGPORT` is not set, it SHALL fall back to port 5432.
 ---
 
 ### Requirement: `enable-mysql-tests` emits connection URL using current `MYSQL_TCP_PORT`
-When `eval "$(enable-mysql-tests)"` is called in a shell where `MYSQL_TCP_PORT` is already
-exported, the script SHALL emit a connection URL referencing that port.
-When `MYSQL_TCP_PORT` is not set, it SHALL fall back to port 3306.
+The `enable-mysql-tests` script SHALL emit a connection URL referencing `MYSQL_TCP_PORT` when
+`eval "$(enable-mysql-tests)"` is called in a shell where `MYSQL_TCP_PORT` is already
+exported. When `MYSQL_TCP_PORT` is not set, it SHALL fall back to port 3306.
 
 #### Scenario: Dynamic port already exported
 - **WHEN** `MYSQL_TCP_PORT=13306` is set and `eval "$(enable-mysql-tests)"` is run

--- a/openspec/specs/flake-check-topology/spec.md
+++ b/openspec/specs/flake-check-topology/spec.md
@@ -99,7 +99,8 @@ that don't carry the tag.
 
 ### Requirement: Lint and drift checks reuse pre-built helper binaries
 
-Checks that only invoke a small in-tree helper binary
+Checks that only invoke a small in-tree helper binary SHALL behave as follows.
+A check that invokes such a helper
 (`cmd/ent-lint`, `cmd/atlas-sum-check`) SHALL consume that binary from
 a single shared `packages.ncps-checktools` derivation (or equivalent
 `passthru`) instead of each re-vendoring Go and re-running
@@ -152,7 +153,8 @@ starting any backend service.
 
 ### Requirement: Coverage is produced by a dedicated derivation
 
-A separate `packages.ncps.coverage` (or `packages.ncps-coverage`)
+A separate coverage derivation SHALL exist as described here.
+This `packages.ncps.coverage` (or `packages.ncps-coverage`)
 derivation SHALL produce a merged `coverage.txt` containing the union
 of profiles from the unit-test and per-backend-cohort test
 derivations. This derivation MUST NOT be a member of the `checks`
@@ -189,8 +191,25 @@ distinct quality property.
 - **AND** there is no `// self'.packages` or `// self'.devShells`
   merge in the expression
 
+### Requirement: Canonical specs are validated in CI
+
+The `checks` attrset SHALL include an `openspec-validate-check` derivation that runs `openspec validate --specs` against the committed `openspec/` tree and fails the build if any canonical capability spec under `openspec/specs/` is structurally invalid (missing `## Purpose`/`## Requirements`, a requirement whose statement lacks a `SHALL`/`MUST` keyword, or a requirement with no `#### Scenario:`). The check SHALL use a narrow source containing only the `openspec/` tree and the `openspec` CLI from nixpkgs, and SHALL NOT require the Go toolchain. This is the spec-health guard that keeps the canonical specs machine-checkable, complementing the change-archival guard.
+
+#### Scenario: A malformed canonical spec fails CI
+
+- **WHEN** a spec under `openspec/specs/` is edited to drop its `## Purpose` section, remove a requirement's `SHALL`/`MUST`, or leave a requirement without a scenario
+- **AND** `nix build .#checks.<system>.openspec-validate-check` (or `nix flake check`) runs
+- **THEN** the build SHALL fail with the `openspec validate --specs` error output
+
+#### Scenario: Well-formed specs pass CI
+
+- **WHEN** every spec under `openspec/specs/` is structurally valid
+- **AND** `nix build .#checks.<system>.openspec-validate-check` runs
+- **THEN** the check SHALL succeed
+
 ### Requirement: Shared helper for database-backed checks
 
+Spinning up backend services for a check SHALL be centralized as described here.
 Spinning up backend services (Postgres, MySQL, Redis, Garage) for a
 check SHALL go through a single Nix helper (`mkCohort`, or an
 equivalent successor) that takes the list of required backends and
@@ -297,8 +316,9 @@ cache.
 
 ### Requirement: Integration cohorts validated on a single CI architecture
 
-Every workflow that validates the integration test suite (`nix flake check`,
-i.e. the backend cohorts and coverage) — both the CI workflow (PRs/pushes) and
+Every workflow that validates the integration test suite SHALL scope it as described here.
+Each such workflow that validates `nix flake check`
+(i.e. the backend cohorts and coverage) — both the CI workflow (PRs/pushes) and
 the release workflow (tag builds) — SHALL run it on exactly one canonical
 architecture (`x86_64-linux`). Non-canonical architectures in the build matrix
 (`aarch64-linux`) MUST NOT run `nix flake check` or build coverage; they MUST

--- a/openspec/specs/fsck/spec.md
+++ b/openspec/specs/fsck/spec.md
@@ -33,8 +33,8 @@ The `totalIssues()` method SHALL include `len(narFilesWithSizeMismatch)` in its 
 - **THEN** it is excluded from `GetCDCNarFilesWithSizeMismatch` regardless of file_size
 
 ### Requirement: Fsck --repair MUST delete size-mismatched CDC NARs
-When `ncps fsck --repair` (or interactive repair) is executed and size-mismatched CDC
-rows are present, the system SHALL delete those `nar_file` rows and cascade cleanup
+The system SHALL, when `ncps fsck --repair` (or interactive repair) is executed and
+size-mismatched CDC rows are present, delete those `nar_file` rows and cascade cleanup
 using the same repair path as `narFilesWithChunkIssues`:
 1. Delete the `nar_file` row (cascades `nar_file_chunks`).
 2. Delete any narinfos that become orphaned as a result.
@@ -131,8 +131,7 @@ When `--verify-content` is active, the fsck CDC summary section SHALL include tw
 
 ### Requirement: Fsck CDC size-mismatch detection MUST scale beyond database driver parameter limits
 
-The implementation of CDC size-mismatch detection (currently
-`queryCDCNarFilesWithSizeMismatch`) SHALL NOT issue any single SQL statement whose
+The implementation of CDC size-mismatch detection (currently `queryCDCNarFilesWithSizeMismatch`) SHALL NOT issue any single SQL statement whose
 bound-parameter count grows unboundedly with the number of CDC `nar_file` rows or
 their joined `narinfo_nar_files`/`narinfos` rows. In particular, it MUST NOT produce
 an `IN ($1...$N)` predicate (whether emitted directly or via an ORM eager-load) where
@@ -170,8 +169,7 @@ strategy changes.
 
 ### Requirement: Fsck chunk-walk MUST scale beyond database driver parameter limits
 
-The implementation that resolves the chunk rows linked to a single `nar_file` (currently
-`chunksForNarFile`) SHALL NOT issue any single SQL statement whose bound-parameter
+The implementation that resolves the chunk rows linked to a single `nar_file` (currently `chunksForNarFile`) SHALL NOT issue any single SQL statement whose bound-parameter
 count grows unboundedly with the number of chunks belonging to that NAR. In particular,
 it MUST NOT produce an `IN ($1...$M)` predicate on chunk IDs (whether emitted directly
 or via an ORM eager-load) where M can exceed 65535.
@@ -188,8 +186,7 @@ the returned slice length equals the link count.
 
 ### Requirement: Fsck MUST NOT introduce other unbounded IN-clause queries
 
-Any future or existing fsck query that materializes a list of IDs (or composite keys)
-and then performs a secondary `In(...)` / `IN (...)` lookup keyed on that list SHALL
+Any future or existing fsck query that materializes a list of IDs (or composite keys) and then performs a secondary `In(...)` / `IN (...)` lookup keyed on that list SHALL
 use the same bounded-batch helper used by the CDC size-mismatch path, or an
 equivalent streaming approach. New code in `pkg/ncps/fsck.go` MUST NOT regress to
 unbounded `With*` eager-loads or unbounded `In(...)` predicates on collections that

--- a/openspec/specs/local-store-initialization/spec.md
+++ b/openspec/specs/local-store-initialization/spec.md
@@ -8,7 +8,7 @@ Defines requirements for initializing the local store directory structure on sta
 
 ### Requirement: Local store directory setup is idempotent
 
-`setupDirs()` must succeed regardless of whether the `store/tmp` directory already exists on disk, so that rolling updates on shared PVCs do not crash the incoming pod.
+`setupDirs()` MUST succeed regardless of whether the `store/tmp` directory already exists on disk, so that rolling updates on shared PVCs do not crash the incoming pod.
 
 #### Scenario: First startup (no existing directories)
 - **WHEN** `setupDirs()` is called and no store directories exist yet

--- a/openspec/specs/narinfo-concurrent-fetch/spec.md
+++ b/openspec/specs/narinfo-concurrent-fetch/spec.md
@@ -11,7 +11,7 @@ caused by the purge guard firing while a NAR download job is still in-flight.
 
 ### Requirement: Concurrent narinfo requests for the same hash must not produce 404 responses
 
-When multiple requests arrive concurrently for a narinfo hash that is being fetched from upstream for the first time, all requests must eventually receive the narinfo (or a valid error), and none must receive a 404 caused by a spurious purge of the narinfo from the database.
+When multiple requests arrive concurrently for a narinfo hash that is being fetched from upstream for the first time, all requests MUST eventually receive the narinfo (or a valid error), and none MUST receive a 404 caused by a spurious purge of the narinfo from the database.
 
 #### Scenario: Two concurrent requests for the same narinfo hash — second request must not get 404
 
@@ -51,18 +51,26 @@ When multiple requests arrive concurrently for a narinfo hash that is being fetc
 
 ### Requirement: The fix must not affect the common (cache-warm) case latency
 
-**Given** narinfo for hash `H` is already stored in the database and NAR is already in the store
-**When** a request for hash `H` arrives
-**Then** `getNarInfoFromDatabase` returns the narinfo directly without any additional synchronization overhead
-**And** no upstream fetch is triggered
+The fix MUST NOT affect the common (cache-warm) case latency: when narinfo for a hash is already stored and the NAR is already in the store, `getNarInfoFromDatabase` SHALL return the narinfo directly without additional synchronization overhead and without triggering an upstream fetch.
+
+#### Scenario: Cache-warm request returns narinfo with no extra overhead
+
+- **WHEN** narinfo for hash `H` is already stored in the database and NAR is already in the store
+- **AND** a request for hash `H` arrives
+- **THEN** `getNarInfoFromDatabase` returns the narinfo directly without any additional synchronization overhead
+- **AND** no upstream fetch is triggered
 
 ### Requirement: The fix must not alter behavior for single-hash sequential requests
 
-**Given** narinfo for hash `H` is fetched by a single request (no concurrency)
-**When** the fetch completes (narinfo stored, NAR downloaded)
-**And** subsequent requests arrive after the job has been removed from `upstreamJobs`
-**Then** `getNarInfoFromDatabase` behaves identically to before the fix
-**And** `HasNarInStore` returns true (NAR is in store) so the purge guard is not triggered
+The fix MUST NOT alter behavior for single-hash sequential requests: after a single request completes a fetch (narinfo stored, NAR downloaded) and the job is removed from `upstreamJobs`, `getNarInfoFromDatabase` SHALL behave identically to before the fix and the purge guard SHALL NOT trigger because the NAR is in store.
+
+#### Scenario: Sequential request after job removal behaves identically to before the fix
+
+- **WHEN** narinfo for hash `H` is fetched by a single request (no concurrency)
+- **AND** the fetch completes (narinfo stored, NAR downloaded)
+- **AND** subsequent requests arrive after the job has been removed from `upstreamJobs`
+- **THEN** `getNarInfoFromDatabase` behaves identically to before the fix
+- **AND** `HasNarInStore` returns true (NAR is in store) so the purge guard is not triggered
 
 ### Requirement: A lock-losing replica MUST NOT return HTTP 500 from narinfo coordination
 

--- a/openspec/specs/task-workflow/spec.md
+++ b/openspec/specs/task-workflow/spec.md
@@ -12,7 +12,7 @@ sub-commands so developers and CI have a single, discoverable entry point.
 ## Requirements
 
 ### Requirement: Taskfile exists at repo root
-A `Taskfile.yml` must exist at the repository root. Running `task` with no arguments must print a list of available tasks.
+A `Taskfile.yml` MUST exist at the repository root. Running `task` with no arguments MUST print a list of available tasks.
 
 #### Scenario: Default task lists available tasks
 - **WHEN** a developer runs `task` (or `task default`) in the repo root
@@ -21,7 +21,7 @@ A `Taskfile.yml` must exist at the repository root. Running `task` with no argum
 ---
 
 ### Requirement: `task fmt` formats all project files
-Running `task fmt` must format all project files by delegating to `nix fmt`.
+Running `task fmt` MUST format all project files by delegating to `nix fmt`.
 
 #### Scenario: Formatting succeeds
 - **WHEN** a developer runs `task fmt`
@@ -34,7 +34,7 @@ Running `task fmt` must format all project files by delegating to `nix fmt`.
 ---
 
 ### Requirement: `task lint` lints Go code
-Running `task lint` must run `golangci-lint run` and exit non-zero if any lint issues are found.
+Running `task lint` MUST run `golangci-lint run` and exit non-zero if any lint issues are found.
 
 #### Scenario: Clean code passes lint
 - **WHEN** a developer runs `task lint` on code with no lint issues
@@ -47,7 +47,7 @@ Running `task lint` must run `golangci-lint run` and exit non-zero if any lint i
 ---
 
 ### Requirement: `task lint:fix` auto-fixes lint issues
-Running `task lint:fix` must run `golangci-lint run --fix` to automatically apply fixable lint corrections.
+Running `task lint:fix` MUST run `golangci-lint run --fix` to automatically apply fixable lint corrections.
 
 #### Scenario: Auto-fixable issues are resolved
 - **WHEN** a developer runs `task lint:fix` with auto-fixable lint issues present
@@ -56,7 +56,7 @@ Running `task lint:fix` must run `golangci-lint run --fix` to automatically appl
 ---
 
 ### Requirement: `task test` runs unit tests without backend services
-Running `task test` must run `go test -race ./...` without requiring any external services (no S3/PostgreSQL/MySQL/Redis).
+Running `task test` MUST run `go test -race ./...` without requiring any external services (no S3/PostgreSQL/MySQL/Redis).
 
 #### Scenario: Unit tests pass
 - **WHEN** a developer runs `task test` with no backend services running
@@ -69,7 +69,7 @@ Running `task test` must run `go test -race ./...` without requiring any externa
 ---
 
 ### Requirement: `task test:integration` runs full test suite with deps pre-started
-Running `task test:integration` must enable all integration env vars and run the full test suite, assuming backing services are already running.
+Running `task test:integration` MUST enable all integration env vars and run the full test suite, assuming backing services are already running.
 
 #### Scenario: Full suite runs when services are available
 - **WHEN** a developer runs `task test:integration` with `nix run .#deps` already running
@@ -131,7 +131,7 @@ call `process-compose down -p $TEST_PC_PORT` to stop the process-compose instanc
 ---
 
 ### Requirement: `task ent:generate` regenerates the Ent client
-Running `task ent:generate` must run `go generate ./ent/...` to regenerate the Ent client from schemas.
+Running `task ent:generate` MUST run `go generate ./ent/...` to regenerate the Ent client from schemas.
 
 #### Scenario: Generate succeeds
 - **WHEN** a developer runs `task ent:generate` after editing an Ent schema
@@ -140,7 +140,7 @@ Running `task ent:generate` must run `go generate ./ent/...` to regenerate the E
 ---
 
 ### Requirement: `task ent:lint` lints Ent schemas
-Running `task ent:lint` must run `go run ./cmd/ent-lint --root .` to enforce the five codegen invariants.
+Running `task ent:lint` MUST run `go run ./cmd/ent-lint --root .` to enforce the five codegen invariants.
 
 #### Scenario: Schemas with no invariant violations pass
 - **WHEN** `task ent:lint` is run on valid schemas
@@ -149,7 +149,7 @@ Running `task ent:lint` must run `go run ./cmd/ent-lint --root .` to enforce the
 ---
 
 ### Requirement: `task ent:check` validates Ent is up to date
-Running `task ent:check` must regenerate the Ent client and then lint it, failing if schemas are out of sync or violate invariants.
+Running `task ent:check` MUST regenerate the Ent client and then lint it, failing if schemas are out of sync or violate invariants.
 
 #### Scenario: Up-to-date clean schemas pass
 - **WHEN** `task ent:check` is run with the generated client in sync with schemas
@@ -158,7 +158,7 @@ Running `task ent:check` must regenerate the Ent client and then lint it, failin
 ---
 
 ### Requirement: `task migrations:gen` generates Atlas migrations
-Running `task migrations:gen NAME=<name>` must run `go run ./cmd/generate-migrations --name=<name>` to emit per-dialect SQL files.
+Running `task migrations:gen NAME=<name>` MUST run `go run ./cmd/generate-migrations --name=<name>` to emit per-dialect SQL files.
 
 #### Scenario: Migration generation with a valid name
 - **WHEN** a developer runs `task migrations:gen NAME=add_foo_column`
@@ -167,7 +167,7 @@ Running `task migrations:gen NAME=<name>` must run `go run ./cmd/generate-migrat
 ---
 
 ### Requirement: `task migrations:sql` generates an empty SQL migration stub
-Running `task migrations:sql NAME=<name>` must run `go run ./cmd/generate-migrations --sql-only --name=<name>`.
+Running `task migrations:sql NAME=<name>` MUST run `go run ./cmd/generate-migrations --sql-only --name=<name>`.
 
 #### Scenario: SQL-only stub created
 - **WHEN** a developer runs `task migrations:sql NAME=backfill_foo`
@@ -176,7 +176,7 @@ Running `task migrations:sql NAME=<name>` must run `go run ./cmd/generate-migrat
 ---
 
 ### Requirement: CLAUDE.md is concise
-`CLAUDE.md` must be reduced to at most ~150 lines, containing only: project overview, prerequisites, quick-start commands (via `task`), architecture package-structure summary, and pointers to `.claude/rules/` and `.agent/skills/`.
+`CLAUDE.md` MUST be reduced to at most ~150 lines, containing only: project overview, prerequisites, quick-start commands (via `task`), architecture package-structure summary, and pointers to `.claude/rules/` and `.agent/skills/`.
 
 #### Scenario: CLAUDE.md fits within 150 lines
 - **WHEN** the updated `CLAUDE.md` is committed


### PR DESCRIPTION
## Summary

`openspec validate --specs` failed for **10 of the 32** canonical specs — nothing in CI guarded their structural validity, so they had silently drifted out of the OpenSpec schema (missing `## Purpose`/`## Requirements`, requirement statements without a `SHALL`/`MUST` keyword, or requirements with no `#### Scenario:`).

**Fix all 10** so `openspec validate --specs` passes (33/33):
- 8 specs (`cdc-chunking`, `cdc-disable`, `dynamic-test-ports`, `flake-check-topology`, `fsck`, `local-store-initialization`, `narinfo-concurrent-fetch`, `task-workflow`): made the flagged requirement statements normative (SHALL/MUST) and added missing scenarios — wording/meaning preserved.
- `api-surface`, `architecture`: restructured the narrative reference docs into `## Purpose` + `## Requirements` + `#### Scenario:` form **without losing content** (all endpoints, data structures, lifecycle flows, tables retained).

**Add a CI guard** — new `openspec-validate-check` flake check that runs `openspec validate --specs` (via `pkgs.openspec`, narrow `openspec/` src, no Go toolchain) so `nix flake check` fails if any canonical spec regresses. This is the spec-health counterpart to the change-archival guard. Documented as a requirement in the `flake-check-topology` spec.

## Test plan

- [x] `openspec validate --specs` → 33 passed, 0 failed
- [x] `nix build .#checks.<system>.openspec-validate-check` succeeds (and fails when a spec is made invalid)
- [x] `task fmt`, `task lint` clean