### PR TITLE
ci: use shared check_mode matrix and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,13 @@ jobs:
       # the slower ARM runner where Postgres times out. See OpenSpec change
       # speed-up-ci; requires kalbasit/gh-actions test_systems input.
       test_systems: '["x86_64-linux"]'
-      # The shared build job no longer runs the monolithic `nix flake check` or
-      # coverage; the `check-matrix`/`checks`/`coverage` jobs below fan each
-      # check out into its own parallel runner instead (much lower wall-clock).
-      # The shared build job still builds/pushes the OCI image per arch.
-      run_flake_check: false
+      # Fan each flake check out into its own parallel job via the shared
+      # workflow's matrix mode (scoped to test_systems), and let it own coverage
+      # too — replacing the bespoke check-matrix/checks/coverage jobs this caller
+      # used to carry. The shared build job still builds/pushes the OCI image per
+      # arch. See OpenSpec change check-matrix in kalbasit/gh-actions.
+      check_mode: matrix
+      coverage: true
       languages: |
         {"go":{"targets":[
           {"attr":"ncps",                                        "file":"nix/packages/ncps/default.nix"},
@@ -50,76 +52,6 @@ jobs:
       gha_pat_token: ${{ secrets.GHA_PAT_TOKEN }}
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
-  # ---- Fanned-out flake checks -----------------------------------------------------
-  # Instead of one `nix flake check` building every check derivation on a single
-  # contended runner, enumerate the checks and run each as its own parallel job.
-  # Wall-clock collapses to the slowest single check + nix setup. Each job pulls
-  # the shared compile cache (_ncps-test-cache/_ncps-base) from Cachix rather than
-  # rebuilding it. See OpenSpec change fan-out-flake-check.
-  check-matrix:
-    runs-on: ubuntu-24.04
-    outputs:
-      checks: ${{ steps.list.outputs.checks }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          persist-credentials: false
-      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
-      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
-        with:
-          name: ncps
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Enumerate checks
-        id: list
-        run: |
-          echo "checks=$(nix eval .#checks.x86_64-linux --apply builtins.attrNames --json)" >> "$GITHUB_OUTPUT"
-  checks:
-    needs: check-matrix
-    runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        check: ${{ fromJson(needs.check-matrix.outputs.checks) }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          persist-credentials: false
-      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
-      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
-        with:
-          name: ncps
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build check
-        # Pass the matrix value via env, not direct `${{ }}` expansion into the
-        # shell: on fork PRs the check names come from `builtins.attrNames` over
-        # the attacker-controlled flake, so interpolating them into `run:` would
-        # be a template-injection vector. Quoted env reference treats it as data.
-        env:
-          CHECK: ${{ matrix.check }}
-        run: nix build ".#checks.x86_64-linux.$CHECK" -L
-  coverage:
-    needs: checks
-    # Coverage is informational (not a gate) and needs the Codecov token, so skip
-    # it on fork PRs. Merges the per-cohort cover.out (built by the `checks` jobs
-    # and pulled from Cachix) into one profile.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          persist-credentials: false
-      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
-      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
-        with:
-          name: ncps
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: Build coverage
-        run: nix build ".#ncps.coverage" -L
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: result-coverage
   # ---- ncps-specific sibling jobs --------------------------------------------------
   # These stay here because they don't generalize across the other consumers.
   # They run their own paths-filter because the reusable workflow doesn't (currently)
@@ -210,9 +142,6 @@ jobs:
     if: always()
     needs:
       - shared
-      - check-matrix
-      - checks
-      - coverage
       - filter
       - generate-database
       - deploy-docs-pages
@@ -220,9 +149,6 @@ jobs:
       - name: Check Workflow Status
         env:
           SHARED_RESULT: ${{ needs.shared.result }}
-          CHECK_MATRIX_RESULT: ${{ needs.check-matrix.result }}
-          CHECKS_RESULT: ${{ needs.checks.result }}
-          COVERAGE_RESULT: ${{ needs.coverage.result }}
           FILTER_RESULT: ${{ needs.filter.result }}
           GENERATE_DATABASE_RESULT: ${{ needs.generate-database.result }}
           DEPLOY_DOCS_PAGES_RESULT: ${{ needs.deploy-docs-pages.result }}
@@ -232,9 +158,6 @@ jobs:
 
           declare -A results=(
             ["shared"]="$SHARED_RESULT"
-            ["check-matrix"]="$CHECK_MATRIX_RESULT"
-            ["checks"]="$CHECKS_RESULT"
-            ["coverage"]="$COVERAGE_RESULT"
             ["filter"]="$FILTER_RESULT"
             ["generate-database"]="$GENERATE_DATABASE_RESULT"
             ["deploy-docs-pages"]="$DEPLOY_DOCS_PAGES_RESULT"


### PR DESCRIPTION
## Summary

- Drop the bespoke `check-matrix` / `checks` / `coverage` jobs now that the shared reusable workflow owns the flake-check fan-out and coverage.
- Set `check_mode: matrix` and `coverage: true` on the `shared` call; remove the deleted jobs from the final gate's `needs` and result enumeration.
- Temporarily pin the shared workflow to the gh-actions `user/wnasreddine/check-matrix` branch to exercise the new inputs in CI.

Depends on kalbasit/gh-actions#12 — repin to `@main` once that merges.

## Test plan

- [x] CI green against the gh-actions branch
- [x] checks fan out per check on `x86_64-linux`
- [x] coverage uploads on non-fork builds; skipped on fork PRs