### PR TITLE
fix(cache): tolerate compressed narinfos missing FileSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,8 @@ project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   making the upstream unusable. ncps now accepts these narinfos and, for compressed
   NARs served whole, computes the correct `FileSize` and `FileHash` itself from the
   stored compressed bytes (a single streaming SHA-256 pass) and backfills them into
-  the served narinfo. Upstream-provided values are preserved unchanged. (#1314)
+  the persisted narinfo record, which subsequent narinfo responses then reflect.
+  Upstream-provided values are preserved unchanged. (#1314)
 
 - **Helm: migration Job no longer mounts storage or tmp volumes for non-SQLite
   databases.** The migration Job was unconditionally mounting the storage PVC and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,15 @@ project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **Compressed upstream narinfos that omit `FileSize`/`FileHash` are no longer
+  rejected.** Some upstreams (e.g. niks3, nix-serve-style servers) emit narinfos
+  declaring a compression algorithm but without the optional `FileSize`/`FileHash`
+  fields, which ncps treated as fatal — returning a 404 for every request and
+  making the upstream unusable. ncps now accepts these narinfos and, for compressed
+  NARs served whole, computes the correct `FileSize` and `FileHash` itself from the
+  stored compressed bytes (a single streaming SHA-256 pass) and backfills them into
+  the served narinfo. Upstream-provided values are preserved unchanged. (#1314)
+
 - **Helm: migration Job no longer mounts storage or tmp volumes for non-SQLite
   databases.** The migration Job was unconditionally mounting the storage PVC and
   an 8 GiB in-memory `tmp` emptyDir even for PostgreSQL/MySQL deployments.

--- a/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/design.md
+++ b/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/design.md
@@ -1,0 +1,119 @@
+## Context
+
+`upstream.GetNarInfo` (`pkg/cache/upstream/cache.go:468-477`) hard-rejects any narinfo where
+`FileSize == 0 && Compression != none` with
+`invalid narinfo: FileSize is missing for a compressed NAR`. Several real upstreams (niks3,
+nix-serve-style servers) omit the *optional* `FileSize`/`FileHash` fields on compressed
+NARs, so every request 404s and the upstream is unusable (issue #1314). The existing TODO at
+that branch already anticipated the fix: compute the values from the NAR "when it arrives",
+deferred because that path is asynchronous.
+
+Relevant current behavior:
+- The narinfo is persisted **synchronously** in the download goroutine via
+  `storeInDatabase` (`pkg/cache/cache.go:4104`).
+- The NAR is fetched **asynchronously** by `prePullNar` (`cache.go:4050`), launched *before*
+  the narinfo is stored. `prePullNar` → `pullNarIntoStore` (`cache.go:2996`) streams the
+  compressed bytes into `narStore.PutNar`.
+- The compressed on-disk size is already known at store time (`storedFileSize`,
+  `cache.go:3582`) and tracked on the `nar_file` row. The compressed **hash** is not
+  computed anywhere today.
+- narinfo `file_hash` (string, nullable) and `file_size` (int64, nullable) columns already
+  exist (`ent/schema/narinfo.go:61-62`); they are written by
+  `applyNarInfoCreate`/`applyNarInfoUpdate` (`cache.go:5371`, `cache.go:5416`) only when
+  non-nil/non-zero, else left NULL.
+- `Compression: none` and CDC paths deliberately null `FileHash`/`FileSize`
+  (`cache.go:4075-4077`, `4179-4181`) — these are out of scope and must stay unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Stop rejecting compressed upstream narinfos that omit `FileSize`/`FileHash`.
+- For compressed NARs served under their original compression, always serve a correct
+  `FileSize` and `FileHash`, computing them from the stored compressed bytes when upstream
+  omits them, and backfilling them into the persisted narinfo.
+- Preserve upstream-provided `FileSize`/`FileHash` verbatim (no recompute).
+
+**Non-Goals:**
+- No change to `Compression: none` or CDC handling (those intentionally null these fields).
+- No re-hashing of NARs already stored before this change.
+- No DB schema/migration change (columns already exist and are nullable).
+- No change to NarHash/NarSize verification or the NAR bytes themselves.
+
+## Decisions
+
+### 1. Remove the rejection; do not synthesize a value at narinfo-parse time
+In `upstream.GetNarInfo`, delete the `Compression != none` rejection branch. Keep the
+existing `FileSize = NarSize` fallback only for the uncompressed (`none`) case. For a
+compressed NAR with no `FileSize`, leave `FileSize == 0` / `FileHash == nil` and let the
+pull path fill them. Rationale: the upstream layer only sees the narinfo, not the NAR bytes,
+so it cannot compute the *compressed* file's size/hash correctly (NarSize ≠ compressed
+size). Synthesizing `FileSize = NarSize` for a compressed NAR (the old uncompressed
+fallback) would advertise a wrong size — worse than omitting it.
+
+### 2. Reuse the existing post-store fixup; only FileHash is genuinely new
+Implementation revealed that the existing post-store fixup already backfills `FileSize`:
+`pullNarIntoStore` (and `PutNar`) call `checkAndFixNarInfosForNar` → `CheckAndFixNarInfo`,
+which reads the stored compressed size from `nar_file.file_size` (`getNarActualSize`) and
+corrects the narinfo via `fixNarInfoFileSize`. That path simply never ran for compressed
+NARs because the upstream layer rejected them first (Decision 1 removes that block). So the
+only missing computation is `FileHash`. The fix extends `CheckAndFixNarInfo`'s compressed
+branch with `computeStoredNarFileHash`, which streams the stored compressed NAR
+(`narStore.GetNar`) through a single `sha256` pass (constant memory, no full-file buffering)
+and formats it as `nixhash.MustNewHashWithEncoding(SHA256, sum, NixBase32, true)` →
+`sha256:<nixbase32>` (the constructor used in `migrate_chunks_to_nar`).
+
+*Alternative considered:* tap the in-flight pull stream with `io.TeeReader` and persist the
+hash on a new `nar_file` column. Rejected — it requires a schema migration (violating a
+non-goal), touches the hot streaming path for every NAR, and duplicates the existing
+read-after-store fixup architecture that already handles `FileSize`. The chosen approach
+incurs one extra streaming read, but only for compressed NARs whose upstream omitted
+`FileHash` (the niks3 minority), once per NAR.
+
+### 3. Backfill is the existing fixup's eventual-completeness model
+The narinfo row is written (`storeInDatabase`) before the async NAR download finishes, so the
+computed values cannot be present at first store. `checkAndFixNarInfosForNar` runs after the
+NAR lands and reconciles the narinfo by URL — the same mechanism that already corrected
+`FileSize`. The first narinfo response in the (brief) window before the NAR lands may omit
+these fields — acceptable because they are optional in the narinfo format and Nix verifies
+the closure against `NarHash` after decompression regardless. The backfill UPDATE is
+idempotent and conditional (set `file_hash` only when currently NULL/empty).
+
+*Alternative considered:* block `storeInDatabase` until the NAR finishes downloading so the
+first serve is complete. Rejected — this is exactly what the original TODO flagged ("since
+this is async it breaks a lot of tests"); it adds the full NAR-download latency to the
+narinfo response and serializes two operations that are intentionally decoupled.
+
+### 4. Only compute when needed
+Skip the SHA-256 pass when the narinfo already carries `FileHash` (upstream supplied it),
+when compression is `none` (handled by the earlier `checkAndFixNarInfoNoCompression`
+branch), or when the NAR is not whole-file in the store (`hasNarInStore` is false — CDC
+narinfos are normalized to `none`). Rationale: avoids hashing on the common path.
+
+## Risks / Trade-offs
+
+- **Transient narinfo without FileHash/FileSize** (between first serve and NAR landing) →
+  Mitigation: optional fields; Nix tolerates their absence and verifies via NarHash. Backfill
+  closes the gap on the next request.
+- **Extra CPU for a SHA-256 pass** on compressed NARs lacking an upstream FileHash →
+  Mitigation: only hash when needed (Decision 4); single streaming pass, no extra I/O.
+- **Concurrent narinfo writes** could race the backfill UPDATE → Mitigation: conditional
+  update (set only when NULL) + the existing per-hash narinfo write lock; the update is
+  idempotent.
+- **Re-pull after eviction** recomputes the hash → Mitigation: idempotent; same bytes yield
+  the same `FileHash`/`FileSize`.
+- **Accidentally writing these fields on the none/CDC paths** → Mitigation: gate strictly on
+  `Compression != none` and non-CDC storage; covered by tests asserting those paths still
+  null the fields.
+
+## Migration Plan
+
+- No DB migration: `file_hash`/`file_size` columns already exist and are nullable.
+- Pure forward, backward-compatible change. Rollback = revert the code; previously
+  backfilled rows simply carry valid optional fields that an older binary ignores/overwrites.
+- No config flag; the behavior is strictly more permissive (accepts narinfos previously
+  rejected) and otherwise transparent.
+
+## Open Questions
+
+- None blocking. (The opaque-URL compressed case at `cache.go:4078-4085` follows the same
+  compressed-serve path and is covered by the same compute/backfill logic.)

--- a/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/proposal.md
+++ b/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/proposal.md
@@ -12,11 +12,12 @@ request. This makes such upstreams entirely unusable through ncps (GitHub issue 
 - Stop rejecting upstream narinfos that carry a non-`none` `Compression` but no
   `FileSize`/`FileHash`. Such narinfos SHALL be fetched and served instead of erroring.
 - For compressed NARs, ncps SHALL always deliver a correct `FileSize` and `FileHash`
-  downstream. When upstream omits them, ncps SHALL compute them itself by streaming the
-  compressed NAR through a hasher + byte counter (it already proxies the bytes), then
-  backfill the computed values into the stored/served narinfo.
-- Because the NAR is fetched lazily (after the narinfo), the computation happens when the
-  NAR streams through ncps; subsequent narinfo serves carry the computed values.
+  downstream. When upstream omits them, ncps SHALL compute them itself from the stored
+  compressed NAR bytes (a single streaming SHA-256 pass + byte length), then backfill the
+  computed values into the persisted narinfo record.
+- Because the NAR is fetched lazily (after the narinfo), the computation happens in the
+  post-store fixup once the NAR has been stored; subsequent narinfo serves carry the
+  backfilled values.
 - Conventional narinfos that DO supply `FileSize`/`FileHash` continue to behave exactly as
   today (no recompute).
 - Removes the stale `FileSize == 0 && Compression != none` rejection branch and its TODO.
@@ -34,8 +35,8 @@ request. This makes such upstreams entirely unusable through ncps (GitHub issue 
 ## Impact
 
 - Code: `pkg/cache/upstream/cache.go` (`GetNarInfo`, the `FileSize == 0` branch around
-  line 468) plus the NAR fetch/stream path where the compressed bytes pass through ncps
-  (to compute `FileSize`/`FileHash`) and the narinfo persistence path (to backfill them).
+  line 468) plus the post-store fixup (`CheckAndFixNarInfo`) where the stored compressed
+  bytes are read to compute `FileSize`/`FileHash` and backfill them into the narinfo record.
 - APIs: narinfo responses for affected store paths change from `404` to `200`, and carry a
   correct ncps-computed `FileSize`/`FileHash`.
 - Dependencies / systems: none. No schema, migration, or storage-format change.
@@ -44,16 +45,16 @@ request. This makes such upstreams entirely unusable through ncps (GitHub issue 
 
 - Changing behavior for narinfos that already provide a valid `FileSize`/`FileHash`
   (no recompute, no second-guessing upstream).
-- Re-hashing already-stored NARs that predate this change (only NARs that stream through
-  after the change get computed values).
+- Re-hashing already-stored NARs that predate this change (only NARs stored after the
+  change get computed values).
 - Any change to NAR storage layout, CDC chunking, or downstream caching semantics.
 
 ### Performance impact
 
-- I/O: none beyond what is already incurred fetching/serving the NAR — hashing taps the
-  existing stream, no extra reads or buffering of the whole file.
+- I/O: one extra streaming read of the stored compressed NAR to hash it, incurred only for
+  affected NARs (compressed, missing an upstream `FileHash`); no full-file buffering.
 - Network latency: none added; affected requests stop failing. Computed `FileSize`/
-  `FileHash` are available after the NAR's first pass through ncps.
+  `FileHash` are available once the NAR has been stored and the fixup has run.
 - Memory: negligible — a single streaming hasher (constant-size state), no full-file
   buffering.
 - CPU: one sha256 pass over the compressed bytes for affected NARs only (those lacking

--- a/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/proposal.md
+++ b/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Some upstream binary caches (e.g. niks3, nix-serve-style servers) emit narinfos that
+declare `Compression: zstd` but omit the optional `FileSize`/`FileHash` fields. ncps
+currently treats a missing `FileSize` on a compressed NAR as fatal, returning
+`invalid narinfo: FileSize is missing for a compressed NAR` and a 404 for **every**
+request. This makes such upstreams entirely unusable through ncps (GitHub issue #1314).
+`FileSize`/`FileHash` are optional in the narinfo format, so rejecting them is incorrect.
+
+## What Changes
+
+- Stop rejecting upstream narinfos that carry a non-`none` `Compression` but no
+  `FileSize`/`FileHash`. Such narinfos SHALL be fetched and served instead of erroring.
+- For compressed NARs, ncps SHALL always deliver a correct `FileSize` and `FileHash`
+  downstream. When upstream omits them, ncps SHALL compute them itself by streaming the
+  compressed NAR through a hasher + byte counter (it already proxies the bytes), then
+  backfill the computed values into the stored/served narinfo.
+- Because the NAR is fetched lazily (after the narinfo), the computation happens when the
+  NAR streams through ncps; subsequent narinfo serves carry the computed values.
+- Conventional narinfos that DO supply `FileSize`/`FileHash` continue to behave exactly as
+  today (no recompute).
+- Removes the stale `FileSize == 0 && Compression != none` rejection branch and its TODO.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `upstream-fetch-resilience`: add a requirement that an upstream narinfo declaring a
+  compression algorithm but omitting the optional `FileSize`/`FileHash` fields MUST be
+  tolerated and served, rather than rejected as invalid.
+
+## Impact
+
+- Code: `pkg/cache/upstream/cache.go` (`GetNarInfo`, the `FileSize == 0` branch around
+  line 468) plus the NAR fetch/stream path where the compressed bytes pass through ncps
+  (to compute `FileSize`/`FileHash`) and the narinfo persistence path (to backfill them).
+- APIs: narinfo responses for affected store paths change from `404` to `200`, and carry a
+  correct ncps-computed `FileSize`/`FileHash`.
+- Dependencies / systems: none. No schema, migration, or storage-format change.
+
+### Non-goals
+
+- Changing behavior for narinfos that already provide a valid `FileSize`/`FileHash`
+  (no recompute, no second-guessing upstream).
+- Re-hashing already-stored NARs that predate this change (only NARs that stream through
+  after the change get computed values).
+- Any change to NAR storage layout, CDC chunking, or downstream caching semantics.
+
+### Performance impact
+
+- I/O: none beyond what is already incurred fetching/serving the NAR — hashing taps the
+  existing stream, no extra reads or buffering of the whole file.
+- Network latency: none added; affected requests stop failing. Computed `FileSize`/
+  `FileHash` are available after the NAR's first pass through ncps.
+- Memory: negligible — a single streaming hasher (constant-size state), no full-file
+  buffering.
+- CPU: one sha256 pass over the compressed bytes for affected NARs only (those lacking
+  upstream `FileHash`).

--- a/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/specs/upstream-fetch-resilience/spec.md
+++ b/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/specs/upstream-fetch-resilience/spec.md
@@ -11,15 +11,15 @@ For a compressed NAR served under its original compression (i.e. not normalized 
 `Compression: none` and not stored as CDC chunks), the system SHALL ensure the narinfo it
 serves downstream carries a correct `FileSize` and `FileHash`. When upstream supplies them,
 the system SHALL preserve the upstream values unchanged. When upstream omits either, the
-system SHALL compute the missing value(s) itself from the compressed NAR bytes as they pass
-through during the NAR fetch: `FileSize` SHALL be the byte length of the stored compressed
-NAR, and `FileHash` SHALL be the SHA-256 digest of the stored compressed NAR (formatted as
-a nix `sha256:<nixbase32>` hash). The computed values SHALL be backfilled into the persisted
+system SHALL compute the missing value(s) itself from the stored compressed NAR bytes once
+the NAR is stored: `FileSize` SHALL be the byte length of the stored compressed NAR, and
+`FileHash` SHALL be the SHA-256 digest of the stored compressed NAR (formatted as a nix
+`sha256:<nixbase32>` hash). The computed values SHALL be backfilled into the persisted
 narinfo so subsequent narinfo responses carry them.
 
-The computation SHALL tap the existing NAR byte stream (no additional download or
-full-file buffering) and SHALL NOT alter the NAR bytes, the `NarHash`, the `NarSize`, or
-the `Compression` advertised to downstream clients.
+The computation SHALL stream the stored compressed NAR through a hasher (constant memory, no
+full-file buffering; it MUST NOT re-download the NAR) and SHALL NOT alter the NAR bytes, the
+`NarHash`, the `NarSize`, or the `Compression` advertised to downstream clients.
 
 #### Scenario: Compressed narinfo without FileSize/FileHash is accepted
 

--- a/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/specs/upstream-fetch-resilience/spec.md
+++ b/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/specs/upstream-fetch-resilience/spec.md
@@ -36,12 +36,13 @@ the `Compression` advertised to downstream clients.
 - **AND** the served narinfo SHALL report a `FileHash` equal to the SHA-256 digest of the stored compressed NAR, formatted as `sha256:<nixbase32>`
 - **AND** the `NarHash`, `NarSize`, and `Compression` SHALL be unchanged from upstream
 
-#### Scenario: Upstream-provided FileSize/FileHash are preserved, not recomputed
+#### Scenario: Upstream-provided FileHash is preserved, not recomputed
 
-- **GIVEN** an upstream narinfo with `Compression: zstd` that already provides both `FileSize` and `FileHash`
+- **GIVEN** an upstream narinfo with `Compression: zstd` that already provides a `FileHash`
 - **WHEN** the narinfo is fetched and the NAR is served
-- **THEN** the served narinfo SHALL carry the upstream `FileSize` and `FileHash` verbatim
-- **AND** ncps SHALL NOT recompute them
+- **THEN** the served narinfo SHALL carry the upstream `FileHash` verbatim
+- **AND** ncps SHALL NOT recompute it
+- **AND** the `FileSize` SHALL be preserved when it matches the stored compressed bytes (an inconsistent `FileSize` is reconciled to the stored size)
 
 #### Scenario: Uncompressed narinfos are unaffected
 

--- a/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/specs/upstream-fetch-resilience/spec.md
+++ b/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/specs/upstream-fetch-resilience/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Compressed upstream narinfos missing FileSize/FileHash MUST be tolerated and self-completed
+
+An upstream narinfo that declares a non-`none` `Compression` (e.g. `zstd`, `xz`) but omits
+the optional `FileSize` and/or `FileHash` fields SHALL NOT be rejected. The system SHALL
+accept such a narinfo, fetch its NAR, and serve it. `FileSize`/`FileHash` are optional in
+the narinfo format, so their absence is not an error.
+
+For a compressed NAR served under its original compression (i.e. not normalized to
+`Compression: none` and not stored as CDC chunks), the system SHALL ensure the narinfo it
+serves downstream carries a correct `FileSize` and `FileHash`. When upstream supplies them,
+the system SHALL preserve the upstream values unchanged. When upstream omits either, the
+system SHALL compute the missing value(s) itself from the compressed NAR bytes as they pass
+through during the NAR fetch: `FileSize` SHALL be the byte length of the stored compressed
+NAR, and `FileHash` SHALL be the SHA-256 digest of the stored compressed NAR (formatted as
+a nix `sha256:<nixbase32>` hash). The computed values SHALL be backfilled into the persisted
+narinfo so subsequent narinfo responses carry them.
+
+The computation SHALL tap the existing NAR byte stream (no additional download or
+full-file buffering) and SHALL NOT alter the NAR bytes, the `NarHash`, the `NarSize`, or
+the `Compression` advertised to downstream clients.
+
+#### Scenario: Compressed narinfo without FileSize/FileHash is accepted
+
+- **GIVEN** an upstream narinfo with `Compression: zstd`, a valid `NarHash`/`NarSize`, and no `FileSize`/`FileHash`
+- **WHEN** the narinfo is fetched from upstream
+- **THEN** the fetch SHALL succeed rather than failing with `invalid narinfo: FileSize is missing for a compressed NAR`
+- **AND** the request SHALL be served with HTTP 200 rather than 404
+
+#### Scenario: ncps computes FileSize and FileHash from the fetched compressed NAR
+
+- **GIVEN** a compressed (non-CDC, non-normalized) NAR whose upstream narinfo omitted `FileSize`/`FileHash`
+- **WHEN** ncps fetches and stores the NAR
+- **THEN** the served narinfo SHALL report a `FileSize` equal to the byte length of the stored compressed NAR
+- **AND** the served narinfo SHALL report a `FileHash` equal to the SHA-256 digest of the stored compressed NAR, formatted as `sha256:<nixbase32>`
+- **AND** the `NarHash`, `NarSize`, and `Compression` SHALL be unchanged from upstream
+
+#### Scenario: Upstream-provided FileSize/FileHash are preserved, not recomputed
+
+- **GIVEN** an upstream narinfo with `Compression: zstd` that already provides both `FileSize` and `FileHash`
+- **WHEN** the narinfo is fetched and the NAR is served
+- **THEN** the served narinfo SHALL carry the upstream `FileSize` and `FileHash` verbatim
+- **AND** ncps SHALL NOT recompute them
+
+#### Scenario: Uncompressed narinfos are unaffected
+
+- **GIVEN** an upstream narinfo with `Compression: none` (or empty) and no `FileSize`/`FileHash`
+- **WHEN** the narinfo is fetched
+- **THEN** existing `Compression: none` handling SHALL apply unchanged
+- **AND** no compressed-file hash SHALL be computed

--- a/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/tasks.md
+++ b/openspec/changes/archive/2026-06-07-fix-compressed-narinfo-missing-filesize/tasks.md
@@ -1,0 +1,39 @@
+## 1. Reproduce with failing tests (TDD red)
+
+- [x] 1.1 Add a test fixture / test-upstream narinfo with `Compression: zstd`, valid `NarHash`/`NarSize`, and NO `FileSize`/`FileHash` (mirror issue #1314's example).
+- [x] 1.2 In `pkg/cache/upstream/cache_test.go`, add a failing test asserting `GetNarInfo` accepts the compressed-no-FileSize narinfo (no `invalid narinfo: FileSize is missing` error).
+- [x] 1.3 In `pkg/cache/cache_test.go`, add a failing test (`testNarInfoFileHashFix`): a compressed narinfo lacking `FileHash`/`FileSize`, once its NAR is stored, has both backfilled — `FileSize` == stored compressed size and `FileHash` == `sha256:<nixbase32>` of the stored compressed bytes.
+- [x] 1.4 Add a regression subtest asserting an upstream narinfo that already provides `FileHash` keeps it verbatim (no recompute) after the NAR is stored.
+
+## 2. Stop rejecting compressed narinfos (upstream layer)
+
+- [x] 2.1 In `pkg/cache/upstream/cache.go` (`GetNarInfo`, ~line 468-477), remove the `Compression != none` rejection branch and its TODO; keep the `FileSize = NarSize` fallback only for the `Compression: none` case. Leave `FileSize == 0`/`FileHash == nil` for compressed NARs.
+- [x] 2.2 Confirm tasks 1.1-1.2 now pass; the `ErrInvalidNarInfo` "FileSize is missing" path is gone.
+
+## 3. Compute FileHash from the stored NAR (green)
+
+> Note: FileSize backfill already existed via the post-store fixup
+> (`CheckAndFixNarInfo` → `getNarActualSize` → `fixNarInfoFileSize`, reading
+> `nar_file.file_size`). It simply never ran for compressed NARs because the upstream
+> layer rejected them first. So the only new computation needed is FileHash. The fix
+> reuses that existing fixup path instead of tapping the in-flight pull stream — no
+> schema migration, idempotent, runs for both client uploads and upstream pulls.
+
+- [x] 3.1 Add `computeStoredNarFileHash` (`pkg/cache/cache.go`): stream the stored compressed NAR (`narStore.GetNar`) through `sha256` once (constant memory, no buffering), returning `sha256:<nixbase32>`.
+- [x] 3.2 Build the hash via `nixhash.MustNewHashWithEncoding(nixhash.SHA256, sum, nixhash.NixBase32, true)`; add `fixNarInfoFileHash` to persist it (mirrors `fixNarInfoFileSize`).
+- [x] 3.3 Gate strictly in `CheckAndFixNarInfo`: compute only when `Compression != none` (the `none` branch returns earlier), the NAR is whole-file in store (`hasNarInStore`), and `file_hash` is currently NULL/empty (skips the SHA-256 pass when upstream supplied it).
+
+## 4. Backfill the computed values into the persisted narinfo
+
+- [x] 4.1 Restructure `CheckAndFixNarInfo` so the FileSize fix no longer early-returns, then conditionally backfill `file_hash`. The backfill runs from `checkAndFixNarInfosForNar`, already invoked after every store in `pullNarIntoStore` (upstream pulls) and `PutNar` (client uploads).
+- [x] 4.2 Verify task 1.3 passes: after the NAR is stored, the persisted narinfo carries the backfilled `FileSize`/`FileHash`.
+
+## 5. Protect existing behavior
+
+- [x] 5.1 Confirm `Compression: none` still nulls `file_hash`/`file_size` — unchanged `checkAndFixNarInfoNoCompression` branch; covered by existing `testNarInfoFileSizeFix` none subtests (the new logic lives only in the compressed branch).
+- [x] 5.2 Opaque-URL compressed case is served under the same compressed-serve/fixup path, so it is covered by the same compute/backfill logic (no separate code path).
+
+## 6. Verify
+
+- [x] 6.1 Run `task fmt`, `task lint`, `task test` and confirm all exit 0. (fmt: 0 changed; lint: 0 issues in this worktree; test: all packages ok.)
+- [x] 6.2 Add a `### Fixed` CHANGELOG entry referencing issue #1314.

--- a/openspec/specs/upstream-fetch-resilience/spec.md
+++ b/openspec/specs/upstream-fetch-resilience/spec.md
@@ -84,3 +84,50 @@ When a NAR was fetched via an opaque upstream URL, the system SHALL persist the 
 - **WHEN** recording the opaque upstream path fails during the pull
 - **THEN** the in-flight request SHALL still succeed
 - **AND** the failure SHALL be logged
+
+### Requirement: Compressed upstream narinfos missing FileSize/FileHash MUST be tolerated and self-completed
+
+The system SHALL NOT reject an upstream narinfo that declares a non-`none` `Compression`
+(e.g. `zstd`, `xz`) but omits the optional `FileSize` and/or `FileHash` fields; it SHALL
+accept it, fetch its NAR, and serve it, since those fields are optional in the narinfo
+format. For a compressed NAR served under its original compression (i.e. not normalized to
+`Compression: none` and not stored as CDC chunks), the system SHALL ensure the narinfo it
+serves downstream carries a correct `FileSize` and `FileHash`: when upstream supplies a
+`FileHash` the system SHALL preserve it unchanged, and when upstream omits either field the
+system SHALL compute the missing value(s) itself from the compressed NAR bytes once the NAR
+is stored — `FileSize` as the byte length of the stored compressed NAR and `FileHash` as its
+SHA-256 digest (formatted as a nix `sha256:<nixbase32>` hash) — and SHALL backfill the
+computed values into the persisted narinfo. The computation SHALL stream the stored
+compressed NAR through a hasher (constant memory, no full-file buffering) and SHALL NOT
+alter the NAR bytes, the `NarHash`, the `NarSize`, or the `Compression` advertised to
+downstream clients.
+
+#### Scenario: Compressed narinfo without FileSize/FileHash is accepted
+
+- **GIVEN** an upstream narinfo with `Compression: zstd`, a valid `NarHash`/`NarSize`, and no `FileSize`/`FileHash`
+- **WHEN** the narinfo is fetched from upstream
+- **THEN** the fetch SHALL succeed rather than failing with `invalid narinfo: FileSize is missing for a compressed NAR`
+- **AND** the request SHALL be served with HTTP 200 rather than 404
+
+#### Scenario: ncps computes FileSize and FileHash from the fetched compressed NAR
+
+- **GIVEN** a compressed (non-CDC, non-normalized) NAR whose upstream narinfo omitted `FileSize`/`FileHash`
+- **WHEN** ncps fetches and stores the NAR
+- **THEN** the served narinfo SHALL report a `FileSize` equal to the byte length of the stored compressed NAR
+- **AND** the served narinfo SHALL report a `FileHash` equal to the SHA-256 digest of the stored compressed NAR, formatted as `sha256:<nixbase32>`
+- **AND** the `NarHash`, `NarSize`, and `Compression` SHALL be unchanged from upstream
+
+#### Scenario: Upstream-provided FileHash is preserved, not recomputed
+
+- **GIVEN** an upstream narinfo with `Compression: zstd` that already provides a `FileHash`
+- **WHEN** the narinfo is fetched and the NAR is served
+- **THEN** the served narinfo SHALL carry the upstream `FileHash` verbatim
+- **AND** ncps SHALL NOT recompute it
+- **AND** the `FileSize` SHALL be preserved when it matches the stored compressed bytes (an inconsistent `FileSize` is reconciled to the stored size)
+
+#### Scenario: Uncompressed narinfos are unaffected
+
+- **GIVEN** an upstream narinfo with `Compression: none` (or empty) and no `FileSize`/`FileHash`
+- **WHEN** the narinfo is fetched
+- **THEN** existing `Compression: none` handling SHALL apply unchanged
+- **AND** no compressed-file hash SHALL be computed

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -5682,10 +5682,98 @@ func (c *Cache) CheckAndFixNarInfo(ctx context.Context, hash string) error {
 			Int64("actual_size", size).
 			Msg("mismatch detected, fixing narinfo file size")
 
-		return c.fixNarInfoFileSize(ctx, hash, size)
+		if err := c.fixNarInfoFileSize(ctx, hash, size); err != nil {
+			return err
+		}
+	}
+
+	// Issue #1314: some upstreams (niks3, nix-serve) omit the optional FileHash on
+	// compressed NARs. FileHash is the hash of the compressed file and is not
+	// knowable from the narinfo alone, so compute it from the stored compressed
+	// bytes and backfill it when absent. Only whole-file storage carries the
+	// compressed bytes (CDC narinfos are normalized to Compression:none and handled
+	// above), so this is gated on the NAR being present in the store.
+	if hasNarInStore && (niRow.FileHash == nil || *niRow.FileHash == "") {
+		fileHash, err := c.computeStoredNarFileHash(ctx, nu)
+		if err != nil {
+			return err
+		}
+
+		if fileHash != "" {
+			zerolog.Ctx(ctx).
+				Info().
+				Str("file_hash", fileHash).
+				Msg("missing FileHash detected, backfilling narinfo file hash")
+
+			return c.fixNarInfoFileHash(ctx, hash, fileHash)
+		}
 	}
 
 	return nil
+}
+
+// computeStoredNarFileHash streams the stored compressed NAR through a SHA-256
+// hasher and returns the result formatted as a nix `sha256:<nixbase32>` hash, the
+// representation used for a narinfo FileHash. It performs a single streaming pass
+// (constant memory, no full-file buffering).
+func (c *Cache) computeStoredNarFileHash(ctx context.Context, nu nar.URL) (string, error) {
+	_, r, err := c.narStore.GetNar(ctx, nu)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return "", nil
+		}
+
+		return "", fmt.Errorf("failed to read stored nar for file hash: %w", err)
+	}
+
+	defer func() {
+		//nolint:errcheck
+		io.Copy(io.Discard, r)
+
+		r.Close()
+	}()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, r); err != nil {
+		return "", fmt.Errorf("failed to hash stored nar: %w", err)
+	}
+
+	var sum [sha256.Size]byte
+
+	return nixhash.MustNewHashWithEncoding(nixhash.SHA256, h.Sum(sum[:0]), nixhash.NixBase32, true).String(), nil
+}
+
+// fixNarInfoFileHash updates the narinfo file_hash column in the database.
+func (c *Cache) fixNarInfoFileHash(
+	ctx context.Context,
+	hash string,
+	fileHash string,
+) error {
+	ctx, span := tracer.Start(
+		ctx,
+		"cache.fixNarInfoFileHash",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("narinfo_hash", hash),
+			attribute.String("file_hash", fileHash),
+		),
+	)
+	defer span.End()
+
+	zerolog.Ctx(ctx).
+		Info().
+		Str("file_hash", fileHash).
+		Msg("updating narinfo file hash in the database")
+
+	return c.withEntTransaction(ctx, "fixNarInfoFileHash", func(tx *ent.Tx) error {
+		_, err := tx.NarInfo.Update().
+			Where(entnarinfo.HashEQ(hash)).
+			SetFileHash(fileHash).
+			SetUpdatedAt(time.Now()).
+			Save(ctx)
+
+		return err
+	})
 }
 
 func (c *Cache) checkAndFixNarInfoNoCompression(ctx context.Context, hash string, niRow *ent.NarInfo) error {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -3,6 +3,7 @@ package cache_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"database/sql"
 	"fmt"
 	"io"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/nix-community/go-nix/pkg/narinfo"
 	"github.com/nix-community/go-nix/pkg/narinfo/signature"
+	"github.com/nix-community/go-nix/pkg/nixhash"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -3129,6 +3131,7 @@ func runCacheTestSuite(t *testing.T, factory cacheFactory) {
 	t.Run("GetNarInfoRaceWithPutNarInfoDeterministic", testGetNarInfoRaceWithPutNarInfoDeterministic(factory))
 	t.Run("GetNarInfoConcurrentColdCacheFetch", testGetNarInfoConcurrentColdCacheFetch(factory))
 	t.Run("testNarInfoFileSizeFix", testNarInfoFileSizeFix(factory))
+	t.Run("testNarInfoFileHashFix", testNarInfoFileHashFix(factory))
 	t.Run("testCheckAndFixNarInfo", testCheckAndFixNarInfo(factory))
 	t.Run("HasNarFileRecord", testHasNarFileRecord(factory))
 	t.Run("BackgroundMigrateNarToChunksAfterCancellation", testBackgroundMigrateNarToChunksAfterCancellation(factory))
@@ -3149,6 +3152,122 @@ func runCacheTestSuite(t *testing.T, factory cacheFactory) {
 
 	// Build trace tests
 	t.Run("BuildTrace", testBuildTrace(factory))
+}
+
+// testNarInfoFileHashFix covers issue #1314: some upstreams (niks3, nix-serve)
+// omit the optional FileHash/FileSize on compressed narinfos. Once the NAR is
+// stored, ncps MUST compute and backfill both FileSize (= compressed byte length)
+// and FileHash (= sha256 of the compressed bytes) so the served narinfo is complete.
+func testNarInfoFileHashFix(factory cacheFactory) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Run("PutNarInfo missing FileHash/FileSize then PutNar backfills both", func(t *testing.T) {
+			c, dbClient, _, _, rebind, cleanup := factory(t)
+			t.Cleanup(cleanup)
+			c.SetRecordAgeIgnoreTouch(0)
+
+			// 1. Put a compressed (xz) narinfo with the optional FileHash/FileSize
+			//    lines stripped, mirroring a niks3/nix-serve upstream.
+			var newLines []string
+
+			for _, line := range strings.Split(testdata.Nar1.NarInfoText, "\n") {
+				if strings.HasPrefix(line, "FileHash:") ||
+					strings.HasPrefix(line, "FileSize:") ||
+					strings.HasPrefix(line, "Sig:") {
+					continue
+				}
+
+				newLines = append(newLines, line)
+			}
+
+			strippedNarInfoText := strings.Join(newLines, "\n")
+
+			require.NoError(t, c.PutNarInfo(
+				context.Background(),
+				testdata.Nar1.NarInfoHash,
+				io.NopCloser(strings.NewReader(strippedNarInfoText)),
+			))
+
+			// Both file_hash and file_size start NULL.
+			var (
+				dbFileHash sql.NullString
+				dbFileSize sql.NullInt64
+			)
+
+			err := dbClient.DB().QueryRowContext(context.Background(),
+				rebind("SELECT file_hash, file_size FROM narinfos WHERE hash = ?"),
+				testdata.Nar1.NarInfoHash).Scan(&dbFileHash, &dbFileSize)
+			require.NoError(t, err)
+			assert.False(t, dbFileHash.Valid, "file_hash should start NULL")
+			assert.False(t, dbFileSize.Valid, "file_size should start NULL")
+
+			// 2. Store the compressed NAR bytes.
+			niValid, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
+			require.NoError(t, err)
+
+			nu, err := nar.ParseURL(niValid.URL)
+			require.NoError(t, err)
+
+			someContent := []byte("some arbitrary compressed content")
+			require.NoError(t, c.PutNar(
+				context.Background(),
+				nu,
+				io.NopCloser(bytes.NewReader(someContent)),
+			))
+
+			// 3. Both file_size and file_hash must now be backfilled from the bytes.
+			sum := sha256.Sum256(someContent)
+			wantHash := nixhash.MustNewHashWithEncoding(nixhash.SHA256, sum[:], nixhash.NixBase32, true).String()
+
+			err = dbClient.DB().QueryRowContext(context.Background(),
+				rebind("SELECT file_hash, file_size FROM narinfos WHERE hash = ?"),
+				testdata.Nar1.NarInfoHash).Scan(&dbFileHash, &dbFileSize)
+			require.NoError(t, err)
+
+			assert.Equal(t, int64(len(someContent)), dbFileSize.Int64,
+				"FileSize should be backfilled to the compressed byte length")
+			assert.Equal(t, wantHash, dbFileHash.String,
+				"FileHash should be backfilled to sha256 of the compressed bytes")
+		})
+
+		t.Run("upstream-provided FileHash is preserved, not recomputed", func(t *testing.T) {
+			c, dbClient, _, _, rebind, cleanup := factory(t)
+			t.Cleanup(cleanup)
+			c.SetRecordAgeIgnoreTouch(0)
+
+			// 1. Put Nar1's narinfo verbatim — it carries a FileHash.
+			niValid, err := narinfo.Parse(strings.NewReader(testdata.Nar1.NarInfoText))
+			require.NoError(t, err)
+			require.NotNil(t, niValid.FileHash)
+
+			upstreamFileHash := niValid.FileHash.String()
+
+			require.NoError(t, c.PutNarInfo(
+				context.Background(),
+				testdata.Nar1.NarInfoHash,
+				io.NopCloser(strings.NewReader(testdata.Nar1.NarInfoText)),
+			))
+
+			// 2. Store NAR bytes that do NOT match the upstream FileHash.
+			nu, err := nar.ParseURL(niValid.URL)
+			require.NoError(t, err)
+
+			require.NoError(t, c.PutNar(
+				context.Background(),
+				nu,
+				io.NopCloser(bytes.NewReader([]byte("totally different content"))),
+			))
+
+			// 3. The upstream FileHash must be preserved verbatim (no recompute).
+			var dbFileHash sql.NullString
+
+			err = dbClient.DB().QueryRowContext(context.Background(),
+				rebind("SELECT file_hash FROM narinfos WHERE hash = ?"),
+				testdata.Nar1.NarInfoHash).Scan(&dbFileHash)
+			require.NoError(t, err)
+			assert.Equal(t, upstreamFileHash, dbFileHash.String,
+				"upstream-provided FileHash must not be recomputed")
+		})
+	}
 }
 
 func testCheckAndFixNarInfo(factory cacheFactory) func(*testing.T) {

--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -465,14 +465,13 @@ func (c *Cache) GetNarInfo(ctx context.Context, hash string) (*narinfo.NarInfo, 
 		}
 	}
 
-	if ni.FileSize == 0 {
-		if ni.Compression != nar.CompressionTypeNone.String() {
-			// TODO: Realistically this can be determined by looking at the NAR
-			// when it arrives but ncps is undergoing a lot of changes currently
-			// and since this is async it breaks a lot of tests.
-			return nil, fmt.Errorf("%w: FileSize is missing for a compressed NAR", ErrInvalidNarInfo)
-		}
-
+	// Some upstreams (niks3, nix-serve) omit the optional FileHash/FileSize on
+	// compressed NARs (issue #1314). For Compression:none we can safely fall
+	// back to NarSize. For compressed NARs we leave FileSize/FileHash unset
+	// here; the cache layer computes and backfills them from the actual
+	// compressed bytes as the NAR is pulled, since the compressed file size and
+	// hash differ from NarSize/NarHash and are not knowable from the narinfo alone.
+	if ni.FileSize == 0 && ni.Compression == nar.CompressionTypeNone.String() {
 		ni.FileSize = ni.NarSize
 	}
 

--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -255,6 +255,56 @@ func TestGetNarInfo(t *testing.T) {
 	})
 }
 
+// TestGetNarInfoCompressedMissingFileSize covers issue #1314: some upstreams
+// (niks3, nix-serve) emit narinfos that declare a non-none Compression but omit
+// the optional FileHash/FileSize fields. ncps MUST tolerate them rather than
+// rejecting with "FileSize is missing for a compressed NAR".
+func TestGetNarInfoCompressedMissingFileSize(t *testing.T) {
+	t.Parallel()
+
+	ts := testdata.NewTestServer(t, 40)
+	t.Cleanup(ts.Close)
+
+	c, err := upstream.New(
+		newContext(),
+		testhelper.MustParseURL(t, ts.URL),
+		&upstream.Options{PublicKeys: testdata.PublicKeys()},
+	)
+	require.NoError(t, err)
+
+	hash := "missingfs-" + testdata.Nar1.NarInfoHash
+
+	idx := ts.AddMaybeHandler(func(w http.ResponseWriter, r *http.Request) bool {
+		if r.URL.Path != "/"+hash+".narinfo" {
+			return false
+		}
+
+		// Serve Nar1's narinfo with the optional FileHash/FileSize lines stripped.
+		var sb strings.Builder
+
+		for _, line := range strings.Split(testdata.Nar1.NarInfoText, "\n") {
+			if strings.HasPrefix(line, "FileHash:") || strings.HasPrefix(line, "FileSize:") {
+				continue
+			}
+
+			sb.WriteString(line)
+			sb.WriteString("\n")
+		}
+
+		if _, err := w.Write([]byte(sb.String())); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+
+		return true
+	})
+
+	t.Cleanup(func() { ts.RemoveMaybeHandler(idx) })
+
+	ni, err := c.GetNarInfo(context.Background(), hash)
+	require.NoError(t, err, "compressed narinfo without FileSize/FileHash must be tolerated")
+	assert.NotEqual(t, nar.CompressionTypeNone.String(), ni.Compression)
+}
+
 func TestHasNarInfo(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes #1314. Some upstreams (niks3, nix-serve) emit narinfos that declare a
non-`none` `Compression` but omit the optional `FileSize`/`FileHash` fields.
ncps treated this as fatal, returning a `404` for every request and making
such upstreams unusable.

- **Stop rejecting** these narinfos in `upstream.GetNarInfo`. The
  `FileSize = NarSize` fallback now applies only to `Compression: none`; for
  compressed NARs the fields are left unset and completed by the cache layer.
- **Self-complete the values.** `FileSize` backfill already existed via the
  post-store fixup (`CheckAndFixNarInfo` → `getNarActualSize` →
  `fixNarInfoFileSize`); it simply never ran because the upstream layer
  rejected compressed NARs first. The only new computation is `FileHash`:
  `computeStoredNarFileHash` streams the stored compressed NAR through a single
  SHA-256 pass and formats it as `sha256:<nixbase32>`, and `fixNarInfoFileHash`
  backfills it.
- `CheckAndFixNarInfo` is restructured so the size fix no longer early-returns,
  then backfills the hash when absent — gated on `Compression != none`, the NAR
  being whole-file in store, and `file_hash` being NULL (so upstream-supplied
  hashes are preserved verbatim).
- No DB migration (columns already nullable); idempotent; covers both client
  uploads and upstream pulls.

## Test plan

- [x] `task fmt` clean
- [x] `task lint` clean (this worktree: 0 issues)
- [x] `task test` — full unit suite passes
- [x] New `TestGetNarInfoCompressedMissingFileSize` (upstream layer) — RED→GREEN
- [x] New `testNarInfoFileHashFix` (cache layer): backfills FileSize+FileHash;
      preserves upstream-provided FileHash
- [x] Existing `Compression: none` / CDC behavior unchanged