### PR TITLE
feat(cache): serve cross-pod NAR from staging

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -405,7 +405,7 @@ func init() {
 		"ncps_download_coordination_fallback_total",
 		metric.WithDescription(
 			"Counts download-lock contention fallbacks by outcome "+
-				"(served_by_peer, take_over, give_up, caller_canceled).",
+				"(served_by_peer, served_from_staging, take_over, give_up, caller_canceled).",
 		),
 		metric.WithUnit("{event}"),
 	)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -543,6 +543,12 @@ type downloadState struct {
 	// Track which upstream served this download (for metrics)
 	upstreamHostname string
 
+	// stagingServe, when non-nil, is not a real local download but a directive to
+	// serve the NAR from cross-pod in-flight staging part-objects. It is set by
+	// pollForDownloadOrTakeOver when a lock-losing waiter detects available staging
+	// parts, and consumed by GetNar to stream from staging instead of storage.
+	stagingServe *stagingServeInfo
+
 	// Channel to signal starting the pull and its completion
 	done   chan struct{} // Signals download fully complete (including database updates)
 	start  chan struct{} // Signals streaming can begin (temp file ready)
@@ -1252,6 +1258,27 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (nar.URL, int64, io.
 		detachedCtx := context.WithoutCancel(ctx)
 		narURLCopy := narURL
 		ds := c.prePullNar(ctx, detachedCtx, &narURLCopy, preferredUpstreamURL, nil, ni)
+
+		// A lock-losing waiter that detected in-flight staging parts serves them
+		// directly: it tails the parts (transcoding to the requested compression if
+		// needed) rather than waiting for the holder's download to finish (#660 /
+		// #1289). This is the cross-pod fast path during the active-download window.
+		if ds.stagingServe != nil {
+			metricAttrs = append(
+				metricAttrs,
+				attribute.String("result", "staging"),
+				attribute.String("status", "success"),
+			)
+
+			var serveErr error
+
+			size, reader, serveErr = c.serveNarFromStaging(ctx, &narURL, ds.stagingServe.hash, ds.stagingServe.compression)
+			if serveErr != nil {
+				metricAttrs = append(metricAttrs, attribute.String("status", "error"))
+			}
+
+			return serveErr
+		}
 
 		// Check if download is complete (closed=true) before adding to WaitGroup
 		// This prevents race with cleanup goroutine calling ds.wg.Wait()
@@ -4225,6 +4252,7 @@ func (c *Cache) prePullNarInfo(ctx context.Context, hash string) *downloadState 
 		narInfoJobKey(hash),
 		hash,
 		true,
+		false, // narinfo downloads are not staged (staging is NAR-only)
 		func(ctx context.Context) bool {
 			if _, err := c.getNarInfoFromDatabase(ctx, hash); err == nil {
 				return true
@@ -4266,6 +4294,7 @@ func (c *Cache) prePullNar(
 		narJobKey(narURL.Hash),
 		narURL.Hash,
 		false,
+		true, // NAR downloads may serve cross-pod waiters from in-flight staging
 		func(ctx context.Context) bool {
 			// A placeholder nar_file row (created by storeInDatabase before chunking
 			// starts, or left by a failed download) must NOT count as an available
@@ -6181,6 +6210,7 @@ func (c *Cache) coordinateDownload(
 	lockKey string,
 	hash string,
 	waitForStorage bool,
+	allowStaging bool,
 	hasAsset func(context.Context) bool,
 	startJob func(*downloadState),
 ) *downloadState {
@@ -6221,7 +6251,7 @@ func (c *Cache) coordinateDownload(
 		// Another server holds the lock. Rather than dead-ending in an HTTP 500,
 		// poll storage for the asset while periodically re-attempting lock
 		// acquisition so we can take over if the holder finishes or fails.
-		ds, tookOver := c.pollForDownloadOrTakeOver(coordCtx, ctx, lockKey, hash, err, hasAsset)
+		ds, tookOver := c.pollForDownloadOrTakeOver(coordCtx, ctx, lockKey, hash, allowStaging, err, hasAsset)
 		if !tookOver {
 			return ds
 		}
@@ -6352,10 +6382,24 @@ func (c *Cache) pollForDownloadOrTakeOver(
 	ctx context.Context,
 	lockKey string,
 	hash string,
+	allowStaging bool,
 	initialErr error,
 	hasAsset func(context.Context) bool,
 ) (*downloadState, bool) {
 	const pollInterval = 200 * time.Millisecond
+
+	// Signal the holder that a cross-pod waiter wants the NAR staged so it can be
+	// served during the active-download window (closes #660 / #1289). Idempotent
+	// and free of churn: it is a one-shot marker the holder reads on its own loop.
+	stagingActive := allowStaging && c.InflightStagingEnabled()
+	if stagingActive {
+		if err := c.markStagingRequested(coordCtx, hash); err != nil {
+			zerolog.Ctx(ctx).Warn().Err(err).Str("hash", hash).
+				Msg("failed to record in-flight staging request; falling back to wait-for-asset")
+
+			stagingActive = false
+		}
+	}
 
 	giveUpBound := c.downloadLockTTL
 	if c.downloadPollTimeout > giveUpBound {
@@ -6387,6 +6431,30 @@ func (c *Cache) pollForDownloadOrTakeOver(
 				ds.doneOnce.Do(func() { close(ds.done) })
 
 				return ds, false
+			}
+
+			// Before re-attempting the lock, see whether the holder has begun
+			// staging the in-flight NAR. If parts are available we serve them
+			// directly (tailing as they land) rather than waiting for the whole
+			// download to finish — the cross-pod fast path for #660 / #1289.
+			if stagingActive {
+				if info := c.stagingServeReady(coordCtx, hash); info != nil {
+					zerolog.Ctx(ctx).Debug().
+						Str("hash", hash).
+						Msg("in-flight staging parts available, serving from staging while peer downloads")
+
+					downloadCoordinationFallbackTotal.Add(ctx, 1,
+						metric.WithAttributes(attribute.String("outcome", "served_from_staging")))
+
+					ds := newDownloadState()
+					ds.closed = true
+					ds.stagingServe = info
+					ds.startOnce.Do(func() { close(ds.start) })
+					ds.storedOnce.Do(func() { close(ds.stored) })
+					ds.doneOnce.Do(func() { close(ds.done) })
+
+					return ds, false
+				}
 			}
 
 			// Re-attempt acquisition without blocking, bounded by the give-up

--- a/pkg/cache/inflight_staging_reader.go
+++ b/pkg/cache/inflight_staging_reader.go
@@ -92,6 +92,11 @@ func (c *Cache) newStagingPartReader(ctx context.Context, hash string) *stagingP
 // Read implements io.Reader, draining each part-object in order and advancing to
 // the next once the current one is exhausted.
 func (r *stagingPartReader) Read(p []byte) (int, error) {
+	// Fail fast if the caller's context is already done, before any part I/O.
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+
 	for {
 		if r.cur == nil {
 			rc, err := r.openPart(r.index)
@@ -161,6 +166,10 @@ func (r *stagingPartReader) openPart(index int64) (io.ReadCloser, error) {
 	for {
 		st, err := r.c.getStagingState(r.ctx, r.hash)
 		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return nil, err
+			}
+
 			return nil, fmt.Errorf("staging reader: read staging_state for %q: %w", r.hash, err)
 		}
 
@@ -178,6 +187,10 @@ func (r *stagingPartReader) openPart(index int64) (io.ReadCloser, error) {
 			// A marker can momentarily lead the object's visibility; treat
 			// not-found as transient and keep polling within the bound.
 			if !errors.Is(err, storage.ErrNotFound) {
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return nil, err
+				}
+
 				return nil, fmt.Errorf("staging reader: get part %d for %q: %w", index, r.hash, err)
 			}
 		case st.Status == stagingStatusComplete:

--- a/pkg/cache/inflight_staging_reader.go
+++ b/pkg/cache/inflight_staging_reader.go
@@ -1,0 +1,254 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
+)
+
+// stagingReadPollInterval is how often a cross-pod reader re-reads staging_state
+// while waiting for the next part-object to become available. It mirrors the
+// progressive-chunk poll cadence.
+const stagingReadPollInterval = 200 * time.Millisecond
+
+var (
+	// errStagingStall is returned when the producer stops advancing parts_available
+	// and never publishes the complete marker within the per-part wait bound. It is
+	// surfaced as a stream error so a truncated NAR is never delivered as a clean
+	// EOF (the nar-concurrent-streaming correctness contract).
+	errStagingStall = errors.New("staging reader: producer stalled before completion")
+
+	// errStagingReset is returned when the staging_state row disappears mid-read
+	// (a takeover reset it), so the reader fails rather than truncating.
+	errStagingReset = errors.New("staging reader: staging_state was reset mid-stream")
+)
+
+// stagingServeInfo carries what a lock-losing waiter needs to serve a NAR from
+// in-flight staging: the hash and the compression the parts hold.
+type stagingServeInfo struct {
+	hash        string
+	compression nar.CompressionType
+}
+
+// stagingServeReady reports whether in-flight staging parts are available to serve
+// for hash. It returns a non-nil directive once at least one part is readable and
+// staging has not been abandoned; otherwise nil. A read error is treated as "not
+// ready" so a transient DB hiccup never diverts the waiter into a broken serve.
+func (c *Cache) stagingServeReady(ctx context.Context, hash string) *stagingServeInfo {
+	st, err := c.getStagingState(ctx, hash)
+	if err != nil || st == nil || st.PartsAvailable <= 0 {
+		return nil
+	}
+
+	return &stagingServeInfo{
+		hash:        hash,
+		compression: nar.CompressionTypeFromString(st.Compression),
+	}
+}
+
+// stagingPartReader reassembles a NAR from ordered staging part-objects, tailing
+// them as the producer commits them. It is the cross-pod analogue of
+// fileAvailableReader: it blocks until the next part is durably available
+// (advertised via staging_state.parts_available), emits a clean io.EOF only once
+// the terminal complete marker is set and every part has been consumed, and
+// surfaces a stream error if the producer stalls or the staging state is reset.
+type stagingPartReader struct {
+	ctx  context.Context //nolint:containedctx // mirrors fileAvailableReader, a streaming reader
+	c    *Cache
+	hash string
+
+	index int64         // next part index to open
+	cur   io.ReadCloser // current part being drained, or nil
+
+	pollEvery time.Duration // how often to re-check staging_state
+	maxWait   time.Duration // per-part bound before declaring a stall
+}
+
+// newStagingPartReader builds a part-tailing reader for hash. The per-part stall
+// bound reuses the progressive-chunk wait timeout for parity.
+func (c *Cache) newStagingPartReader(ctx context.Context, hash string) *stagingPartReader {
+	c.cdcMu.RLock()
+	maxWait := c.chunkWaitTimeout
+	c.cdcMu.RUnlock()
+
+	if maxWait <= 0 {
+		maxWait = defaultChunkWaitTimeout
+	}
+
+	return &stagingPartReader{
+		ctx:       ctx,
+		c:         c,
+		hash:      hash,
+		pollEvery: stagingReadPollInterval,
+		maxWait:   maxWait,
+	}
+}
+
+// Read implements io.Reader, draining each part-object in order and advancing to
+// the next once the current one is exhausted.
+func (r *stagingPartReader) Read(p []byte) (int, error) {
+	for {
+		if r.cur == nil {
+			rc, err := r.openPart(r.index)
+			if err != nil {
+				return 0, err
+			}
+
+			r.cur = rc
+		}
+
+		n, err := r.cur.Read(p)
+		if n > 0 {
+			if errors.Is(err, io.EOF) {
+				// Defer the EOF to the next call so trailing bytes are not dropped.
+				r.advance()
+			}
+
+			return n, nil
+		}
+
+		if errors.Is(err, io.EOF) {
+			r.advance()
+
+			continue
+		}
+
+		if err != nil {
+			return 0, err
+		}
+	}
+}
+
+// advance closes the current part and moves to the next index.
+func (r *stagingPartReader) advance() {
+	if r.cur != nil {
+		_ = r.cur.Close()
+		r.cur = nil
+	}
+
+	r.index++
+}
+
+// Close releases the in-flight part-object, if any.
+func (r *stagingPartReader) Close() error {
+	if r.cur != nil {
+		err := r.cur.Close()
+		r.cur = nil
+
+		return err
+	}
+
+	return nil
+}
+
+// openPart blocks until part index is durably available and returns it, or
+// returns io.EOF when staging is complete and every part has been consumed, or a
+// stream error on stall / reset / context cancellation.
+func (r *stagingPartReader) openPart(index int64) (io.ReadCloser, error) {
+	ticker := time.NewTicker(r.pollEvery)
+	defer ticker.Stop()
+
+	// Per-part bound: reset implicitly per call, so a steadily-advancing producer
+	// is never penalised while a stalled one is caught.
+	timeout := time.NewTimer(r.maxWait)
+	defer timeout.Stop()
+
+	for {
+		st, err := r.c.getStagingState(r.ctx, r.hash)
+		if err != nil {
+			return nil, fmt.Errorf("staging reader: read staging_state for %q: %w", r.hash, err)
+		}
+
+		if st == nil {
+			return nil, fmt.Errorf("%w: %q", errStagingReset, r.hash)
+		}
+
+		switch {
+		case index < st.PartsAvailable:
+			rc, err := r.c.narStore.GetStagingPart(r.ctx, r.hash, index)
+			if err == nil {
+				return rc, nil
+			}
+
+			// A marker can momentarily lead the object's visibility; treat
+			// not-found as transient and keep polling within the bound.
+			if !errors.Is(err, storage.ErrNotFound) {
+				return nil, fmt.Errorf("staging reader: get part %d for %q: %w", index, r.hash, err)
+			}
+		case st.Status == stagingStatusComplete:
+			// All parts are written and we have consumed them: clean EOF.
+			return nil, io.EOF
+		}
+
+		select {
+		case <-r.ctx.Done():
+			return nil, r.ctx.Err()
+		case <-timeout.C:
+			return nil, fmt.Errorf("%w: part %d of %q after %s", errStagingStall, index, r.hash, r.maxWait)
+		case <-ticker.C:
+		}
+	}
+}
+
+// stagingMultiReadCloser adapts a transcoding reader (e.g. a decompressor) while
+// still closing the underlying part-tailing reader.
+type stagingMultiReadCloser struct {
+	io.Reader
+
+	closers []io.Closer
+}
+
+func (m *stagingMultiReadCloser) Close() error {
+	var firstErr error
+
+	for _, c := range m.closers {
+		if err := c.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return firstErr
+}
+
+// serveNarFromStaging builds a streaming reader that serves the NAR for hash from
+// its in-flight staging part-objects. When the staged bytes are compressed but the
+// client wants them uncompressed it transcodes on the fly, at parity with the
+// same-pod streaming path, and rewrites narURL.Compression to the compression
+// actually served. It returns size -1 because the length is not known up front.
+func (c *Cache) serveNarFromStaging(
+	ctx context.Context,
+	narURL *nar.URL,
+	hash string,
+	staged nar.CompressionType,
+) (int64, io.ReadCloser, error) {
+	reader := c.newStagingPartReader(ctx, hash)
+
+	if !isNoneCompression(staged) && isNoneCompression(narURL.Compression) {
+		dr, err := nar.DecompressReader(ctx, reader, staged)
+		if err != nil {
+			_ = reader.Close()
+
+			return 0, nil, fmt.Errorf("staging serve: decompress %s for %q: %w", staged, hash, err)
+		}
+
+		narURL.Compression = nar.CompressionTypeNone
+
+		return -1, &stagingMultiReadCloser{Reader: dr, closers: []io.Closer{dr, reader}}, nil
+	}
+
+	// Serve the staged bytes as-is and advertise their compression.
+	narURL.Compression = staged
+
+	return -1, reader, nil
+}
+
+// isNoneCompression reports whether ct represents uncompressed bytes. Both the
+// explicit "none" type and the empty string (the staging_state default) count.
+func isNoneCompression(ct nar.CompressionType) bool {
+	return ct == nar.CompressionTypeNone || ct == nar.CompressionType("")
+}

--- a/pkg/cache/inflight_staging_reader_internal_test.go
+++ b/pkg/cache/inflight_staging_reader_internal_test.go
@@ -1,0 +1,152 @@
+package cache
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage/local"
+)
+
+// putStagingParts splits content into partSize-byte part-objects and writes them
+// for hash, returning the number of parts written.
+func putStagingParts(t *testing.T, store *local.Store, hash, content string, partSize int) int64 {
+	t.Helper()
+
+	ctx := context.Background()
+
+	var index int64
+
+	for off := 0; off < len(content); off += partSize {
+		end := off + partSize
+		if end > len(content) {
+			end = len(content)
+		}
+
+		_, err := store.PutStagingPart(ctx, hash, index, bytes.NewReader([]byte(content[off:end])), int64(end-off))
+		require.NoError(t, err)
+
+		index++
+	}
+
+	return index
+}
+
+// TestStagingPartReader_ReadsCompleteParts verifies that a reader tailing fully
+// staged part-objects reassembles the complete, byte-correct NAR and then emits a
+// clean EOF once the terminal complete marker is set.
+func TestStagingPartReader_ReadsCompleteParts(t *testing.T) {
+	t.Parallel()
+
+	c, _, store, _, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+
+	ctx := context.Background()
+
+	const (
+		hash    = "abcabcabcabcabcabcabcabcabcabc12"
+		content = "abcdefghijklmno" // 15 bytes -> 4 parts (4,4,4,3)
+	)
+
+	nParts := putStagingParts(t, store, hash, content, 4)
+
+	require.NoError(t, c.markStagingRequested(ctx, hash))
+	require.NoError(t, c.advanceStagingParts(ctx, hash, nParts, ""))
+	require.NoError(t, c.markStagingComplete(ctx, hash))
+
+	r := c.newStagingPartReader(ctx, hash)
+	defer r.Close()
+
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	assert.Equal(t, content, string(got))
+}
+
+// TestStagingPartReader_StallSurfacesError verifies that when the producer stalls
+// — parts_available stops advancing and the complete marker never arrives — the
+// reader surfaces a stream error after the per-part wait bound rather than a clean
+// EOF at a truncated length (#660 / #1289 correctness contract).
+func TestStagingPartReader_StallSurfacesError(t *testing.T) {
+	t.Parallel()
+
+	c, _, store, _, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+
+	ctx := context.Background()
+
+	const (
+		hash    = "deaddeaddeaddeaddeaddeaddeaddead"
+		content = "abcdefgh" // 2 parts of 4, but the producer "stalls" after 1
+	)
+
+	putStagingParts(t, store, hash, content, 4)
+
+	require.NoError(t, c.markStagingRequested(ctx, hash))
+	// Only the first part is advertised; status stays "staging" (never complete).
+	require.NoError(t, c.advanceStagingParts(ctx, hash, 1, ""))
+
+	r := c.newStagingPartReader(ctx, hash)
+	defer r.Close()
+
+	// Short stall bound so the test does not wait the production default.
+	r.maxWait = 200 * time.Millisecond
+	r.pollEvery = 20 * time.Millisecond
+
+	got, err := io.ReadAll(r)
+	require.Error(t, err, "a stalled producer must surface a stream error")
+	require.NotErrorIs(t, err, io.EOF)
+	assert.Equal(t, content[:4], string(got), "bytes read before the stall are still delivered")
+}
+
+// TestServeNarFromStaging_Transcodes verifies that when the staged compression
+// differs from the requested compression, the serve path transcodes on the fly
+// (parity with the same-pod path) and advertises the compression actually served.
+func TestServeNarFromStaging_Transcodes(t *testing.T) {
+	t.Parallel()
+
+	c, _, store, _, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	c.SetInflightStaging(true, 5*time.Minute, 1<<20, true)
+
+	ctx := context.Background()
+
+	const (
+		hash      = "feedfeedfeedfeedfeedfeedfeedfeed"
+		plaintext = "the quick brown fox jumps over the lazy dog"
+	)
+
+	// Stage the NAR in zstd; a reader requesting uncompressed must get plaintext.
+	staged := CompressZstd(t, plaintext)
+	nParts := putStagingParts(t, store, hash, staged, 1<<20)
+
+	require.NoError(t, c.markStagingRequested(ctx, hash))
+	require.NoError(t, c.advanceStagingParts(ctx, hash, nParts, nar.CompressionTypeZstd.String()))
+	require.NoError(t, c.markStagingComplete(ctx, hash))
+
+	narURL := nar.URL{Hash: hash, Compression: nar.CompressionTypeNone}
+
+	size, reader, err := c.serveNarFromStaging(ctx, &narURL, hash, nar.CompressionTypeZstd)
+	require.NoError(t, err)
+
+	defer reader.Close()
+
+	assert.Equal(t, int64(-1), size, "in-flight staging serves a streaming response of unknown length")
+	assert.Equal(t, nar.CompressionTypeNone, narURL.Compression,
+		"the served URL must advertise the compression actually served (decompressed)")
+
+	got, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, string(got))
+}


### PR DESCRIPTION
Reader side of in-flight NAR staging (#660 / #1289, group 6). A lock-losing
waiter now records a staging request on the contended hash and, on each poll
tick in pollForDownloadOrTakeOver, checks whether the holder has begun
staging. Once parts_available > 0 it returns a serve-from-staging directive
instead of waiting for the whole download; GetNar then streams the NAR by
tailing the part-objects.

The new stagingPartReader is the cross-pod analogue of fileAvailableReader:
it drains part-objects in order, blocks until the next part is durably
advertised via staging_state.parts_available, emits a clean io.EOF only once
the terminal complete marker is set and every part is consumed, and surfaces a
stream error (never a truncated clean EOF) if the producer stalls past the
per-part wait bound or the staging state is reset mid-stream. serveNarFromStaging
transcodes on the fly when the staged compression differs from the requested
one — at parity with the same-pod path — and advertises the served compression.

Staging is gated to NAR downloads only (narinfo passes allowStaging=false) and
to the distributed-locker feature guard, so single-instance and uncontended
downloads are unaffected. Cross-pod HTTP serve is exercised end-to-end in the
group-13 Redis+S3 integration test; the reader contracts are unit-tested here.