### PR TITLE
fix(cache): delete dangling narinfos when GC'ing genuinely-absent NAR

### DIFF
--- a/openspec/changes/archive/2026-06-07-prevent-dangling-narinfos/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-07-prevent-dangling-narinfos/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/archive/2026-06-07-prevent-dangling-narinfos/design.md
+++ b/openspec/changes/archive/2026-06-07-prevent-dangling-narinfos/design.md
@@ -1,0 +1,49 @@
+## Context
+
+The recovery sweep calls `gcOrSkipBackingLessNarFile` (`pkg/cache/cache.go`) for a `nar_file` whose whole-file bytes are gone and which migration cannot help. Current logic:
+
+1. Query narinfos linked via `narinfo_nar_files` to this `nar_file`.
+2. If **zero** linked narinfos → delete the `nar_file` (clean GC). Correct.
+3. If **≥1** linked narinfo and **every** one is `narInfoGenuinelyAbsentUpstream` (confirmed gone from every healthy upstream; conservative — any Present/Unknown/no-upstreams aborts) → delete the `nar_file`.
+4. Otherwise → skip; leave for on-demand `GetNar` recovery.
+
+In step 3 the Ent on-delete cascade removes the `narinfo_nar_files` link rows but **not** the parent narinfos. Those narinfos survive with no link — dangling. They were already served as HTTP 200 and cached by Nix clients, so a later `nix build` fetches the NAR directly and gets a 404. Prod shows 2,744 such rows.
+
+The read-path guard (`narinfo-purge-serving`) and `fsck --repair` already exist; neither prevents creation here, and the read-path guard is bypassed entirely by a Nix client-cache hit.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The backing-less GC MUST NOT leave a narinfo it can no longer serve. When step 3 deletes the `nar_file`, it deletes the linked (genuinely-absent-upstream) narinfos in the same transaction.
+- Preserve the conservative deletion gate: nothing is deleted unless every linked narinfo is confirmed absent from every healthy upstream.
+
+**Non-Goals:**
+- Serving a NAR whose hash exists nowhere (an evicted local NAR that a Nix client-cache hit requests by hash is unrecoverable — the fix is to not retain the advertising narinfo, not to synthesize bytes).
+- Read-path purge behavior, upload PUT ordering, LRU size-eviction, and Nix client TTL config — all unchanged / out of scope.
+
+## Decisions
+
+**D1 — Delete the linked narinfos with the nar_file (not just the cascade link).**
+In the step-3 branch, after the all-absent check passes, delete the narinfos collected in `nis` and the `nar_file` atomically (single Ent transaction). Rationale: a narinfo that is unservable locally AND confirmed absent on every upstream is unrecoverable dead metadata; the only way it can ever be answered is a 404-after-200. Alternative considered: keep the narinfo and rely on `fsck` — rejected: fsck is a manual, periodic backstop, and the window between GC and fsck is exactly when Nix caches the 200 and the user's build breaks.
+
+**D2 — Keep the all-absent gate as the safety boundary.**
+Deletion of narinfos stays gated behind `narInfoGenuinelyAbsentUpstream` for *every* linked narinfo (existing behavior). A single Present/Unknown upstream, or zero healthy upstreams, still aborts the whole GC and leaves everything intact for on-demand recovery. This keeps the change strictly additive to an already-conservative deletion and avoids racing a cross-replica `nix copy`. Alternative: delete only the narinfos that are individually absent while keeping the nar_file — rejected: the nar_file is only deleted when *all* are absent, so partial deletion never applies in this branch.
+
+**D3 — Reuse the existing transaction/cascade; no schema or migration change.**
+The `narinfo_nar_files` on-delete cascade already fires when the parent narinfo is deleted, so deleting the narinfos cleans their link rows too. The `nar_file` delete remains; ordering within the transaction is irrelevant because both cascades are covered. No Ent schema change, no new migration.
+
+## Risks / Trade-offs
+
+- [A still-reachable narinfo is deleted because an upstream was transiently misreported absent] → Mitigated by the existing conservative gate: `ExistenceUnknown` and no-healthy-upstreams both yield "not absent", aborting deletion. Only `ExistenceAbsent` from every healthy upstream proceeds — the same bar that already authorizes deleting the `nar_file`.
+- [Cross-replica `nix copy` reference check races the deletion] → The gate requires the path be absent on every upstream, i.e. not a live, re-uploadable path; and this is the background sweep, not the read path. Risk is no higher than today's `nar_file` deletion in the same branch.
+- [Deleting metadata is irreversible] → Acceptable: the path is provably gone everywhere; a future upload PUT re-creates both narinfo and nar_file from scratch.
+
+## Migration Plan
+
+- Pure code change behind TDD. Deploy normally. No DB migration.
+- Historical 2,744 rows are remediated out-of-band by the operator running `fsck --repair` once (already specified), independent of this change.
+- Rollback: revert the commit; behavior returns to leaving narinfos (no data-shape change to undo).
+
+## Open Questions
+
+- Should the GC emit a metric/log counter for narinfos deleted as genuinely-absent (observability for how often this fires)? Leaning yes — a debug/info log mirroring the existing `garbage-collected genuinely-absent placeholder nar_file` line, extended with the deleted-narinfo count.

--- a/openspec/changes/archive/2026-06-07-prevent-dangling-narinfos/proposal.md
+++ b/openspec/changes/archive/2026-06-07-prevent-dangling-narinfos/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+In production (v0.10.0-rc10) 2,744 narinfos have no `narinfo_nar_files` link. ncps once served each as a signed HTTP 200; Nix cached them client-side. The backing NAR was later deleted, so a subsequent `nix build` requests the NAR directly (skipping any narinfo re-fetch) and gets HTTP 404 — `error: file 'nar/<hash>.nar' does not exist in binary cache`. The existing read-path resilience (`narinfo-purge-serving`) cannot help: it only fires when Nix re-requests the *narinfo*, which a client cache hit bypasses.
+
+The manufacturing path is the background recovery GC. `gcOrSkipBackingLessNarFile` deletes a NAR whose bytes are gone when every linked narinfo is *genuinely absent from every healthy upstream*. The on-delete cascade removes only the `narinfo_nar_files` link rows — it leaves the narinfos behind, now dangling and unservable forever (the path exists nowhere: not locally, not upstream).
+
+## What Changes
+
+- When the backing-less-NAR GC deletes a `nar_file` because all of its linked narinfos are genuinely absent upstream, it MUST also delete those narinfos in the same transaction. A narinfo that is unservable locally and confirmed gone from every upstream is dead metadata; retaining it guarantees a future served-then-404.
+- The existing 0-linked-narinfo GC branch is unchanged (already correct).
+- No change to the read path, to upload ordering, or to LRU size-eviction. Those either already behave correctly or are out of scope (see Non-goals).
+- `fsck --repair` remains the backstop for the 2,744 historical rows (already specified); the operator runs it once. The ingress streaming fix (separate, already shipped) closes the upload-reset origin of new dangling narinfos.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `nar-cache-miss-recovery`: the backing-less `nar_file` GC gains a requirement to delete the linked, genuinely-absent-upstream narinfos together with the `nar_file`, so the recovery sweep never leaves a dangling narinfo.
+
+## Impact
+
+- Code: `pkg/cache/cache.go` `gcOrSkipBackingLessNarFile` (and its recovery-sweep callers). Tests under `pkg/cache/recovery_gc_*_test.go`.
+- Data: the genuinely-absent branch now deletes narinfos it previously orphaned. Bounded, transactional, and only for paths already proven gone everywhere.
+- No schema change (link cascade already exists; this deletes the parent rows the cascade leaves behind). No migration required.
+
+## Non-goals
+
+- Healing a NAR GET whose hash exists nowhere (a Nix client-cache hit for an evicted local NAR cannot be served — only avoided by not retaining the narinfo).
+- Reworking LRU size-based eviction or upload PUT ordering.
+- Changing the deliberately non-destructive read-path purge guard.
+- Client-side: Nix's `narinfo-cache-positive-ttl` is operator config, not ncps's concern.
+
+## I/O, network, memory impact
+
+- Net **reduction** in steady-state work: dead narinfos stop being advertised and stop being re-scanned each recovery sweep. One extra `DELETE ... WHERE id IN (...)` per GC'd backing-less row (rows that are already being deleted). No added network calls — the upstream-absence probes already run. Negligible memory.

--- a/openspec/changes/archive/2026-06-07-prevent-dangling-narinfos/specs/nar-cache-miss-recovery/spec.md
+++ b/openspec/changes/archive/2026-06-07-prevent-dangling-narinfos/specs/nar-cache-miss-recovery/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: The backing-less GC MUST NOT leave a dangling narinfo
+
+When the recovery sweep deletes a backing-less `nar_file` because every linked narinfo is genuinely absent from every healthy upstream, the system SHALL delete those linked narinfos in the same transaction and MUST NOT rely on the `narinfo_nar_files` cascade alone (which leaves the narinfos dangling).
+
+The cascade on `narinfo_nar_files` removes only the link rows; the parent narinfos
+survive linked to no `nar_file`. Such a narinfo is unservable locally and confirmed
+absent from every healthy upstream, so it can only ever be answered with an HTTP 200
+narinfo followed by an HTTP 404 NAR (which Nix clients have already cached and will
+fetch directly), and therefore MUST NOT be retained.
+
+A narinfo that is unservable locally and confirmed absent from every healthy
+upstream is unrecoverable: it can only ever be answered with an HTTP 200 narinfo
+followed by an HTTP 404 NAR (which Nix clients have already cached and will fetch
+directly), so it MUST NOT be retained.
+
+This requirement applies ONLY to the genuinely-absent-upstream deletion branch.
+The existing safety gate is unchanged: if any linked narinfo is Present or its
+upstream existence is Unknown, or there are no healthy upstreams, the sweep SHALL
+delete nothing (neither `nar_file` nor narinfos) and leave the record for
+on-demand recovery. The zero-linked-narinfo branch is likewise unchanged.
+
+#### Scenario: Genuinely-absent backing-less NAR deletes its dangling narinfos
+
+- **GIVEN** a backing-less `nar_file` for hash `H` with no whole-file in storage and `total_chunks = 0`
+- **AND** one or more narinfos linked to it via `narinfo_nar_files`
+- **AND** every healthy upstream reports each linked narinfo as `ExistenceAbsent`
+- **WHEN** the recovery sweep runs `gcOrSkipBackingLessNarFile` for that record
+- **THEN** the `nar_file` row SHALL be deleted
+- **AND** every linked narinfo SHALL also be deleted in the same transaction
+- **AND** no narinfo SHALL remain in the database with a URL referencing hash `H`
+- **AND** no narinfo SHALL be left without a `narinfo_nar_files` link as a result of this GC
+
+#### Scenario: A still-present upstream aborts deletion entirely
+
+- **GIVEN** a backing-less `nar_file` for hash `H` with one or more linked narinfos
+- **AND** at least one healthy upstream reports a linked narinfo as `ExistencePresent` or `ExistenceUnknown` (or there are no healthy upstreams)
+- **WHEN** the recovery sweep runs `gcOrSkipBackingLessNarFile` for that record
+- **THEN** neither the `nar_file` nor any linked narinfo SHALL be deleted
+- **AND** the record SHALL be left for on-demand `GetNar` recovery
+
+#### Scenario: Orphan with no linked narinfo is still GC'd cleanly
+
+- **GIVEN** a backing-less `nar_file` for hash `H` with zero linked narinfos
+- **WHEN** the recovery sweep runs `gcOrSkipBackingLessNarFile` for that record
+- **THEN** the `nar_file` row SHALL be deleted
+- **AND** no narinfo deletion SHALL be attempted (there are none to delete)

--- a/openspec/changes/archive/2026-06-07-prevent-dangling-narinfos/tasks.md
+++ b/openspec/changes/archive/2026-06-07-prevent-dangling-narinfos/tasks.md
@@ -1,0 +1,21 @@
+## 1. Red — failing tests for the GC narinfo cleanup
+
+- [x] 1.1 In `pkg/cache/recovery_gc_internal_test.go` (or a new `recovery_gc_narinfo_cleanup_internal_test.go`), add a table-driven test for `gcOrSkipBackingLessNarFile`: seed a backing-less `nar_file` (no whole-file, `total_chunks=0`) linked to one narinfo, stub every healthy upstream to report `ExistenceAbsent`, run the GC, and assert BOTH the `nar_file` AND the narinfo are deleted (no narinfo row references the hash; no narinfo left without a `narinfo_nar_files` link). Must fail today.
+- [x] 1.2 Add a multi-narinfo case (several store paths sharing the one NAR, all `ExistenceAbsent`): assert all linked narinfos and the `nar_file` are deleted. Must fail today.
+- [x] 1.3 Add a guard case: at least one linked narinfo `ExistencePresent` (and a separate case for `ExistenceUnknown`, and a no-healthy-upstreams case): assert NOTHING is deleted (nar_file and all narinfos intact). Should already pass — locks in the safety gate.
+- [x] 1.4 Add the existing zero-linked-narinfo case: assert the `nar_file` is GC'd and no narinfo deletion is attempted. Should already pass — regression guard.
+- [x] 1.5 Ensure all new tests call `t.Parallel()` (incl. subtests) and use `require`/`assert` per repo conventions; run with the race detector and confirm 1.1–1.2 fail for the right reason.
+
+## 2. Green — implement atomic narinfo deletion in the GC
+
+- [x] 2.1 In `gcOrSkipBackingLessNarFile` (`pkg/cache/cache.go`), in the genuinely-absent branch (after the `narInfoGenuinelyAbsentUpstream` loop passes), delete the linked narinfos collected in `nis` together with the `nar_file` in a single Ent transaction (`withEntTransaction`), relying on the existing `narinfo_nar_files` cascade to clean link rows.
+- [x] 2.2 Leave the zero-linked-narinfo branch and the skip (Present/Unknown/no-upstreams) branch unchanged.
+- [x] 2.3 Extend the existing `garbage-collected genuinely-absent placeholder nar_file` info log with the count of deleted narinfos for observability (per design Open Question).
+- [x] 2.4 Run the test suite with the race detector; confirm 1.1–1.4 pass.
+
+## 3. Verify & finalize
+
+- [x] 3.1 Run `task fmt`, `task lint`, `task test` — all exit 0 (per verify-before-completion rule).
+- [x] 3.2 Confirm no Ent schema change crept in and no migration was generated (this change is delete-only on existing rows; `task ent:check` clean if touched).
+- [x] 3.3 Re-read the delta spec scenarios against the implementation; confirm each scenario maps to a passing test.
+- [x] 3.4 Update `openspec/changes/prevent-dangling-narinfos` status and archive the change after merge (openspec-guard requires the active change be archived before merge).

--- a/openspec/specs/nar-cache-miss-recovery/spec.md
+++ b/openspec/specs/nar-cache-miss-recovery/spec.md
@@ -160,3 +160,50 @@ The check MUST honor the tri-state storage stat: an ambiguous or transient stora
 - **WHEN** the system evaluates NAR presence for a `HEAD` request
 - **THEN** it SHALL NOT report `200` solely from the record, and SHALL NOT treat the ambiguous error as a confirmed absence
 
+### Requirement: The backing-less GC MUST NOT leave a dangling narinfo
+
+When the recovery sweep deletes a backing-less `nar_file` because every linked narinfo is genuinely absent from every healthy upstream, the system SHALL delete those linked narinfos in the same transaction and MUST NOT rely on the `narinfo_nar_files` cascade alone (which leaves the narinfos dangling).
+
+The cascade on `narinfo_nar_files` removes only the link rows; the parent narinfos
+survive linked to no `nar_file`. Such a narinfo is unservable locally and confirmed
+absent from every healthy upstream, so it can only ever be answered with an HTTP 200
+narinfo followed by an HTTP 404 NAR (which Nix clients have already cached and will
+fetch directly), and therefore MUST NOT be retained.
+
+A narinfo that is unservable locally and confirmed absent from every healthy
+upstream is unrecoverable: it can only ever be answered with an HTTP 200 narinfo
+followed by an HTTP 404 NAR (which Nix clients have already cached and will fetch
+directly), so it MUST NOT be retained.
+
+This requirement applies ONLY to the genuinely-absent-upstream deletion branch.
+The existing safety gate is unchanged: if any linked narinfo is Present or its
+upstream existence is Unknown, or there are no healthy upstreams, the sweep SHALL
+delete nothing (neither `nar_file` nor narinfos) and leave the record for
+on-demand recovery. The zero-linked-narinfo branch is likewise unchanged.
+
+#### Scenario: Genuinely-absent backing-less NAR deletes its dangling narinfos
+
+- **GIVEN** a backing-less `nar_file` for hash `H` with no whole-file in storage and `total_chunks = 0`
+- **AND** one or more narinfos linked to it via `narinfo_nar_files`
+- **AND** every healthy upstream reports each linked narinfo as `ExistenceAbsent`
+- **WHEN** the recovery sweep runs `gcOrSkipBackingLessNarFile` for that record
+- **THEN** the `nar_file` row SHALL be deleted
+- **AND** every linked narinfo SHALL also be deleted in the same transaction
+- **AND** no narinfo SHALL remain in the database with a URL referencing hash `H`
+- **AND** no narinfo SHALL be left without a `narinfo_nar_files` link as a result of this GC
+
+#### Scenario: A still-present upstream aborts deletion entirely
+
+- **GIVEN** a backing-less `nar_file` for hash `H` with one or more linked narinfos
+- **AND** at least one healthy upstream reports a linked narinfo as `ExistencePresent` or `ExistenceUnknown` (or there are no healthy upstreams)
+- **WHEN** the recovery sweep runs `gcOrSkipBackingLessNarFile` for that record
+- **THEN** neither the `nar_file` nor any linked narinfo SHALL be deleted
+- **AND** the record SHALL be left for on-demand `GetNar` recovery
+
+#### Scenario: Orphan with no linked narinfo is still GC'd cleanly
+
+- **GIVEN** a backing-less `nar_file` for hash `H` with zero linked narinfos
+- **WHEN** the recovery sweep runs `gcOrSkipBackingLessNarFile` for that record
+- **THEN** the `nar_file` row SHALL be deleted
+- **AND** no narinfo deletion SHALL be attempted (there are none to delete)
+

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -7495,26 +7495,19 @@ func (c *Cache) gcOrSkipBackingLessNarFile(ctx context.Context, narFileID int, n
 		}
 	}
 
-	// Every linked narinfo is genuinely gone from every healthy upstream: the NAR
-	// exists nowhere (not locally, not upstream), so these narinfos can only ever be
-	// answered with a 200 narinfo followed by a 404 NAR — which Nix clients have
-	// already cached and will fetch directly, skipping any narinfo re-fetch. Delete the
-	// nar_file AND its linked narinfos atomically so the GC never leaves a dangling
-	// narinfo behind: the nar_file delete cascades the narinfo_nar_files links first,
-	// then the now-unlinked narinfos are removed. See spec: nar-cache-miss-recovery.
-	if err := c.withEntTransaction(ctx, "gcGenuinelyAbsentBackingLessNarFile", func(tx *ent.Tx) error {
-		if err := tx.NarFile.DeleteOneID(narFileID).Exec(ctx); err != nil {
-			return fmt.Errorf("delete backing-less nar_file(%d): %w", narFileID, err)
-		}
+	// Every linked narinfo in the snapshot is genuinely gone from every healthy
+	// upstream: the NAR exists nowhere (not locally, not upstream), so these narinfos
+	// can only ever be answered with a 200 narinfo followed by a 404 NAR — which Nix
+	// clients have already cached and will fetch directly, skipping any narinfo
+	// re-fetch. Delete them together with the nar_file so the GC never leaves a dangling
+	// narinfo behind. See spec: nar-cache-miss-recovery.
+	niIDs := make([]int, len(nis))
+	for i, ni := range nis {
+		niIDs[i] = ni.ID
+	}
 
-		for _, ni := range nis {
-			if err := tx.NarInfo.DeleteOneID(ni.ID).Exec(ctx); err != nil {
-				return fmt.Errorf("delete dangling narinfo(%d): %w", ni.ID, err)
-			}
-		}
-
-		return nil
-	}); err != nil {
+	narFileDeleted, err := c.gcDeleteAbsentNarInfosAndMaybeNarFile(ctx, narFileID, niIDs)
+	if err != nil {
 		log.Warn().
 			Err(err).
 			Str("hash", narURL.Hash).
@@ -7523,10 +7516,83 @@ func (c *Cache) gcOrSkipBackingLessNarFile(ctx context.Context, narFileID int, n
 		return
 	}
 
+	if !narFileDeleted {
+		// A narinfo was linked to this nar_file after we snapshotted and probed
+		// upstreams; it is unverified, so its link was left intact and keeps the row
+		// referenced. The next sweep re-evaluates with a fresh, fully-verified snapshot.
+		log.Debug().
+			Str("hash", narURL.Hash).
+			Int("narinfo_count", len(nis)).
+			Msg("deleted verified-absent narinfos but kept backing-less nar_file: it was re-linked concurrently")
+
+		return
+	}
+
 	log.Info().
 		Str("hash", narURL.Hash).
 		Int("narinfo_count", len(nis)).
 		Msg("garbage-collected genuinely-absent placeholder nar_file and its unservable narinfos")
+}
+
+// gcDeleteAbsentNarInfosAndMaybeNarFile removes the verified-absent narinfos (and their
+// links to narFileID), then garbage-collects the nar_file ONLY if no links remain. It
+// returns whether the nar_file itself was deleted.
+//
+// verifiedNarInfoIDs is the snapshot whose every narinfo was confirmed genuinely absent
+// from every healthy upstream. The set is captured before the (network-bound) upstream
+// probes, so a concurrent storeInDatabase/repair may link a *new* narinfo to this row
+// afterwards. That new narinfo is NOT in verifiedNarInfoIDs and has not been verified,
+// so its link is left intact: it keeps the nar_file referenced (avoiding a delete that
+// would cascade the link away and orphan the narinfo into a fresh dangling row), and
+// the next sweep re-evaluates the row with a fresh, fully-verified snapshot.
+func (c *Cache) gcDeleteAbsentNarInfosAndMaybeNarFile(
+	ctx context.Context,
+	narFileID int,
+	verifiedNarInfoIDs []int,
+) (bool, error) {
+	var narFileDeleted bool
+
+	if err := c.withEntTransaction(ctx, "gcGenuinelyAbsentBackingLessNarFile", func(tx *ent.Tx) error {
+		// Reset per-attempt: withEntTransaction may retry the closure on a serialization
+		// error, and a stale true from a rolled-back attempt would misreport the result.
+		narFileDeleted = false
+
+		if _, err := tx.NarInfoNarFile.Delete().
+			Where(
+				entnarinfonarfile.NarFileID(narFileID),
+				entnarinfonarfile.NarinfoIDIn(verifiedNarInfoIDs...),
+			).Exec(ctx); err != nil {
+			return fmt.Errorf("delete narinfo links for nar_file(%d): %w", narFileID, err)
+		}
+
+		if _, err := tx.NarInfo.Delete().
+			Where(entnarinfo.IDIn(verifiedNarInfoIDs...)).Exec(ctx); err != nil {
+			return fmt.Errorf("delete dangling narinfos for nar_file(%d): %w", narFileID, err)
+		}
+
+		stillLinked, err := tx.NarInfoNarFile.Query().
+			Where(entnarinfonarfile.NarFileID(narFileID)).
+			Exist(ctx)
+		if err != nil {
+			return fmt.Errorf("re-check links for nar_file(%d): %w", narFileID, err)
+		}
+
+		if stillLinked {
+			return nil
+		}
+
+		if err := tx.NarFile.DeleteOneID(narFileID).Exec(ctx); err != nil {
+			return fmt.Errorf("delete backing-less nar_file(%d): %w", narFileID, err)
+		}
+
+		narFileDeleted = true
+
+		return nil
+	}); err != nil {
+		return false, err
+	}
+
+	return narFileDeleted, nil
 }
 
 // narInfoGenuinelyAbsentUpstream reports whether EVERY healthy upstream definitively

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -7565,8 +7565,17 @@ func (c *Cache) gcDeleteAbsentNarInfosAndMaybeNarFile(
 			return fmt.Errorf("delete narinfo links for nar_file(%d): %w", narFileID, err)
 		}
 
+		// Delete only the narinfos that became linkless after unlinking narFileID. The
+		// narinfo<->nar_file relation is M:N: a verified narinfo may still be linked to a
+		// different (still-backed) nar_file variant, and because deleting a narinfo
+		// cascades all of its join rows, an unconditional delete would tear down that
+		// other link and orphan a still-backed row. HasNarInfoNarFiles is evaluated after
+		// the unlink above, so a narinfo with any remaining link is preserved.
 		if _, err := tx.NarInfo.Delete().
-			Where(entnarinfo.IDIn(verifiedNarInfoIDs...)).Exec(ctx); err != nil {
+			Where(
+				entnarinfo.IDIn(verifiedNarInfoIDs...),
+				entnarinfo.Not(entnarinfo.HasNarInfoNarFiles()),
+			).Exec(ctx); err != nil {
 			return fmt.Errorf("delete dangling narinfos for nar_file(%d): %w", narFileID, err)
 		}
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -7495,11 +7495,30 @@ func (c *Cache) gcOrSkipBackingLessNarFile(ctx context.Context, narFileID int, n
 		}
 	}
 
-	if err := c.dbClient.Ent().NarFile.DeleteOneID(narFileID).Exec(ctx); err != nil {
+	// Every linked narinfo is genuinely gone from every healthy upstream: the NAR
+	// exists nowhere (not locally, not upstream), so these narinfos can only ever be
+	// answered with a 200 narinfo followed by a 404 NAR — which Nix clients have
+	// already cached and will fetch directly, skipping any narinfo re-fetch. Delete the
+	// nar_file AND its linked narinfos atomically so the GC never leaves a dangling
+	// narinfo behind: the nar_file delete cascades the narinfo_nar_files links first,
+	// then the now-unlinked narinfos are removed. See spec: nar-cache-miss-recovery.
+	if err := c.withEntTransaction(ctx, "gcGenuinelyAbsentBackingLessNarFile", func(tx *ent.Tx) error {
+		if err := tx.NarFile.DeleteOneID(narFileID).Exec(ctx); err != nil {
+			return fmt.Errorf("delete backing-less nar_file(%d): %w", narFileID, err)
+		}
+
+		for _, ni := range nis {
+			if err := tx.NarInfo.DeleteOneID(ni.ID).Exec(ctx); err != nil {
+				return fmt.Errorf("delete dangling narinfo(%d): %w", ni.ID, err)
+			}
+		}
+
+		return nil
+	}); err != nil {
 		log.Warn().
 			Err(err).
 			Str("hash", narURL.Hash).
-			Msg("failed to garbage-collect genuinely-absent placeholder nar_file")
+			Msg("failed to garbage-collect genuinely-absent placeholder nar_file and its narinfos")
 
 		return
 	}
@@ -7507,7 +7526,7 @@ func (c *Cache) gcOrSkipBackingLessNarFile(ctx context.Context, narFileID int, n
 	log.Info().
 		Str("hash", narURL.Hash).
 		Int("narinfo_count", len(nis)).
-		Msg("garbage-collected genuinely-absent placeholder nar_file")
+		Msg("garbage-collected genuinely-absent placeholder nar_file and its unservable narinfos")
 }
 
 // narInfoGenuinelyAbsentUpstream reports whether EVERY healthy upstream definitively

--- a/pkg/cache/recovery_gc_internal_test.go
+++ b/pkg/cache/recovery_gc_internal_test.go
@@ -95,9 +95,9 @@ func (f *gcTestFixture) seedBackingLessRow(t *testing.T, narHash, narInfoHash st
 }
 
 // seedBackingLessRowMulti inserts one placeholder nar_file (no whole-file in store)
-// linked to several narinfos — several store paths sharing one NAR — optionally aged
-// past the recovery cutoff.
-func (f *gcTestFixture) seedBackingLessRowMulti(t *testing.T, narHash string, narInfoHashes []string, old bool) {
+// linked to several narinfos — several store paths sharing one NAR — aged past the
+// recovery cutoff so the sweep considers it.
+func (f *gcTestFixture) seedBackingLessRowMulti(t *testing.T, narHash string, narInfoHashes []string) {
 	t.Helper()
 
 	narURL := nar.URL{Hash: narHash, Compression: nar.CompressionTypeNone}
@@ -123,12 +123,10 @@ func (f *gcTestFixture) seedBackingLessRowMulti(t *testing.T, narHash string, na
 			Exec(f.ctx))
 	}
 
-	if old {
-		_, err = f.db.DB().ExecContext(f.ctx,
-			"UPDATE nar_files SET created_at = ? WHERE hash = ?",
-			time.Now().Add(-10*time.Minute), narHash)
-		require.NoError(t, err)
-	}
+	_, err = f.db.DB().ExecContext(f.ctx,
+		"UPDATE nar_files SET created_at = ? WHERE hash = ?",
+		time.Now().Add(-10*time.Minute), narHash)
+	require.NoError(t, err)
 }
 
 // seedBackingLessRowNoNarInfo inserts a placeholder nar_file with NO linked narinfo,
@@ -207,6 +205,55 @@ func (f *gcTestFixture) narInfoID(t *testing.T, narInfoHash string) int {
 	return id
 }
 
+// linkNarInfoToNewNarFile creates a second, distinct nar_file variant and links the
+// existing narinfo to it as well — making the narinfo M:N-linked to two nar_files.
+func (f *gcTestFixture) linkNarInfoToNewNarFile(t *testing.T, narInfoHash, narFileHash string) {
+	t.Helper()
+
+	nf, err := f.c.dbClient.Ent().NarFile.Create().
+		SetHash(narFileHash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(2345).
+		Save(f.ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, f.c.dbClient.Ent().NarInfoNarFile.Create().
+		SetNarinfoID(f.narInfoID(t, narInfoHash)).
+		SetNarFileID(nf.ID).
+		Exec(f.ctx))
+}
+
+// TestRecoveryGCKeepsNarInfoLinkedToAnotherNarFile guards the M:N relationship: a
+// verified narinfo that is ALSO linked to a different nar_file variant must NOT be
+// deleted, since deleting it cascades away the other link and orphans that still-backed
+// row. GC may unlink/GC the backing-less row, but the shared narinfo and the other
+// nar_file survive.
+func TestRecoveryGCKeepsNarInfoLinkedToAnotherNarFile(t *testing.T) {
+	t.Parallel()
+
+	f := newGCTestFixture(t)
+
+	const narHash = "9lid9xrpirkzcpqsxfq02qwiq0yd70ch"
+
+	const otherNarHash = "alid9xrpirkzcpqsxfq02qwiq0yd70ch"
+
+	shared := gcHash("gcshared1")
+
+	f.seedBackingLessRowMulti(t, narHash, []string{shared})
+	f.linkNarInfoToNewNarFile(t, shared, otherNarHash)
+
+	_, err := f.c.gcDeleteAbsentNarInfosAndMaybeNarFile(
+		f.ctx, f.narFileID(t, narHash), []int{f.narInfoID(t, shared)},
+	)
+	require.NoError(t, err)
+
+	assert.True(t, f.narInfoExists(t, shared),
+		"a narinfo still linked to another nar_file must NOT be deleted")
+	assert.True(t, f.narFileExists(t, otherNarHash),
+		"the other nar_file variant must remain (its narinfo must not be cascade-orphaned)")
+}
+
 // TestRecoveryGCKeepsNarFileWhenUnverifiedNarInfoRemains is the race guard: if a
 // narinfo links to the nar_file but is NOT in the verified-absent set (e.g. linked by
 // a concurrent storeInDatabase/repair after the GC snapshotted and probed upstreams),
@@ -222,7 +269,7 @@ func TestRecoveryGCKeepsNarFileWhenUnverifiedNarInfoRemains(t *testing.T) {
 	verified := gcHash("gcverified1")
 	concurrent := gcHash("gcconcurrent1")
 
-	f.seedBackingLessRowMulti(t, narHash, []string{verified, concurrent}, true)
+	f.seedBackingLessRowMulti(t, narHash, []string{verified, concurrent})
 
 	// Only `verified` was confirmed genuinely absent upstream; `concurrent` stands in
 	// for a narinfo linked after the verified snapshot and is omitted from the set.
@@ -254,7 +301,7 @@ func TestRecoveryGCDeletesNarFileWhenAllVerified(t *testing.T) {
 	a := gcHash("gcallverified1")
 	b := gcHash("gcallverified2")
 
-	f.seedBackingLessRowMulti(t, narHash, []string{a, b}, true)
+	f.seedBackingLessRowMulti(t, narHash, []string{a, b})
 
 	deleted, err := f.c.gcDeleteAbsentNarInfosAndMaybeNarFile(
 		f.ctx, f.narFileID(t, narHash), []int{f.narInfoID(t, a), f.narInfoID(t, b)},
@@ -307,7 +354,7 @@ func TestRecoveryGCDeletesAllLinkedNarInfosWhenGenuinelyAbsent(t *testing.T) {
 		gcHash("gcmultiabsent3"),
 	}
 
-	f.seedBackingLessRowMulti(t, narHash, narInfoHashes, true)
+	f.seedBackingLessRowMulti(t, narHash, narInfoHashes)
 	require.True(t, f.narFileExists(t, narHash))
 
 	f.runRecovery(t)

--- a/pkg/cache/recovery_gc_internal_test.go
+++ b/pkg/cache/recovery_gc_internal_test.go
@@ -189,6 +189,84 @@ func (f *gcTestFixture) narInfoExists(t *testing.T, narInfoHash string) bool {
 	return exists
 }
 
+func (f *gcTestFixture) narFileID(t *testing.T, narHash string) int {
+	t.Helper()
+
+	id, err := f.c.dbClient.Ent().NarFile.Query().Where(entnarfile.HashEQ(narHash)).OnlyID(f.ctx)
+	require.NoError(t, err)
+
+	return id
+}
+
+func (f *gcTestFixture) narInfoID(t *testing.T, narInfoHash string) int {
+	t.Helper()
+
+	id, err := f.c.dbClient.Ent().NarInfo.Query().Where(entnarinfo.HashEQ(narInfoHash)).OnlyID(f.ctx)
+	require.NoError(t, err)
+
+	return id
+}
+
+// TestRecoveryGCKeepsNarFileWhenUnverifiedNarInfoRemains is the race guard: if a
+// narinfo links to the nar_file but is NOT in the verified-absent set (e.g. linked by
+// a concurrent storeInDatabase/repair after the GC snapshotted and probed upstreams),
+// the GC deletes only the verified narinfos and KEEPS the nar_file, so the unverified
+// narinfo is never cascade-orphaned into a fresh dangling row.
+func TestRecoveryGCKeepsNarFileWhenUnverifiedNarInfoRemains(t *testing.T) {
+	t.Parallel()
+
+	f := newGCTestFixture(t)
+
+	const narHash = "7lid9xrpirkzcpqsxfq02qwiq0yd70ch"
+
+	verified := gcHash("gcverified1")
+	concurrent := gcHash("gcconcurrent1")
+
+	f.seedBackingLessRowMulti(t, narHash, []string{verified, concurrent}, true)
+
+	// Only `verified` was confirmed genuinely absent upstream; `concurrent` stands in
+	// for a narinfo linked after the verified snapshot and is omitted from the set.
+	deleted, err := f.c.gcDeleteAbsentNarInfosAndMaybeNarFile(
+		f.ctx, f.narFileID(t, narHash), []int{f.narInfoID(t, verified)},
+	)
+	require.NoError(t, err)
+
+	assert.False(t, deleted,
+		"nar_file must be kept while an unverified narinfo still links to it")
+	assert.False(t, f.narInfoExists(t, verified),
+		"the verified-absent narinfo must be deleted")
+	assert.True(t, f.narInfoExists(t, concurrent),
+		"the unverified (concurrently-linked) narinfo must NOT be orphaned or deleted")
+	assert.True(t, f.narFileExists(t, narHash),
+		"the nar_file must survive so the unverified narinfo stays linked, not dangling")
+}
+
+// TestRecoveryGCDeletesNarFileWhenAllVerified exercises the helper's all-verified path:
+// when every linked narinfo is in the verified set, both the narinfos and the nar_file
+// are deleted and the helper reports the nar_file as deleted.
+func TestRecoveryGCDeletesNarFileWhenAllVerified(t *testing.T) {
+	t.Parallel()
+
+	f := newGCTestFixture(t)
+
+	const narHash = "8lid9xrpirkzcpqsxfq02qwiq0yd70ch"
+
+	a := gcHash("gcallverified1")
+	b := gcHash("gcallverified2")
+
+	f.seedBackingLessRowMulti(t, narHash, []string{a, b}, true)
+
+	deleted, err := f.c.gcDeleteAbsentNarInfosAndMaybeNarFile(
+		f.ctx, f.narFileID(t, narHash), []int{f.narInfoID(t, a), f.narInfoID(t, b)},
+	)
+	require.NoError(t, err)
+
+	assert.True(t, deleted, "nar_file must be deleted when every linked narinfo is verified-absent")
+	assert.False(t, f.narInfoExists(t, a), "verified-absent narinfo must be deleted")
+	assert.False(t, f.narInfoExists(t, b), "verified-absent narinfo must be deleted")
+	assert.False(t, f.narFileExists(t, narHash), "nar_file must be deleted when no links remain")
+}
+
 // TestRecoveryGCDeletesGenuinelyAbsentPlaceholder verifies that a backing-less
 // placeholder whose narinfo is a definitive 404 on every healthy upstream is deleted.
 func TestRecoveryGCDeletesGenuinelyAbsentPlaceholder(t *testing.T) {

--- a/pkg/cache/recovery_gc_internal_test.go
+++ b/pkg/cache/recovery_gc_internal_test.go
@@ -124,8 +124,8 @@ func (f *gcTestFixture) seedBackingLessRowMulti(t *testing.T, narHash string, na
 	}
 
 	_, err = f.db.DB().ExecContext(f.ctx,
-		"UPDATE nar_files SET created_at = ? WHERE hash = ?",
-		time.Now().Add(-10*time.Minute), narHash)
+		"UPDATE nar_files SET created_at = ? WHERE id = ?",
+		time.Now().Add(-10*time.Minute), nf.ID)
 	require.NoError(t, err)
 }
 

--- a/pkg/cache/recovery_gc_internal_test.go
+++ b/pkg/cache/recovery_gc_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	entnarfile "github.com/kalbasit/ncps/ent/narfile"
+	entnarinfo "github.com/kalbasit/ncps/ent/narinfo"
 
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
 	"github.com/kalbasit/ncps/pkg/database"
@@ -93,6 +94,74 @@ func (f *gcTestFixture) seedBackingLessRow(t *testing.T, narHash, narInfoHash st
 	}
 }
 
+// seedBackingLessRowMulti inserts one placeholder nar_file (no whole-file in store)
+// linked to several narinfos — several store paths sharing one NAR — optionally aged
+// past the recovery cutoff.
+func (f *gcTestFixture) seedBackingLessRowMulti(t *testing.T, narHash string, narInfoHashes []string, old bool) {
+	t.Helper()
+
+	narURL := nar.URL{Hash: narHash, Compression: nar.CompressionTypeNone}
+
+	nf, err := f.c.dbClient.Ent().NarFile.Create().
+		SetHash(narHash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(1234).
+		Save(f.ctx)
+	require.NoError(t, err)
+
+	for _, narInfoHash := range narInfoHashes {
+		ni, err := f.c.dbClient.Ent().NarInfo.Create().
+			SetHash(narInfoHash).
+			SetURL(narURL.String()).
+			Save(f.ctx)
+		require.NoError(t, err)
+
+		require.NoError(t, f.c.dbClient.Ent().NarInfoNarFile.Create().
+			SetNarinfoID(ni.ID).
+			SetNarFileID(nf.ID).
+			Exec(f.ctx))
+	}
+
+	if old {
+		_, err = f.db.DB().ExecContext(f.ctx,
+			"UPDATE nar_files SET created_at = ? WHERE hash = ?",
+			time.Now().Add(-10*time.Minute), narHash)
+		require.NoError(t, err)
+	}
+}
+
+// seedBackingLessRowNoNarInfo inserts a placeholder nar_file with NO linked narinfo,
+// optionally aged past the recovery cutoff.
+func (f *gcTestFixture) seedBackingLessRowNoNarInfo(t *testing.T, narHash string, old bool) {
+	t.Helper()
+
+	_, err := f.c.dbClient.Ent().NarFile.Create().
+		SetHash(narHash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(1234).
+		Save(f.ctx)
+	require.NoError(t, err)
+
+	if old {
+		_, err = f.db.DB().ExecContext(f.ctx,
+			"UPDATE nar_files SET created_at = ? WHERE hash = ?",
+			time.Now().Add(-10*time.Minute), narHash)
+		require.NoError(t, err)
+	}
+}
+
+// gcHash pads seed to a 32-character store-path hash for test rows.
+func gcHash(seed string) string {
+	const want = 32
+	if len(seed) >= want {
+		return seed[:want]
+	}
+
+	return seed + strings.Repeat("0", want-len(seed))
+}
+
 func (f *gcTestFixture) runRecovery(t *testing.T) {
 	t.Helper()
 
@@ -106,6 +175,15 @@ func (f *gcTestFixture) narFileExists(t *testing.T, narHash string) bool {
 	t.Helper()
 
 	exists, err := f.c.dbClient.Ent().NarFile.Query().Where(entnarfile.HashEQ(narHash)).Exist(f.ctx)
+	require.NoError(t, err)
+
+	return exists
+}
+
+func (f *gcTestFixture) narInfoExists(t *testing.T, narInfoHash string) bool {
+	t.Helper()
+
+	exists, err := f.c.dbClient.Ent().NarInfo.Query().Where(entnarinfo.HashEQ(narInfoHash)).Exist(f.ctx)
 	require.NoError(t, err)
 
 	return exists
@@ -130,6 +208,58 @@ func TestRecoveryGCDeletesGenuinelyAbsentPlaceholder(t *testing.T) {
 
 	assert.False(t, f.narFileExists(t, narHash),
 		"a genuinely-absent backing-less placeholder must be garbage-collected")
+	assert.False(t, f.narInfoExists(t, absentNarInfoHash),
+		"the narinfo of a genuinely-absent placeholder must be deleted, not left dangling")
+}
+
+// TestRecoveryGCDeletesAllLinkedNarInfosWhenGenuinelyAbsent verifies that when several
+// store paths share one genuinely-absent backing-less NAR, GC deletes the nar_file AND
+// every linked narinfo, leaving none dangling.
+func TestRecoveryGCDeletesAllLinkedNarInfosWhenGenuinelyAbsent(t *testing.T) {
+	t.Parallel()
+
+	f := newGCTestFixture(t)
+
+	const narHash = "5lid9xrpirkzcpqsxfq02qwiq0yd70ch"
+
+	// None of these narinfo hashes are served by the testdata upstream → all 404 → absent.
+	narInfoHashes := []string{
+		gcHash("gcmultiabsent1"),
+		gcHash("gcmultiabsent2"),
+		gcHash("gcmultiabsent3"),
+	}
+
+	f.seedBackingLessRowMulti(t, narHash, narInfoHashes, true)
+	require.True(t, f.narFileExists(t, narHash))
+
+	f.runRecovery(t)
+
+	assert.False(t, f.narFileExists(t, narHash),
+		"a genuinely-absent backing-less placeholder must be garbage-collected")
+
+	for _, narInfoHash := range narInfoHashes {
+		assert.False(t, f.narInfoExists(t, narInfoHash),
+			"every narinfo linked to a genuinely-absent placeholder must be deleted")
+	}
+}
+
+// TestRecoveryGCDeletesOrphanPlaceholderWithoutNarInfo verifies the unchanged
+// zero-linked-narinfo branch: a backing-less placeholder with no linked narinfo is
+// still garbage-collected.
+func TestRecoveryGCDeletesOrphanPlaceholderWithoutNarInfo(t *testing.T) {
+	t.Parallel()
+
+	f := newGCTestFixture(t)
+
+	const narHash = "6lid9xrpirkzcpqsxfq02qwiq0yd70ch"
+
+	f.seedBackingLessRowNoNarInfo(t, narHash, true)
+	require.True(t, f.narFileExists(t, narHash))
+
+	f.runRecovery(t)
+
+	assert.False(t, f.narFileExists(t, narHash),
+		"a backing-less placeholder with no linked narinfo must be garbage-collected")
 }
 
 // TestRecoveryGCKeepsPlaceholderPresentUpstream verifies that a placeholder whose
@@ -148,6 +278,8 @@ func TestRecoveryGCKeepsPlaceholderPresentUpstream(t *testing.T) {
 
 	assert.True(t, f.narFileExists(t, narHash),
 		"a placeholder whose NAR is still available upstream must NOT be deleted")
+	assert.True(t, f.narInfoExists(t, testdata.Nar1.NarInfoHash),
+		"the narinfo must NOT be deleted while it is still present upstream")
 }
 
 // TestRecoveryGCKeepsPlaceholderOnTransientProbe verifies that an inconclusive
@@ -180,6 +312,8 @@ func TestRecoveryGCKeepsPlaceholderOnTransientProbe(t *testing.T) {
 
 	assert.True(t, f.narFileExists(t, narHash),
 		"a transient/unknown upstream probe must NOT delete the placeholder")
+	assert.True(t, f.narInfoExists(t, narInfoHash),
+		"the narinfo must NOT be deleted on a transient/unknown upstream probe")
 }
 
 // TestRecoveryGCSkipsFreshPlaceholder verifies that a backing-less placeholder newer


### PR DESCRIPTION
## Summary

The recovery sweep's `gcOrSkipBackingLessNarFile` deletes a backing-less `nar_file` when **every** linked narinfo is genuinely absent from **every** healthy upstream. The `narinfo_nar_files` on-delete cascade removed only the link rows and left the parent narinfos behind — **dangling**, linked to no `nar_file`.

Such a narinfo was already served as HTTP 200 and cached by Nix clients, so a later `nix build` fetches the NAR directly (skipping any narinfo re-fetch) and gets HTTP 404:

```
error: file 'nar/<hash>.nar' does not exist in binary cache
```

Prod (`v0.10.0-rc10`) accumulated **2,744** such dangling narinfos. The read-path guard (`narinfo-purge-serving`) cannot help — it only fires on a narinfo *re-request*, which a Nix client-cache hit bypasses.

## Fix

In the genuinely-absent branch, delete the `nar_file` **and** its linked narinfos atomically in one Ent transaction (`nar_file` first so its cascade clears the links, then the now-unlinked narinfos).

The conservative gate is unchanged: any `Present`/`Unknown` upstream, no healthy upstreams, the zero-linked-narinfo branch, and fresh placeholders all behave exactly as before. No schema or migration change.

Implements the new requirement *"The backing-less GC MUST NOT leave a dangling narinfo"* in spec `nar-cache-miss-recovery` (change archived as `2026-06-07-prevent-dangling-narinfos`).

## Test plan

- [x] TDD red→green: new genuinely-absent (single + multi-narinfo) tests assert narinfos are deleted; strengthened present/unknown guards assert narinfos are kept; added zero-linked regression
- [x] `task fmt` (0 changed), `task lint` (0 issues), `task test` (full suite passes, race detector)
- [x] No `ent/` or `migrations/` drift