### PR TITLE
feat(storage): in-flight staging part-objects

### DIFF
--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -485,6 +485,78 @@ func (s *Store) PutNar(ctx context.Context, narURL nar.URL, body io.Reader, _ in
 	return written, os.Chmod(narPath, fileMode)
 }
 
+// PutStagingPart writes one immutable in-flight staging part-object.
+func (s *Store) PutStagingPart(
+	ctx context.Context,
+	hash string,
+	index int64,
+	body io.Reader,
+	_ int64,
+) (int64, error) {
+	_, span := tracer.Start(ctx, "local.PutStagingPart", trace.WithSpanKind(trace.SpanKindInternal))
+	defer span.End()
+
+	partPath := s.stagingPartPath(hash, index)
+
+	if err := os.MkdirAll(filepath.Dir(partPath), dirMode); err != nil {
+		return 0, fmt.Errorf("error creating staging dir for %q: %w", partPath, err)
+	}
+
+	f, err := os.CreateTemp(s.storeTMPPath(), hash+"-*.part")
+	if err != nil {
+		return 0, fmt.Errorf("error creating the temporary staging part file: %w", err)
+	}
+
+	written, err := io.Copy(f, body)
+	if err != nil {
+		f.Close()
+		os.Remove(f.Name())
+
+		return 0, fmt.Errorf("error writing the staging part to the temporary file: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		return 0, fmt.Errorf("error closing the temporary staging part file: %w", err)
+	}
+
+	if err := os.Rename(f.Name(), partPath); err != nil {
+		return 0, fmt.Errorf("error creating the staging part file %q: %w", partPath, err)
+	}
+
+	return written, os.Chmod(partPath, fileMode)
+}
+
+// GetStagingPart opens a staging part-object for reading.
+func (s *Store) GetStagingPart(ctx context.Context, hash string, index int64) (io.ReadCloser, error) {
+	_, span := tracer.Start(ctx, "local.GetStagingPart", trace.WithSpanKind(trace.SpanKindInternal))
+	defer span.End()
+
+	partPath := s.stagingPartPath(hash, index)
+
+	f, err := os.Open(partPath)
+	if os.IsNotExist(err) {
+		return nil, storage.ErrNotFound
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("error opening the staging part file %q: %w", partPath, err)
+	}
+
+	return f, nil
+}
+
+// DeleteStagingParts removes all staging part-objects for hash.
+func (s *Store) DeleteStagingParts(ctx context.Context, hash string) error {
+	_, span := tracer.Start(ctx, "local.DeleteStagingParts", trace.WithSpanKind(trace.SpanKindInternal))
+	defer span.End()
+
+	if err := os.RemoveAll(s.stagingPartDir(hash)); err != nil {
+		return fmt.Errorf("error deleting staging parts for %q: %w", hash, err)
+	}
+
+	return nil
+}
+
 // DeleteNar deletes the nar from the store.
 func (s *Store) DeleteNar(ctx context.Context, narURL nar.URL) error {
 	// Normalize the NAR URL to handle URLs with embedded narinfo hash prefix
@@ -623,6 +695,17 @@ func (s *Store) storePath() string        { return filepath.Join(s.path, "store"
 func (s *Store) storeNarInfoPath() string { return filepath.Join(s.storePath(), "narinfo") }
 func (s *Store) storeNarPath() string     { return filepath.Join(s.storePath(), "nar") }
 func (s *Store) storeTMPPath() string     { return filepath.Join(s.storePath(), "tmp") }
+func (s *Store) storeStagingPath() string { return filepath.Join(s.storePath(), "staging") }
+
+// stagingPartDir is the directory holding all part-objects for one NAR hash.
+func (s *Store) stagingPartDir(hash string) string {
+	return filepath.Join(s.storeStagingPath(), hash)
+}
+
+// stagingPartPath is the on-disk path of one staging part-object.
+func (s *Store) stagingPartPath(hash string, index int64) string {
+	return filepath.Join(s.stagingPartDir(hash), fmt.Sprintf("%020d.part", index))
+}
 
 func (s *Store) setupDirs() error {
 	allPaths := []string{

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -496,6 +496,10 @@ func (s *Store) PutStagingPart(
 	_, span := tracer.Start(ctx, "local.PutStagingPart", trace.WithSpanKind(trace.SpanKindInternal))
 	defer span.End()
 
+	if index < 0 {
+		return 0, fmt.Errorf("%w: staging part index %d must be >= 0", storage.ErrInvalidArgument, index)
+	}
+
 	partPath := s.stagingPartPath(hash, index)
 
 	if err := os.MkdirAll(filepath.Dir(partPath), dirMode); err != nil {
@@ -516,10 +520,14 @@ func (s *Store) PutStagingPart(
 	}
 
 	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+
 		return 0, fmt.Errorf("error closing the temporary staging part file: %w", err)
 	}
 
 	if err := os.Rename(f.Name(), partPath); err != nil {
+		os.Remove(f.Name())
+
 		return 0, fmt.Errorf("error creating the staging part file %q: %w", partPath, err)
 	}
 

--- a/pkg/storage/local/staging_part_test.go
+++ b/pkg/storage/local/staging_part_test.go
@@ -64,3 +64,16 @@ func TestStagingParts_WriteReadDelete(t *testing.T) {
 	// Delete is a no-op when nothing exists.
 	require.NoError(t, s.DeleteStagingParts(ctx, hash))
 }
+
+func TestStagingParts_NegativeIndexRejected(t *testing.T) {
+	t.Parallel()
+
+	s, err := local.New(newContext(), t.TempDir())
+	require.NoError(t, err)
+
+	const hash = "abcdef0123456789abcdef0123456789"
+
+	_, err = s.PutStagingPart(newContext(), hash, -1, strings.NewReader("x"), 1)
+	require.ErrorIs(t, err, storage.ErrInvalidArgument,
+		"a negative part index must be rejected, not written to an invalid path")
+}

--- a/pkg/storage/local/staging_part_test.go
+++ b/pkg/storage/local/staging_part_test.go
@@ -1,0 +1,66 @@
+package local_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/storage"
+	"github.com/kalbasit/ncps/pkg/storage/local"
+)
+
+func TestStagingParts_WriteReadDelete(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	s, err := local.New(newContext(), dir)
+	require.NoError(t, err)
+
+	ctx := newContext()
+
+	const hash = "abcdef0123456789abcdef0123456789"
+
+	// A missing part reads as a confirmed not-found.
+	_, err = s.GetStagingPart(ctx, hash, 0)
+	require.ErrorIs(t, err, storage.ErrNotFound,
+		"a part that was never written must read as ErrNotFound")
+
+	// Write three ordered parts.
+	parts := []string{"part-zero-", "part-one--", "part-two--"}
+	for i, p := range parts {
+		n, putErr := s.PutStagingPart(ctx, hash, int64(i), strings.NewReader(p), int64(len(p)))
+		require.NoError(t, putErr)
+		assert.Equal(t, int64(len(p)), n)
+	}
+
+	// Read them back and confirm contiguous reassembly in index order.
+	var got strings.Builder
+
+	for i := range parts {
+		rc, getErr := s.GetStagingPart(ctx, hash, int64(i))
+		require.NoError(t, getErr)
+
+		b, readErr := io.ReadAll(rc)
+		require.NoError(t, readErr)
+		require.NoError(t, rc.Close())
+
+		got.Write(b)
+	}
+
+	assert.Equal(t, strings.Join(parts, ""), got.String(),
+		"reassembling parts 0..N in order must yield the original byte stream")
+
+	// Delete reclaims every part for the hash.
+	require.NoError(t, s.DeleteStagingParts(ctx, hash))
+
+	_, err = s.GetStagingPart(ctx, hash, 0)
+	require.ErrorIs(t, err, storage.ErrNotFound,
+		"after DeleteStagingParts, parts must be gone")
+
+	// Delete is a no-op when nothing exists.
+	require.NoError(t, s.DeleteStagingParts(ctx, hash))
+}

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -749,6 +749,93 @@ func (s *Store) narPath(narURL nar.URL) (string, error) {
 	return s.prefix + "/store/nar/" + tfp, nil
 }
 
+// stagingPartDirKey is the key prefix holding all staging part-objects for hash.
+func (s *Store) stagingPartDirKey(hash string) string {
+	if s.prefix == "" {
+		return "store/staging/" + hash + "/"
+	}
+
+	return s.prefix + "/store/staging/" + hash + "/"
+}
+
+// stagingPartKey is the object key of one staging part-object.
+func (s *Store) stagingPartKey(hash string, index int64) string {
+	return fmt.Sprintf("%s%020d.part", s.stagingPartDirKey(hash), index)
+}
+
+// PutStagingPart writes one immutable in-flight staging part-object.
+func (s *Store) PutStagingPart(
+	ctx context.Context,
+	hash string,
+	index int64,
+	body io.Reader,
+	size int64,
+) (int64, error) {
+	_, span := tracer.Start(ctx, "s3.PutStagingPart", trace.WithSpanKind(trace.SpanKindInternal))
+	defer span.End()
+
+	objSize := size
+	if objSize <= 0 {
+		objSize = -1
+	}
+
+	result, err := s.client.PutObject(
+		ctx,
+		s.bucket,
+		s.stagingPartKey(hash, index),
+		body,
+		objSize,
+		minio.PutObjectOptions{ContentType: "application/octet-stream"},
+	)
+	if err != nil {
+		return 0, fmt.Errorf("error putting staging part to S3: %w", err)
+	}
+
+	return result.Size, nil
+}
+
+// GetStagingPart opens a staging part-object for reading.
+func (s *Store) GetStagingPart(ctx context.Context, hash string, index int64) (io.ReadCloser, error) {
+	_, span := tracer.Start(ctx, "s3.GetStagingPart", trace.WithSpanKind(trace.SpanKindInternal))
+	defer span.End()
+
+	obj, err := s.client.GetObject(ctx, s.bucket, s.stagingPartKey(hash, index), minio.GetObjectOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error getting staging part from S3: %w", err)
+	}
+
+	if _, err := obj.Stat(); err != nil {
+		obj.Close()
+
+		if minio.ToErrorResponse(err).Code == s3NoSuchKey {
+			return nil, storage.ErrNotFound
+		}
+
+		return nil, fmt.Errorf("error stat'ing staging part from S3: %w", err)
+	}
+
+	return obj, nil
+}
+
+// DeleteStagingParts removes all staging part-objects for hash.
+func (s *Store) DeleteStagingParts(ctx context.Context, hash string) error {
+	_, span := tracer.Start(ctx, "s3.DeleteStagingParts", trace.WithSpanKind(trace.SpanKindInternal))
+	defer span.End()
+
+	opts := minio.ListObjectsOptions{Prefix: s.stagingPartDirKey(hash), Recursive: true}
+	for object := range s.client.ListObjects(ctx, s.bucket, opts) {
+		if object.Err != nil {
+			return fmt.Errorf("error listing staging parts for %q: %w", hash, object.Err)
+		}
+
+		if err := s.client.RemoveObject(ctx, s.bucket, object.Key, minio.RemoveObjectOptions{}); err != nil {
+			return fmt.Errorf("error removing staging part %q: %w", object.Key, err)
+		}
+	}
+
+	return nil
+}
+
 func testBucketAccess(ctx context.Context, client *minio.Client, bucket string) error {
 	log := zerolog.Ctx(ctx)
 

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -774,17 +774,26 @@ func (s *Store) PutStagingPart(
 	_, span := tracer.Start(ctx, "s3.PutStagingPart", trace.WithSpanKind(trace.SpanKindInternal))
 	defer span.End()
 
-	objSize := size
-	if objSize <= 0 {
-		objSize = -1
+	key := s.stagingPartKey(hash, index)
+
+	// When the size is unknown, stream via multipart (PartSize set) rather than
+	// PutObject(-1), which buffers the entire part in memory and can OOM the
+	// holder for large parts. Mirrors PutNar's unknown-size path.
+	if size <= 0 {
+		written, err := s.putObjectStream(ctx, key, body, "application/octet-stream")
+		if err != nil {
+			return 0, fmt.Errorf("error putting staging part to S3: %w", err)
+		}
+
+		return written, nil
 	}
 
 	result, err := s.client.PutObject(
 		ctx,
 		s.bucket,
-		s.stagingPartKey(hash, index),
+		key,
 		body,
-		objSize,
+		size,
 		minio.PutObjectOptions{ContentType: "application/octet-stream"},
 	)
 	if err != nil {
@@ -823,14 +832,35 @@ func (s *Store) DeleteStagingParts(ctx context.Context, hash string) error {
 	defer span.End()
 
 	opts := minio.ListObjectsOptions{Prefix: s.stagingPartDirKey(hash), Recursive: true}
-	for object := range s.client.ListObjects(ctx, s.bucket, opts) {
-		if object.Err != nil {
-			return fmt.Errorf("error listing staging parts for %q: %w", hash, object.Err)
-		}
+	objectsCh := make(chan minio.ObjectInfo)
 
-		if err := s.client.RemoveObject(ctx, s.bucket, object.Key, minio.RemoveObjectOptions{}); err != nil {
-			return fmt.Errorf("error removing staging part %q: %w", object.Key, err)
+	var listErr error
+
+	// Feed the listing into RemoveObjects, which batches deletions (up to 1000 per
+	// request) instead of one HTTP round-trip per part — a large NAR can have many
+	// parts. Listing errors are captured and surfaced after the delete drains.
+	go func() {
+		defer close(objectsCh)
+
+		for object := range s.client.ListObjects(ctx, s.bucket, opts) {
+			if object.Err != nil {
+				listErr = object.Err
+
+				return
+			}
+
+			objectsCh <- object
 		}
+	}()
+
+	for rErr := range s.client.RemoveObjects(ctx, s.bucket, objectsCh, minio.RemoveObjectsOptions{}) {
+		if rErr.Err != nil {
+			return fmt.Errorf("error removing staging part %q: %w", rErr.ObjectName, rErr.Err)
+		}
+	}
+
+	if listErr != nil {
+		return fmt.Errorf("error listing staging parts for %q: %w", hash, listErr)
 	}
 
 	return nil

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -18,6 +18,10 @@ var (
 	// ErrAlreadyExists is returned the store already has a file with the
 	// same name.
 	ErrAlreadyExists = errors.New("file already exists")
+
+	// ErrInvalidArgument is returned when a store method is called with an
+	// argument that violates its documented contract (e.g. a negative index).
+	ErrInvalidArgument = errors.New("invalid argument")
 )
 
 // ConfigStore represents a store for the ncps to use for storing
@@ -95,9 +99,13 @@ type NarStore interface {
 	WalkNars(ctx context.Context, fn func(narURL nar.URL) error) error
 
 	// PutStagingPart writes one in-flight staging part-object for a NAR hash at
-	// the given zero-based index. Parts are immutable once written. If size > 0
-	// it is the known byte length of body. It returns the number of bytes written.
-	// See change serve-whole-nar-in-flight.
+	// the given zero-based index, which MUST be >= 0 (a negative index returns
+	// ErrInvalidArgument). Parts are immutable by protocol: the producer writes
+	// each index exactly once, so backends do not need to guard against rewrites
+	// (a duplicate write of the same (hash, index) overwrites idempotently rather
+	// than erroring). If size > 0 it is the known byte length of body; if size <= 0
+	// the length is unknown and body is streamed to EOF. It returns the number of
+	// bytes written. See change serve-whole-nar-in-flight.
 	PutStagingPart(ctx context.Context, hash string, index int64, body io.Reader, size int64) (int64, error)
 
 	// GetStagingPart opens the staging part-object for hash at index for reading.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -93,4 +93,19 @@ type NarStore interface {
 
 	// WalkNars walks all NAR files in the store and calls fn for each one.
 	WalkNars(ctx context.Context, fn func(narURL nar.URL) error) error
+
+	// PutStagingPart writes one in-flight staging part-object for a NAR hash at
+	// the given zero-based index. Parts are immutable once written. If size > 0
+	// it is the known byte length of body. It returns the number of bytes written.
+	// See change serve-whole-nar-in-flight.
+	PutStagingPart(ctx context.Context, hash string, index int64, body io.Reader, size int64) (int64, error)
+
+	// GetStagingPart opens the staging part-object for hash at index for reading.
+	// The caller must close the returned io.ReadCloser. A missing part returns
+	// storage.ErrNotFound.
+	GetStagingPart(ctx context.Context, hash string, index int64) (io.ReadCloser, error)
+
+	// DeleteStagingParts removes all staging part-objects for hash. It is a no-op
+	// when none exist.
+	DeleteStagingParts(ctx context.Context, hash string) error
 }


### PR DESCRIPTION
Add staging part-object storage to the NarStore interface and both
backends (local, S3), the transport layer for in-flight NAR staging
(GitHub #660, #1289). Parts are immutable, fixed-size, sequentially
indexed objects under a per-hash staging namespace that any replica can
read while another is still downloading.

Why: S3 cannot serve an in-progress object, so to stream an in-flight
NAR cross-pod the holder must commit completed immutable pieces during
the download. These methods are the storage substrate; the holder/reader
wiring lands in a later commit.

How:
- NarStore gains PutStagingPart / GetStagingPart / DeleteStagingParts.
- local: parts live at <root>/staging/<hash>/<index>.part, written via
  atomic temp+rename so a part is only readable once fully committed.
- s3: keys <prefix>/store/staging/<hash>/<index>.part; delete lists and
  removes the per-hash prefix. A missing part returns storage.ErrNotFound.