### PR TITLE
feat(cache): reclaim in-flight staging artifacts

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -519,6 +519,12 @@ type Cache struct {
 
 	// Wait group to track background operations
 	backgroundWG sync.WaitGroup
+
+	// shutdownCh is closed by Close() to interrupt background sleeps (e.g. the
+	// in-flight staging retention grace) so shutdown is not blocked for the full
+	// grace duration. Work skipped on shutdown is reclaimed by the periodic sweep.
+	shutdownCh   chan struct{}
+	shutdownOnce sync.Once
 }
 
 type downloadState struct {
@@ -723,6 +729,7 @@ func New(
 		upstreamJobs:         make(map[string]*downloadState),
 		upstreamCaches:       make([]*upstream.Cache, 0),
 		recordAgeIgnoreTouch: recordAgeIgnoreTouch,
+		shutdownCh:           make(chan struct{}),
 	}
 
 	if err := c.validateHostname(hostName); err != nil {
@@ -1133,6 +1140,14 @@ func (c *Cache) StartCron(ctx context.Context) {
 
 // Close waits for all background operations to complete.
 func (c *Cache) Close() {
+	// Signal background sleeps (e.g. the in-flight staging retention grace) to wake
+	// and exit so shutdown is not blocked for the full grace duration.
+	c.shutdownOnce.Do(func() {
+		if c.shutdownCh != nil {
+			close(c.shutdownCh)
+		}
+	})
+
 	// Stop the cron first and wait for any in-flight scheduled job (e.g. CDC lazy
 	// recovery) to return: cron.Stop() prevents new scheduling and returns a context
 	// that completes once running jobs finish. This guarantees no scheduled job can

--- a/pkg/cache/inflight_staging.go
+++ b/pkg/cache/inflight_staging.go
@@ -134,7 +134,13 @@ func (c *Cache) stageInflightNar(ctx context.Context, hash string, ds *downloadS
 			Err(err).
 			Str("hash", hash).
 			Msg("in-flight staging producer stopped with error; staging parts left for GC/takeover")
+
+		return
 	}
+
+	// Staging is complete and the final representation is committed: reclaim the
+	// staging artifacts after the retention grace, letting cross-pod readers drain.
+	c.scheduleStagingReclaim(hash)
 }
 
 // waitForStagingRequest polls staging_state on a coarse ticker until a cross-pod

--- a/pkg/cache/inflight_staging.go
+++ b/pkg/cache/inflight_staging.go
@@ -312,3 +312,18 @@ func (c *Cache) resetStagingState(ctx context.Context, hash string) error {
 
 	return nil
 }
+
+// deleteStagingState removes the staging_state row for hash entirely. It is the
+// terminal counterpart to resetStagingState, used by reclaimStaging once the
+// staging lifecycle is over (completed-and-reclaimed, or orphan-swept). Deleting
+// an absent row is a no-op.
+func (c *Cache) deleteStagingState(ctx context.Context, hash string) error {
+	_, err := c.dbClient.Ent().StagingState.Delete().
+		Where(stagingstate.HashEQ(hash)).
+		Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("delete staging state for %q: %w", hash, err)
+	}
+
+	return nil
+}

--- a/pkg/cache/inflight_staging_gc.go
+++ b/pkg/cache/inflight_staging_gc.go
@@ -1,0 +1,156 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/rs/zerolog"
+
+	"github.com/kalbasit/ncps/pkg/analytics"
+)
+
+// reclaimStaging deletes the staging part-objects and the staging_state record
+// for hash. It is idempotent: deleting absent parts / records is a no-op.
+func (c *Cache) reclaimStaging(ctx context.Context, hash string) error {
+	if err := c.narStore.DeleteStagingParts(ctx, hash); err != nil {
+		return fmt.Errorf("reclaim staging parts for %q: %w", hash, err)
+	}
+
+	if err := c.resetStagingState(ctx, hash); err != nil {
+		return fmt.Errorf("reclaim staging state for %q: %w", hash, err)
+	}
+
+	return nil
+}
+
+// scheduleStagingReclaim reclaims the staging artifacts for hash after the
+// retention grace elapses, giving any in-flight cross-pod readers time to drain.
+// It is the event-driven path, launched once the holder finishes staging (the
+// final representation is now committed). The grace wait is interrupted by Close()
+// so shutdown is not delayed; anything skipped on shutdown is caught by the sweep.
+func (c *Cache) scheduleStagingReclaim(hash string) {
+	grace := c.InflightStagingRetention()
+
+	c.backgroundWG.Add(1)
+
+	analytics.SafeGo(context.Background(), func() {
+		defer c.backgroundWG.Done()
+
+		if grace > 0 {
+			timer := time.NewTimer(grace)
+			defer timer.Stop()
+
+			select {
+			case <-timer.C:
+			case <-c.shutdownCh:
+				return
+			}
+		}
+
+		if err := c.reclaimStaging(context.Background(), hash); err != nil {
+			zerolog.Ctx(context.Background()).Warn().
+				Err(err).
+				Str("hash", hash).
+				Msg("failed to reclaim in-flight staging artifacts after grace")
+		}
+	})
+}
+
+// sweepStagingGC reclaims staging records that the event-driven path missed:
+//   - completed staging whose retention grace has elapsed (a defensive backstop
+//     for the event-driven reclaim), and
+//   - orphaned staging whose holder died and was never taken over, detected by
+//     updated_at staleness exceeding orphanAge (a live holder advances
+//     parts_available — and thus updated_at — as it stages, so staleness, not
+//     age, is the liveness signal; see the #1230 lesson on age-as-death proxies).
+//
+// It returns the number of records reclaimed.
+func (c *Cache) sweepStagingGC(ctx context.Context, retention, orphanAge time.Duration) (int, error) {
+	rows, err := c.dbClient.Ent().StagingState.Query().All(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("staging GC: list staging_state: %w", err)
+	}
+
+	now := time.Now()
+	reclaimed := 0
+
+	for _, st := range rows {
+		// updated_at advances as a live holder stages; fall back to created_at when
+		// the row has never been updated (a bare request marker).
+		ref := st.CreatedAt
+		if st.UpdatedAt != nil {
+			ref = *st.UpdatedAt
+		}
+
+		stale := now.Sub(ref)
+
+		var due bool
+		if st.Status == stagingStatusComplete {
+			due = stale > retention
+		} else {
+			due = stale > orphanAge
+		}
+
+		if !due {
+			continue
+		}
+
+		if err := c.reclaimStaging(ctx, st.Hash); err != nil {
+			zerolog.Ctx(ctx).Warn().
+				Err(err).
+				Str("hash", st.Hash).
+				Msg("staging GC: failed to reclaim a staging record")
+
+			continue
+		}
+
+		reclaimed++
+	}
+
+	return reclaimed, nil
+}
+
+// stagingOrphanAge is the updated_at staleness beyond which a non-complete staging
+// record is presumed orphaned (its holder died). It is generous: it exceeds the
+// whole window during which a live holder could still be refreshing its download
+// lock and advancing parts, plus the retention grace.
+func (c *Cache) stagingOrphanAge() time.Duration {
+	bound := c.downloadLockTTL
+	if c.downloadPollTimeout > bound {
+		bound = c.downloadPollTimeout
+	}
+
+	return bound + c.InflightStagingRetention()
+}
+
+// AddInflightStagingGCCronJob registers the periodic staging GC sweep.
+func (c *Cache) AddInflightStagingGCCronJob(ctx context.Context, schedule cron.Schedule) {
+	zerolog.Ctx(ctx).
+		Info().
+		Time("next-run", schedule.Next(time.Now())).
+		Msg("adding a cronjob for in-flight staging GC")
+
+	c.cron.Schedule(schedule, cron.FuncJob(c.runStagingGC(ctx)))
+}
+
+// runStagingGC returns the cron job body for the periodic staging sweep.
+func (c *Cache) runStagingGC(ctx context.Context) func() {
+	return func() {
+		if !c.InflightStagingEnabled() {
+			return
+		}
+
+		n, err := c.sweepStagingGC(ctx, c.InflightStagingRetention(), c.stagingOrphanAge())
+		if err != nil {
+			zerolog.Ctx(ctx).Warn().Err(err).Msg("in-flight staging GC sweep failed")
+
+			return
+		}
+
+		if n > 0 {
+			zerolog.Ctx(ctx).Info().Int("reclaimed", n).Msg("in-flight staging GC sweep reclaimed records")
+		}
+	}
+}

--- a/pkg/cache/inflight_staging_gc.go
+++ b/pkg/cache/inflight_staging_gc.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -11,14 +12,42 @@ import (
 	"github.com/kalbasit/ncps/pkg/analytics"
 )
 
-// reclaimStaging deletes the staging part-objects and the staging_state record
-// for hash. It is idempotent: deleting absent parts / records is a no-op.
+// shutdownContext returns a context that is cancelled when the cache's Close()
+// runs (shutdownCh closed), so background DB/storage cleanup cannot outlive
+// shutdown and block Close() indefinitely. The caller MUST invoke the returned
+// cancel to release the watcher goroutine. When shutdownCh is nil (a Cache built
+// without New()), it degrades to a plain cancellable context.
+func (c *Cache) shutdownContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if c.shutdownCh == nil {
+		return ctx, cancel
+	}
+
+	go func() {
+		select {
+		case <-c.shutdownCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	return ctx, cancel
+}
+
+// reclaimStaging is terminal cleanup: it deletes the staging part-objects AND the
+// staging_state record for hash. It is used by the GC sweep and the
+// post-completion reclaim, where the staging lifecycle is over, so the row must be
+// removed (resetting it to "requested" instead would make the sweep resurrect it
+// forever). The takeover path uses resetStagingState instead, which preserves the
+// row so a persisting cross-pod waiter is re-served. It is idempotent: deleting
+// absent parts / records is a no-op.
 func (c *Cache) reclaimStaging(ctx context.Context, hash string) error {
 	if err := c.narStore.DeleteStagingParts(ctx, hash); err != nil {
 		return fmt.Errorf("reclaim staging parts for %q: %w", hash, err)
 	}
 
-	if err := c.resetStagingState(ctx, hash); err != nil {
+	if err := c.deleteStagingState(ctx, hash); err != nil {
 		return fmt.Errorf("reclaim staging state for %q: %w", hash, err)
 	}
 
@@ -38,18 +67,28 @@ func (c *Cache) scheduleStagingReclaim(hash string) {
 	analytics.SafeGo(context.Background(), func() {
 		defer c.backgroundWG.Done()
 
+		// A shutdown-bound context interrupts both the grace wait and the reclaim
+		// itself, so a stalled DeleteStagingParts/resetStagingState cannot keep
+		// Close() blocked on backgroundWG.
+		ctx, cancel := c.shutdownContext()
+		defer cancel()
+
 		if grace > 0 {
 			timer := time.NewTimer(grace)
 			defer timer.Stop()
 
 			select {
 			case <-timer.C:
-			case <-c.shutdownCh:
+			case <-ctx.Done():
 				return
 			}
 		}
 
-		if err := c.reclaimStaging(context.Background(), hash); err != nil {
+		if err := c.reclaimStaging(ctx, hash); err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+
 			zerolog.Ctx(context.Background()).Warn().
 				Err(err).
 				Str("hash", hash).
@@ -125,32 +164,45 @@ func (c *Cache) stagingOrphanAge() time.Duration {
 	return bound + c.InflightStagingRetention()
 }
 
-// AddInflightStagingGCCronJob registers the periodic staging GC sweep.
+// AddInflightStagingGCCronJob registers the periodic staging GC sweep. It binds
+// only the logger from ctx, not ctx itself: each sweep derives a fresh
+// shutdown-bound context, so a request/startup-scoped registration ctx being
+// cancelled can never silently disable later sweeps.
 func (c *Cache) AddInflightStagingGCCronJob(ctx context.Context, schedule cron.Schedule) {
-	zerolog.Ctx(ctx).
-		Info().
+	log := zerolog.Ctx(ctx)
+
+	log.Info().
 		Time("next-run", schedule.Next(time.Now())).
 		Msg("adding a cronjob for in-flight staging GC")
 
-	c.cron.Schedule(schedule, cron.FuncJob(c.runStagingGC(ctx)))
+	c.cron.Schedule(schedule, cron.FuncJob(c.runStagingGC(log)))
 }
 
-// runStagingGC returns the cron job body for the periodic staging sweep.
-func (c *Cache) runStagingGC(ctx context.Context) func() {
+// runStagingGC returns the cron job body for the periodic staging sweep. It
+// creates a fresh shutdown-bound context per run rather than closing over a
+// caller context that may later be cancelled.
+func (c *Cache) runStagingGC(log *zerolog.Logger) func() {
 	return func() {
 		if !c.InflightStagingEnabled() {
 			return
 		}
 
+		ctx, cancel := c.shutdownContext()
+		defer cancel()
+
 		n, err := c.sweepStagingGC(ctx, c.InflightStagingRetention(), c.stagingOrphanAge())
 		if err != nil {
-			zerolog.Ctx(ctx).Warn().Err(err).Msg("in-flight staging GC sweep failed")
+			if errors.Is(err, context.Canceled) {
+				return
+			}
+
+			log.Warn().Err(err).Msg("in-flight staging GC sweep failed")
 
 			return
 		}
 
 		if n > 0 {
-			zerolog.Ctx(ctx).Info().Int("reclaimed", n).Msg("in-flight staging GC sweep reclaimed records")
+			log.Info().Int("reclaimed", n).Msg("in-flight staging GC sweep reclaimed records")
 		}
 	}
 }

--- a/pkg/cache/inflight_staging_gc_internal_test.go
+++ b/pkg/cache/inflight_staging_gc_internal_test.go
@@ -1,0 +1,162 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/ent/stagingstate"
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
+)
+
+// TestReclaimStaging_DeletesPartsAndRecord verifies that reclaiming staging
+// removes both the part-objects and the staging_state record.
+func TestReclaimStaging_DeletesPartsAndRecord(t *testing.T) {
+	t.Parallel()
+
+	c, _, store, _, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+
+	ctx := context.Background()
+
+	const hash = "1111111111111111111111111111aaaa"
+
+	nParts := putStagingParts(t, store, hash, "abcdefghij", 4)
+	require.NoError(t, c.markStagingRequested(ctx, hash))
+	require.NoError(t, c.advanceStagingParts(ctx, hash, nParts, nar.CompressionTypeNone.String()))
+	require.NoError(t, c.markStagingComplete(ctx, hash))
+
+	require.NoError(t, c.reclaimStaging(ctx, hash))
+
+	st, err := c.getStagingState(ctx, hash)
+	require.NoError(t, err)
+	assert.Nil(t, st, "staging_state record must be deleted")
+
+	_, err = store.GetStagingPart(ctx, hash, 0)
+	require.ErrorIs(t, err, storage.ErrNotFound, "part-objects must be deleted")
+}
+
+// TestScheduleStagingReclaim_DeletesAfterGrace verifies the event-driven reclaim:
+// once staging completes, the artifacts are deleted after the retention grace.
+func TestScheduleStagingReclaim_DeletesAfterGrace(t *testing.T) {
+	t.Parallel()
+
+	c, _, store, _, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	// Tiny grace so the test does not wait the production default.
+	c.SetInflightStaging(true, 50*time.Millisecond, 4, true)
+
+	ctx := context.Background()
+
+	const hash = "2222222222222222222222222222bbbb"
+
+	nParts := putStagingParts(t, store, hash, "abcdefghij", 4)
+	require.NoError(t, c.markStagingRequested(ctx, hash))
+	require.NoError(t, c.advanceStagingParts(ctx, hash, nParts, nar.CompressionTypeNone.String()))
+	require.NoError(t, c.markStagingComplete(ctx, hash))
+
+	c.scheduleStagingReclaim(hash)
+
+	require.Eventually(t, func() bool {
+		st, err := c.getStagingState(ctx, hash)
+
+		return err == nil && st == nil
+	}, 5*time.Second, 20*time.Millisecond, "staging must be reclaimed after the grace period")
+
+	_, err := store.GetStagingPart(ctx, hash, 0)
+	require.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+// TestSweepStagingGC_ReclaimsOrphansAndStaleComplete verifies the periodic sweep:
+// it reclaims orphaned staging (holder died: non-complete and stale beyond
+// orphanAge) and completed staging past its retention grace, while leaving fresh
+// completed staging in place.
+func TestSweepStagingGC_ReclaimsOrphansAndStaleComplete(t *testing.T) {
+	t.Parallel()
+
+	c, _, store, _, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	c.SetInflightStaging(true, time.Hour, 4, true)
+
+	ctx := context.Background()
+
+	const (
+		orphan       = "33333333333333333333333333330000" // non-complete, stale -> reclaim
+		completeOld  = "44444444444444444444444444441111" // complete, stale > retention -> reclaim
+		completeNew  = "55555555555555555555555555552222" // complete, fresh -> keep
+		orphanFresh  = "66666666666666666666666666663333" // non-complete, fresh -> keep
+		retentionArg = time.Hour
+		orphanArg    = time.Minute
+	)
+
+	// Orphan: staging in progress, holder died (updated_at stale).
+	putStagingParts(t, store, orphan, "abcd", 4)
+	require.NoError(t, c.markStagingRequested(ctx, orphan))
+	require.NoError(t, c.advanceStagingParts(ctx, orphan, 1, nar.CompressionTypeNone.String()))
+	forceStagingUpdatedAt(t, c, orphan, time.Now().Add(-90*time.Minute))
+
+	// Complete but past retention.
+	putStagingParts(t, store, completeOld, "efgh", 4)
+	require.NoError(t, c.markStagingRequested(ctx, completeOld))
+	require.NoError(t, c.advanceStagingParts(ctx, completeOld, 1, nar.CompressionTypeNone.String()))
+	require.NoError(t, c.markStagingComplete(ctx, completeOld))
+	forceStagingUpdatedAt(t, c, completeOld, time.Now().Add(-2*time.Hour))
+
+	// Complete and fresh.
+	putStagingParts(t, store, completeNew, "ijkl", 4)
+	require.NoError(t, c.markStagingRequested(ctx, completeNew))
+	require.NoError(t, c.advanceStagingParts(ctx, completeNew, 1, nar.CompressionTypeNone.String()))
+	require.NoError(t, c.markStagingComplete(ctx, completeNew))
+
+	// Non-complete but fresh (a live holder mid-staging).
+	putStagingParts(t, store, orphanFresh, "mnop", 4)
+	require.NoError(t, c.markStagingRequested(ctx, orphanFresh))
+	require.NoError(t, c.advanceStagingParts(ctx, orphanFresh, 1, nar.CompressionTypeNone.String()))
+
+	n, err := c.sweepStagingGC(ctx, retentionArg, orphanArg)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n, "exactly the orphan and the stale-complete records are reclaimed")
+
+	assertStagingAbsent(t, c, store, orphan)
+	assertStagingAbsent(t, c, store, completeOld)
+	assertStagingPresent(t, c, completeNew)
+	assertStagingPresent(t, c, orphanFresh)
+}
+
+func forceStagingUpdatedAt(t *testing.T, c *Cache, hash string, when time.Time) {
+	t.Helper()
+
+	n, err := c.dbClient.Ent().StagingState.Update().
+		Where(stagingstate.HashEQ(hash)).
+		SetUpdatedAt(when).
+		Save(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+}
+
+func assertStagingAbsent(t *testing.T, c *Cache, store storage.NarStore, hash string) {
+	t.Helper()
+
+	st, err := c.getStagingState(context.Background(), hash)
+	require.NoError(t, err)
+	assert.Nil(t, st, "staging_state for %q must be reclaimed", hash)
+
+	_, err = store.GetStagingPart(context.Background(), hash, 0)
+	require.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func assertStagingPresent(t *testing.T, c *Cache, hash string) {
+	t.Helper()
+
+	st, err := c.getStagingState(context.Background(), hash)
+	require.NoError(t, err)
+	require.NotNil(t, st, "staging_state for %q must be preserved", hash)
+}

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -1349,6 +1349,17 @@ func createCache(
 		return nil, err
 	}
 
+	// Periodic in-flight staging GC: reclaims completed staging past its retention
+	// grace and orphaned staging whose holder died. Only meaningful when staging is
+	// active (enabled + distributed locker).
+	if inflightStagingEnabled && stagingDistributed {
+		zerolog.Ctx(ctx).
+			Info().
+			Msg("setting up in-flight staging GC cron job")
+
+		c.AddInflightStagingGCCronJob(ctx, cron.Every(time.Minute))
+	}
+
 	c.StartCron(ctx)
 
 	return c, nil


### PR DESCRIPTION
GC / retention for in-flight NAR staging (group 8). Two reclaim paths:

- Event-driven: once the holder finishes staging (the final representation is
  now committed), scheduleStagingReclaim deletes the staging part-objects and
  staging_state record after the configurable retention grace, letting cross-pod
  readers drain first. The grace wait is interrupted by a new Cache shutdown
  channel so Close() is never blocked for the full grace; anything skipped on
  shutdown is caught by the sweep.
- Periodic sweep: a cron job (registered when staging is enabled with a
  distributed locker) reclaims completed staging past its retention grace and
  orphaned staging whose holder died. Liveness is detected by updated_at
  staleness exceeding a generous orphan age (a live holder advances
  parts_available, and thus updated_at, while staging) rather than treating
  created_at age as a death proxy — the #1230 lesson; created_at is the fallback
  only when a bare request marker was never updated.