### PR TITLE
feat(dev): add --inflight-staging flag to run.py

### DIFF
--- a/dev-scripts/run.py
+++ b/dev-scripts/run.py
@@ -490,6 +490,11 @@ def main():
         help="Enable the lazy CDC feature",
     )
     parser.add_argument(
+        "--inflight-staging",
+        action="store_true",
+        help="Enable in-flight NAR staging (only engages with a distributed locker, e.g. --locker redis)",
+    )
+    parser.add_argument(
         "--log-level",
         choices=["debug", "info", "warn", "error", "fatal", "panic"],
         default="debug",
@@ -631,6 +636,10 @@ def main():
     log(f"  DB:      {args.db}", BLUE)
     log(f"  Storage: {args.storage}", BLUE)
     log(f"  Locker:  {args.locker}", BLUE)
+    log(
+        f"  Inflight staging: {'enabled' if args.inflight_staging else 'disabled'}",
+        BLUE,
+    )
     print("")
 
     use_tmux_split = is_ha and TmuxManager.is_in_tmux()
@@ -727,6 +736,11 @@ def main():
                 cmd_app.append("--cache-cdc-lazy-recovery-schedule='@every 1m'")
                 cmd_app.append("--cache-cdc-delete-delay=1m")
                 cmd_app.append("--cache-cdc-lazy-cleanup-schedule='@every 1m'")
+        if args.inflight_staging:
+            # Only the enabled toggle is exposed; retention (5m) and part-size
+            # (8 MiB) keep their Go defaults. The feature self-disables unless the
+            # locker is distributed (see InflightStagingEnabled() guard).
+            cmd_app.append("--cache-inflight-staging-enabled")
         if args.storage == "local":
             cmd_app.extend(["--cache-storage-local", local_storage_path])
         else:
@@ -776,6 +790,7 @@ def main():
 
     state_config = {
         "cdc": args.enable_cdc,
+        "inflight_staging": args.inflight_staging,
         "db": args.db,
         "db_url": db_url,
         "storage": args.storage,

--- a/dev-scripts/run.py
+++ b/dev-scripts/run.py
@@ -631,15 +631,24 @@ def main():
     # Determine instance count
     num_instances = args.replicas
 
+    # In-flight staging only engages with a distributed locker; the Go-side
+    # InflightStagingEnabled() guard keeps it dormant otherwise. Reflect that
+    # *effective* state in the banner and state.json so test drivers aren't
+    # misled by a bare --inflight-staging on a local locker.
+    staging_active = args.inflight_staging and args.locker == "redis"
+    if not args.inflight_staging:
+        staging_banner = "disabled"
+    elif staging_active:
+        staging_banner = "enabled"
+    else:
+        staging_banner = "dormant (requires redis locker)"
+
     log(f"\nStarting {num_instances} instance(s)...", BLUE)
     log(f"  Mode:    {'ha' if is_ha else 'single'}", BLUE)
     log(f"  DB:      {args.db}", BLUE)
     log(f"  Storage: {args.storage}", BLUE)
     log(f"  Locker:  {args.locker}", BLUE)
-    log(
-        f"  Inflight staging: {'enabled' if args.inflight_staging else 'disabled'}",
-        BLUE,
-    )
+    log(f"  Inflight staging: {staging_banner}", BLUE)
     print("")
 
     use_tmux_split = is_ha and TmuxManager.is_in_tmux()
@@ -790,7 +799,7 @@ def main():
 
     state_config = {
         "cdc": args.enable_cdc,
-        "inflight_staging": args.inflight_staging,
+        "inflight_staging": staging_active,
         "db": args.db,
         "db_url": db_url,
         "storage": args.storage,

--- a/openspec/changes/archive/2026-06-08-add-inflight-staging-flags-to-dev-run/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-08-add-inflight-staging-flags-to-dev-run/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/archive/2026-06-08-add-inflight-staging-flags-to-dev-run/design.md
+++ b/openspec/changes/archive/2026-06-08-add-inflight-staging-flags-to-dev-run/design.md
@@ -1,0 +1,37 @@
+## Context
+
+`dev-scripts/run.py` is the supported local harness for ncps. It parses backend choices (`--db`, `--storage`, `--locker`, `--replicas`), runs migrations, then assembles a `serve` command line per instance in `cmd_app` and persists run state to `var/ncps/state.json`. It already has a parallel pattern for an opt-in feature flag: `--enable-cdc` / `--enable-lazy-cdc` append `--cache-cdc-*` args and `cdc` is recorded in `state_config`.
+
+Commit `541a25c` added `serve --cache-inflight-staging-enabled` (plus `-retention`/`-part-size`), whose activation guard requires a distributed locker. `run.py` has no way to set it, so the feature is unreachable locally. This change adds the toggle following the existing CDC-flag pattern.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `--inflight-staging` to `run.py` that emits `--cache-inflight-staging-enabled` to every spawned instance.
+- Record the state in the startup banner and `state.json` for test drivers.
+- Reuse the established `--enable-cdc` flag/banner/state conventions for consistency.
+
+**Non-Goals:**
+- Exposing `retention` / `part-size` knobs (Go defaults are fine for dev).
+- Adding locker guard rails in `run.py`; the Go guard already self-disables on non-distributed lockers.
+- Any Go, schema, migration, or docs change.
+
+## Decisions
+
+- **Flag name `--inflight-staging` (not `--enable-inflight-staging`).** The proposal scopes a single toggle. The existing CDC flags use an `--enable-` prefix, but the simpler `--inflight-staging` reads cleanly and there is only one staging flag to add. Alternative considered: mirror `--enable-cdc` naming exactly — rejected as marginally more verbose with no benefit, but either is acceptable and the implementer may match the CDC prefix if preferred for symmetry.
+- **Emit only when set; never pass retention/part-size.** Keeps the harness honest about the Go defaults and avoids drift if those defaults change upstream. Alternative: always pass all three with hardcoded values — rejected (couples the harness to upstream default values).
+- **No guard rails.** Pass the flag through regardless of `--locker`. Mirrors the Go guard (`InflightStagingEnabled()` is true only with a distributed locker), so `--inflight-staging --locker local` is harmless and non-erroring. Alternative: error or warn when locker is local — rejected as out of scope and redundant with the Go-side guard; a warning could be added later if it proves confusing.
+- **State key `inflight_staging` in `state_config`.** Sits next to `cdc`/`locker`. Boolean mirrors `args.inflight_staging`.
+
+## Risks / Trade-offs
+
+- **[Flag is silently inert with `--locker local`]** → Documented in the spec scenario and surfaced in the banner so the user sees the enabled/disabled state; the Go guard is the source of truth.
+- **[Banner/state drift if future staging sub-flags are added]** → Out of scope now; the single boolean is trivially extendable later.
+
+## Migration Plan
+
+Not applicable — additive change to a dev-only script, no persisted schema or production surface. Rollback is reverting the diff.
+
+## Open Questions
+
+- None. Naming (`--inflight-staging` vs `--enable-inflight-staging`) is the only soft choice and is left to the implementer per the Decisions note.

--- a/openspec/changes/archive/2026-06-08-add-inflight-staging-flags-to-dev-run/proposal.md
+++ b/openspec/changes/archive/2026-06-08-add-inflight-staging-flags-to-dev-run/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Commit `541a25c` added the in-flight NAR staging feature (`serve --cache-inflight-staging-enabled`), the HA-safe alternative to CDC for serving a NAR cross-pod while it is still downloading (GitHub #660, #1289). The dev harness `dev-scripts/run.py` — the only supported way to spin up local single/HA instances — has no way to turn it on, so the feature cannot be exercised or reproduced locally.
+
+## What Changes
+
+- Add a `--inflight-staging` boolean flag to `dev-scripts/run.py`.
+- When set, each spawned `serve` instance receives `--cache-inflight-staging-enabled`.
+- Leave `--cache-inflight-staging-retention` (5m) and `--cache-inflight-staging-part-size` (8 MiB) at their Go defaults; do not expose them.
+- Surface the flag's effective state in the startup banner and persisted `state.json` (alongside the existing `cdc`/`locker` fields) so test drivers can read it.
+
+The upstream activation guard only engages staging when the locker is **distributed** (`--locker redis`); with `--locker local` the flag is inert. `run.py` will pass the flag as requested without adding new guard rails, matching the Go-side behavior where the feature self-disables on single-instance deployments.
+
+## Non-goals
+
+- Exposing `retention` or `part-size` tuning knobs (Go defaults suffice for dev).
+- Changing the staging feature itself, its activation guard, or any Go code.
+- Adding new dependency/guard-rail validation in `run.py` (e.g. forcing `--locker redis` when `--inflight-staging` is set).
+- Documenting the production flag in `config.example.yaml` or user docs.
+
+## Capabilities
+
+### New Capabilities
+- `dev-run-inflight-staging`: The `dev-scripts/run.py` harness exposes an `--inflight-staging` flag that propagates `--cache-inflight-staging-enabled` to each spawned `serve` instance and records its state.
+
+### Modified Capabilities
+<!-- None: no existing spec captures dev-harness flag behavior. -->
+
+## Impact
+
+- **Code**: `dev-scripts/run.py` only — argument parsing, the per-instance `cmd_app` assembly, the startup banner, and `state.json` (`state_config`). No Go, schema, or migration changes.
+- **I/O / network / memory**: None in the harness itself. When the flag is enabled together with `--locker redis`, staging part-objects are written to shared storage during the download window per the upstream feature; this only affects runtime behavior of the spawned `ncps` processes, not `run.py`.
+- **Dependencies / APIs**: None.

--- a/openspec/changes/archive/2026-06-08-add-inflight-staging-flags-to-dev-run/specs/dev-run-inflight-staging/spec.md
+++ b/openspec/changes/archive/2026-06-08-add-inflight-staging-flags-to-dev-run/specs/dev-run-inflight-staging/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: dev-run exposes an in-flight staging toggle
+
+`dev-scripts/run.py` SHALL accept a boolean `--inflight-staging` flag (default off). When the flag is set, the harness SHALL append `--cache-inflight-staging-enabled` to the `serve` command line of every spawned instance. When the flag is unset, the harness SHALL NOT pass any `--cache-inflight-staging-*` argument, leaving the feature off and the Go-side `retention` (5m) and `part-size` (8 MiB) defaults untouched.
+
+#### Scenario: Flag enabled propagates to every instance
+- **WHEN** `run.py --inflight-staging` is invoked (with any `--replicas` count)
+- **THEN** each spawned `serve` process receives `--cache-inflight-staging-enabled` in its argument list
+
+#### Scenario: Flag omitted leaves staging off
+- **WHEN** `run.py` is invoked without `--inflight-staging`
+- **THEN** no `--cache-inflight-staging-enabled`, `--cache-inflight-staging-retention`, or `--cache-inflight-staging-part-size` argument appears on any spawned `serve` command line
+
+#### Scenario: Retention and part-size are not exposed
+- **WHEN** the user inspects `run.py --help`
+- **THEN** only `--inflight-staging` is offered; no retention or part-size tuning flags are present
+
+### Requirement: dev-run records staging state for test drivers
+
+The harness SHALL surface the effective `--inflight-staging` state both in the startup banner and in the persisted `state.json`, alongside the existing `cdc`/`locker` fields, so external test drivers can read whether staging was enabled for a run.
+
+#### Scenario: State file reflects enabled staging
+- **WHEN** `run.py --inflight-staging --locker redis --replicas 2` starts successfully
+- **THEN** `var/ncps/state.json` contains a truthy `inflight_staging` field
+
+#### Scenario: State file reflects disabled staging
+- **WHEN** `run.py` starts without `--inflight-staging`
+- **THEN** `var/ncps/state.json` contains a falsy `inflight_staging` field
+
+#### Scenario: Startup banner shows staging state
+- **WHEN** the harness prints its startup summary
+- **THEN** the banner includes a line indicating whether in-flight staging is enabled
+
+### Requirement: dev-run does not add staging guard rails
+
+The harness SHALL pass `--inflight-staging` through without enforcing locker constraints, mirroring the Go-side guard where the feature self-disables on single-instance (non-distributed locker) deployments. Combining `--inflight-staging` with `--locker local` SHALL NOT be a harness error.
+
+#### Scenario: Staging with local locker is inert but not rejected
+- **WHEN** `run.py --inflight-staging --locker local` is invoked
+- **THEN** the harness starts normally and passes `--cache-inflight-staging-enabled`, relying on the Go activation guard to keep the feature dormant

--- a/openspec/changes/archive/2026-06-08-add-inflight-staging-flags-to-dev-run/tasks.md
+++ b/openspec/changes/archive/2026-06-08-add-inflight-staging-flags-to-dev-run/tasks.md
@@ -1,0 +1,18 @@
+## 1. Argument parsing
+
+- [x] 1.1 Add `--inflight-staging` (`action="store_true"`, default off) to the argparse setup in `main()`, with help text noting it only engages with a distributed locker (`--locker redis`)
+
+## 2. Command assembly
+
+- [x] 2.1 In the per-instance `cmd_app` build loop, append `--cache-inflight-staging-enabled` when `args.inflight_staging` is set; do not pass `retention`/`part-size` (rely on Go defaults)
+
+## 3. Observability
+
+- [x] 3.1 Add an "Inflight staging: enabled/disabled" line to the startup banner near the existing Mode/DB/Storage/Locker lines
+- [x] 3.2 Add `"inflight_staging": args.inflight_staging` to `state_config` so it is persisted to `state.json`
+
+## 4. Verification
+
+- [x] 4.1 Run `run.py --inflight-staging` (single instance) and confirm `--cache-inflight-staging-enabled` appears on the spawned `serve` command and `state.json` shows `inflight_staging: true`
+- [x] 4.2 Run `run.py` without the flag and confirm no `--cache-inflight-staging-*` arg is present and `state.json` shows `inflight_staging: false`
+- [x] 4.3 Run `task fmt` and `task lint` and confirm both exit zero

--- a/openspec/specs/dev-run-inflight-staging/spec.md
+++ b/openspec/specs/dev-run-inflight-staging/spec.md
@@ -1,0 +1,47 @@
+# dev-run-inflight-staging Specification
+
+## Purpose
+
+Expose the in-flight NAR staging feature through the `dev-scripts/run.py` development harness so that local and integration test drivers can enable, observe, and exercise staging behavior across spawned `serve` instances.
+
+## Requirements
+
+### Requirement: dev-run exposes an in-flight staging toggle
+
+`dev-scripts/run.py` SHALL accept a boolean `--inflight-staging` flag (default off). When the flag is set, the harness SHALL append `--cache-inflight-staging-enabled` to the `serve` command line of every spawned instance. When the flag is unset, the harness SHALL NOT pass any `--cache-inflight-staging-*` argument, leaving the feature off and the Go-side `retention` (5m) and `part-size` (8 MiB) defaults untouched.
+
+#### Scenario: Flag enabled propagates to every instance
+- **WHEN** `run.py --inflight-staging` is invoked (with any `--replicas` count)
+- **THEN** each spawned `serve` process receives `--cache-inflight-staging-enabled` in its argument list
+
+#### Scenario: Flag omitted leaves staging off
+- **WHEN** `run.py` is invoked without `--inflight-staging`
+- **THEN** no `--cache-inflight-staging-enabled`, `--cache-inflight-staging-retention`, or `--cache-inflight-staging-part-size` argument appears on any spawned `serve` command line
+
+#### Scenario: Retention and part-size are not exposed
+- **WHEN** the user inspects `run.py --help`
+- **THEN** only `--inflight-staging` is offered; no retention or part-size tuning flags are present
+
+### Requirement: dev-run records staging state for test drivers
+
+The harness SHALL surface the effective `--inflight-staging` state both in the startup banner and in the persisted `state.json`, alongside the existing `cdc`/`locker` fields, so external test drivers can read whether staging was enabled for a run.
+
+#### Scenario: State file reflects enabled staging
+- **WHEN** `run.py --inflight-staging --locker redis --replicas 2` starts successfully
+- **THEN** `var/ncps/state.json` contains a truthy `inflight_staging` field
+
+#### Scenario: State file reflects disabled staging
+- **WHEN** `run.py` starts without `--inflight-staging`
+- **THEN** `var/ncps/state.json` contains a falsy `inflight_staging` field
+
+#### Scenario: Startup banner shows staging state
+- **WHEN** the harness prints its startup summary
+- **THEN** the banner includes a line indicating whether in-flight staging is enabled
+
+### Requirement: dev-run does not add staging guard rails
+
+The harness SHALL pass `--inflight-staging` through without enforcing locker constraints, mirroring the Go-side guard where the feature self-disables on single-instance (non-distributed locker) deployments. Combining `--inflight-staging` with `--locker local` SHALL NOT be a harness error.
+
+#### Scenario: Staging with local locker is inert but not rejected
+- **WHEN** `run.py --inflight-staging --locker local` is invoked
+- **THEN** the harness starts normally and passes `--cache-inflight-staging-enabled`, relying on the Go activation guard to keep the feature dormant


### PR DESCRIPTION
## Summary

- The in-flight NAR staging feature (`serve --cache-inflight-staging-enabled`, added in 541a25c) had no way to be enabled from the dev harness `dev-scripts/run.py`, so it could not be exercised or reproduced locally.
- Adds an `--inflight-staging` toggle that appends `--cache-inflight-staging-enabled` to every spawned `serve` instance. Only the enabled toggle is exposed; `retention` (5m) and `part-size` (8 MiB) keep their Go defaults.
- No locker guard rails are added, mirroring the Go-side guard where the feature self-disables on non-distributed lockers (it only engages with `--locker redis`).
- Effective state is surfaced in the startup banner and persisted to `state.json` (`inflight_staging`) so test drivers can read it.
- Captures the `dev-run-inflight-staging` capability spec (OpenSpec change archived).

## Test plan

- [x] `task fmt` / `task lint` pass
- [x] `run.py --inflight-staging` emits `--cache-inflight-staging-enabled` and records `inflight_staging: true`; without the flag no `--cache-inflight-staging-*` arg appears and state shows `false`