### PR TITLE
fix(ci): drop codecov_token secret from release build

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -11,7 +11,7 @@ jobs:
     uses: kalbasit/gh-actions/.github/workflows/build.yml@main
     with:
       systems: '["x86_64-linux", "aarch64-linux"]'
-      # Validate the integration suite + coverage on x86_64-linux only (the
+      # Validate the integration suite on x86_64-linux only (the
       # cohorts are architecture-independent). The aarch64-linux leg still
       # builds and pushes its OCI image for the multi-arch manifest, but no
       # longer re-runs the suite on the slower/flakier ARM runner. Mirrors the
@@ -24,7 +24,6 @@ jobs:
       push_oci: true
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
   helm:
     uses: ./.github/workflows/helm.yml


### PR DESCRIPTION
## Problem

The `v0.10.0-rc11` release failed with a `startup_failure` before any job ran:

> Invalid workflow file: `.github/workflows/releases.yml#L27`
> Invalid secret, `codecov_token` is not defined in the referenced workflow.

## Root cause

`kalbasit/gh-actions` `build.yml` ([#12](https://github.com/kalbasit/gh-actions/pull/12)) moved coverage to `ci.yml`'s fork-safe Codecov job and **dropped its `codecov_token` secret**. Our `releases.yml` calls `build.yml@main` directly and still passed `codecov_token`. GitHub Actions rejects a caller that passes a secret the reusable workflow doesn't declare, so the whole run fails at startup.

## Fix

Remove the `codecov_token` secret from the release build call — the release build does not run coverage. Also trim the now-stale `+ coverage` comment. Remaining secrets (`cachix_auth_token`, `dockerhub_token`) match `build.yml`'s declared interface.

After merge, re-tag `v0.10.0-rc11` (or cut a new rc) to re-run the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)