### PR TITLE
feat(cache): stage in-flight NAR on contention

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2969,6 +2969,21 @@ func (c *Cache) pullNarIntoStore(
 	// CDC chunking is in progress. The CDC goroutine is responsible for cleanup.
 	keepJobAlive := false
 
+	// In-flight staging producer: once a cross-pod waiter is detected for this NAR
+	// hash, stage the in-flight bytes to shared storage as part-objects so other
+	// replicas can serve a complete NAR during the download (closes #660 / #1289).
+	// It is a no-op until the feature is enabled (with a distributed locker) AND a
+	// waiter appears, so the common single-reader download pays nothing.
+	if c.InflightStagingEnabled() {
+		c.backgroundWG.Add(1)
+
+		analytics.SafeGo(ctx, func() {
+			defer c.backgroundWG.Done()
+
+			c.stageInflightNar(ctx, narURL.Hash, ds)
+		})
+	}
+
 	defer func() {
 		if keepJobAlive {
 			// CDC goroutine will handle job removal and ds.done closing.

--- a/pkg/cache/inflight_staging.go
+++ b/pkg/cache/inflight_staging.go
@@ -1,14 +1,30 @@
 package cache
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"time"
+
+	"github.com/rs/zerolog"
 
 	"github.com/kalbasit/ncps/ent"
 	"github.com/kalbasit/ncps/ent/stagingstate"
 )
+
+// stagingActivationPollInterval is how often the holder's staging producer reads
+// staging_state looking for a cross-pod waiter before staging activates (D10). It
+// is coarse on purpose: backfill-from-zero makes late activation harmless, so this
+// only needs to be cheap, not low-latency.
+const stagingActivationPollInterval = time.Second
+
+// defaultInflightStagingPartSize is the fallback staging part size (8 MiB, the
+// conventional S3 multipart part size) used when the configured part size is unset
+// or non-positive. See --cache-inflight-staging-part-size (D2a).
+const defaultInflightStagingPartSize int64 = 8 << 20
 
 // staging_state.status values. See ent/schema/staging_state.go. The "complete"
 // and "abandoned" terminal statuses are introduced alongside the staging
@@ -19,11 +35,19 @@ const (
 	stagingStatusRequested = "requested"
 	// stagingStatusStaging: the holder is actively writing part-objects.
 	stagingStatusStaging = "staging"
+	// stagingStatusComplete: the holder finished writing every part-object;
+	// parts_available is final. A cross-pod reader that has consumed all
+	// parts_available parts can then emit a clean EOF rather than waiting.
+	stagingStatusComplete = "complete"
 )
 
 // errStagingStateMissing is returned when an operation expects a staging_state
 // row for a hash but none exists.
 var errStagingStateMissing = errors.New("no staging_state row")
+
+// errStagingNoTempFile is returned when the staging producer is asked to stage a
+// download state that has no temp file path yet.
+var errStagingNoTempFile = errors.New("staging producer: download state has no temp file path")
 
 // markStagingRequested records that a cross-pod waiter wants the NAR for hash
 // staged. It is idempotent: if a staging_state row already exists for the hash
@@ -79,6 +103,173 @@ func (c *Cache) advanceStagingParts(ctx context.Context, hash string, partsAvail
 
 	if n == 0 {
 		return fmt.Errorf("advance staging parts for %q: %w", hash, errStagingStateMissing)
+	}
+
+	return nil
+}
+
+// stageInflightNar runs in the holder's download goroutine. It does nothing until
+// a cross-pod waiter records a staging request for hash (and the feature is
+// enabled with a distributed locker). Once a request appears it tails the holder's
+// temp file and writes the in-flight NAR to shared storage as ordered, fixed-size,
+// immutable part-objects — backfilling from offset zero, then appending as bytes
+// arrive — advancing staging_state.parts_available as each part becomes durable.
+//
+// It returns when the download completes, the context is cancelled, or staging
+// fails. When no waiter ever appears it returns having created nothing (zero
+// overhead until contention).
+func (c *Cache) stageInflightNar(ctx context.Context, hash string, ds *downloadState) {
+	if !c.InflightStagingEnabled() {
+		return
+	}
+
+	if !c.waitForStagingRequest(ctx, hash, ds) {
+		// The download ended (or the context was cancelled) before any cross-pod
+		// waiter asked for staging: nothing to do.
+		return
+	}
+
+	if err := c.produceStagingParts(ctx, hash, ds); err != nil {
+		zerolog.Ctx(ctx).Warn().
+			Err(err).
+			Str("hash", hash).
+			Msg("in-flight staging producer stopped with error; staging parts left for GC/takeover")
+	}
+}
+
+// waitForStagingRequest polls staging_state on a coarse ticker until a cross-pod
+// waiter's request marker appears for hash. It returns true once a request is
+// observed, or false if the download finishes (ds.done) or the context is
+// cancelled first. It checks once immediately so an already-recorded request
+// activates without waiting a full tick.
+func (c *Cache) waitForStagingRequest(ctx context.Context, hash string, ds *downloadState) bool {
+	if c.stagingRequested(ctx, hash) {
+		return true
+	}
+
+	ticker := time.NewTicker(stagingActivationPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-ds.done:
+			// One last check: a waiter may have raced the download's completion.
+			return c.stagingRequested(ctx, hash)
+		case <-ticker.C:
+			if c.stagingRequested(ctx, hash) {
+				return true
+			}
+		}
+	}
+}
+
+// stagingRequested reports whether a staging_state row exists for hash. A read
+// error is treated as "not requested" so a transient DB hiccup never spuriously
+// activates staging.
+func (c *Cache) stagingRequested(ctx context.Context, hash string) bool {
+	st, err := c.getStagingState(ctx, hash)
+	if err != nil {
+		zerolog.Ctx(ctx).Warn().
+			Err(err).
+			Str("hash", hash).
+			Msg("error reading staging_state while waiting for a staging request")
+
+		return false
+	}
+
+	return st != nil
+}
+
+// produceStagingParts tails the holder's temp file from offset zero and writes it
+// to shared storage as fixed-size part-objects, advancing parts_available after
+// each part is durable. It records the temp file's native compression (D9) so a
+// cross-pod reader can transcode at parity with the same-pod path. It returns when
+// the whole NAR has been staged (clean EOF), or with an error on failure.
+func (c *Cache) produceStagingParts(ctx context.Context, hash string, ds *downloadState) error {
+	// The temp file path and its compression are set before ds.start is closed.
+	select {
+	case <-ds.start:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	ds.mu.Lock()
+	assetPath := ds.assetPath
+	compression := ds.tempFileCompression
+	ds.mu.Unlock()
+
+	if assetPath == "" {
+		return errStagingNoTempFile
+	}
+
+	f, err := os.Open(assetPath)
+	if err != nil {
+		return fmt.Errorf("staging producer: open temp file %q: %w", assetPath, err)
+	}
+	defer f.Close()
+
+	partSize := c.InflightStagingPartSize()
+	if partSize <= 0 {
+		partSize = defaultInflightStagingPartSize
+	}
+
+	// fileAvailableReader blocks until bytes are available and returns io.EOF once
+	// ds.finalSize is reached, so reading it from offset zero naturally backfills
+	// the already-written prefix and then appends new bytes as they arrive.
+	reader := &fileAvailableReader{f: f, ds: ds, ctx: ctx}
+
+	buf := make([]byte, partSize)
+
+	var index int64
+
+	for {
+		n, readErr := io.ReadFull(reader, buf)
+		if n > 0 {
+			if _, err := c.narStore.PutStagingPart(ctx, hash, index, bytes.NewReader(buf[:n]), int64(n)); err != nil {
+				return fmt.Errorf("staging producer: put part %d for %q: %w", index, hash, err)
+			}
+
+			index++
+
+			if err := c.advanceStagingParts(ctx, hash, index, compression.String()); err != nil {
+				return fmt.Errorf("staging producer: advance parts for %q: %w", hash, err)
+			}
+		}
+
+		// io.EOF: clean end with no trailing bytes. io.ErrUnexpectedEOF: the final
+		// short part was already written above. Both mean the NAR is fully staged,
+		// so publish the terminal marker that lets readers emit a clean EOF.
+		if errors.Is(readErr, io.EOF) || errors.Is(readErr, io.ErrUnexpectedEOF) {
+			if err := c.markStagingComplete(ctx, hash); err != nil {
+				return fmt.Errorf("staging producer: mark complete for %q: %w", hash, err)
+			}
+
+			return nil
+		}
+
+		if readErr != nil {
+			return fmt.Errorf("staging producer: read temp file for %q: %w", hash, readErr)
+		}
+	}
+}
+
+// markStagingComplete marks staging for hash as complete: every part-object has
+// been written and parts_available is final. A reader tailing the parts uses this
+// to emit a clean EOF after consuming all parts instead of waiting indefinitely.
+func (c *Cache) markStagingComplete(ctx context.Context, hash string) error {
+	n, err := c.dbClient.Ent().StagingState.Update().
+		Where(stagingstate.HashEQ(hash)).
+		SetStatus(stagingStatusComplete).
+		SetUpdatedAt(time.Now()).
+		Save(ctx)
+	if err != nil {
+		return fmt.Errorf("mark staging complete for %q: %w", hash, err)
+	}
+
+	if n == 0 {
+		return fmt.Errorf("mark staging complete for %q: %w", hash, errStagingStateMissing)
 	}
 
 	return nil

--- a/pkg/cache/inflight_staging.go
+++ b/pkg/cache/inflight_staging.go
@@ -165,9 +165,13 @@ func (c *Cache) waitForStagingRequest(ctx context.Context, hash string, ds *down
 	}
 }
 
-// stagingRequested reports whether a staging_state row exists for hash. A read
-// error is treated as "not requested" so a transient DB hiccup never spuriously
-// activates staging.
+// stagingRequested reports whether hash has a staging_state row in the
+// "requested" status — the holder's activation signal. A read error is treated
+// as "not requested" so a transient DB hiccup never spuriously activates
+// staging. A row left in a terminal/in-progress status (staging/complete) from
+// an earlier cycle must NOT re-activate a later holder: that would re-stage with
+// no active waiter and duplicate immutable part uploads. A takeover reset rewinds
+// the row to "requested" (see resetStagingState), which re-arms activation.
 func (c *Cache) stagingRequested(ctx context.Context, hash string) bool {
 	st, err := c.getStagingState(ctx, hash)
 	if err != nil {
@@ -179,7 +183,7 @@ func (c *Cache) stagingRequested(ctx context.Context, hash string) bool {
 		return false
 	}
 
-	return st != nil
+	return st != nil && st.Status == stagingStatusRequested
 }
 
 // produceStagingParts tails the holder's temp file from offset zero and writes it

--- a/pkg/cache/inflight_staging.go
+++ b/pkg/cache/inflight_staging.go
@@ -198,7 +198,15 @@ func (c *Cache) produceStagingParts(ctx context.Context, hash string, ds *downlo
 	ds.mu.Lock()
 	assetPath := ds.assetPath
 	compression := ds.tempFileCompression
+	downloadErr := ds.downloadError
 	ds.mu.Unlock()
+
+	// If the download failed to start (e.g. upstream 404 or a connection
+	// timeout), assetPath is empty. Surface the real download error rather than
+	// the generic "no temp file" sentinel, which would otherwise mask the cause.
+	if downloadErr != nil {
+		return downloadErr
+	}
 
 	if assetPath == "" {
 		return errStagingNoTempFile

--- a/pkg/cache/inflight_staging_internal_test.go
+++ b/pkg/cache/inflight_staging_internal_test.go
@@ -103,3 +103,44 @@ func TestStagingState_AdvancePartsAndReset(t *testing.T) {
 	assert.Equal(t, int64(0), got.PartsAvailable, "reset must rewind progress to zero")
 	assert.Equal(t, stagingStatusRequested, got.Status, "reset must move status back to requested for a clean re-stage")
 }
+
+// TestStagingState_RequestedOnlyActivatesOnRequested verifies that the holder's
+// activation signal fires only while a row is in the "requested" status. A row
+// left in a terminal/in-progress status (staging/complete) from an earlier cycle
+// must NOT re-activate a later holder, otherwise the holder would re-stage with
+// no active waiter and duplicate immutable part uploads. A subsequent reset back
+// to "requested" (takeover) must re-arm activation.
+func TestStagingState_RequestedOnlyActivatesOnRequested(t *testing.T) {
+	t.Parallel()
+
+	c, _, _, _, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	ctx := context.Background()
+
+	const hash = "1234567890abcdef1234567890abcdef"
+
+	// No row yet: not requested.
+	assert.False(t, c.stagingRequested(ctx, hash),
+		"no staging_state row must read as not requested")
+
+	// Fresh request: activation fires.
+	require.NoError(t, c.markStagingRequested(ctx, hash))
+	assert.True(t, c.stagingRequested(ctx, hash),
+		"a requested row must activate staging")
+
+	// Holder began staging: a later holder must not re-activate.
+	require.NoError(t, c.advanceStagingParts(ctx, hash, 1, nar.CompressionTypeXz.String()))
+	assert.False(t, c.stagingRequested(ctx, hash),
+		"a row in the staging status must not re-activate a later holder")
+
+	// Staging finished (terminal): still must not re-activate.
+	require.NoError(t, c.markStagingComplete(ctx, hash))
+	assert.False(t, c.stagingRequested(ctx, hash),
+		"a completed row must not re-activate a later holder with no waiter")
+
+	// Takeover reset re-arms the request.
+	require.NoError(t, c.resetStagingState(ctx, hash))
+	assert.True(t, c.stagingRequested(ctx, hash),
+		"a reset row must re-activate staging for a takeover holder")
+}

--- a/pkg/cache/inflight_staging_producer_internal_test.go
+++ b/pkg/cache/inflight_staging_producer_internal_test.go
@@ -1,0 +1,236 @@
+package cache
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
+	"github.com/kalbasit/ncps/pkg/storage/local"
+)
+
+// newCompletedStagingDownloadState writes content to a temp file under dir and
+// returns a downloadState that looks like a holder which has finished writing the
+// whole NAR to its temp file (finalSize set), so a producer tailing it reads the
+// full content and then sees EOF.
+func newCompletedStagingDownloadState(
+	t *testing.T,
+	dir, content string,
+	comp nar.CompressionType,
+) *downloadState {
+	t.Helper()
+
+	f, err := os.CreateTemp(dir, "staging-src-*.nar")
+	require.NoError(t, err)
+
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	ds := newDownloadState()
+	ds.assetPath = f.Name()
+	ds.tempFileCompression = comp
+	ds.bytesWritten = int64(len(content))
+	ds.finalSize = int64(len(content))
+	ds.startOnce.Do(func() { close(ds.start) })
+
+	return ds
+}
+
+// readStagingParts reassembles part-objects 0..n-1 for hash into a single string.
+func readStagingParts(t *testing.T, store *local.Store, hash string, n int64) string {
+	t.Helper()
+
+	var out []byte
+
+	for i := int64(0); i < n; i++ {
+		rc, err := store.GetStagingPart(context.Background(), hash, i)
+		require.NoError(t, err, "part %d must be readable", i)
+
+		b, err := io.ReadAll(rc)
+		require.NoError(t, err)
+		require.NoError(t, rc.Close())
+
+		out = append(out, b...)
+	}
+
+	return string(out)
+}
+
+// TestStageInflightNar_ActivatesOnRequest verifies that, with the feature enabled
+// and a cross-pod waiter's staging request already recorded, the holder stages the
+// in-flight NAR as ordered part-objects and advances parts_available so the bytes
+// reassemble exactly.
+func TestStageInflightNar_ActivatesOnRequest(t *testing.T) {
+	t.Parallel()
+
+	c, _, store, dir, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	// Distributed locker + small part size so the NAR spans multiple parts.
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+
+	ctx := context.Background()
+
+	const (
+		hash    = "0123456789abcdef0123456789abcdef"
+		content = "abcdefghij" // 10 bytes -> parts of 4, 4, 2
+	)
+
+	ds := newCompletedStagingDownloadState(t, dir, content, nar.CompressionTypeNone)
+
+	// A waiter recorded a staging request before the holder runs.
+	require.NoError(t, c.markStagingRequested(ctx, hash))
+
+	c.stageInflightNar(ctx, hash, ds)
+
+	st, err := c.getStagingState(ctx, hash)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	assert.Equal(t, int64(3), st.PartsAvailable, "10 bytes at part size 4 = 3 parts")
+	assert.Equal(t, stagingStatusComplete, st.Status,
+		"a fully-staged NAR must end in the terminal 'complete' status")
+
+	assert.Equal(t, content, readStagingParts(t, store, hash, st.PartsAvailable))
+}
+
+// TestStageInflightNar_BackfillsThenAppends verifies activation mid-download: the
+// holder backfills the already-written prefix as parts from index zero, then
+// appends parts as new bytes arrive, recording the temp file's compression. The
+// reassembled parts cover the full NAR byte range exactly once.
+func TestStageInflightNar_BackfillsThenAppends(t *testing.T) {
+	t.Parallel()
+
+	c, _, store, dir, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+
+	ctx := context.Background()
+
+	const hash = "11112222333344445555666677778888"
+
+	content := []byte("abcdefghijklmnopqrst") // 20 bytes -> 5 parts of 4
+
+	f, err := os.CreateTemp(dir, "src-*.nar")
+	require.NoError(t, err)
+
+	ds := newDownloadState()
+	ds.assetPath = f.Name()
+	ds.tempFileCompression = nar.CompressionTypeXz
+
+	// The holder has already written an 8-byte prefix before activation.
+	_, err = f.Write(content[:8])
+	require.NoError(t, err)
+
+	ds.bytesWritten = 8
+	ds.startOnce.Do(func() { close(ds.start) })
+
+	// A waiter requests staging mid-download.
+	require.NoError(t, c.markStagingRequested(ctx, hash))
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		c.stageInflightNar(ctx, hash, ds)
+	}()
+
+	// Drive the rest of the download one byte at a time, broadcasting progress.
+	for i := 8; i < len(content); i++ {
+		_, werr := f.Write(content[i : i+1])
+		require.NoError(t, werr)
+
+		ds.mu.Lock()
+		ds.bytesWritten++
+		ds.mu.Unlock()
+		ds.cond.Broadcast()
+	}
+
+	ds.mu.Lock()
+	ds.finalSize = int64(len(content))
+	ds.mu.Unlock()
+	ds.cond.Broadcast()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("staging producer did not finish")
+	}
+
+	require.NoError(t, f.Close())
+
+	st, err := c.getStagingState(ctx, hash)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	assert.Equal(t, int64(5), st.PartsAvailable, "20 bytes at part size 4 = 5 parts")
+	assert.Equal(t, stagingStatusComplete, st.Status)
+	assert.Equal(t, nar.CompressionTypeXz.String(), st.Compression,
+		"staged compression must match the temp file's native compression")
+	assert.Equal(t, string(content), readStagingParts(t, store, hash, st.PartsAvailable),
+		"reassembled parts must cover the full NAR byte range exactly once")
+}
+
+// TestStageInflightNar_NoRequestNoStaging verifies the zero-overhead path: when no
+// waiter ever records a request and the download ends, the holder stages nothing.
+func TestStageInflightNar_NoRequestNoStaging(t *testing.T) {
+	t.Parallel()
+
+	c, _, store, dir, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+
+	ctx := context.Background()
+
+	const hash = "ffffffffffffffffffffffffffffffff"
+
+	ds := newCompletedStagingDownloadState(t, dir, "abcdefghij", nar.CompressionTypeNone)
+	// Download already finished and no waiter ever appeared.
+	ds.doneOnce.Do(func() { close(ds.done) })
+
+	c.stageInflightNar(ctx, hash, ds)
+
+	st, err := c.getStagingState(ctx, hash)
+	require.NoError(t, err)
+	assert.Nil(t, st, "no staging_state should be created without a waiter")
+
+	_, err = store.GetStagingPart(ctx, hash, 0)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+// TestStageInflightNar_DisabledDoesNothing verifies that when the feature is
+// disabled, the holder never stages even if a request marker is present.
+func TestStageInflightNar_DisabledDoesNothing(t *testing.T) {
+	t.Parallel()
+
+	c, _, store, dir, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	// Feature left disabled (default).
+	ctx := context.Background()
+
+	const hash = "aaaabbbbccccddddeeeeffff00001111"
+
+	ds := newCompletedStagingDownloadState(t, dir, "abcdefghij", nar.CompressionTypeNone)
+
+	require.NoError(t, c.markStagingRequested(ctx, hash))
+
+	c.stageInflightNar(ctx, hash, ds)
+
+	st, err := c.getStagingState(ctx, hash)
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	assert.Equal(t, stagingStatusRequested, st.Status, "status must stay 'requested' when disabled")
+	assert.Equal(t, int64(0), st.PartsAvailable)
+
+	_, err = store.GetStagingPart(ctx, hash, 0)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}


### PR DESCRIPTION
Holder side of in-flight NAR staging (#660 / #1289, group 5). When the
feature is enabled with a distributed locker, the download goroutine now
launches a staging producer that does nothing until a cross-pod waiter
records a staging_state request for the hash. On activation it tails the
holder's temp file via fileAvailableReader, which naturally backfills the
already-written prefix from offset zero and then appends as bytes arrive,
writing the NAR to shared storage as fixed-size immutable part-objects and
advancing staging_state.parts_available after each part is durable. When
the whole NAR is staged it publishes a terminal 'complete' status so a
cross-pod reader can emit a clean EOF instead of waiting indefinitely.

The producer records the temp file's native compression (ds.tempFileCompression,
D9) so a cross-pod reader can transcode at parity with the same-pod path,
and it is path-agnostic: the same tail-the-temp-file logic covers the
eager-pipe, eager-simple, lazy and non-CDC download paths. Zero overhead
until contention: no staging row read activates work unless a waiter exists,
and the local (non-distributed) locker never stages at all.