### PR TITLE
docs: document closure pinning feature (#1021)

### DIFF
--- a/docs/!!!meta.json
+++ b/docs/!!!meta.json
@@ -1863,6 +1863,34 @@
                                     "format": "markdown",
                                     "dataFileName": "CDC.md",
                                     "attachments": []
+                                },
+                                {
+                                    "isClone": false,
+                                    "noteId": "Pn1ngClsrDoc",
+                                    "notePath": [
+                                        "C3Wj5rq7ksjn",
+                                        "0RC0xXheV6Ng",
+                                        "MOpVLDkI8rwp",
+                                        "Pn1ngClsrDoc"
+                                    ],
+                                    "title": "Pinning",
+                                    "notePosition": 20,
+                                    "prefix": null,
+                                    "isExpanded": false,
+                                    "type": "text",
+                                    "mime": "text/html",
+                                    "attributes": [
+                                        {
+                                            "type": "label",
+                                            "name": "shareAlias",
+                                            "value": "pinning",
+                                            "isInheritable": false,
+                                            "position": 10
+                                        }
+                                    ],
+                                    "format": "markdown",
+                                    "dataFileName": "Pinning.md",
+                                    "attachments": []
                                 }
                             ]
                         },

--- a/docs/!!!meta.json
+++ b/docs/!!!meta.json
@@ -1881,6 +1881,27 @@
                                     "mime": "text/html",
                                     "attributes": [
                                         {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "96JPlIXsD5jk",
+                                            "isInheritable": false,
+                                            "position": 30
+                                        },
+                                        {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "IBQM2rv4W4XZ",
+                                            "isInheritable": false,
+                                            "position": 40
+                                        },
+                                        {
+                                            "type": "relation",
+                                            "name": "internalLink",
+                                            "value": "QXVK8oy1Fxt4",
+                                            "isInheritable": false,
+                                            "position": 50
+                                        },
+                                        {
                                             "type": "label",
                                             "name": "shareAlias",
                                             "value": "pinning",

--- a/docs/docs/User Guide/Features/Pinning.md
+++ b/docs/docs/User Guide/Features/Pinning.md
@@ -2,37 +2,24 @@
 
 ## Closure Pinning
 
-Closure pinning lets you protect specific store paths — and everything they
-depend on — from being removed by `ncps`'s automatic cache cleanup.
+Closure pinning lets you protect specific store paths — and everything they depend on — from being removed by `ncps`'s automatic cache cleanup.
 
 ## Overview
 
-By default, `ncps` keeps the cache within `--cache-max-size` by periodically
-evicting the **L**east **R**ecently **U**sed (LRU) entries. This is the right
-behavior for most paths, but sometimes you want a path to stay in the cache
-regardless of how recently it was accessed — for example:
+By default, `ncps` keeps the cache within `--cache-max-size` by periodically evicting the **L**east **R**ecently **U**sed (LRU) entries. This is the right behavior for most paths, but sometimes you want a path to stay in the cache regardless of how recently it was accessed — for example:
 
 - The toolchain or base closure for your CI, so builds never re-download it.
 - A specific release you want available offline.
 - A large dependency closure that is expensive to re-fetch from upstream.
 
-Pinning a closure marks a narinfo **and all of its transitive references** as
-protected. While pinned, none of those paths are eligible for LRU eviction. When
-you no longer need the guarantee, you unpin the closure and the paths become
-normal eviction candidates again.
+Pinning a closure marks a narinfo **and all of its transitive references** as protected. While pinned, none of those paths are eligible for LRU eviction. When you no longer need the guarantee, you unpin the closure and the paths become normal eviction candidates again.
 
 > [!NOTE]
-> Pinning protects the **entire closure**, not just the single store path you
-> name. When you pin a path, `ncps` walks its references and protects every NAR
-> reachable from it. If some references are not yet in the local cache, `ncps`
-> attempts to fetch them from the configured upstream caches at pin time so the
-> whole closure is present and protected.
+> Pinning protects the **entire closure**, not just the single store path you name. When you pin a path, `ncps` walks its references and protects every NAR reachable from it. If some references are not yet in the local cache, `ncps` attempts to fetch them from the configured upstream caches at pin time so the whole closure is present and protected.
 
 ## API
 
-Pinning is controlled through three HTTP endpoints. The `{hash}` segment is the
-store-path hash portion of the narinfo — the same hash used in the
-`{hash}.narinfo` URL (e.g. `2imigbs1vnh9bdyf42z9mvq23pdshgw4`).
+Pinning is controlled through three HTTP endpoints. The `{hash}` segment is the store-path hash portion of the narinfo — the same hash used in the `{hash}.narinfo` URL (e.g. `2imigbs1vnh9bdyf42z9mvq23pdshgw4`).
 
 | Method | Path | Description |
 | --- | --- | --- |
@@ -49,11 +36,9 @@ curl -X POST http://your-ncps-hostname:8501/pin/2imigbs1vnh9bdyf42z9mvq23pdshgw4
 **Responses:**
 
 - `200 OK` — the closure is pinned.
-- `404 Not Found` — no narinfo with that hash exists in the cache, so there is
-  nothing to pin. Fetch or upload the path first, then pin it.
+- `404 Not Found` — no narinfo with that hash exists in the cache, so there is nothing to pin. Fetch or upload the path first, then pin it.
 
-Pinning is **idempotent**: pinning an already-pinned closure simply returns
-`200 OK` and changes nothing.
+Pinning is **idempotent**: pinning an already-pinned closure simply returns `200 OK` and changes nothing.
 
 ### Unpin a closure
 
@@ -63,11 +48,9 @@ curl -X DELETE http://your-ncps-hostname:8501/pin/2imigbs1vnh9bdyf42z9mvq23pdshg
 
 **Responses:**
 
-- `200 OK` — the closure is no longer pinned. After unpinning, the narinfo and
-  its references become normal LRU-eviction candidates again.
+- `200 OK` — the closure is no longer pinned. After unpinning, the narinfo and its references become normal LRU-eviction candidates again.
 
-Unpinning is also **idempotent**: unpinning a closure that is not pinned returns
-`200 OK`.
+Unpinning is also **idempotent**: unpinning a closure that is not pinned returns `200 OK`.
 
 ### List pinned closures
 
@@ -75,8 +58,7 @@ Unpinning is also **idempotent**: unpinning a closure that is not pinned returns
 curl http://your-ncps-hostname:8501/pins
 ```
 
-Returns a JSON array of the pinned root hashes with
-`Content-Type: application/json`:
+Returns a JSON array of the pinned root hashes with `Content-Type: application/json`:
 
 ```json
 ["2imigbs1vnh9bdyf42z9mvq23pdshgw4", "1q8w7e6r5t4y3u2i1o0p9a8s7d6f5g4h"]
@@ -89,19 +71,13 @@ When nothing is pinned, the response is an empty array:
 ```
 
 > [!NOTE]
-> The list contains only the **roots** you pinned, not their expanded transitive
-> references. The full set of protected paths is computed from these roots at
-> eviction time.
+> The list contains only the **roots** you pinned, not their expanded transitive references. The full set of protected paths is computed from these roots at eviction time.
 
 ## Notes and Limitations
 
-- Pins have **no expiry or TTL**. A pinned closure stays protected until you
-  explicitly unpin it.
-- Pinning protects paths from LRU eviction only. It does not affect `--cache-max-size`
-  accounting — pinned paths still count toward the total cache size, so pinning
-  more than your size budget can prevent cleanup from reaching the target.
-- The hash you pin must already exist as a narinfo in the cache; pinning does not
-  by itself import a brand-new path that `ncps` has never seen.
+- Pins have **no expiry or TTL**. A pinned closure stays protected until you explicitly unpin it.
+- Pinning protects paths from LRU eviction only. It does not affect `--cache-max-size` accounting — pinned paths still count toward the total cache size, so pinning more than your size budget can prevent cleanup from reaching the target.
+- The hash you pin must already exist as a narinfo in the cache; pinning does not by itself import a brand-new path that `ncps` has never seen.
 
 ## Related Documentation
 

--- a/docs/docs/User Guide/Features/Pinning.md
+++ b/docs/docs/User Guide/Features/Pinning.md
@@ -1,0 +1,110 @@
+# Pinning
+
+## Closure Pinning
+
+Closure pinning lets you protect specific store paths — and everything they
+depend on — from being removed by `ncps`'s automatic cache cleanup.
+
+## Overview
+
+By default, `ncps` keeps the cache within `--cache-max-size` by periodically
+evicting the **L**east **R**ecently **U**sed (LRU) entries. This is the right
+behavior for most paths, but sometimes you want a path to stay in the cache
+regardless of how recently it was accessed — for example:
+
+- The toolchain or base closure for your CI, so builds never re-download it.
+- A specific release you want available offline.
+- A large dependency closure that is expensive to re-fetch from upstream.
+
+Pinning a closure marks a narinfo **and all of its transitive references** as
+protected. While pinned, none of those paths are eligible for LRU eviction. When
+you no longer need the guarantee, you unpin the closure and the paths become
+normal eviction candidates again.
+
+> [!NOTE]
+> Pinning protects the **entire closure**, not just the single store path you
+> name. When you pin a path, `ncps` walks its references and protects every NAR
+> reachable from it. If some references are not yet in the local cache, `ncps`
+> attempts to fetch them from the configured upstream caches at pin time so the
+> whole closure is present and protected.
+
+## API
+
+Pinning is controlled through three HTTP endpoints. The `{hash}` segment is the
+store-path hash portion of the narinfo — the same hash used in the
+`{hash}.narinfo` URL (e.g. `2imigbs1vnh9bdyf42z9mvq23pdshgw4`).
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/pin/{hash}.narinfo` | Pin the closure rooted at `{hash}`. |
+| `DELETE` | `/pin/{hash}.narinfo` | Unpin the closure rooted at `{hash}`. |
+| `GET` | `/pins` | List all pinned closure hashes. |
+
+### Pin a closure
+
+```sh
+curl -X POST http://your-ncps-hostname:8501/pin/2imigbs1vnh9bdyf42z9mvq23pdshgw4.narinfo
+```
+
+**Responses:**
+
+- `200 OK` — the closure is pinned.
+- `404 Not Found` — no narinfo with that hash exists in the cache, so there is
+  nothing to pin. Fetch or upload the path first, then pin it.
+
+Pinning is **idempotent**: pinning an already-pinned closure simply returns
+`200 OK` and changes nothing.
+
+### Unpin a closure
+
+```sh
+curl -X DELETE http://your-ncps-hostname:8501/pin/2imigbs1vnh9bdyf42z9mvq23pdshgw4.narinfo
+```
+
+**Responses:**
+
+- `200 OK` — the closure is no longer pinned. After unpinning, the narinfo and
+  its references become normal LRU-eviction candidates again.
+
+Unpinning is also **idempotent**: unpinning a closure that is not pinned returns
+`200 OK`.
+
+### List pinned closures
+
+```sh
+curl http://your-ncps-hostname:8501/pins
+```
+
+Returns a JSON array of the pinned root hashes with
+`Content-Type: application/json`:
+
+```json
+["2imigbs1vnh9bdyf42z9mvq23pdshgw4", "1q8w7e6r5t4y3u2i1o0p9a8s7d6f5g4h"]
+```
+
+When nothing is pinned, the response is an empty array:
+
+```json
+[]
+```
+
+> [!NOTE]
+> The list contains only the **roots** you pinned, not their expanded transitive
+> references. The full set of protected paths is computed from these roots at
+> eviction time.
+
+## Notes and Limitations
+
+- Pins have **no expiry or TTL**. A pinned closure stays protected until you
+  explicitly unpin it.
+- Pinning protects paths from LRU eviction only. It does not affect `--cache-max-size`
+  accounting — pinned paths still count toward the total cache size, so pinning
+  more than your size budget can prevent cleanup from reaching the target.
+- The hash you pin must already exist as a narinfo in the cache; pinning does not
+  by itself import a brand-new path that `ncps` has never seen.
+
+## Related Documentation
+
+- <a class="reference-link" href="../Usage/Cache%20Management.md">Cache Management</a> — size limits and LRU cleanup
+- <a class="reference-link" href="../Getting%20Started/Concepts.md">Concepts</a> — how caching and eviction work
+- <a class="reference-link" href="../Configuration/Reference.md">Reference</a> — all configuration options

--- a/docs/docs/User Guide/Getting Started/Concepts.md
+++ b/docs/docs/User Guide/Getting Started/Concepts.md
@@ -272,6 +272,7 @@ Plan storage based on usage:
 - **Medium team (10-50 users)**: 50-200GB
 - **Large team (50+ users)**: 200GB-1TB+
 - **LRU cleanup**: Automatically manages size with `--cache-max-size`
+- **Pinning**: Protect specific closures from LRU eviction — see <a class="reference-link" href="../Features/Pinning.md">Pinning</a>
 
 ## Next Steps
 

--- a/docs/docs/User Guide/Usage/Cache Management.md
+++ b/docs/docs/User Guide/Usage/Cache Management.md
@@ -69,13 +69,9 @@ Trigger cleanup manually (not implemented via API, use systemctl/docker restart 
 
 ### Protecting Paths from Eviction
 
-LRU cleanup will evict any path once it becomes the least recently used, even one
-you want to keep. To exempt specific store paths — and their entire closure —
-from eviction, **pin** them. Pinned closures are excluded from LRU cleanup until
-you unpin them.
+LRU cleanup will evict any path once it becomes the least recently used, even one you want to keep. To exempt specific store paths — and their entire closure — from eviction, **pin** them. Pinned closures are excluded from LRU cleanup until you unpin them.
 
-See <a class="reference-link" href="../Features/Pinning.md">Pinning</a> for the
-pin, unpin, and list endpoints.
+See <a class="reference-link" href="../Features/Pinning.md">Pinning</a> for the pin, unpin, and list endpoints.
 
 ## Monitoring
 

--- a/docs/docs/User Guide/Usage/Cache Management.md
+++ b/docs/docs/User Guide/Usage/Cache Management.md
@@ -67,6 +67,16 @@ cache:
 
 Trigger cleanup manually (not implemented via API, use systemctl/docker restart with updated config).
 
+### Protecting Paths from Eviction
+
+LRU cleanup will evict any path once it becomes the least recently used, even one
+you want to keep. To exempt specific store paths — and their entire closure —
+from eviction, **pin** them. Pinned closures are excluded from LRU cleanup until
+you unpin them.
+
+See <a class="reference-link" href="../Features/Pinning.md">Pinning</a> for the
+pin, unpin, and list endpoints.
+
 ## Monitoring
 
 ### Cache Statistics
@@ -245,6 +255,7 @@ nix copy --to http://your-ncps-hostname:8501/upload ./your-package
 
 ## Related Documentation
 
+- <a class="reference-link" href="../Features/Pinning.md">Pinning</a> - Protect closures from LRU eviction
 - <a class="reference-link" href="../Configuration/Storage.md">Storage</a> - Storage backends
 - <a class="reference-link" href="../Operations/Monitoring.md">Monitoring</a> - Monitor cache metrics
 - <a class="reference-link" href="../Operations/Troubleshooting.md">Troubleshooting</a> - Solve issues

--- a/openspec/changes/archive/2026-06-08-document-closure-pinning/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-08-document-closure-pinning/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/archive/2026-06-08-document-closure-pinning/design.md
+++ b/openspec/changes/archive/2026-06-08-document-closure-pinning/design.md
@@ -1,0 +1,86 @@
+## Context
+
+Closure pinning (#1108) is fully implemented and behaviorally specified in the
+`closure-pinning` spec, but has no entry in the published documentation. The
+docs live in `docs/` as a Trilium export: markdown files under
+`docs/docs/<Section>/<Page>.md` plus a single `docs/!!!meta.json` that defines
+the note tree, titles, and `shareAlias` slugs. A page that is not registered in
+`!!!meta.json` is not published.
+
+The implementation surface to document (verified against source):
+
+- `pkg/server/server.go`: `POST /pin/{hash}.narinfo` → `pinClosure`,
+  `DELETE /pin/{hash}.narinfo` → `unpinClosure`, `GET /pins` → `listPins`.
+- Handlers return `200 OK` on success; pin returns `404 Not Found` when the
+  narinfo hash is unknown; `GET /pins` returns a JSON array of hash strings with
+  `Content-Type: application/json` (empty array when nothing is pinned).
+- `pkg/cache/cache.go`: pin/unpin are idempotent; pinning protects the narinfo
+  **and all transitive references** from LRU eviction; missing references are
+  fetched from upstream at pin time.
+- The closest existing analog page is `docs/docs/User Guide/Features/CDC.md`,
+  which establishes the section, tone, and the `> [!NOTE]`/`> [!CAUTION]`
+  callout style and "Related Documentation" footer used across the site.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give operators a single discoverable page that explains what pinning does, the
+  three endpoints, and copy-paste `curl` examples that match the real contract.
+- Wire the page into the published tree (`!!!meta.json`) and cross-link it from
+  the two places eviction is discussed (Cache Management, Concepts).
+- Close #1021 by making the feature documented and findable.
+
+**Non-Goals:**
+
+- Changing any pinning behavior or its spec's behavioral requirements.
+- Documenting internals (BFS traversal, Ent queries) on the user page.
+- Restructuring the Trilium export or its tooling.
+
+## Decisions
+
+- **Place the page under `User Guide → Features` as `Pinning.md`, parallel to
+  `CDC.md`.** Pinning is a user-facing, opt-in cache feature exactly like CDC, so
+  it belongs beside it rather than buried inside Cache Management. Alternatives
+  considered: (a) a subsection inside `Usage/Cache Management.md` — rejected
+  because pinning is a distinct feature with its own endpoints and deserves a
+  stable slug; (b) `Operations/` — rejected, that section is for migrations/fsck
+  maintenance tasks, not feature usage.
+
+- **Register one new note in `!!!meta.json` under the `features` parent** with
+  `title: "Pinning"`, `dataFileName: "Pinning.md"`, and
+  `shareAlias: "pinning"`, mirroring the existing CDC note's attribute shape.
+  The `noteId` is a Trilium-style 12-char alphanumeric id; pick a fresh value not
+  already present in the file. This is the only structural edit.
+
+- **Derive all documented behavior from source, not from the PR description.**
+  Status codes, idempotency, the 404-on-unknown-hash case, and the JSON
+  array-of-strings response are taken from `pkg/server/server.go` and
+  `pkg/cache/cache.go` so the docs cannot drift from the spec.
+
+- **Express the spec delta as an added documentation requirement on
+  `closure-pinning`**, not a new capability, so the docs are verifiable against
+  the same spec that defines the behavior (single source of truth).
+
+## Risks / Trade-offs
+
+- [Docs drift from behavior over time] → Anchor the spec delta requirement to the
+  endpoints/status codes so future behavior changes must update the doc page too;
+  reference the `closure-pinning` spec from the page's footer.
+- [`!!!meta.json` is large and hand-edited; a malformed edit breaks the export] →
+  Insert the new note object next to the CDC note, copy its exact attribute
+  shape, and validate the file parses as JSON before completing.
+- [Chosen `noteId` collides with an existing id] → Grep the file for the chosen
+  id and confirm zero matches before writing.
+
+## Migration Plan
+
+Pure documentation; no deployment, no runtime change, nothing to roll back.
+Revert is a single-commit removal of the page, the meta entry, and the
+cross-links. Verification is by inspection: the page renders, `!!!meta.json`
+parses, and every documented endpoint/status code matches source.
+
+## Open Questions
+
+- None. Endpoint contract, status codes, and response shapes are all confirmed
+  in source; placement follows the existing CDC precedent.

--- a/openspec/changes/archive/2026-06-08-document-closure-pinning/proposal.md
+++ b/openspec/changes/archive/2026-06-08-document-closure-pinning/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+Closure pinning shipped in #1108 (the `POST/DELETE /pin/{hash}.narinfo` and
+`GET /pins` HTTP endpoints that protect a narinfo and its transitive references
+from LRU eviction), but it was never documented. Issue #1021 — the original
+request for cachix-style pins — stays open only because users have no way to
+discover or use the feature. The behavior is stable and fully specified; the
+remaining gap is purely documentation.
+
+## What Changes
+
+- Add a new user-facing page **User Guide → Features → Pinning** (sibling of the
+  existing `Features/CDC.md`) describing what pinning is, the three HTTP
+  endpoints, request/response shapes and status codes, idempotency, transitive
+  closure protection, and worked `curl` examples.
+- Register the new page in `docs/!!!meta.json` (Trilium export index) under the
+  `features` note so it appears in the published documentation tree.
+- Cross-link the new page from **Usage → Cache Management** (which documents LRU
+  cleanup) and from **Getting Started → Concepts** where eviction is introduced,
+  so operators managing cache size discover pinning as the way to protect paths.
+- No code, API, schema, or runtime behavior changes.
+
+## Capabilities
+
+### New Capabilities
+
+- _(none)_
+
+### Modified Capabilities
+
+- `closure-pinning`: add a documentation requirement stating that the pin/unpin/
+  list endpoints and their LRU-protection semantics SHALL be described in the
+  user-facing documentation. This makes the docs a verifiable part of the spec
+  (single source of truth) without altering any existing behavioral requirement.
+
+## Impact
+
+- **Docs**: new `docs/docs/User Guide/Features/Pinning.md`; edits to
+  `docs/!!!meta.json`, `Usage/Cache Management.md`, and
+  `Getting Started/Concepts.md`. Content/structure only — no doc tooling change.
+- **Code / API / database**: none. The endpoints, `pinned_closures` table, and
+  eviction logic are untouched.
+- **I/O, network latency, memory**: no measurable change — documentation only,
+  nothing in the serving or eviction path is modified.
+- **Issue tracking**: closes #1021.
+
+## Non-goals
+
+- Changing pinning behavior, endpoint paths, payloads, or status codes.
+- Adding a CLI subcommand, authentication, or a TTL/expiry for pins (the feature
+  has none today; documenting a non-existent capability would mislead users).
+- Documenting internal implementation details (BFS closure traversal, Ent
+  queries) beyond what an operator needs — those belong to the developer guide
+  and the existing `closure-pinning` spec, not the user feature page.
+- Regenerating or restructuring the Trilium doc export beyond adding the one new
+  note and its cross-links.

--- a/openspec/changes/archive/2026-06-08-document-closure-pinning/specs/closure-pinning/spec.md
+++ b/openspec/changes/archive/2026-06-08-document-closure-pinning/specs/closure-pinning/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Closure pinning is documented in the user guide
+The user-facing documentation SHALL include a dedicated page describing the
+closure pinning feature so operators can discover and use it. The page MUST
+cover the pin, unpin, and list endpoints, their success and error status codes,
+the idempotency of pin and unpin, and that pinning protects a narinfo and all
+its transitive references from LRU eviction.
+
+#### Scenario: A discoverable feature page exists
+- **WHEN** the documentation is published
+- **THEN** a page titled "Pinning" exists under the User Guide → Features section
+- **AND** it is registered in `docs/!!!meta.json` with a stable `shareAlias` slug so it appears in the navigation tree
+
+#### Scenario: Endpoints are documented to match the implementation
+- **WHEN** a reader follows the Pinning page
+- **THEN** it documents `POST /pin/{hash}.narinfo` returning `200 OK` on success and `404 Not Found` for an unknown narinfo hash
+- **AND** documents `DELETE /pin/{hash}.narinfo` returning `200 OK` (idempotent)
+- **AND** documents `GET /pins` returning a JSON array of pinned narinfo hashes with `Content-Type: application/json`
+
+#### Scenario: Eviction-protection semantics are explained
+- **WHEN** a reader follows the Pinning page
+- **THEN** it states that a pinned closure and all of its transitive references are excluded from LRU eviction
+- **AND** it provides at least one worked `curl` example for pinning, unpinning, and listing
+
+#### Scenario: The feature is cross-linked from cache-size guidance
+- **WHEN** a reader is on the Cache Management or Getting Started → Concepts page where LRU eviction is described
+- **THEN** a link points to the Pinning page as the supported way to protect store paths from eviction

--- a/openspec/changes/archive/2026-06-08-document-closure-pinning/tasks.md
+++ b/openspec/changes/archive/2026-06-08-document-closure-pinning/tasks.md
@@ -1,0 +1,26 @@
+## 1. Confirm the contract from source
+
+- [x] 1.1 Re-read `pkg/server/server.go` pin routes/handlers (`pinClosure`, `unpinClosure`, `listPins`) and confirm methods, paths, and status codes (`200`, `404`, JSON array + `application/json`).
+- [x] 1.2 Re-read `pkg/cache/cache.go` (`PinClosure`, `UnpinClosure`, `ListPinnedClosures`, `GetPinnedClosureHashes`) and confirm idempotency, 404-on-unknown-narinfo, transitive-reference protection, and upstream fetch-at-pin behavior.
+- [x] 1.3 Open `docs/docs/User Guide/Features/CDC.md` and note the callout style, heading structure, and "Related Documentation" footer to mirror.
+
+## 2. Write the Pinning feature page
+
+- [x] 2.1 Create `docs/docs/User Guide/Features/Pinning.md` with an Overview explaining what pinning protects and why (LRU eviction protection for a narinfo + its transitive closure).
+- [x] 2.2 Document the three endpoints (`POST`/`DELETE /pin/{hash}.narinfo`, `GET /pins`) with request/response shapes, status codes, idempotency notes, and the unknown-hash `404` case.
+- [x] 2.3 Add worked `curl` examples for pinning, unpinning, and listing pins (including the empty-list response).
+- [x] 2.4 Add a "Related Documentation" footer linking to Cache Management and the closure-pinning behavior; note that pins have no TTL/expiry today.
+
+## 3. Register and cross-link the page
+
+- [x] 3.1 Choose a fresh 12-char Trilium `noteId` and grep `docs/!!!meta.json` to confirm it does not already exist.
+- [x] 3.2 Add the new note object under the `features` parent in `docs/!!!meta.json`, mirroring the CDC note's attribute shape (`title: "Pinning"`, `dataFileName: "Pinning.md"`, `shareAlias: "pinning"`).
+- [x] 3.3 Add a link to the Pinning page from `docs/docs/User Guide/Usage/Cache Management.md` (LRU cleanup section) as the supported way to protect paths from eviction.
+- [x] 3.4 Add a link to the Pinning page from `docs/docs/User Guide/Getting Started/Concepts.md` where eviction is introduced.
+
+## 4. Verify
+
+- [x] 4.1 Validate `docs/!!!meta.json` still parses as valid JSON and the new entry is well-formed.
+- [x] 4.2 Proofread the page: every documented endpoint, status code, and response shape matches the source confirmed in Group 1.
+- [x] 4.3 Run `task fmt` and confirm it exits cleanly (no doc/markdown reformatting left pending).
+- [x] 4.4 Confirm issue #1021 is addressed by the new page and note it for the closing comment/PR description.

--- a/openspec/specs/closure-pinning/spec.md
+++ b/openspec/specs/closure-pinning/spec.md
@@ -69,3 +69,30 @@ When pinning a closure, the system SHALL attempt to fetch missing narinfos from 
 - **THEN** the system SHALL attempt to fetch those narinfos from upstream caches
 - **AND** SHALL pin all successfully fetched narinfos as part of the closure
 
+### Requirement: Closure pinning is documented in the user guide
+The user-facing documentation SHALL include a dedicated page describing the
+closure pinning feature so operators can discover and use it. The page MUST
+cover the pin, unpin, and list endpoints, their success and error status codes,
+the idempotency of pin and unpin, and that pinning protects a narinfo and all
+its transitive references from LRU eviction.
+
+#### Scenario: A discoverable feature page exists
+- **WHEN** the documentation is published
+- **THEN** a page titled "Pinning" exists under the User Guide → Features section
+- **AND** it is registered in `docs/!!!meta.json` with a stable `shareAlias` slug so it appears in the navigation tree
+
+#### Scenario: Endpoints are documented to match the implementation
+- **WHEN** a reader follows the Pinning page
+- **THEN** it documents `POST /pin/{hash}.narinfo` returning `200 OK` on success and `404 Not Found` for an unknown narinfo hash
+- **AND** documents `DELETE /pin/{hash}.narinfo` returning `200 OK` (idempotent)
+- **AND** documents `GET /pins` returning a JSON array of pinned narinfo hashes with `Content-Type: application/json`
+
+#### Scenario: Eviction-protection semantics are explained
+- **WHEN** a reader follows the Pinning page
+- **THEN** it states that a pinned closure and all of its transitive references are excluded from LRU eviction
+- **AND** it provides at least one worked `curl` example for pinning, unpinning, and listing
+
+#### Scenario: The feature is cross-linked from cache-size guidance
+- **WHEN** a reader is on the Cache Management or Getting Started → Concepts page where LRU eviction is described
+- **THEN** a link points to the Pinning page as the supported way to protect store paths from eviction
+


### PR DESCRIPTION
## Summary

Closure pinning shipped in #1108 — the `POST`/`DELETE /pin/{hash}.narinfo` and `GET /pins` endpoints that protect a narinfo and its transitive references from LRU eviction — but was never documented, leaving #1021 open. This PR documents it.

- **New page** `docs/docs/User Guide/Features/Pinning.md` (modeled on the existing CDC feature page): overview of why to pin, the three HTTP endpoints with status codes, idempotency notes, the unknown-hash `404` case, and worked `curl` examples (including the empty `/pins` response). All behavior is derived from `pkg/server/server.go` and `pkg/cache/cache.go` so the docs match the spec.
- **Published in the nav tree**: registered the page in the Trilium export index (`docs/!!!meta.json`) under the `features` note with a `pinning` slug.
- **Cross-links**: from Cache Management (new "Protecting Paths from Eviction" subsection + Related Documentation) and Getting Started → Concepts (Storage Requirements) where LRU eviction is introduced.
- **Spec + OpenSpec**: added a documentation requirement to the `closure-pinning` spec and archived the `document-closure-pinning` change.

No code, API, schema, or runtime behavior changes.

Closes #1021.

## Test plan

- [x] `task fmt` clean (0 files changed)
- [x] `docs/!!!meta.json` parses as valid JSON; Pinning note registered with a unique `noteId`
- [x] `openspec validate --specs` passes for `closure-pinning`
- [x] Reviewer: confirm documented endpoints/status codes match the implementation
- n/a `task lint` / `task test` — documentation-only change, no Go/SQL touched