### PR TITLE
docs: in-flight NAR staging for HA

### DIFF
--- a/docs/docs/User Guide/Configuration/Reference.md
+++ b/docs/docs/User Guide/Configuration/Reference.md
@@ -189,6 +189,24 @@ ncps serve \
 
 See <a class="reference-link" href="../Features/CDC.md">CDC</a> for details.
 
+## In-flight NAR Staging Options (HA)
+
+In-flight NAR staging lets a replica serve a NAR to other replicas **while it is
+still downloading**, by staging it to shared storage as ordered part-objects once
+a second replica waits for the same NAR. It is an HA-safe alternative to CDC (it
+satisfies the Helm `replicaCount > 1` guard) and is **off by default** with **zero
+overhead until cross-pod contention** — it only activates with a distributed
+(Redis) lock and only when another replica actually waits for the same NAR.
+
+| Flag | Description | Environment Variable | Default |
+| --- | --- | --- | --- |
+| `--cache-inflight-staging-enabled` | Serve a NAR cross-pod while it is still downloading by staging it to shared storage as part-objects | `CACHE_INFLIGHT_STAGING_ENABLED` | `false` |
+| `--cache-inflight-staging-retention` | Grace period to retain staging part-objects after the NAR's final representation is committed, so in-flight readers drain before reclamation | `CACHE_INFLIGHT_STAGING_RETENTION` | `5m` |
+| `--cache-inflight-staging-part-size` | Size in bytes of each staging part-object (a transport unit, distinct from CDC chunk sizes) | `CACHE_INFLIGHT_STAGING_PART_SIZE` | `8388608` (8 MiB) |
+
+In-flight staging resolves the cross-pod serve-during-download gap for **all** CDC
+modes (non-CDC, lazy-CDC, eager-CDC) — see issue #660.
+
 ## Security & Signing
 
 | Option | Description | Environment Variable | Default |

--- a/docs/docs/User Guide/Configuration/Reference.md
+++ b/docs/docs/User Guide/Configuration/Reference.md
@@ -204,7 +204,7 @@ overhead until cross-pod contention** — it only activates with a distributed
 | `--cache-inflight-staging-retention` | Grace period to retain staging part-objects after the NAR's final representation is committed, so in-flight readers drain before reclamation | `CACHE_INFLIGHT_STAGING_RETENTION` | `5m` |
 | `--cache-inflight-staging-part-size` | Size in bytes of each staging part-object (a transport unit, distinct from CDC chunk sizes) | `CACHE_INFLIGHT_STAGING_PART_SIZE` | `8388608` (8 MiB) |
 
-In-flight staging resolves the cross-pod serve-during-download gap for **all** CDC
+In-flight staging resolves the cross-pod serve-during-download gap for **all**
 modes (non-CDC, lazy-CDC, eager-CDC) — see issue #660.
 
 ## Security & Signing

--- a/docs/docs/User Guide/Deployment/High Availability.md
+++ b/docs/docs/User Guide/Deployment/High Availability.md
@@ -58,9 +58,12 @@ Running multiple ncps instances provides:
    - **NOTE: MySQL is only supported for data storage, NOT for distributed locking.**
 1. **Load balancer** to distribute requests
    - nginx, HAProxy, cloud load balancer, etc.
-1. **CDC (Content-Defined Chunking) feature**
-   - **CRITICAL:** You must enable CDC when running multiple replicas. Failure to do so will result in timeouts and instability, as documented in [issue #660](https://github.com/kalbasit/ncps/issues/660).
-   - Enable by setting `config.cdc.enabled=true`.
+1. **A serve-during-download mechanism: CDC _or_ in-flight NAR staging**
+   - **CRITICAL:** When running multiple replicas you must enable **one** of these so a replica can serve a NAR that another replica is still downloading. Without either, a second replica requesting an in-flight NAR waits past client timeouts, causing instability, as documented in [issue #660](https://github.com/kalbasit/ncps/issues/660).
+   - **In-flight NAR staging (recommended default):** set `config.inflightStaging.enabled=true`. It is the lightweight option — zero overhead until a second replica actually contends for the same NAR, no chunking/deduplication CPU cost, and it covers the serve-during-download window for all modes. It activates only with the distributed (Redis) lock.
+   - **CDC (Content-Defined Chunking):** set `config.cdc.enabled=true`. Choose this when you also want chunk-level deduplication across NARs.
+   - Enabling either satisfies the chart's `replicaCount > 1` validation guard. The previous `config.cdc.iLoveTimeouts` bypass has been **removed** — migrate by enabling in-flight staging (or CDC).
+   - **Request-affinity routing** (pinning a NAR's requests to one replica via the load balancer) remains an optional latency optimization, not a correctness requirement.
 
 ### Network Requirements
 

--- a/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
+++ b/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
@@ -186,7 +186,19 @@ Configuration for the temporary directory used for downloads and transient opera
 | `config.cdc.backgroundWorkers` | Number of background workers for lazy chunking | `null` (server default: number of CPUs) |
 | `config.cdc.deleteDelay` | Delay before deleting compressed NAR files after chunking completes | `24h` |
 | `config.cdc.chunkWaitTimeout` | Maximum time to wait for a single chunk during progressive CDC streaming. Align with your gateway timeout on high-latency storage. | `null` (server default: `30s`) |
-| `config.cdc.iLoveTimeouts` | Bypass flag for HA validation without CDC | `false` |
+
+### In-flight NAR Staging Configuration
+
+In-flight NAR staging is an HA-safe alternative to CDC: it serves a NAR across
+replicas while it is still downloading. Enabling it (or CDC) satisfies the
+`replicaCount > 1` validation guard. It has zero overhead until a second replica
+contends for the same NAR and only activates with a distributed (Redis) lock.
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `config.inflightStaging.enabled` | Serve a NAR cross-pod while it is still downloading by staging it to shared storage as part-objects | `false` |
+| `config.inflightStaging.retention` | Grace period to retain staging part-objects after the NAR's final representation is committed | `5m` |
+| `config.inflightStaging.partSize` | Size in bytes of each staging part-object | `8388608` (8 MiB) |
 
 ### Database Configuration
 


### PR DESCRIPTION
Document in-flight NAR staging (group 11):
- Configuration Reference: new In-flight NAR Staging Options section covering
  --cache-inflight-staging-enabled / -retention / -part-size.
- Helm Chart Reference: add the config.inflightStaging.* rows; remove the
  config.cdc.iLoveTimeouts row.
- High Availability: HA now requires CDC OR in-flight staging, with staging as
  the recommended lightweight default; document the iLoveTimeouts removal and
  note request-affinity routing as an optional optimization, not a requirement.