### PR TITLE
feat(chart): HA via CDC or in-flight staging

### DIFF
--- a/charts/ncps/templates/_helpers.tpl
+++ b/charts/ncps/templates/_helpers.tpl
@@ -191,7 +191,7 @@ This function will fail the template rendering if invalid configurations are det
   {{- end -}}
 
   {{- /* HA serve-during-download validation: CDC or in-flight staging */ -}}
-  {{- if and (gt (int .Values.replicaCount) 1) (not .Values.config.cdc.enabled) (not .Values.config.inflightStaging.enabled) -}}
+  {{- if and (gt (int .Values.replicaCount) 1) (not .Values.config.cdc.enabled) (not (and .Values.config.inflightStaging .Values.config.inflightStaging.enabled)) -}}
     {{- fail "High availability mode (replicaCount > 1) requires either CDC (config.cdc.enabled=true) or in-flight NAR staging (config.inflightStaging.enabled=true) so NARs can be served across replicas during download. In-flight staging is the lightweight default (zero overhead until contention). See https://github.com/kalbasit/ncps/issues/660." -}}
   {{- end -}}
 {{- end -}}

--- a/charts/ncps/templates/_helpers.tpl
+++ b/charts/ncps/templates/_helpers.tpl
@@ -190,9 +190,9 @@ This function will fail the template rendering if invalid configurations are det
     {{- fail "You should not enable migrations with mode 'initContainer' when running multiple replicas, you risk corrupting your database. Set migration.mode to 'job' or 'argocd' instead, or set migration.iLoveCorruptedDatabases to true if you know what you are doing." -}}
   {{- end -}}
 
-  {{- /* CDC validation for HA */ -}}
-  {{- if and (gt (int .Values.replicaCount) 1) (not .Values.config.cdc.enabled) (not .Values.config.cdc.iLoveTimeouts) -}}
-    {{- fail "High availability mode (replicaCount > 1) requires CDC to be enabled (config.cdc.enabled=true) to prevent timeouts and instability. See https://github.com/kalbasit/ncps/issues/660. Set config.cdc.iLoveTimeouts to true if you accept this risk." -}}
+  {{- /* HA serve-during-download validation: CDC or in-flight staging */ -}}
+  {{- if and (gt (int .Values.replicaCount) 1) (not .Values.config.cdc.enabled) (not .Values.config.inflightStaging.enabled) -}}
+    {{- fail "High availability mode (replicaCount > 1) requires either CDC (config.cdc.enabled=true) or in-flight NAR staging (config.inflightStaging.enabled=true) so NARs can be served across replicas during download. In-flight staging is the lightweight default (zero overhead until contention). See https://github.com/kalbasit/ncps/issues/660." -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/ncps/templates/configmap.yaml
+++ b/charts/ncps/templates/configmap.yaml
@@ -59,6 +59,16 @@ data:
         chunk-wait-timeout: {{ .Values.config.cdc.chunkWaitTimeout | quote }}
         {{- end }}
       {{- end }}
+      {{- if .Values.config.inflightStaging.enabled }}
+      inflight-staging:
+        enabled: true
+        {{- if .Values.config.inflightStaging.retention }}
+        retention: {{ .Values.config.inflightStaging.retention | quote }}
+        {{- end }}
+        {{- if .Values.config.inflightStaging.partSize }}
+        part-size: {{ printf "%.0f" (.Values.config.inflightStaging.partSize | float64) }}
+        {{- end }}
+      {{- end }}
 
       {{- if and (or (eq .Values.config.database.type "postgresql") (eq .Values.config.database.type "mysql")) (or .Values.config.database.pool.maxOpenConns .Values.config.database.pool.maxIdleConns) }}
       database:

--- a/charts/ncps/templates/configmap.yaml
+++ b/charts/ncps/templates/configmap.yaml
@@ -59,14 +59,14 @@ data:
         chunk-wait-timeout: {{ .Values.config.cdc.chunkWaitTimeout | quote }}
         {{- end }}
       {{- end }}
-      {{- if .Values.config.inflightStaging.enabled }}
+      {{- if and .Values.config.inflightStaging .Values.config.inflightStaging.enabled }}
       inflight-staging:
         enabled: true
         {{- if .Values.config.inflightStaging.retention }}
         retention: {{ .Values.config.inflightStaging.retention | quote }}
         {{- end }}
         {{- if .Values.config.inflightStaging.partSize }}
-        part-size: {{ printf "%.0f" (.Values.config.inflightStaging.partSize | float64) }}
+        part-size: {{ .Values.config.inflightStaging.partSize | int }}
         {{- end }}
       {{- end }}
 

--- a/charts/ncps/tests/validation_test.yaml
+++ b/charts/ncps/tests/validation_test.yaml
@@ -254,7 +254,7 @@ tests:
       - isKind:
           of: ConfigMap
 
-  - it: should fail HA without CDC enabled
+  - it: should fail HA with neither CDC nor in-flight staging
     set:
       config.hostname: test.example.com
       replicaCount: 2
@@ -268,15 +268,16 @@ tests:
       config.storage.s3.accessKeyId: test-key
       config.storage.s3.secretAccessKey: test-secret
       config.cdc.enabled: false
+      config.inflightStaging.enabled: false
       config.redis.enabled: true
       config.redis.addresses:
         - redis:6379
       migration.mode: job
     asserts:
       - failedTemplate:
-          errorMessage: "High availability mode (replicaCount > 1) requires CDC to be enabled (config.cdc.enabled=true) to prevent timeouts and instability. See https://github.com/kalbasit/ncps/issues/660. Set config.cdc.iLoveTimeouts to true if you accept this risk."
+          errorMessage: "High availability mode (replicaCount > 1) requires either CDC (config.cdc.enabled=true) or in-flight NAR staging (config.inflightStaging.enabled=true) so NARs can be served across replicas during download. In-flight staging is the lightweight default (zero overhead until contention). See https://github.com/kalbasit/ncps/issues/660."
 
-  - it: should pass HA without CDC but with bypass flag
+  - it: should still fail HA when a (now-removed) iLoveTimeouts bypass is supplied
     set:
       config.hostname: test.example.com
       replicaCount: 2
@@ -290,7 +291,54 @@ tests:
       config.storage.s3.accessKeyId: test-key
       config.storage.s3.secretAccessKey: test-secret
       config.cdc.enabled: false
+      config.inflightStaging.enabled: false
       config.cdc.iLoveTimeouts: true
+      config.redis.enabled: true
+      config.redis.addresses:
+        - redis:6379
+      migration.mode: job
+    asserts:
+      - failedTemplate:
+          errorMessage: "High availability mode (replicaCount > 1) requires either CDC (config.cdc.enabled=true) or in-flight NAR staging (config.inflightStaging.enabled=true) so NARs can be served across replicas during download. In-flight staging is the lightweight default (zero overhead until contention). See https://github.com/kalbasit/ncps/issues/660."
+
+  - it: should pass HA with in-flight staging and no CDC
+    set:
+      config.hostname: test.example.com
+      replicaCount: 2
+      mode: deployment
+      config.database.type: postgresql
+      config.database.postgresql.host: postgres
+      config.database.postgresql.password: test123
+      config.storage.type: s3
+      config.storage.s3.bucket: my-bucket
+      config.storage.s3.endpoint: https://s3.amazonaws.com
+      config.storage.s3.accessKeyId: test-key
+      config.storage.s3.secretAccessKey: test-secret
+      config.cdc.enabled: false
+      config.inflightStaging.enabled: true
+      config.redis.enabled: true
+      config.redis.addresses:
+        - redis:6379
+      migration.mode: job
+    asserts:
+      - isKind:
+          of: ConfigMap
+
+  - it: should pass HA with CDC and no in-flight staging
+    set:
+      config.hostname: test.example.com
+      replicaCount: 2
+      mode: deployment
+      config.database.type: postgresql
+      config.database.postgresql.host: postgres
+      config.database.postgresql.password: test123
+      config.storage.type: s3
+      config.storage.s3.bucket: my-bucket
+      config.storage.s3.endpoint: https://s3.amazonaws.com
+      config.storage.s3.accessKeyId: test-key
+      config.storage.s3.secretAccessKey: test-secret
+      config.cdc.enabled: true
+      config.inflightStaging.enabled: false
       config.redis.enabled: true
       config.redis.addresses:
         - redis:6379

--- a/charts/ncps/values.yaml
+++ b/charts/ncps/values.yaml
@@ -10,8 +10,11 @@ global:
 # Number of replicas
 # For HA mode, set to 2 or more
 # For single instance, set to 1
-# WARNING: If setting replicaCount > 1, you MUST also enable CDC (config.cdc.enabled: true)
-# to prevent data corruption. See https://github.com/kalbasit/ncps/issues/660
+# WARNING: If setting replicaCount > 1, you MUST enable either CDC
+# (config.cdc.enabled: true) or in-flight NAR staging
+# (config.inflightStaging.enabled: true) so NARs can be served across replicas
+# during download. In-flight staging is the lightweight default (zero overhead
+# until contention). See https://github.com/kalbasit/ncps/issues/660
 replicaCount: 1
 
 # Deployment mode: "deployment" or "statefulset"
@@ -168,8 +171,9 @@ config:
   # Chunks are stored in the same backend as NAR files (different prefix/directory)
   cdc:
     # Enable CDC for deduplication (experimental)
-    # REQUIRED for HA deployments (replicaCount > 1) to prevent timeouts and instability.
-    # See https://github.com/kalbasit/ncps/issues/660
+    # One of CDC or in-flight staging (config.inflightStaging.enabled) is required
+    # for HA deployments (replicaCount > 1) to serve NARs across replicas during
+    # download. See https://github.com/kalbasit/ncps/issues/660
     enabled: false
     min: 16384
     avg: 65536
@@ -202,10 +206,22 @@ config:
     # avoiding spurious 504s. Leave null to use the server default (30s).
     chunkWaitTimeout: null
 
-    # Bypass flag for HA validation without CDC
-    # Use with EXTREME CAUTION. Doing so may result in timeouts and instability.
-    # See https://github.com/kalbasit/ncps/issues/660 for more details.
-    iLoveTimeouts: false
+  # In-flight NAR staging: serve a NAR cross-pod while it is still downloading by
+  # staging it to shared storage as part-objects once another replica waits for it.
+  # An HA-safe alternative to CDC that satisfies the replicaCount > 1 guard. Off by
+  # default; only active with a distributed (Redis) lock and zero overhead until a
+  # second replica contends for the same NAR. See
+  # https://github.com/kalbasit/ncps/issues/660
+  inflightStaging:
+    enabled: false
+
+    # Grace period to retain staging part-objects after the NAR's final
+    # representation is committed, so in-flight readers drain before reclamation.
+    retention: 5m
+
+    # Size in bytes of each staging part-object (a transport unit, distinct from
+    # CDC chunk sizes). Default 8 MiB.
+    partSize: 8388608
 
   # Storage backend (choose ONE)
   storage:

--- a/nix/k8s-tests/config.nix
+++ b/nix/k8s-tests/config.nix
@@ -222,7 +222,7 @@ rec {
       name = "ha-s3-postgres";
       description = "High availability with S3 storage, PostgreSQL, and Redis locks";
       replicas = 2;
-      cdc.iLoveTimeouts = true;
+      inflightStaging.enabled = true;
       mode = "deployment";
       migration.mode = "job";
       storage = {
@@ -249,7 +249,7 @@ rec {
       name = "ha-s3-mariadb";
       description = "High availability with S3 storage, MariaDB, and Redis locks";
       replicas = 2;
-      cdc.iLoveTimeouts = true;
+      inflightStaging.enabled = true;
       mode = "deployment";
       migration.mode = "job";
       storage = {
@@ -609,11 +609,11 @@ rec {
                     enabled = false;
                   };
 
-              # CDC Configuration
-              cdc = {
-                # Enabled is set by features ("cdc"), but we default strictly here
-                # iLoveTimeouts logic:
-                iLoveTimeouts = perm.cdc.iLoveTimeouts or false;
+              # In-flight NAR staging: an HA-safe alternative to CDC. Enabled per
+              # permutation — the HA permutations that previously set
+              # cdc.iLoveTimeouts now exercise real staging instead.
+              inflightStaging = {
+                enabled = perm.inflightStaging.enabled or false;
               };
             };
           };


### PR DESCRIPTION
Helm chart HA validation for in-flight staging (group 10, BREAKING). The
replicaCount > 1 guard in _helpers.tpl now passes when EITHER config.cdc.enabled
OR config.inflightStaging.enabled is set, with no bypass. Because staging is
zero-overhead-until-contention, every HA operator can satisfy the guard safely,
so the accept-the-risk escape hatch protected no remaining use case.

BREAKING: config.cdc.iLoveTimeouts is removed. Migration: set
config.inflightStaging.enabled=true (or config.cdc.enabled=true). A validation
test asserts that supplying the now-unrecognized iLoveTimeouts no longer
bypasses the guard.

- values.yaml: add config.inflightStaging.{enabled,retention,partSize}; remove
  config.cdc.iLoveTimeouts; update HA warnings.
- configmap.yaml: render config.inflightStaging.* into the ncps config
  (cache.inflight-staging.*), formatting part-size as an integer.
- tests/validation_test.yaml: neither-fails, staging-passes, cdc-passes, and
  iLoveTimeouts-no-longer-bypasses cases (helm unittest green, 157 tests).
- nix/k8s-tests/config.nix: the two HA permutations that ran with
  cdc.iLoveTimeouts now exercise real in-flight staging instead.