### PR TITLE
feat(cache): prefer staging over progressive chunks

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -8117,6 +8117,21 @@ func (c *Cache) getNarFromChunks(ctx context.Context, narURL *nar.URL) (int64, i
 		return 0, nil, err
 	}
 
+	// During the chunking window (total_chunks == 0), prefer in-flight staging over
+	// progressive chunk streaming: the staged whole-NAR parts are a complete,
+	// ordered representation, so serving from them avoids the fragile
+	// streamProgressiveChunks reassembly that can truncate (#1289). Steady-state
+	// chunk serving (total_chunks > 0) is unaffected — it never reaches this branch.
+	if totalChunks == 0 && c.InflightStagingEnabled() {
+		if info := c.stagingServeReady(ctx, narURL.Hash); info != nil {
+			zerolog.Ctx(ctx).Debug().
+				Str("hash", narURL.Hash).
+				Msg("serving NAR from in-flight staging in preference to progressive chunks")
+
+			return c.serveNarFromStaging(ctx, narURL, info.hash, info.compression)
+		}
+	}
+
 	// Always clear TransparentZstd here so the goroutine uses GetChunk (decompressed
 	// bytes) and the HTTP layer re-encodes everything into a single zstd stream when
 	// the client accepts it.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -8128,6 +8128,11 @@ func (c *Cache) getNarFromChunks(ctx context.Context, narURL *nar.URL) (int64, i
 				Str("hash", narURL.Hash).
 				Msg("serving NAR from in-flight staging in preference to progressive chunks")
 
+			// serveNarFromStaging sets narURL.Compression to what it actually
+			// serves; clear TransparentZstd so the HTTP layer never expects a zstd
+			// stream when the staged bytes are decompressed (or non-zstd).
+			narURL.TransparentZstd = false
+
 			return c.serveNarFromStaging(ctx, narURL, info.hash, info.compression)
 		}
 	}

--- a/pkg/cache/inflight_staging_precedence_internal_test.go
+++ b/pkg/cache/inflight_staging_precedence_internal_test.go
@@ -1,0 +1,136 @@
+package cache
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/testdata"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// TestGetNarFromChunks_PrefersStagingDuringChunkingWindow verifies that during the
+// eager-CDC chunking window (total_chunks == 0), when in-flight staging parts are
+// available, the read path serves the complete NAR from staging instead of the
+// fragile progressive-chunk path (#1289).
+func TestGetNarFromChunks_PrefersStagingDuringChunkingWindow(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := newCDCCacheForStreaming(t)
+
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+	// A short progressive wait so that, if staging were wrongly skipped, the test
+	// would surface a fast timeout instead of the staged bytes.
+	c.SetChunkWaitTimeout(200 * time.Millisecond)
+
+	const content = "the complete staged nar bytes!!" // 31 bytes
+
+	hash := testdata.Nar1.NarHash
+
+	// A nar_file that is legitimately mid-chunking: total_chunks == 0 and no chunk
+	// will ever arrive on the progressive path.
+	_, err := c.dbClient.Ent().NarFile.Create().
+		SetHash(hash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(uint64(len(content))).
+		SetTotalChunks(0).
+		SetChunkingStartedAt(time.Now()).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Stage the whole NAR as part-objects (uncompressed, matching the request).
+	nParts := putStagingParts(t, c.narStore, hash, content, 4)
+	require.NoError(t, c.markStagingRequested(ctx, hash))
+	require.NoError(t, c.advanceStagingParts(ctx, hash, nParts, nar.CompressionTypeNone.String()))
+	require.NoError(t, c.markStagingComplete(ctx, hash))
+
+	narURL := nar.URL{Hash: hash, Compression: nar.CompressionTypeNone}
+
+	_, rc, err := c.getNarFromChunks(ctx, &narURL)
+	require.NoError(t, err)
+
+	defer rc.Close()
+
+	body, readErr := readAllWithin(t, rc, 5*time.Second)
+	require.NoError(t, readErr, "staging serve must complete, not stall on progressive chunks")
+	assert.Equal(t, content, string(body))
+}
+
+// TestGetNarFromChunks_NoStagingFallsBackToProgressive verifies that with
+// total_chunks == 0 and no staging parts available, the read path falls back to
+// the progressive-chunk path as before (it does not divert into a broken staging
+// serve).
+func TestGetNarFromChunks_NoStagingFallsBackToProgressive(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := newCDCCacheForStreaming(t)
+
+	// Feature enabled, but no staging_state row will exist for the hash.
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+	c.SetChunkWaitTimeout(200 * time.Millisecond)
+
+	hash := testdata.Nar1.NarHash
+
+	_, err := c.dbClient.Ent().NarFile.Create().
+		SetHash(hash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(12345).
+		SetTotalChunks(0).
+		SetChunkingStartedAt(time.Now()).
+		Save(ctx)
+	require.NoError(t, err)
+
+	narURL := nar.URL{Hash: hash, Compression: nar.CompressionTypeNone}
+
+	_, rc, err := c.getNarFromChunks(ctx, &narURL)
+	require.NoError(t, err)
+
+	defer rc.Close()
+
+	// The progressive path is taken: with no chunk ever arriving it times out
+	// (proving the request was not served from a non-existent staging set).
+	_, readErr := readAllWithin(t, rc, 5*time.Second)
+	require.Error(t, readErr, "with no staging the progressive path must be used and time out")
+	assert.NotErrorIs(t, readErr, io.EOF)
+}
+
+// TestGetNarFromChunks_SteadyStateIgnoresStaging verifies that once chunking is
+// complete (total_chunks > 0), serving proceeds from chunks regardless of any
+// staging parts that may still linger for the hash.
+func TestGetNarFromChunks_SteadyStateIgnoresStaging(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := newCDCCacheForStreaming(t)
+
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+
+	const chunkContent = "the real chunked content served from chunks"
+
+	hash := testhelper.MustRandBase32NarHash()
+
+	// Store a fully-chunked NAR (total_chunks > 0).
+	narURL := nar.URL{Hash: hash, Compression: nar.CompressionTypeNone}
+	require.NoError(t, c.PutNar(ctx, narURL, io.NopCloser(strings.NewReader(chunkContent))))
+
+	// Lingering staging parts with DIFFERENT bytes must be ignored in steady state.
+	nParts := putStagingParts(t, c.narStore, hash, "STALE STAGING BYTES THAT MUST NOT BE SERVED", 4)
+	require.NoError(t, c.markStagingRequested(ctx, hash))
+	require.NoError(t, c.advanceStagingParts(ctx, hash, nParts, nar.CompressionTypeNone.String()))
+	require.NoError(t, c.markStagingComplete(ctx, hash))
+
+	_, rc, err := c.getNarFromChunks(ctx, &narURL)
+	require.NoError(t, err)
+
+	defer rc.Close()
+
+	body, readErr := readAllWithin(t, rc, 5*time.Second)
+	require.NoError(t, readErr)
+	assert.Equal(t, chunkContent, string(body), "steady-state serving must come from chunks, not staging")
+}

--- a/pkg/cache/inflight_staging_reader_internal_test.go
+++ b/pkg/cache/inflight_staging_reader_internal_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/kalbasit/ncps/pkg/nar"
-	"github.com/kalbasit/ncps/pkg/storage/local"
+	"github.com/kalbasit/ncps/pkg/storage"
 )
 
 // putStagingParts splits content into partSize-byte part-objects and writes them
 // for hash, returning the number of parts written.
-func putStagingParts(t *testing.T, store *local.Store, hash, content string, partSize int) int64 {
+func putStagingParts(t *testing.T, store storage.NarStore, hash, content string, partSize int) int64 {
 	t.Helper()
 
 	ctx := context.Background()


### PR DESCRIPTION
Read-path precedence for in-flight staging during the eager-CDC chunking
window (#1289, group 7). getNarFromChunks now, when total_chunks == 0 and
staging is enabled, checks for available staging parts and serves the
complete whole-NAR representation from them instead of entering
streamProgressiveChunks. The staged parts are an ordered, complete copy, so
this avoids the fragile progressive reassembly that can truncate.

The precedence is strictly scoped to the chunking window: total_chunks > 0
never reaches the branch, so steady-state chunk serving is unchanged, and
when no staging parts are present the progressive path remains the fallback.
The shared putStagingParts test helper now takes the NarStore interface so the
precedence tests can stage via c.narStore.