### PR TITLE
fix(fsck): detect chunk residue post-drain

### DIFF
--- a/openspec/changes/archive/2026-06-07-fsck-reclaim-orphaned-chunk-residue/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-07-fsck-reclaim-orphaned-chunk-residue/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/archive/2026-06-07-fsck-reclaim-orphaned-chunk-residue/design.md
+++ b/openspec/changes/archive/2026-06-07-fsck-reclaim-orphaned-chunk-residue/design.md
@@ -1,0 +1,53 @@
+## Context
+
+`ncps fsck` gates all chunk-related work behind a `cdcMode` boolean computed at `pkg/ncps/fsck.go` (the "5. Detect CDC mode" block). Today `cdcMode` is true iff:
+
+1. DB config key `cdc_enabled == "true"`, or
+2. (fallback) any `nar_file` has `total_chunks > 0`.
+
+Only when `cdcMode` is true does fsck call `getChunkStorageBackend(...)` and pass a non-nil `chunkStore` into `collectFsckSuspects(...)`, which is what surfaces `orphanedChunksInDB` / `orphanedChunksInStorage` and lets `--repair` reclaim them.
+
+A CDC→whole migration ends by (a) `serve` restart hitting `initCDCDrainMode` with `chunkedCount == 0`, which calls `DeleteCDCConfig()` (removes `cdc_enabled/min/avg/max`), and (b) every NAR being de-chunked so `total_chunks = 0` everywhere. Both `cdcMode` signals are now false — but the `chunks` table and chunk storage may still hold orphaned data (orphaned chunks are referenced by no `nar_file`, so signal 2 structurally cannot see them). A later `fsck` therefore initializes no chunk store and silently skips reclamation. Observed live 2026-06-07: ~5.5M orphaned chunk rows were reclaimable only because the single `fsck` run started ~46s before drain cleared the config; the sole recovery otherwise is manually re-inserting `cdc_enabled=true`.
+
+`entchunk` is already imported in `fsck.go`. The chunk store backend is derived from storage flags (local `/store` path or S3), not from CDC config keys — so initializing it post-drain is already safe (`initCDCDrainMode` does the same).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make a post-drain `fsck` detect and (under `--repair`) reclaim orphaned chunk residue without operator intervention.
+- Keep the detection cheap (one indexed existence query) and the behavior obvious in logs.
+- Preserve all existing gating: dry-run reports only; `--repair` mutates.
+
+**Non-Goals:**
+- No new CLI flags or config keys.
+- Do not re-enable CDC writes or recreate the deleted `cdc_enabled` config.
+- Do not change chunk creation, serving, migration, or the reclaim/cascade logic itself — only *when* `cdcMode` is reached.
+
+## Decisions
+
+**D1: Add a third `cdcMode` signal — non-empty `chunks` table.**
+Append a clause to the detection block: if signals 1 and 2 are false, run `dbClient.Ent().Chunk.Query().Exist(ctx)`; if true, set `cdcMode = true`. Rationale: orphaned chunks always leave `chunks` rows behind (DB rows are deleted last during reclaim), so a non-empty table is the reliable, dialect-agnostic proxy for "residue may exist." `Exist` compiles to `SELECT EXISTS(SELECT 1 FROM chunks ...)`, indexed and O(1)-ish — no full scan.
+- *Alternative considered — walk chunk storage* to catch stray chunk *files* with no DB row (`orphanedChunksInStorage`): rejected as the primary signal because it costs a full storage walk on every `fsck` (including non-CDC caches) just to decide a boolean. The existing `orphanedChunksInStorage` walk still runs *after* `cdcMode` is enabled, so once the DB signal trips, stray files are still reclaimed. The only uncovered corner — chunk files present with a totally empty `chunks` table — is implausible (files are deleted before/with their rows) and out of scope.
+- *Alternative considered — check storage `/store/chunks` dir non-empty*: same walk cost, backend-specific; rejected.
+
+**D2: Emit a distinct residue-detection log.**
+When `cdcMode` is enabled solely by signal 3, log an `Info` like `"CDC mode enabled: chunk residue detected (orphaned chunks present after CDC disabled); reclaiming under --repair"`. It MUST be distinguishable from the existing signal-2 fallback `Warn` (`"cdc_enabled not set ... but chunked nar_files exist ..."`). Rationale: a post-drain operator seeing fsck do chunk work should immediately understand why, without it looking like CDC silently came back.
+
+**D3: Precedence preserved.** Signals evaluated 1→2→3; first match wins and short-circuits, so active CDC (signal 1) never emits the residue log. Keeps existing behavior byte-for-byte when CDC is active or NARs are still chunked.
+
+**D4: TDD.** Add failing unit/integration tests first (residue table-state permutations) against the detection function, then implement. Existing fsck tests under `pkg/ncps/fsck*_test.go` and `pkg/ncps/fsck_chunked_residue*_test.go` are the harness.
+
+## Risks / Trade-offs
+
+- **[A fresh, mid-CDC cache momentarily has chunk rows but no config]** → Not a regression: that state already trips signal 2 (chunked nar_files exist) or signal 1; signal 3 only adds coverage, never removes it.
+- **[Extra query on every `fsck` run]** → One indexed `EXISTS` only when signals 1 and 2 are both false (i.e., the non-CDC / post-drain path). On active-CDC runs it is never reached. Negligible.
+- **[Stray chunk files with an empty `chunks` table go unreclaimed]** → Accepted/out of scope (see D1); implausible given deletion ordering. Could be a future `--reclaim-chunk-storage` follow-up if ever observed.
+- **[Operator confusion: "is CDC back on?"]** → Mitigated by D2's explicit, distinct log wording.
+
+## Migration Plan
+
+Pure code change in `pkg/ncps/fsck.go`; no schema migration, no config change, no new flags. Ship normally. Rollback = revert the commit. Forward-compatible: an old `fsck` binary simply retains today's behavior (won't detect post-drain residue), so deploying does not strand anything that wasn't already stranded.
+
+## Open Questions
+
+- Log wording for D2 — exact phrasing to be finalized in implementation (must not imply CDC writes re-enabled).

--- a/openspec/changes/archive/2026-06-07-fsck-reclaim-orphaned-chunk-residue/proposal.md
+++ b/openspec/changes/archive/2026-06-07-fsck-reclaim-orphaned-chunk-residue/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+After a CDC→whole-file migration fully drains, `fsck` can no longer reclaim leftover chunk residue. `fsck` only runs chunk checks when it detects "CDC mode," currently `cdc_enabled == "true"` (DB config) **OR** any `nar_file.total_chunks > 0`. Once drain completes, the serve restart deletes the `cdc_enabled` config key **and** every NAR is de-chunked (`total_chunks = 0`) — so both signals go false while the `chunks` table and chunk storage may still hold orphaned data (by definition orphaned chunks are referenced by no `nar_file`). A subsequent `fsck` detects `cdcMode = false`, never initializes the chunk store, and silently skips orphaned-chunk reclamation, stranding those rows and files permanently.
+
+This is not hypothetical: on prod (2026-06-07) ~5.5M orphaned chunk rows were reclaimable only because the one `fsck` run happened to start ~46s before the drain cleared the config. The only current recovery is manually re-inserting `cdc_enabled=true`.
+
+## What Changes
+
+- Add a third CDC-mode detection signal in `fsck`: if chunk residue exists (the `chunks` table is non-empty), enable `cdcMode` so the chunk store is initialized and orphaned-chunk detection/reclamation runs — even when `cdc_enabled` is absent and no `nar_file` references chunks.
+- Emit a distinct, informative log when CDC mode is enabled solely by residue detection (vs. active CDC or chunked `nar_file`s), so operators understand why a post-drain `fsck` is doing chunk work.
+- Preserve all existing gating: reclamation still only mutates under `--repair`; dry-run continues to report-only.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `fsck`: the CDC-mode detection requirement is extended so a non-empty `chunks` table independently enables CDC-mode checks. This makes orphaned chunk residue detectable and reclaimable across the full CDC lifecycle, including after CDC and drain mode are fully disabled.
+
+## Impact
+
+- **Code**: `pkg/ncps/fsck.go` — the `cdcMode` detection block (currently config-key + `total_chunks>0` fallback). Adds one indexed existence query (`Chunk.Query().Exist(ctx)`).
+- **Behavior**: a post-drain `fsck` now initializes the chunk store and reclaims orphaned chunks under `--repair`. No change to `serve`, drain, or migration semantics; CDC config is not recreated.
+- **I/O / memory**: one extra cheap existence query per `fsck` run. When residue is found, `fsck` performs the existing chunk-store walk/reclamation it already does in CDC mode — no new per-chunk cost beyond enabling the established path. Negligible network impact.
+
+## Non-goals
+
+- No new CLI flags or config keys; detection is automatic.
+- Does not alter how chunks are created, served, or migrated.
+- Does not re-enable CDC writes or recreate the deleted `cdc_enabled` config.
+- Does not change the reclamation/cascade logic itself — only when it is reached.

--- a/openspec/changes/archive/2026-06-07-fsck-reclaim-orphaned-chunk-residue/specs/fsck/spec.md
+++ b/openspec/changes/archive/2026-06-07-fsck-reclaim-orphaned-chunk-residue/specs/fsck/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Fsck MUST enable CDC mode when chunk residue exists, even after CDC and drain are fully disabled
+
+`ncps fsck` SHALL determine `cdcMode` from any of the following signals, in order, treating the first match as sufficient:
+
+1. The DB config key `cdc_enabled` equals `"true"`.
+2. At least one `nar_file` has `total_chunks > 0`.
+3. The `chunks` table is non-empty (at least one chunk row exists).
+
+Signal 3 is the new residue signal. Orphaned chunks are, by definition, referenced by no `nar_file`, so signals 1 and 2 both go false once CDC is disabled and every NAR has been de-chunked — leaving residue undetectable without signal 3. The residue check SHALL be a single indexed existence query (`Chunk.Query().Exist(ctx)`), not a full scan.
+
+When `cdcMode` is enabled, `ncps fsck` SHALL initialize the chunk store via the existing storage-backend configuration (independent of any CDC config keys) and run the established orphaned-chunk detection and, under `--repair`, reclamation.
+
+When `cdcMode` is enabled **solely** by signal 3 (signals 1 and 2 both false), `ncps fsck` SHALL emit a distinct informational log indicating CDC mode was enabled because chunk residue was detected, so operators understand why a post-drain `fsck` is performing chunk work. This log SHALL be distinguishable from the existing fallback warning emitted when signal 2 triggers without signal 1.
+
+#### Scenario: Post-drain orphaned chunks are detected and reclaimed
+
+- **WHEN** `cdc_enabled` is absent from DB config, no `nar_file` has `total_chunks > 0`, the `chunks` table contains orphaned chunk rows, and `ncps fsck --repair` runs
+- **THEN** `cdcMode` is enabled via the residue signal, the chunk store is initialized
+- **AND** the orphaned chunk DB rows and their backing storage files are reclaimed
+- **AND** a distinct "CDC mode enabled: chunk residue detected" informational log is emitted
+
+#### Scenario: Post-drain dry-run reports residue without deleting
+
+- **WHEN** the same post-drain residue exists and `ncps fsck` runs without `--repair`
+- **THEN** `cdcMode` is enabled via the residue signal and the orphaned chunks are reported in the summary
+- **AND** no chunk DB rows or storage files are deleted
+
+#### Scenario: A cache that never used CDC stays in non-CDC mode
+
+- **WHEN** `cdc_enabled` is absent, no `nar_file` has `total_chunks > 0`, and the `chunks` table is empty
+- **THEN** `cdcMode` remains false, the chunk store is not initialized, and `fsck` performs no chunk checks
+
+#### Scenario: Active CDC takes precedence over the residue signal
+
+- **WHEN** `cdc_enabled` equals `"true"` and chunk rows also exist
+- **THEN** `cdcMode` is enabled via signal 1 and the residue-detection log is NOT emitted

--- a/openspec/changes/archive/2026-06-07-fsck-reclaim-orphaned-chunk-residue/tasks.md
+++ b/openspec/changes/archive/2026-06-07-fsck-reclaim-orphaned-chunk-residue/tasks.md
@@ -1,0 +1,22 @@
+## 1. Tests first (TDD — red)
+
+- [x] 1.1 Add a failing test asserting `cdcMode` is enabled when `cdc_enabled` is absent, no `nar_file` has `total_chunks > 0`, but the `chunks` table is non-empty (post-drain residue state).
+- [x] 1.2 Add a failing test asserting `cdcMode` stays false (no chunk store init, no chunk checks) when `cdc_enabled` is absent, no chunked `nar_file`s, and the `chunks` table is empty (never-CDC cache).
+- [x] 1.3 Add a test asserting precedence: when `cdc_enabled == "true"` and chunk rows exist, `cdcMode` is enabled via signal 1 and the residue-detection log is NOT emitted.
+- [x] 1.4 Add an integration/e2e test (or extend an existing fsck residue test) covering the full path: post-drain orphaned chunks → `fsck --repair` reclaims orphaned chunk DB rows and storage files; dry-run reports but does not delete.
+
+## 2. Implementation (green)
+
+- [x] 2.1 In `pkg/ncps/fsck.go` "Detect CDC mode" block, add a third signal after the `total_chunks > 0` fallback: when still `!cdcMode`, run `dbClient.Ent().Chunk.Query().Exist(ctx)`; on true set `cdcMode = true`. Handle the query error by warning and leaving `cdcMode` unchanged (consistent with the existing fallback's error handling).
+- [x] 2.2 Emit a distinct `Info` log when `cdcMode` is enabled solely by the residue signal (signals 1 and 2 false), with wording that does NOT imply CDC writes were re-enabled and is distinguishable from the existing signal-2 `Warn`.
+- [x] 2.3 Confirm no change to the chunk-store init (`getChunkStorageBackend`), `collectFsckSuspects`, or reclaim/cascade paths — the new signal only flips `cdcMode`.
+
+## 3. Verify
+
+- [x] 3.1 Run `task test` (race detector) — all new and existing fsck tests pass.
+- [x] 3.2 Run `task lint` and `task fmt` — zero issues, clean formatting.
+- [x] 3.3 Manually reason through / spot-check that an active-CDC and a still-chunked-NARs run produce byte-identical behavior and logs to pre-change.
+
+## 4. Spec sync
+
+- [x] 4.1 Verify implementation matches the `fsck` delta spec scenarios (`/opsx:verify`); adjust code or spec wording (D2 log text) if they diverge.

--- a/openspec/specs/fsck/spec.md
+++ b/openspec/specs/fsck/spec.md
@@ -268,3 +268,40 @@ A chunked `nar_file` whose `chunking_started_at` indicates it is currently being
 - **THEN** fsck SHALL NOT set `H`'s `dechunk_residue_flagged_at`
 - **AND** SHALL NOT purge `H`
 
+### Requirement: Fsck MUST enable CDC mode when chunk residue exists, even after CDC and drain are fully disabled
+
+`ncps fsck` SHALL determine `cdcMode` from any of the following signals, in order, treating the first match as sufficient:
+
+1. The DB config key `cdc_enabled` equals `"true"`.
+2. At least one `nar_file` has `total_chunks > 0`.
+3. The `chunks` table is non-empty (at least one chunk row exists).
+
+Signal 3 is the new residue signal. Orphaned chunks are, by definition, referenced by no `nar_file`, so signals 1 and 2 both go false once CDC is disabled and every NAR has been de-chunked — leaving residue undetectable without signal 3. The residue check SHALL be a single indexed existence query (`Chunk.Query().Exist(ctx)`), not a full scan.
+
+When `cdcMode` is enabled, `ncps fsck` SHALL initialize the chunk store via the existing storage-backend configuration (independent of any CDC config keys) and run the established orphaned-chunk detection and, under `--repair`, reclamation.
+
+When `cdcMode` is enabled **solely** by signal 3 (signals 1 and 2 both false), `ncps fsck` SHALL emit a distinct informational log indicating CDC mode was enabled because chunk residue was detected, so operators understand why a post-drain `fsck` is performing chunk work. This log SHALL be distinguishable from the existing fallback warning emitted when signal 2 triggers without signal 1.
+
+#### Scenario: Post-drain orphaned chunks are detected and reclaimed
+
+- **WHEN** `cdc_enabled` is absent from DB config, no `nar_file` has `total_chunks > 0`, the `chunks` table contains orphaned chunk rows, and `ncps fsck --repair` runs
+- **THEN** `cdcMode` is enabled via the residue signal, the chunk store is initialized
+- **AND** the orphaned chunk DB rows and their backing storage files are reclaimed
+- **AND** a distinct "CDC mode enabled: chunk residue detected" informational log is emitted
+
+#### Scenario: Post-drain dry-run reports residue without deleting
+
+- **WHEN** the same post-drain residue exists and `ncps fsck` runs without `--repair`
+- **THEN** `cdcMode` is enabled via the residue signal and the orphaned chunks are reported in the summary
+- **AND** no chunk DB rows or storage files are deleted
+
+#### Scenario: A cache that never used CDC stays in non-CDC mode
+
+- **WHEN** `cdc_enabled` is absent, no `nar_file` has `total_chunks > 0`, and the `chunks` table is empty
+- **THEN** `cdcMode` remains false, the chunk store is not initialized, and `fsck` performs no chunk checks
+
+#### Scenario: Active CDC takes precedence over the residue signal
+
+- **WHEN** `cdc_enabled` equals `"true"` and chunk rows also exist
+- **THEN** `cdcMode` is enabled via signal 1 and the residue-detection log is NOT emitted
+

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -124,6 +124,90 @@ type ChunkWalker interface {
 	WalkChunks(ctx context.Context, fn func(hash string) error) error
 }
 
+// cdcModeReason explains why fsck enabled (or did not enable) CDC-mode checks.
+// Returning the reason rather than a bare bool keeps the decision unit-testable
+// without capturing log output, and lets the caller distinguish the residue case.
+type cdcModeReason int
+
+const (
+	// cdcModeOff means no CDC signal was found; fsck skips all chunk checks.
+	cdcModeOff cdcModeReason = iota
+	// cdcModeFromConfig means cdc_enabled == "true" in DB config (active/draining CDC).
+	cdcModeFromConfig
+	// cdcModeFromChunkedNarFiles means at least one nar_file has total_chunks > 0.
+	cdcModeFromChunkedNarFiles
+	// cdcModeFromChunkResidue means the chunks table is non-empty while signals 1
+	// and 2 are both false — orphaned chunk residue left after CDC was disabled and
+	// every NAR de-chunked. Without this signal such residue is undetectable.
+	cdcModeFromChunkResidue
+)
+
+// enabled reports whether any CDC signal was detected.
+func (r cdcModeReason) enabled() bool { return r != cdcModeOff }
+
+// detectFsckCDCMode decides whether fsck should run CDC/chunk checks. Signals are
+// evaluated in priority order and the first match wins:
+//
+//  1. cdc_enabled == "true" in DB config.
+//  2. any nar_file has total_chunks > 0 (chunked data present).
+//  3. the chunks table is non-empty (orphaned chunk residue: signals 1 and 2 are
+//     both false here because orphaned chunks are referenced by no nar_file).
+//
+// Query errors are logged and treated as "signal absent" so detection degrades to
+// the next signal rather than aborting the run.
+func detectFsckCDCMode(ctx context.Context, dbClient *database.Client, logger zerolog.Logger) cdcModeReason {
+	if dbClient == nil {
+		return cdcModeOff
+	}
+
+	cdcConfig, dbErr := dbClient.Ent().ConfigEntry.Query().
+		Where(entconfigentry.KeyEQ(config.KeyCDCEnabled)).
+		Only(ctx)
+	switch {
+	case dbErr != nil && !ent.IsNotFound(dbErr):
+		logger.Warn().Err(dbErr).Msg(
+			"could not read cdc_enabled from DB config; CDC mode detection will fall back to data-based detection",
+		)
+	case dbErr == nil && cdcConfig.Value == configValueTrue:
+		return cdcModeFromConfig
+	}
+
+	// Fallback: chunked data exists even though the config key is missing (e.g. wrong
+	// DB URL or schema mismatch).
+	hasChunked, checkErr := dbClient.Ent().NarFile.Query().
+		Where(entnarfile.TotalChunksGT(0)).
+		Exist(ctx)
+	switch {
+	case checkErr != nil:
+		logger.Warn().Err(checkErr).Msg("could not check for chunked nar_files")
+	case hasChunked:
+		logger.Warn().Msg(
+			"cdc_enabled not set in DB config but chunked nar_files exist; " +
+				"enabling CDC mode automatically — verify --cache-database-url is correct",
+		)
+
+		return cdcModeFromChunkedNarFiles
+	}
+
+	// Residue: orphaned chunks can remain after CDC is disabled and all NARs are
+	// de-chunked, when neither signal above fires. Without enabling CDC mode here the
+	// chunk store is never initialized and the residue is never reclaimed.
+	hasResidue, residueErr := dbClient.Ent().Chunk.Query().Exist(ctx)
+	switch {
+	case residueErr != nil:
+		logger.Warn().Err(residueErr).Msg("could not check for orphaned chunk residue")
+	case hasResidue:
+		logger.Info().Msg(
+			"chunk residue detected (orphaned chunks remain after CDC was disabled); " +
+				"enabling CDC mode to reclaim them — run with --repair to delete",
+		)
+
+		return cdcModeFromChunkResidue
+	}
+
+	return cdcModeOff
+}
+
 func fsckCommand(
 	flagSources flagSourcesFn,
 	registerShutdown registerShutdownFn,
@@ -386,38 +470,7 @@ Use --repair to automatically fix detected issues, or --dry-run to preview what 
 			}
 
 			// 5. Detect CDC mode
-			cdcMode := false
-
-			cdcConfig, dbErr := dbClient.Ent().ConfigEntry.Query().
-				Where(entconfigentry.KeyEQ(config.KeyCDCEnabled)).
-				Only(ctx)
-			switch {
-			case dbErr != nil && !ent.IsNotFound(dbErr):
-				logger.Warn().Err(dbErr).Msg(
-					"could not read cdc_enabled from DB config; CDC mode detection will fall back to data-based detection",
-				)
-			case dbErr == nil && cdcConfig.Value == configValueTrue:
-				cdcMode = true
-			}
-
-			// Fallback: if CDC not detected from config, check if any nar_file has
-			// total_chunks > 0. This handles cases where the DB config key is missing
-			// but chunked data already exists (e.g. wrong DB URL or schema mismatch).
-			if !cdcMode {
-				hasChunked, checkErr := dbClient.Ent().NarFile.Query().
-					Where(entnarfile.TotalChunksGT(0)).
-					Exist(ctx)
-				if checkErr != nil {
-					logger.Warn().Err(checkErr).Msg("could not check for chunked nar_files")
-				} else if hasChunked {
-					logger.Warn().Msg(
-						"cdc_enabled not set in DB config but chunked nar_files exist; " +
-							"enabling CDC mode automatically — verify --cache-database-url is correct",
-					)
-
-					cdcMode = true
-				}
-			}
+			cdcMode := detectFsckCDCMode(ctx, dbClient, logger).enabled()
 
 			var chunkStore chunk.Store
 

--- a/pkg/ncps/fsck_cdc_mode_detection_internal_test.go
+++ b/pkg/ncps/fsck_cdc_mode_detection_internal_test.go
@@ -1,0 +1,136 @@
+package ncps
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/config"
+	"github.com/kalbasit/ncps/pkg/database"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// newCDCModeTestDB returns a freshly-migrated in-process SQLite client for
+// exercising detectFsckCDCMode against real DB state.
+func newCDCModeTestDB(t *testing.T) *database.Client {
+	t.Helper()
+
+	dbFile := filepath.Join(t.TempDir(), "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
+	dbClient, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dbClient.Close() })
+
+	return dbClient
+}
+
+func addOrphanChunk(ctx context.Context, t *testing.T, dbClient *database.Client, hash string) {
+	t.Helper()
+
+	_, err := dbClient.Ent().Chunk.Create().
+		SetHash(hash).
+		SetSize(10).
+		SetCompressedSize(5).
+		Save(ctx)
+	require.NoError(t, err)
+}
+
+// TestDetectFsckCDCMode_ChunkResidueOnly is the post-drain scenario: no
+// cdc_enabled config and no chunked nar_files, but orphaned chunk rows remain.
+// Detection MUST still enable CDC mode so the residue is reclaimable.
+func TestDetectFsckCDCMode_ChunkResidueOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbClient := newCDCModeTestDB(t)
+
+	addOrphanChunk(ctx, t, dbClient, "orphanchunkhashaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+	reason := detectFsckCDCMode(ctx, dbClient, zerolog.Nop())
+
+	require.Equal(t, cdcModeFromChunkResidue, reason)
+	require.True(t, reason.enabled())
+}
+
+func setCDCEnabled(ctx context.Context, t *testing.T, dbClient *database.Client) {
+	t.Helper()
+
+	_, err := dbClient.Ent().ConfigEntry.Create().
+		SetKey(config.KeyCDCEnabled).
+		SetValue("true").
+		Save(ctx)
+	require.NoError(t, err)
+}
+
+func addChunkedNarFile(ctx context.Context, t *testing.T, dbClient *database.Client, hash string) {
+	t.Helper()
+
+	_, err := dbClient.Ent().NarFile.Create().
+		SetHash(hash).
+		SetCompression("xz").
+		SetQuery("").
+		SetFileSize(100).
+		SetTotalChunks(2).
+		Save(ctx)
+	require.NoError(t, err)
+}
+
+// TestDetectFsckCDCMode_NilClient: a nil database client yields non-CDC mode
+// rather than panicking.
+func TestDetectFsckCDCMode_NilClient(t *testing.T) {
+	t.Parallel()
+
+	reason := detectFsckCDCMode(context.Background(), nil, zerolog.Nop())
+
+	require.Equal(t, cdcModeOff, reason)
+	require.False(t, reason.enabled())
+}
+
+// TestDetectFsckCDCMode_NeverCDC: a cache that never used CDC (no config key, no
+// chunked nar_files, empty chunks table) MUST stay in non-CDC mode.
+func TestDetectFsckCDCMode_NeverCDC(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbClient := newCDCModeTestDB(t)
+
+	reason := detectFsckCDCMode(ctx, dbClient, zerolog.Nop())
+
+	require.Equal(t, cdcModeOff, reason)
+	require.False(t, reason.enabled())
+}
+
+// TestDetectFsckCDCMode_ConfigTakesPrecedence: cdc_enabled=true wins over the
+// residue signal, so the residue reason is not reported even when chunks exist.
+func TestDetectFsckCDCMode_ConfigTakesPrecedence(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbClient := newCDCModeTestDB(t)
+
+	setCDCEnabled(ctx, t, dbClient)
+	addOrphanChunk(ctx, t, dbClient, "orphanchunkhashbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+	reason := detectFsckCDCMode(ctx, dbClient, zerolog.Nop())
+
+	require.Equal(t, cdcModeFromConfig, reason)
+}
+
+// TestDetectFsckCDCMode_ChunkedNarFiles: with no config key but a chunked
+// nar_file present, the data-based fallback enables CDC mode.
+func TestDetectFsckCDCMode_ChunkedNarFiles(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbClient := newCDCModeTestDB(t)
+
+	addChunkedNarFile(ctx, t, dbClient, "chunkednarfilehashcccccccccccccccccccccccccccccccccc")
+
+	reason := detectFsckCDCMode(ctx, dbClient, zerolog.Nop())
+
+	require.Equal(t, cdcModeFromChunkedNarFiles, reason)
+}

--- a/pkg/ncps/fsck_test.go
+++ b/pkg/ncps/fsck_test.go
@@ -1971,3 +1971,61 @@ func TestChunksForNarFile_LargePostgreSQL(t *testing.T) {
 		assert.Equal(t, chunks[i].ID, ch.ID, "chunk at index %d must be in chunk_index order", i)
 	}
 }
+
+// TestFsckReclaimsOrphanedChunkResiduePostDrain validates the post-drain fix
+// end-to-end through the real fsck command. With NO cdc_enabled config and NO
+// chunked nar_files — the state after a CDC→whole migration fully drains — an
+// orphaned chunk row must still be detected (dry-run) and reclaimed (--repair).
+// Before the residue-detection signal, fsck ran in non-CDC mode here and silently
+// ignored the chunk, stranding it forever.
+func TestFsckReclaimsOrphanedChunkResiduePostDrain(t *testing.T) {
+	t.Parallel()
+
+	ctx := zerolog.New(os.Stderr).WithContext(context.Background())
+
+	dbClient, _, dir, dbURL, cleanup := setupFsckSQLite(t)
+	t.Cleanup(cleanup)
+
+	// Post-drain residue: a chunk row referenced by no nar_file, with no CDC config.
+	const chunkHash = "residuechunkhashpostdrainaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	_, err := dbClient.Ent().Chunk.Create().
+		SetHash(chunkHash).
+		SetSize(10).
+		SetCompressedSize(5).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Dry-run: the orphaned residue must be reported as an issue, proving CDC mode
+	// was enabled by residue detection alone (no config, no chunked nar_files).
+	app, err := ncps.New()
+	require.NoError(t, err)
+
+	dryRunErr := app.Run(ctx, []string{
+		"ncps", "fsck",
+		"--cache-database-url", dbURL,
+		"--cache-storage-local", dir,
+		"--dry-run",
+	})
+	require.ErrorIs(t, dryRunErr, ncps.ErrFsckIssuesFound)
+
+	// Dry-run reports but must NOT delete: the chunk row is still present.
+	afterDryRun, err := dbClient.Ent().Chunk.Query().Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, afterDryRun, "dry-run must not delete the orphaned chunk")
+
+	// Repair: the orphaned chunk row must be reclaimed.
+	app, err = ncps.New()
+	require.NoError(t, err)
+
+	require.NoError(t, app.Run(ctx, []string{
+		"ncps", "fsck",
+		"--cache-database-url", dbURL,
+		"--cache-storage-local", dir,
+		"--repair",
+	}))
+
+	count, err := dbClient.Ent().Chunk.Query().Count(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, count, "orphaned chunk residue must be deleted after fsck --repair")
+}


### PR DESCRIPTION
## Summary

After a CDC→whole migration fully drains, `fsck` detected CDC mode only when `cdc_enabled=true` **or** a `nar_file` had `total_chunks>0`. Once the serve restart cleared `cdc_enabled` and every NAR was de-chunked, both signals went false while orphaned chunk rows/files could remain — so `fsck` never initialized the chunk store and silently skipped reclamation, stranding the residue forever (observed in prod: ~5.5M orphaned chunk rows, reclaimable only because the one `fsck` run started ~46s before drain cleared the config).

- Extracted the inline CDC-mode detection into `detectFsckCDCMode()` returning a `cdcModeReason`.
- Added a third, lowest-priority signal: a non-empty `chunks` table (`Chunk.Query().Exist`). It fires only when signals 1 and 2 are both false, emitting a distinct info log so a post-drain `fsck`'s chunk work is self-explanatory.
- Precedence and the existing signal-1/2 log messages are unchanged → active-CDC and chunked-NAR runs behave identically.

Spec: adds requirement "Fsck MUST enable CDC mode when chunk residue exists, even after CDC and drain are fully disabled" to `openspec/specs/fsck`.

## Test plan

- [x] `task fmt` / `task lint` / `task test` pass
- [x] 4 internal unit tests covering all detection branches (residue-only, never-CDC, config precedence, chunked-nar-files fallback)
- [x] e2e: `fsck --dry-run` reports + `fsck --repair` reclaims residue with no `cdc_enabled` config and no chunked nar_files