### PR TITLE
feat(cache): restart staging on holder death

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -6255,6 +6255,11 @@ func (c *Cache) coordinateDownload(
 
 	c.upstreamJobsMu.Unlock()
 
+	// tookOverDownload records whether we reached the post-lock path by taking over
+	// a dead holder's lock (vs. acquiring a free lock), so the staging reset runs
+	// only on a genuine takeover.
+	tookOverDownload := false
+
 	// Acquire lock with retry (handled internally by Redis locker)
 	if err := c.downloadLocker.Lock(ctx, lockKey, c.downloadLockTTL); err != nil {
 		zerolog.Ctx(ctx).Warn().
@@ -6273,10 +6278,24 @@ func (c *Cache) coordinateDownload(
 
 		// Fell through: we re-acquired the lock and now own the download.
 		// Continue into the normal post-lock path below.
+		tookOverDownload = true
 	}
 
 	// Start a background goroutine to refresh the lock TTL periodically.
 	stopRefresher := lock.StartRefresher(ctx, c.downloadLocker, lockKey, c.downloadLockTTL)
+
+	// On takeover the previous holder died: discard its partial (truncated)
+	// staging parts and reset staging_state to "requested" so this fresh download
+	// re-stages from zero if a cross-pod waiter still wants it. Done AFTER the
+	// refresher is running so the storage+DB cleanup cannot outlive the lock TTL
+	// and let yet another replica take over mid-cleanup. ctx is the detached
+	// background context, so the reset is not tied to caller cancellation.
+	if tookOverDownload && allowStaging && c.InflightStagingEnabled() {
+		if err := c.resetStagingForTakeover(ctx, hash); err != nil {
+			zerolog.Ctx(ctx).Warn().Err(err).Str("hash", hash).
+				Msg("failed to reset staging on takeover; orphan sweep will reclaim it")
+		}
+	}
 
 	// Double check local jobs and asset presence under lock
 	if hasAsset(ctx) {
@@ -6458,23 +6477,15 @@ func (c *Cache) pollForDownloadOrTakeOver(
 			//
 			// Takeover is attempted BEFORE serving from staging: an acquirable lock
 			// means the holder is gone (dead/failed), so its staging parts are at
-			// best a truncated prefix. We discard them and restart the download from
-			// zero rather than tailing a producer that will never complete (D5).
+			// best a truncated prefix. The caller discards them and restarts the
+			// download from zero (after the lock refresher is running) rather than
+			// tailing a producer that will never complete (D5).
 			acquired, lockErr := c.downloadLocker.TryLock(deadlineCtx, lockKey, c.downloadLockTTL)
 			if lockErr == nil && acquired {
 				zerolog.Ctx(ctx).Debug().
 					Str("hash", hash).
 					Str("lock_key", lockKey).
 					Msg("re-acquired download lock, taking over the download")
-
-				if stagingActive {
-					// Discard the dead holder's partial staging so the fresh download
-					// re-stages from zero; a reader is never handed truncated parts.
-					if err := c.reclaimStaging(context.WithoutCancel(coordCtx), hash); err != nil {
-						zerolog.Ctx(ctx).Warn().Err(err).Str("hash", hash).
-							Msg("failed to reset staging on takeover; orphan sweep will reclaim it")
-					}
-				}
 
 				downloadCoordinationFallbackTotal.Add(ctx, 1,
 					metric.WithAttributes(attribute.String("outcome", "take_over")))

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -6448,10 +6448,44 @@ func (c *Cache) pollForDownloadOrTakeOver(
 				return ds, false
 			}
 
-			// Before re-attempting the lock, see whether the holder has begun
-			// staging the in-flight NAR. If parts are available we serve them
-			// directly (tailing as they land) rather than waiting for the whole
-			// download to finish — the cross-pod fast path for #660 / #1289.
+			// Re-attempt acquisition without blocking, bounded by the give-up
+			// deadline. TryLock is a single non-blocking attempt, so a tick can
+			// never stall the poll loop or outlive deadlineCtx / caller
+			// cancellation (a blocking Lock retries internally and could do
+			// exactly that). Success means the previous holder released the lock
+			// (it finished or failed) without the asset appearing, so we take
+			// over as the sole downloader.
+			//
+			// Takeover is attempted BEFORE serving from staging: an acquirable lock
+			// means the holder is gone (dead/failed), so its staging parts are at
+			// best a truncated prefix. We discard them and restart the download from
+			// zero rather than tailing a producer that will never complete (D5).
+			acquired, lockErr := c.downloadLocker.TryLock(deadlineCtx, lockKey, c.downloadLockTTL)
+			if lockErr == nil && acquired {
+				zerolog.Ctx(ctx).Debug().
+					Str("hash", hash).
+					Str("lock_key", lockKey).
+					Msg("re-acquired download lock, taking over the download")
+
+				if stagingActive {
+					// Discard the dead holder's partial staging so the fresh download
+					// re-stages from zero; a reader is never handed truncated parts.
+					if err := c.reclaimStaging(context.WithoutCancel(coordCtx), hash); err != nil {
+						zerolog.Ctx(ctx).Warn().Err(err).Str("hash", hash).
+							Msg("failed to reset staging on takeover; orphan sweep will reclaim it")
+					}
+				}
+
+				downloadCoordinationFallbackTotal.Add(ctx, 1,
+					metric.WithAttributes(attribute.String("outcome", "take_over")))
+
+				return nil, true
+			}
+
+			// The lock is still held (holder alive): if it has begun staging the
+			// in-flight NAR, serve the parts directly (tailing as they land) rather
+			// than waiting for the whole download to finish — the cross-pod fast path
+			// for #660 / #1289.
 			if stagingActive {
 				if info := c.stagingServeReady(coordCtx, hash); info != nil {
 					zerolog.Ctx(ctx).Debug().
@@ -6470,26 +6504,6 @@ func (c *Cache) pollForDownloadOrTakeOver(
 
 					return ds, false
 				}
-			}
-
-			// Re-attempt acquisition without blocking, bounded by the give-up
-			// deadline. TryLock is a single non-blocking attempt, so a tick can
-			// never stall the poll loop or outlive deadlineCtx / caller
-			// cancellation (a blocking Lock retries internally and could do
-			// exactly that). Success means the previous holder released the lock
-			// (it finished or failed) without the asset appearing, so we take
-			// over as the sole downloader.
-			acquired, lockErr := c.downloadLocker.TryLock(deadlineCtx, lockKey, c.downloadLockTTL)
-			if lockErr == nil && acquired {
-				zerolog.Ctx(ctx).Debug().
-					Str("hash", hash).
-					Str("lock_key", lockKey).
-					Msg("re-acquired download lock, taking over the download")
-
-				downloadCoordinationFallbackTotal.Add(ctx, 1,
-					metric.WithAttributes(attribute.String("outcome", "take_over")))
-
-				return nil, true
 			}
 		case <-deadlineCtx.Done():
 			ds := newDownloadState()

--- a/pkg/cache/inflight_staging_gc.go
+++ b/pkg/cache/inflight_staging_gc.go
@@ -54,6 +54,23 @@ func (c *Cache) reclaimStaging(ctx context.Context, hash string) error {
 	return nil
 }
 
+// resetStagingForTakeover discards a dead holder's partial (truncated) staging
+// part-objects and resets staging_state to "requested" so the taking-over holder
+// re-stages from zero if a cross-pod waiter still wants it. Unlike reclaimStaging
+// it preserves the row: deleting it would drop the waiter's request marker (the
+// waiter records it once, before its poll loop) and strand it on a full re-download.
+func (c *Cache) resetStagingForTakeover(ctx context.Context, hash string) error {
+	if err := c.narStore.DeleteStagingParts(ctx, hash); err != nil {
+		return fmt.Errorf("reset staging parts on takeover for %q: %w", hash, err)
+	}
+
+	if err := c.resetStagingState(ctx, hash); err != nil {
+		return fmt.Errorf("reset staging state on takeover for %q: %w", hash, err)
+	}
+
+	return nil
+}
+
 // scheduleStagingReclaim reclaims the staging artifacts for hash after the
 // retention grace elapses, giving any in-flight cross-pod readers time to drain.
 // It is the event-driven path, launched once the holder finishes staging (the

--- a/pkg/cache/inflight_staging_takeover_internal_test.go
+++ b/pkg/cache/inflight_staging_takeover_internal_test.go
@@ -1,0 +1,107 @@
+package cache
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
+)
+
+// TestPollTakeover_DiscardsStaleStaging verifies that when a waiter re-acquires
+// the (expired) download lock — the holder died — it takes over the download and
+// discards the dead holder's partial staging part-objects and staging_state, so
+// the restarted download re-stages from zero (D5).
+func TestPollTakeover_DiscardsStaleStaging(t *testing.T) {
+	t.Parallel()
+
+	c, _, store, _, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+
+	ctx := context.Background()
+
+	const (
+		hash    = "deadbeefdeadbeefdeadbeefdeadbeef"
+		lockKey = "takeover-test-lock"
+	)
+
+	// A dead holder left a partial, never-completed staging set behind.
+	putStagingParts(t, store, hash, "abcd", 4)
+	require.NoError(t, c.markStagingRequested(ctx, hash))
+	require.NoError(t, c.advanceStagingParts(ctx, hash, 1, nar.CompressionTypeNone.String()))
+
+	// The lock is free (the holder's lock expired), so TryLock succeeds on the
+	// first tick and the waiter takes over.
+	ds, tookOver := c.pollForDownloadOrTakeOver(
+		ctx, ctx, lockKey, hash, true, storage.ErrNotFound,
+		func(context.Context) bool { return false },
+	)
+	require.True(t, tookOver, "an acquirable lock means the holder is gone: take over")
+	assert.Nil(t, ds)
+
+	// The new owner now holds the lock; release it.
+	require.NoError(t, c.downloadLocker.Unlock(ctx, lockKey))
+
+	// The dead holder's partial staging was discarded.
+	st, err := c.getStagingState(ctx, hash)
+	require.NoError(t, err)
+	assert.Nil(t, st, "staging_state must be reset on takeover")
+
+	_, err = store.GetStagingPart(ctx, hash, 0)
+	require.ErrorIs(t, err, storage.ErrNotFound, "partial parts must be discarded on takeover")
+}
+
+// TestStagingTakeover_NoTruncatedServeAcrossDeath verifies the correctness
+// contract across a holder-death + takeover transition: a reader tailing the dead
+// holder's partial (never-completed) staging surfaces a stream error rather than a
+// clean EOF at a truncated length, and the takeover then discards those parts.
+func TestStagingTakeover_NoTruncatedServeAcrossDeath(t *testing.T) {
+	t.Parallel()
+
+	c, _, store, _, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+
+	ctx := context.Background()
+
+	const (
+		hash    = "cafecafecafecafecafecafecafecafe"
+		lockKey = "takeover-truncation-lock"
+	)
+
+	// Holder died after staging only the first of (conceptually) several parts.
+	putStagingParts(t, store, hash, "abcd", 4)
+	require.NoError(t, c.markStagingRequested(ctx, hash))
+	require.NoError(t, c.advanceStagingParts(ctx, hash, 1, nar.CompressionTypeNone.String()))
+
+	// A reader tailing this partial set delivers the prefix then stalls — and
+	// surfaces a stream error, never a truncated clean EOF.
+	r := c.newStagingPartReader(ctx, hash)
+	r.maxWait = 200 * time.Millisecond
+	r.pollEvery = 20 * time.Millisecond
+
+	body, readErr := io.ReadAll(r)
+	require.NoError(t, r.Close())
+	require.Error(t, readErr, "a never-completed staging set must not read as a clean EOF")
+	require.NotErrorIs(t, readErr, io.EOF)
+	assert.Equal(t, "abcd", string(body), "the partial prefix is delivered, but not as success")
+
+	// Takeover discards the truncated parts so a fresh download re-stages cleanly.
+	_, tookOver := c.pollForDownloadOrTakeOver(
+		ctx, ctx, lockKey, hash, true, storage.ErrNotFound,
+		func(context.Context) bool { return false },
+	)
+	require.True(t, tookOver)
+	require.NoError(t, c.downloadLocker.Unlock(ctx, lockKey))
+
+	_, err := store.GetStagingPart(ctx, hash, 0)
+	require.ErrorIs(t, err, storage.ErrNotFound)
+}

--- a/pkg/cache/inflight_staging_takeover_internal_test.go
+++ b/pkg/cache/inflight_staging_takeover_internal_test.go
@@ -49,10 +49,17 @@ func TestPollTakeover_DiscardsStaleStaging(t *testing.T) {
 	// The new owner now holds the lock; release it.
 	require.NoError(t, c.downloadLocker.Unlock(ctx, lockKey))
 
-	// The dead holder's partial staging was discarded.
+	// coordinateDownload runs the staging reset after the lock refresher is active;
+	// invoke it directly here to exercise the takeover cleanup.
+	require.NoError(t, c.resetStagingForTakeover(ctx, hash))
+
+	// The dead holder's partial parts are discarded, but the staging_state row is
+	// preserved (reset to "requested") so a persisting cross-pod waiter is re-served.
 	st, err := c.getStagingState(ctx, hash)
 	require.NoError(t, err)
-	assert.Nil(t, st, "staging_state must be reset on takeover")
+	require.NotNil(t, st, "the request marker must survive takeover")
+	assert.Equal(t, int64(0), st.PartsAvailable, "reset rewinds progress to zero")
+	assert.Equal(t, stagingStatusRequested, st.Status, "reset preserves the request for re-staging")
 
 	_, err = store.GetStagingPart(ctx, hash, 0)
 	require.ErrorIs(t, err, storage.ErrNotFound, "partial parts must be discarded on takeover")
@@ -94,7 +101,10 @@ func TestStagingTakeover_NoTruncatedServeAcrossDeath(t *testing.T) {
 	require.NotErrorIs(t, readErr, io.EOF)
 	assert.Equal(t, "abcd", string(body), "the partial prefix is delivered, but not as success")
 
-	// Takeover discards the truncated parts so a fresh download re-stages cleanly.
+	// Takeover re-acquires the lock; coordinateDownload then runs resetStagingForTakeover
+	// once the lock refresher is active. The reset discards the truncated parts so a
+	// fresh download re-stages cleanly, while preserving the staging_state row at
+	// "requested" so a persisting cross-pod waiter is re-served.
 	_, tookOver := c.pollForDownloadOrTakeOver(
 		ctx, ctx, lockKey, hash, true, storage.ErrNotFound,
 		func(context.Context) bool { return false },
@@ -102,6 +112,14 @@ func TestStagingTakeover_NoTruncatedServeAcrossDeath(t *testing.T) {
 	require.True(t, tookOver)
 	require.NoError(t, c.downloadLocker.Unlock(ctx, lockKey))
 
+	require.NoError(t, c.resetStagingForTakeover(ctx, hash))
+
 	_, err := store.GetStagingPart(ctx, hash, 0)
-	require.ErrorIs(t, err, storage.ErrNotFound)
+	require.ErrorIs(t, err, storage.ErrNotFound, "truncated parts must be discarded on takeover")
+
+	st, err := c.getStagingState(ctx, hash)
+	require.NoError(t, err)
+	require.NotNil(t, st, "the waiter's request marker must survive takeover")
+	assert.Equal(t, int64(0), st.PartsAvailable, "reset rewinds progress to zero")
+	assert.Equal(t, stagingStatusRequested, st.Status, "reset preserves the request for re-staging")
 }


### PR DESCRIPTION
Holder-death takeover for in-flight staging (D5, group 9). In
pollForDownloadOrTakeOver the lock re-acquisition (takeover) is now attempted
BEFORE serving from staging: an acquirable lock means the holder is gone
(died or failed), so its staging parts are at best a truncated prefix. On
takeover the new owner discards the dead holder's partial part-objects and
resets staging_state, then restarts the download from zero via the existing
post-lock path and re-stages cleanly if contention persists.

Reordering takeover ahead of the staging-serve branch also guarantees the
correctness contract across a death+takeover transition: a reader tailing a
never-completed staging set surfaces a stream error (the part-tailing reader's
stall handling), never a clean EOF at a truncated length, and the orphaned
parts are reclaimed by the takeover rather than tailed as if complete.