### PR TITLE
test: fix dev/test harness S3 tooling and k8s probes (k8s-tests 13/13)

### DIFF
--- a/dev-scripts/run.py
+++ b/dev-scripts/run.py
@@ -416,41 +416,49 @@ def perform_clean():
             except subprocess.TimeoutExpired:
                 log(f"  Warning: {engine} cleanup timed out", RED)
 
-    # 3. Remove all s3 files
-    if shutil.which("mc"):
-        log("  Cleaning S3 storage...", YELLOW)
-        endpoint = S3_CONFIG["endpoint"]
-        access_key = S3_CONFIG["access_key"]
-        secret_key = S3_CONFIG["secret_key"]
+    # 3. Empty the S3 bucket's objects (keep the bucket itself).
+    #
+    # Uses boto3 — declared in the devshell (nix/devshells/flake-module.nix)
+    # and already used by the k8s-tests — rather than the MinIO client `mc`,
+    # which is NOT provided by the flake (it only happens to be on a
+    # developer's global PATH) and whose long-term maintenance is uncertain.
+    #
+    # We delete objects rather than the bucket: the dev Garage access key is
+    # scoped to the pre-provisioned `test-bucket` and lacks global
+    # createBucket permission, so deleting + recreating the bucket fails
+    # (Forbidden) and silently bricks S3 for the rest of the session.
+    log("  Cleaning S3 storage...", YELLOW)
+    try:
+        import boto3
+        from botocore.config import Config as BotoConfig
+
         bucket = S3_CONFIG["bucket"]
-        mc_env = os.environ.copy()
-        # Construct MC_HOST_clean env var. Note: we use a specific alias 'clean'
-        # The format for MC_HOST_<alias> is http(s)://ACCESS_KEY:SECRET_KEY@HOST:PORT
-        parsed_endpoint = urlparse(endpoint)
-        mc_url = parsed_endpoint._replace(
-            netloc=f"{access_key}:{secret_key}@{parsed_endpoint.hostname}:{parsed_endpoint.port}"
-        ).geturl()
-        mc_env["MC_HOST_clean"] = mc_url
-        try:
-            subprocess.run(
-                ["mc", "rb", "--force", f"clean/{bucket}"],
-                env=mc_env,
-                check=False,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                timeout=5,
-            )
-            # Re-create the bucket
-            subprocess.run(
-                ["mc", "mb", f"clean/{bucket}"],
-                env=mc_env,
-                check=False,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                timeout=5,
-            )
-        except subprocess.TimeoutExpired:
-            log("  Warning: S3 cleanup timed out", RED)
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=S3_CONFIG["endpoint"],
+            aws_access_key_id=S3_CONFIG["access_key"],
+            aws_secret_access_key=S3_CONFIG["secret_key"],
+            region_name=S3_CONFIG["region"],
+            config=BotoConfig(
+                s3={"addressing_style": "path"},
+                signature_version="s3v4",
+                connect_timeout=5,
+                read_timeout=15,
+                retries={"max_attempts": 2},
+            ),
+        )
+        paginator = s3.get_paginator("list_objects_v2")
+        batch = []
+        for page in paginator.paginate(Bucket=bucket):
+            for obj in page.get("Contents", []):
+                batch.append({"Key": obj["Key"]})
+                if len(batch) == 1000:  # S3 delete_objects caps at 1000 keys
+                    s3.delete_objects(Bucket=bucket, Delete={"Objects": batch})
+                    batch = []
+        if batch:
+            s3.delete_objects(Bucket=bucket, Delete={"Objects": batch})
+    except Exception as e:  # noqa: BLE001 — cleanup is best-effort
+        log(f"  Warning: S3 cleanup failed: {e}", RED)
 
     # 4. Delete all redis keys
     if shutil.which("redis-cli"):

--- a/dev-scripts/test-cdc-lifecycle-e2e.py
+++ b/dev-scripts/test-cdc-lifecycle-e2e.py
@@ -493,11 +493,25 @@ def total_nar_count(db):
     return rows[0][0] if rows else 0
 
 
+def quote_ident(db, name):
+    """Quote a SQL identifier for the given dialect.
+
+    `key` is a reserved word in MySQL/MariaDB and must be backtick-quoted;
+    sqlite and postgres accept the SQL-standard double-quote form.
+    """
+    if db == "mysql":
+        return f"`{name}`"
+    return f'"{name}"'
+
+
 def cdc_config_keys_present(db):
     """Which cdc_* keys are present in the config table."""
     placeholders = ",".join("?" for _ in CDC_KEYS)
+    key = quote_ident(db, "key")
     rows = db_query(
-        db, f"SELECT key FROM config WHERE key IN ({placeholders})", tuple(CDC_KEYS)
+        db,
+        f"SELECT {key} FROM config WHERE {key} IN ({placeholders})",
+        tuple(CDC_KEYS),
     )
     return sorted(r[0] for r in rows)
 

--- a/dev-scripts/test-migration-e2e.py
+++ b/dev-scripts/test-migration-e2e.py
@@ -149,27 +149,39 @@ def reset_everything():
             timeout=15,
         )
 
-    log("reset: recreating S3 bucket", Y)
-    mc_env = os.environ.copy()
-    parsed = urlparse(S3["endpoint"])
-    mc_env["MC_HOST_e2e"] = (
-        f"http://{S3['access_key']}:{S3['secret_key']}"
-        f"@{parsed.hostname}:{parsed.port}"
+    # Empty the S3 bucket's objects (keep the bucket itself). Uses boto3 —
+    # declared in the devshell — rather than the MinIO client `mc`, which is
+    # not provided by the flake. The dev Garage access key is scoped to the
+    # pre-provisioned bucket and lacks createBucket permission, so deleting +
+    # recreating the bucket fails (Forbidden); emptying objects is equivalent.
+    log("reset: emptying S3 bucket", Y)
+    import boto3
+    from botocore.config import Config as BotoConfig
+
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=S3["endpoint"],
+        aws_access_key_id=S3["access_key"],
+        aws_secret_access_key=S3["secret_key"],
+        region_name=S3.get("region", "us-east-1"),
+        config=BotoConfig(
+            s3={"addressing_style": "path"},
+            signature_version="s3v4",
+            connect_timeout=5,
+            read_timeout=15,
+            retries={"max_attempts": 2},
+        ),
     )
-    subprocess.run(
-        ["mc", "rb", "--force", f"e2e/{S3['bucket']}"],
-        env=mc_env,
-        check=False,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        timeout=15,
-    )
-    subprocess.run(
-        ["mc", "mb", f"e2e/{S3['bucket']}"],
-        env=mc_env,
-        check=True,
-        timeout=15,
-    )
+    paginator = s3.get_paginator("list_objects_v2")
+    batch = []
+    for page in paginator.paginate(Bucket=S3["bucket"]):
+        for obj in page.get("Contents", []):
+            batch.append({"Key": obj["Key"]})
+            if len(batch) == 1000:  # S3 delete_objects caps at 1000 keys
+                s3.delete_objects(Bucket=S3["bucket"], Delete={"Objects": batch})
+                batch = []
+    if batch:
+        s3.delete_objects(Bucket=S3["bucket"], Delete={"Objects": batch})
 
     log("reset: flushing Redis", Y)
     subprocess.run(

--- a/dev-scripts/test-migration-e2e.py
+++ b/dev-scripts/test-migration-e2e.py
@@ -54,8 +54,12 @@ NEW_PACKAGE = "nixpkgs#jq"
 S3 = {
     "endpoint": "http://127.0.0.1:9000",
     "bucket": "test-bucket",
-    "access_key": "test-access-key",
-    "secret_key": "test-secret-key",
+    "region": "us-east-1",
+    # Real dev Garage credentials (provisioned by nix/process-compose, and
+    # used by dev-scripts/run.py). The previous "test-access-key" placeholders
+    # are not provisioned on the Garage server, so boto3 auth would fail.
+    "access_key": "GK1234567890abcdef12345678",
+    "secret_key": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 }
 
 DB_URLS = {

--- a/nix/k8s-tests/src/k8s_tests.py
+++ b/nix/k8s-tests/src/k8s_tests.py
@@ -96,6 +96,36 @@ class K8sTestsCLI:
         except FileNotFoundError:
             self.error(f"Command not found: {cmd[0]}")
 
+    def run_cmd_with_retry(self, cmd: List[str], attempts: int = 6, delay: int = 20):
+        """Run a command, retrying on non-zero exit.
+
+        Helm fetches operator charts from GitHub release assets whose CDN
+        intermittently returns `504 Gateway Timeout`. A single transient fetch
+        failure should not abort the entire cluster bring-up, so retry a few
+        times before surfacing the error the way `run_cmd` would.
+        """
+        result = None
+        for attempt in range(1, attempts + 1):
+            result = self.run_cmd(cmd, capture_output=True, check=False)
+            if result.returncode == 0:
+                return result
+            if attempt < attempts:
+                last_line = ""
+                if result.stderr:
+                    lines = result.stderr.strip().splitlines()
+                    last_line = lines[-1] if lines else ""
+                self.log(
+                    f"   ⚠️  '{cmd[0]}' failed (attempt {attempt}/{attempts}), "
+                    f"retrying in {delay}s: {last_line}"
+                )
+                time.sleep(delay)
+        err_msg = f"Command failed after {attempts} attempts: {' '.join(cmd)}"
+        if result is not None and result.stdout:
+            err_msg += f"\nSTDOUT: {result.stdout.strip()}"
+        if result is not None and result.stderr:
+            err_msg += f"\nSTDERR: {result.stderr.strip()}"
+        self.error(err_msg)
+
     # --- Cluster Management ---
 
     def cmd_cluster_create(self):
@@ -399,9 +429,11 @@ spec:
             ]
         )
 
-        # Operators
+        # Operators. Retry each install: these charts are fetched from GitHub
+        # release assets, whose CDN intermittently returns 504 (see
+        # run_cmd_with_retry).
         self.log("   - Installing Operators...")
-        self.run_cmd(
+        self.run_cmd_with_retry(
             [
                 "helm",
                 "upgrade",
@@ -414,7 +446,7 @@ spec:
                 "--wait",
             ]
         )
-        self.run_cmd(
+        self.run_cmd_with_retry(
             [
                 "helm",
                 "upgrade",
@@ -427,7 +459,7 @@ spec:
                 "--wait",
             ]
         )
-        self.run_cmd(
+        self.run_cmd_with_retry(
             [
                 "helm",
                 "upgrade",
@@ -442,7 +474,7 @@ spec:
                 "--wait",
             ]
         )
-        self.run_cmd(
+        self.run_cmd_with_retry(
             [
                 "helm",
                 "upgrade",

--- a/nix/k8s-tests/src/k8s_tests.py
+++ b/nix/k8s-tests/src/k8s_tests.py
@@ -108,6 +108,10 @@ class K8sTestsCLI:
         for attempt in range(1, attempts + 1):
             result = self.run_cmd(cmd, capture_output=True, check=False)
             if result.returncode == 0:
+                # capture_output swallows stdout; surface it in verbose mode so a
+                # successful (possibly retried) install is still visible.
+                if self.verbose and result.stdout:
+                    self.log(result.stdout.strip())
                 return result
             if attempt < attempts:
                 last_line = ""

--- a/nix/k8s-tests/src/k8s_tests_tester.py
+++ b/nix/k8s-tests/src/k8s_tests_tester.py
@@ -686,7 +686,12 @@ class NCPSTester:
                     "--image=nouchka/sqlite3:latest",
                     "-it=false",
                     "--quiet",
-                    "--profile=restricted",
+                    # No --profile=restricted: it sets runAsNonRoot on the
+                    # ephemeral container, which the kubelet rejects because the
+                    # nouchka/sqlite3 image runs as root ("container has
+                    # runAsNonRoot and image will run as root" -> the debug
+                    # container never starts and the probe times out). Match the
+                    # storage probe, which uses the default profile.
                     "--",
                     "sh",
                     "-c",
@@ -727,7 +732,12 @@ class NCPSTester:
                     "--image=nouchka/sqlite3:latest",
                     "-it=false",
                     "--quiet",
-                    "--profile=restricted",
+                    # No --profile=restricted: it sets runAsNonRoot on the
+                    # ephemeral container, which the kubelet rejects because the
+                    # nouchka/sqlite3 image runs as root ("container has
+                    # runAsNonRoot and image will run as root" -> the debug
+                    # container never starts and the probe times out). Match the
+                    # storage probe, which uses the default profile.
                     "--",
                     "sh",
                     "-c",

--- a/openspec/changes/archive/2026-06-08-fix-dev-test-harness-tooling/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-08-fix-dev-test-harness-tooling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/archive/2026-06-08-fix-dev-test-harness-tooling/design.md
+++ b/openspec/changes/archive/2026-06-08-fix-dev-test-harness-tooling/design.md
@@ -1,0 +1,48 @@
+## Context
+
+These are dev/test-harness fixes (no ncps product code). The unifying theme is
+making the dev/test tooling depend only on what the flake actually provides and
+on the actual permission/policy constraints of the dev environment.
+
+## Decisions
+
+### S3 cleanup: `boto3`, empty objects (not `mc`, not delete+recreate)
+
+- **Why `boto3` over `mc`**: `boto3` is already declared in the dev shell
+  (`nix/devshells/flake-module.nix`) and used by `nix/k8s-tests`. `mc` is not in
+  the flake at all — it only worked off a developer's personal `PATH`, and the
+  `dev-s3-backend` spec already forbids MinIO tooling. `aws` (awscli2) is also in
+  the flake, but `boto3` keeps the dev scripts dependency-free of an external CLI
+  and matches the existing k8s-tests pattern.
+- **Why empty objects instead of delete+recreate**: the dev Garage access key is
+  scoped to the pre-provisioned `test-bucket` and lacks `createBucket`. Deleting
+  the bucket (`mc rb`) and recreating it (`mc mb`) fails on the recreate
+  (`Forbidden`) and leaves no bucket. Emptying objects
+  (`list_objects_v2` → `delete_objects`) achieves the same "clean bucket" state
+  with the permissions the key actually has, and is idempotent across restarts.
+
+### mysql identifier quoting
+
+`key` is a reserved word in MySQL/MariaDB but not (in this context) in
+sqlite/postgres, which is why the bug only manifested on mysql. A small
+`quote_ident(db, name)` keeps the probe portable: backticks for `mysql`,
+double-quotes elsewhere.
+
+### k8s SQLite probe profile
+
+`kubectl debug --profile=restricted` injects `runAsNonRoot: true` into the
+ephemeral debug container. The `nouchka/sqlite3` image runs as root, so the
+kubelet refuses to create the container. The storage probe already demonstrates
+the working pattern — same `kubectl debug` against the same hardened pods, but
+without `--profile=restricted`, so the root `busybox` image is permitted. Drop
+the profile from the SQLite probe to match. (The ncps pods' own hardening is
+unchanged; only the throwaway debug container's policy is relaxed, scoped to the
+test harness.)
+
+## Risks / Trade-offs
+
+- Relaxing the debug container off `restricted` lets it run as root — acceptable
+  for an ephemeral, test-only introspection container that must read a
+  root-owned DB file; it does not weaken the ncps pod's own security context.
+- The boto3 cleanup assumes the bucket already exists (provisioned by
+  `nix run .#deps`); a best-effort no-op is fine since the bucket is pre-created.

--- a/openspec/changes/archive/2026-06-08-fix-dev-test-harness-tooling/proposal.md
+++ b/openspec/changes/archive/2026-06-08-fix-dev-test-harness-tooling/proposal.md
@@ -1,0 +1,89 @@
+## Why
+
+A pre-`v0.10.0` test sweep surfaced three dev/test-harness bugs (the ncps
+product itself was healthy in every suite — these are tooling defects):
+
+1. **`dev-scripts/run.py --clean` bricks the Garage bucket.** It deleted the
+   bucket with `mc rb` then tried to recreate it with `mc mb`. The dev Garage
+   access key is scoped to the pre-provisioned `test-bucket` and lacks global
+   `createBucket` permission, so `mc mb` fails (`Forbidden`) — and the error is
+   swallowed (`check=False`, stderr→`/dev/null`). After the first `--clean` the
+   bucket is gone for the rest of the session, so every subsequent S3-backed run
+   fails with `bucket not found` / `ncps did not become ready`. The same
+   delete-then-recreate pattern exists in `dev-scripts/test-migration-e2e.py`.
+
+2. **`mc` is not provided by the flake.** It only works because it happens to be
+   on a developer's global `PATH`. The `dev-s3-backend` spec already forbids
+   MinIO/`mc` in the dev shell, process-compose, `preCheck`, and k8s tests — but
+   never enumerated the `dev-scripts/` helpers, which is exactly the gap these
+   scripts exploited. MinIO tooling is being dropped from the ecosystem.
+
+3. **The CDC lifecycle e2e driver fails on MariaDB.** `cdc_config_keys_present`
+   issues `SELECT key FROM config WHERE key IN (...)` with `key` unquoted. `key`
+   is a reserved word in MySQL/MariaDB, so the probe throws error 1064 and the
+   `mysql` lifecycle never runs (it works on sqlite/postgres).
+
+4. **The k8s-tests SQLite database probe times out (2 of 13 permutations fail).**
+   `nix/k8s-tests/src/k8s_tests_tester.py` introspects the SQLite DB with
+   `kubectl debug --image=nouchka/sqlite3:latest --profile=restricted`. The
+   `restricted` profile sets `runAsNonRoot` on the ephemeral container, but the
+   `nouchka/sqlite3` image runs as root, so the kubelet rejects it
+   (`CreateContainerConfigError: container has runAsNonRoot and image will run as
+   root`); the debug container never starts and the 60s probe times out. ncps +
+   SQLite is healthy (HTTP narinfo serving reads the DB; the storage probe — which
+   uses the same `kubectl debug` *without* `--profile=restricted` — passes).
+
+5. **`k8s-tests cluster create` aborts on a single transient operator-chart 504.**
+   The four operator charts (cnpg, mariadb-operator ×2, redis-operator) are
+   `helm`-installed from GitHub release assets with no retry. GitHub's
+   release-asset CDN intermittently returns `504 Gateway Timeout`, so any one
+   transient failure aborts the entire cluster bring-up before ncps is deployed.
+
+## What Changes
+
+- `dev-scripts/run.py`: replace the `mc`-based S3 cleanup with `boto3` (a
+  declared dev-shell dependency, already used by `nix/k8s-tests`). Empty the
+  bucket's objects via `list_objects_v2` + `delete_objects` instead of
+  deleting+recreating it, so no `createBucket` permission is needed.
+- `dev-scripts/test-migration-e2e.py`: same `mc` → `boto3` empty-the-bucket
+  change in `reset_everything`.
+- `dev-scripts/test-cdc-lifecycle-e2e.py`: add a dialect-aware `quote_ident`
+  helper and quote `key` (backticks for mysql, double-quotes for sqlite/postgres)
+  in `cdc_config_keys_present`.
+- `nix/k8s-tests/src/k8s_tests_tester.py`: drop `--profile=restricted` from the
+  two SQLite `kubectl debug` invocations so the root sqlite image is permitted,
+  matching the working storage probe.
+- `nix/k8s-tests/src/k8s_tests.py`: add `run_cmd_with_retry` and wrap the four
+  operator `helm upgrade --install` calls. The operator charts are fetched from
+  GitHub release assets whose CDN intermittently returns `504 Gateway Timeout`;
+  a single transient failure previously aborted the whole `cluster create`
+  before any ncps pod was deployed.
+- No **BREAKING** changes. No production (`pkg/`, `cmd/`, `ent/`) code changes.
+
+## Capabilities
+
+- **New Capabilities**: none.
+- **Modified Capabilities**:
+  - `dev-s3-backend` — extends the "Dev S3 backend SHALL be Garage" requirement's
+    MinIO/`mc` prohibition to explicitly include the `dev-scripts/` helpers, and
+    adds a scenario requiring dev/test scripts to manage the bucket via the S3
+    SDK (`boto3`) by emptying objects (not delete-and-recreate).
+
+## Impact
+
+- **Code**: `dev-scripts/run.py`, `dev-scripts/test-migration-e2e.py`,
+  `dev-scripts/test-cdc-lifecycle-e2e.py`, `nix/k8s-tests/src/k8s_tests_tester.py`.
+- **Behavior**: S3-backed CDC/migration e2e runs no longer self-corrupt the
+  bucket; the `mysql` CDC lifecycle runs to completion; `k8s-tests all` reaches
+  13/13. No change to ncps runtime behavior.
+- **Dependencies**: removes the undeclared global `mc` dependency from
+  `dev-scripts/`; relies only on `boto3`, already in the dev shell.
+
+## Non-goals
+
+- Pre-loading the `nouchka/sqlite3` / `busybox` debug images into Kind to avoid
+  Docker Hub at test time (a separate, pre-existing concern; the image pull is
+  not the failure here — the security-policy rejection is).
+- Granting the dev Garage key `createBucket` permission (emptying objects is the
+  simpler, sufficient fix).
+- Any change to ncps product code.

--- a/openspec/changes/archive/2026-06-08-fix-dev-test-harness-tooling/specs/dev-s3-backend/spec.md
+++ b/openspec/changes/archive/2026-06-08-fix-dev-test-harness-tooling/specs/dev-s3-backend/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: Dev S3 backend SHALL be Garage
+
+Local development and `nix flake check` SHALL use [Garage](https://garagehq.deuxfleurs.fr/) (`pkgs.garage`) as the S3-compatible object store. MinIO (`pkgs.minio`, `pkgs.minio-client`) SHALL NOT be referenced in the dev shell, process-compose services, Nix package `preCheck`, the dev/test helper scripts under `dev-scripts/`, or k8s integration tests. Dev/test scripts that manipulate the S3 backend (e.g. resetting the bucket between runs) SHALL use the S3 SDK already provided by the dev shell (`boto3`), not the MinIO client `mc`.
+
+#### Scenario: Dev shell exposes Garage, not MinIO
+
+- **WHEN** a developer enters the Nix dev shell
+- **THEN** `garage --version` SHALL succeed
+- **AND** `minio --version` and `mc --version` SHALL NOT be in `PATH`
+
+#### Scenario: `nix run .#deps` starts a Garage server
+
+- **WHEN** a developer runs `nix run .#deps`
+- **THEN** a Garage server SHALL be started under process-compose
+- **AND** the server SHALL accept S3 v4 signed requests on `127.0.0.1:9000`
+- **AND** no MinIO process SHALL be started
+
+#### Scenario: `nix flake check` exercises the S3 backend against Garage
+
+- **WHEN** `nix flake check` runs the ncps package check phase
+- **THEN** the `preCheck` phase SHALL start a Garage server
+- **AND** integration tests gated by `NCPS_TEST_S3_*` env vars SHALL run against Garage
+- **AND** all S3 integration tests SHALL pass
+
+#### Scenario: Dev/test scripts reset the bucket via the S3 SDK, not `mc`
+
+- **WHEN** a dev/test helper script under `dev-scripts/` resets the S3 bucket between runs
+- **THEN** it SHALL empty the bucket's objects using `boto3` (the S3 SDK in the dev shell)
+- **AND** it SHALL NOT invoke `mc` (the MinIO client) or assume `mc` is on `PATH`
+- **AND** it SHALL NOT delete-and-recreate the bucket, because the dev access key is scoped to the pre-provisioned bucket and cannot create buckets

--- a/openspec/changes/archive/2026-06-08-fix-dev-test-harness-tooling/tasks.md
+++ b/openspec/changes/archive/2026-06-08-fix-dev-test-harness-tooling/tasks.md
@@ -1,0 +1,24 @@
+## 1. Replace `mc` with `boto3` in dev-script S3 cleanup
+
+- [x] 1.1 `dev-scripts/run.py`: rewrite the S3 cleanup in `cleanup()` to use `boto3` (endpoint/credentials from `S3_CONFIG`, path-style addressing) and empty the bucket via `list_objects_v2` paginator + `delete_objects` (1000-key batches); drop the `mc rb`/`mc mb` calls and the `shutil.which("mc")` gate.
+- [x] 1.2 `dev-scripts/test-migration-e2e.py`: rewrite `reset_everything`'s S3 reset the same way (empty objects via `boto3`), removing the `mc rb`/`mc mb` (the latter ran with `check=True`, hard-failing the run).
+- [x] 1.3 Confirm no remaining `mc`/`MC_HOST_*` references in `dev-scripts/`.
+
+## 2. Fix the mysql reserved-word quoting in the CDC driver
+
+- [x] 2.1 `dev-scripts/test-cdc-lifecycle-e2e.py`: add `quote_ident(db, name)` (backticks for `mysql`, double-quotes for sqlite/postgres) and quote `key` in `cdc_config_keys_present`'s `SELECT key FROM config WHERE key IN (...)`.
+
+## 3. Fix the k8s-tests SQLite probe
+
+- [x] 3.1 `nix/k8s-tests/src/k8s_tests_tester.py`: remove `--profile=restricted` from both SQLite `kubectl debug` invocations so the root `nouchka/sqlite3` image is permitted, matching the storage probe (which omits the profile and passes).
+
+## 4. Harden operator install against transient GitHub-CDN 504s
+
+- [x] 4.1 `nix/k8s-tests/src/k8s_tests.py`: add `run_cmd_with_retry` and wrap the four operator `helm upgrade --install` calls (cnpg, mariadb-operator-crds, mariadb-operator, redis-operator). Operator charts are fetched from GitHub release assets whose CDN intermittently returns `504 Gateway Timeout`; a single transient fetch failure previously aborted the entire `cluster create`.
+
+## 5. Validate
+
+- [x] 5.1 `task fmt`, `task lint` (0 issues), `task test` — all exit 0.
+- [x] 5.2 Full CDC lifecycle matrix green: sqlite (s3+local), postgres (s3+local), mysql (s3) all PASS via `dev-scripts/test-cdc-lifecycle-e2e.py` against `nix run .#deps`.
+- [x] 5.3 `k8s-tests all` reaches **13/13** (was 11/13) — confirmed live: both `single-local-sqlite` and `single-s3-sqlite` now report `✅ Database: SQLite database accessible`, the exact check that previously timed out. The same run exercised the operator-install retry (cnpg's chart 504'd on attempts 1–4, then succeeded → `Cluster created successfully`), validating both fixes.
+- [x] 5.4 Update affected spec: `dev-s3-backend` MinIO/`mc` prohibition extended to `dev-scripts/`, plus an SDK-cleanup scenario.

--- a/openspec/specs/dev-s3-backend/spec.md
+++ b/openspec/specs/dev-s3-backend/spec.md
@@ -3,12 +3,10 @@
 ## Purpose
 
 Defines the S3-compatible object storage backend used for local development, `nix flake check`, and Kubernetes integration tests, including the env var contract tests and scripts depend on.
-
 ## Requirements
-
 ### Requirement: Dev S3 backend SHALL be Garage
 
-Local development and `nix flake check` SHALL use [Garage](https://garagehq.deuxfleurs.fr/) (`pkgs.garage`) as the S3-compatible object store. MinIO (`pkgs.minio`, `pkgs.minio-client`) SHALL NOT be referenced in the dev shell, process-compose services, Nix package `preCheck`, or k8s integration tests.
+Local development and `nix flake check` SHALL use [Garage](https://garagehq.deuxfleurs.fr/) (`pkgs.garage`) as the S3-compatible object store. MinIO (`pkgs.minio`, `pkgs.minio-client`) SHALL NOT be referenced in the dev shell, process-compose services, Nix package `preCheck`, the dev/test helper scripts under `dev-scripts/`, or k8s integration tests. Dev/test scripts that manipulate the S3 backend (e.g. resetting the bucket between runs) SHALL use the S3 SDK already provided by the dev shell (`boto3`), not the MinIO client `mc`.
 
 #### Scenario: Dev shell exposes Garage, not MinIO
 
@@ -29,6 +27,13 @@ Local development and `nix flake check` SHALL use [Garage](https://garagehq.deux
 - **THEN** the `preCheck` phase SHALL start a Garage server
 - **AND** integration tests gated by `NCPS_TEST_S3_*` env vars SHALL run against Garage
 - **AND** all S3 integration tests SHALL pass
+
+#### Scenario: Dev/test scripts reset the bucket via the S3 SDK, not `mc`
+
+- **WHEN** a dev/test helper script under `dev-scripts/` resets the S3 bucket between runs
+- **THEN** it SHALL empty the bucket's objects using `boto3` (the S3 SDK in the dev shell)
+- **AND** it SHALL NOT invoke `mc` (the MinIO client) or assume `mc` is on `PATH`
+- **AND** it SHALL NOT delete-and-recreate the bucket, because the dev access key is scoped to the pre-provisioned bucket and cannot create buckets
 
 ### Requirement: Dev S3 backend SHALL expose a backend-neutral env var contract
 
@@ -97,3 +102,4 @@ The Kind-based integration test harness (`nix/k8s-tests/`) SHALL deploy Garage a
 - **WHEN** `k8s-tests cluster create` provisions the Kind cluster
 - **THEN** the Garage container image SHALL be pre-loaded into Kind nodes (matching how MinIO was loaded previously)
 - **AND** image pulls SHALL NOT depend on Docker Hub at test time
+


### PR DESCRIPTION
## Summary

A pre-`v0.10.0` test sweep surfaced four **dev/test-harness** bugs. The ncps product itself was healthy in every suite (unit `-race`, full integration against live backends, helm unittest, and the CDC lifecycle on sqlite/postgres) — these are tooling defects only. No production (`pkg/`, `cmd/`, `ent/`) code is touched.

1. **`run.py` / `test-migration-e2e.py` — S3 cleanup bricked the bucket.** They deleted the Garage bucket (`mc rb`) then tried to recreate it (`mc mb`). The dev Garage access key is scoped to the pre-provisioned `test-bucket` and lacks `createBucket`, so the recreate failed (`Forbidden`) and was swallowed — bricking S3 for the rest of the session (first S3 run passes, all later ones fail `bucket not found`). Replaced with **`boto3`** (a declared dev-shell dep, already used by `nix/k8s-tests`), which **empties the bucket's objects** instead of delete+recreate. `mc` is not provided by the flake at all — it only worked off a developer's global `PATH`.

2. **`test-cdc-lifecycle-e2e.py` — mysql reserved word.** `cdc_config_keys_present` ran `SELECT key FROM config …` with `key` unquoted; `key` is reserved in MySQL/MariaDB, so the probe threw error 1064 and the `mysql` lifecycle never ran. Added a dialect-aware `quote_ident` (backticks on mysql, double-quotes elsewhere).

3. **`k8s_tests_tester.py` — SQLite probe timed out (2/13 k8s permutations failed).** The probe used `kubectl debug --image=nouchka/sqlite3 --profile=restricted`; the `restricted` profile sets `runAsNonRoot`, which the kubelet rejects for the root sqlite image (`CreateContainerConfigError: container has runAsNonRoot and image will run as root`) → the debug container never starts → 60s timeout. Dropped `--profile=restricted` to match the **passing storage probe** (same `kubectl debug`, no profile). ncps + SQLite was always healthy (narinfo serving reads the DB).

4. **`k8s_tests.py` — operator install aborted on a transient 504.** The four operator charts (cnpg, mariadb-operator ×2, redis-operator) are `helm`-installed from GitHub release assets with no retry; GitHub's release-asset CDN intermittently returns `504 Gateway Timeout`, so one transient failure aborted the whole `cluster create`. Added `run_cmd_with_retry` around the operator installs.

Also updates the **`dev-s3-backend`** spec (archived openspec change `fix-dev-test-harness-tooling`): the MinIO/`mc` prohibition now explicitly covers `dev-scripts/`, plus a scenario requiring dev/test scripts to reset the bucket via the S3 SDK (`boto3`), not `mc`.

## Test plan

- [x] `task fmt`, `task lint` (0 issues), `task test` (29 pkgs, `-race`) — all green
- [x] Full CDC lifecycle matrix green via `dev-scripts/test-cdc-lifecycle-e2e.py`: sqlite (s3+local), postgres (s3+local), mysql (s3)
- [x] `k8s-tests all` = **13/13** (was 11/13); both sqlite permutations now report `Database: SQLite database accessible`. Same run exercised the operator retry (cnpg chart 504'd 4× then succeeded).
- [x] `helm unittest charts/ncps` — 157/157
- [x] `openspec validate fix-dev-test-harness-tooling --strict` passes; change archived