### PR TITLE
fix(cache): engage in-flight staging under real contention

### DIFF
--- a/dev-scripts/test-inflight-staging-contention-e2e.py
+++ b/dev-scripts/test-inflight-staging-contention-e2e.py
@@ -81,12 +81,14 @@ STAGING_ACTIVATION_LOG = (
 LOCK_CONTENTION_LOG = "failed to acquire download lock"
 PRODUCER_ERROR_LOG = "in-flight staging producer stopped with error"
 
-# Staging commits parts of the streamed NAR at the Go default part size (8 MiB),
-# so activation needs a NAR comfortably larger than that — enough parts must
-# commit while the holder is still downloading for a waiter to observe them.
-# nixpkgs#go (~216 MiB NAR) clears that bar with margin. Override with --package;
-# if staging does not activate, the run fails and suggests a larger package.
-DEFAULT_PACKAGE = "nixpkgs#go"
+# Activation needs the holder's NAR download to outlast a few staging-activation
+# poll ticks so a waiter's request is observed mid-download (and the streamed NAR
+# must exceed the 8 MiB part size so parts commit while downloading). The package
+# must also be substitutable from the configured upstream. nixpkgs#gcc-unwrapped
+# (~gcc, several-hundred-MiB NAR, Hydra-built on cache.nixos.org) clears both bars
+# and is verified to activate staging. Override with --package; if staging does
+# not activate, the run fails and suggests a larger package.
+DEFAULT_PACKAGE = "nixpkgs#gcc-unwrapped"
 
 # Colors
 G = "\033[0;32m"
@@ -147,9 +149,20 @@ def start_cluster(db, storage, replicas, log_path, *, cdc=False):
     ]
     if cdc:
         args.append("--enable-cdc")
+    # Optional upstream override. run.py defaults to cache.nixos.org, but a
+    # locally-realised package (the canonical reference) may be on the dev
+    # substituter and not yet on cache.nixos.org, which would 404 the narinfo.
+    # Point ncps at a substituter that has the package for a deterministic run:
+    #   NCPS_E2E_UPSTREAM_URL=https://ncps.example.com
+    #   NCPS_E2E_UPSTREAM_KEY=cache-name:base64key
+    upstream_url = os.environ.get("NCPS_E2E_UPSTREAM_URL")
+    upstream_key = os.environ.get("NCPS_E2E_UPSTREAM_KEY")
+    if upstream_url and upstream_key:
+        args += ["--cache-url", upstream_url, "--cache-public-key", upstream_key]
     log(
         f"start_cluster: db={db} storage={storage} replicas={replicas} "
-        f"cdc={cdc} locker=redis inflight-staging=on",
+        f"cdc={cdc} locker=redis inflight-staging=on"
+        + (f" upstream={upstream_url}" if upstream_url and upstream_key else ""),
         G,
     )
     f = open(log_path, "w", encoding="utf-8")
@@ -489,8 +502,9 @@ def run_phase(db, storage, replicas, clients, cdc, package, results_dir):
             elif contended:
                 hint = (
                     "a waiter lost the download lock but staging never engaged; the "
-                    "holder polls for waiters every 1s, so use a larger --package "
-                    "whose NAR download outlasts a few poll ticks"
+                    "holder polls for waiters periodically, so the NAR download must "
+                    "outlast a few poll ticks — use a larger --package (its compressed "
+                    "NAR download needs to take comfortably longer than a poll interval)"
                 )
             else:
                 hint = (

--- a/dev-scripts/test-inflight-staging-contention-e2e.py
+++ b/dev-scripts/test-inflight-staging-contention-e2e.py
@@ -122,6 +122,20 @@ def check(cond, msg):
 # ---------------------------------------------------------------------------
 
 
+def redact_url(url):
+    """Strip any userinfo/query (possible credentials) from a URL for logging."""
+    try:
+        from urllib.parse import urlsplit, urlunsplit
+
+        parts = urlsplit(url)
+        netloc = parts.hostname or ""
+        if parts.port:
+            netloc += f":{parts.port}"
+        return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+    except Exception:  # noqa: BLE001 — logging helper must never raise
+        return "<redacted>"
+
+
 def ports_for(replicas):
     return [BASE_PORT + i for i in range(replicas)]
 
@@ -157,12 +171,23 @@ def start_cluster(db, storage, replicas, log_path, *, cdc=False):
     #   NCPS_E2E_UPSTREAM_KEY=cache-name:base64key
     upstream_url = os.environ.get("NCPS_E2E_UPSTREAM_URL")
     upstream_key = os.environ.get("NCPS_E2E_UPSTREAM_KEY")
-    if upstream_url and upstream_key:
+    upstream_active = bool(upstream_url) and bool(upstream_key)
+    if bool(upstream_url) != bool(upstream_key):
+        # Partial config is almost always a mistake; surface it loudly rather than
+        # silently falling back to run.py's default upstream (a confusing failure).
+        log(
+            "WARNING: only one of NCPS_E2E_UPSTREAM_URL / NCPS_E2E_UPSTREAM_KEY is "
+            "set — both are required to override the upstream. Ignoring the partial "
+            "override and using run.py's default upstream.",
+            Y,
+        )
+    if upstream_active:
         args += ["--cache-url", upstream_url, "--cache-public-key", upstream_key]
     log(
         f"start_cluster: db={db} storage={storage} replicas={replicas} "
         f"cdc={cdc} locker=redis inflight-staging=on"
-        + (f" upstream={upstream_url}" if upstream_url and upstream_key else ""),
+        # Redact any userinfo/query (possible credentials) before logging the URL.
+        + (f" upstream={redact_url(upstream_url)}" if upstream_active else ""),
         G,
     )
     f = open(log_path, "w", encoding="utf-8")

--- a/openspec/changes/archive/2026-06-08-fix-inflight-staging-producer-temp-race/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-08-fix-inflight-staging-producer-temp-race/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/archive/2026-06-08-fix-inflight-staging-producer-temp-race/design.md
+++ b/openspec/changes/archive/2026-06-08-fix-inflight-staging-producer-temp-race/design.md
@@ -1,0 +1,45 @@
+## Context
+
+In-flight NAR staging engages when a lock-losing waiter records a `staging_state` "requested" marker and the download holder, seeing it, copies the in-flight NAR to shared storage as part-objects so the waiter serves complete bytes instead of a half-written stream. The `test-inflight-staging-contention-e2e.py` driver proved that on real, fast downloads the feature never serves, due to two coupled issues in `pkg/cache/inflight_staging.go`:
+
+- `stagingActivationPollInterval = time.Second` (line 22): the holder's `waitForStagingRequest` polls `staging_state` once per second. The comment calls late activation "harmless" because of backfill-from-zero — but a download that finishes within one tick means the request is only observed via the `case <-ds.done` branch (line 163), i.e. *after* the download completed.
+- `produceStagingParts` then reads `ds.assetPath` with `os.Open` (line 225). On completion the holder's temp file has already been moved into final storage, so the open fails with ENOENT and the producer logs a WARN error (`inflight_staging.go:132-136`) — staging never produces a single part.
+
+`downloadState` (`pkg/cache/cache.go:540-547`) already carries the signals needed: `assetPath`, `finalSize` (0 until the download is done), `downloadError`, and the `done`/`start` channels.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The producer treats "download already completed / temp file gone" as a clean no-op, not an error — no spurious WARN, no failed activation.
+- Activation engages promptly once a cross-pod waiter requests staging, so the feature actually serves during realistic contended downloads rather than only multi-second ones.
+- Prove the fix with the existing contention e2e driver (green activation) plus focused `pkg/cache` unit tests, via TDD.
+
+**Non-Goals:**
+- Changing part size, retention, or the part-object format/layout.
+- Touching the CDC/lazy chunking internals beyond what the chunking-window test exercises.
+- Tuning the e2e driver's default package (a harness concern).
+
+## Decisions
+
+**D1 — Graceful no-op when the download already completed.**
+Before opening the temp file, `produceStagingParts` checks whether the download has already finished (the request was observed via the `<-ds.done` path, or `ds.finalSize != 0` with the temp file gone). In that case it returns `nil` — the NAR is already committed to storage and waiters serve from there; staging-from-temp-file is moot. Additionally, an ENOENT from `os.Open(ds.assetPath)` is reclassified as "already committed" (clean return), never a WARN error. *Alternative considered:* keep erroring but downgrade the log to debug — rejected: it still counts as a failed producer and leaves staging_state in a misleading state; a clean no-op is the correct semantics.
+
+**D2 — Shorten the holder's activation poll to match the waiter's cadence.**
+Staging requests are recorded *only* by cross-pod waiters: `markStagingRequested` is called exclusively from `pollForDownloadOrTakeOver` (cache.go:6524), the lock-loser path. Same-process concurrent requests share the one `downloadState` and stream the shared temp file via `fileAvailableReader` — they never record a request. So there is no in-process signal to wake on; the holder learns of a waiter only by reading `staging_state`. The fix is therefore to lower `stagingActivationPollInterval` from `1s` to `200ms`, matching the waiter's own `pollInterval` (cache.go:6517), so the holder observes the request within ~200ms and stages while the download is still in flight. *Alternatives considered:* (a) a per-hash local signal on `downloadState` — rejected: inapplicable, since same-node waiters never request staging and cross-node ones can't reach an in-process channel; (b) a DB LISTEN/NOTIFY channel — Postgres-only, doesn't generalize to sqlite/mysql. A short poll is portable and, being holder-only and stopping on the first observed request, costs near zero.
+
+**D3 — Keep backfill-from-zero.** Activation that lands mid-download still backfills the already-downloaded prefix from offset zero (unchanged behavior), so "prompt" only improves the window — it never changes correctness of the staged bytes.
+
+## Risks / Trade-offs
+
+- **[A shorter cross-node poll adds DB read load under contention]** → Only the holder polls, only while a download is in flight and no request has yet been seen; it stops the instant a request appears. Bounded and short-lived.
+- **[Signal plumbing on `downloadState` risks a missed/duplicate wake]** → Treat the signal as a hint, not the source of truth: `waitForStagingRequest` always re-reads `staging_state` after a wake (and on the `<-ds.done` final check), so a missed signal degrades to the poll and a spurious signal degrades to a no-op read.
+- **[ENOENT could mask a genuine storage fault]** → Scope the clean-return strictly to the "download already complete" condition (`ds.finalSize != 0` / `<-ds.done` observed); an ENOENT while the download is still in flight remains an error.
+
+## Migration Plan
+
+Pure behavior fix in `pkg/cache`; no schema, config, or API change. Ships as a normal deploy; rollback is a git revert. The e2e driver (already on the parent branch) is the multi-process acceptance gate.
+
+## Open Questions
+
+- Exact shortened cross-node poll interval (e.g. 100–250ms) — pick the largest value that still lands inside the e2e's contended-download window, to minimize idle DB reads.
+- Whether to also emit a single debug line when staging no-ops because the download already completed, to keep the path observable without log noise.

--- a/openspec/changes/archive/2026-06-08-fix-inflight-staging-producer-temp-race/proposal.md
+++ b/openspec/changes/archive/2026-06-08-fix-inflight-staging-producer-temp-race/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The new `dev-scripts/test-inflight-staging-contention-e2e.py` driver (change `test-harness-coverage-audit`) reproduced genuine cross-replica contention and proved in-flight NAR staging **never actually serves** on real, fast downloads. Two coupled defects:
+
+1. **Producer races a deleted temp file.** `produceStagingParts` opens the holder's download temp file (`pkg/cache/inflight_staging.go:225`, `os.Open(ds.assetPath)`). When a waiter's staging request is observed only at download completion — the `<-ds.done` branch of `waitForStagingRequest` returns `true` — the temp file has already been moved to final storage, so the open fails with `no such file or directory` and the producer logs a WARN error instead of cleanly no-op'ing.
+2. **Activation is too sluggish to engage.** `stagingActivationPollInterval = 1s` (`inflight_staging.go:22`): the holder only checks for waiters once per second. Any download finishing within ~1s never has staging engage mid-stream, so contended readers silently fall back to storage-polling. The feature is effectively dormant except for multi-second downloads, defeating its purpose (#660 / #1289).
+
+## What Changes
+
+- **Producer no-ops gracefully when the download already completed.** If the staging request is observed at/after completion (temp file gone, `ds.finalSize` set), `produceStagingParts` returns without error — the NAR is already in storage and waiters serve from it. No more spurious WARN; an ENOENT on the temp file is treated as "already committed", not a failure.
+- **Make activation prompt.** Replace (or supplement) the 1s poll with a signal: when a waiter records a staging request, the holder is notified immediately so it begins staging while the download is still in-flight. This lets staging engage on realistic contended downloads rather than only multi-second ones.
+- **Validate green via the existing harness.** With these fixes, `task test:inflight-staging-contention` (adequately-sized `--package`) shows staging activate and serve in the **download window** across both the `local` and `s3` backends. (The **chunking window** surfaced a *separate* CDC serve-route defect — the non-downloading replica 404s the NAR instead of serving from staging — which this fix neither causes nor addresses; it is deferred to its own change.)
+
+## Capabilities
+
+### Modified Capabilities
+- `inflight-nar-staging`: the producer MUST treat a completed download / absent temp file as a clean no-op (not an error), and staging activation MUST engage promptly once a cross-pod waiter requests it, not only after a coarse poll interval.
+
+## Impact
+
+- **Code**: `pkg/cache/inflight_staging.go` (producer + activation wait), small `downloadState` signalling in `pkg/cache/cache.go`. TDD on `pkg/cache` unit tests + the e2e driver for the multi-process proof.
+- **I/O / latency / memory**: no change to steady-state serving; staging engages slightly sooner under contention (the intended behavior). Eliminates spurious WARN log noise.
+
+## Non-goals
+
+- Changing the staging part size, retention, or the storage/part-object format.
+- Fixing the **chunking-window CDC serve-route 404** (the non-downloading replica 404s the NAR under CDC) — surfaced during validation, distinct from the producer temp-race; deferred to its own change.
+- Reworking the lazy/CDC chunking paths.
+
+(Validation required two small e2e-harness adjustments on this branch: the driver's default `--package` was set to `nixpkgs#gcc-unwrapped` — large enough to reliably activate and present on the upstream — and an opt-in `NCPS_E2E_UPSTREAM_URL/KEY` override was added so a locally-realised package can be fetched deterministically.)

--- a/openspec/changes/archive/2026-06-08-fix-inflight-staging-producer-temp-race/specs/inflight-nar-staging/spec.md
+++ b/openspec/changes/archive/2026-06-08-fix-inflight-staging-producer-temp-race/specs/inflight-nar-staging/spec.md
@@ -1,0 +1,23 @@
+## MODIFIED Requirements
+
+### Requirement: Staging activates only on cross-pod contention
+
+When the feature is enabled, a replica holding the download lock SHALL begin staging only after it observes a cross-pod waiter for the same NAR hash, recorded as a request marker in the `staging_state` record. A replica using the local (non-distributed) locker SHALL never stage, because no cross-pod waiter can exist. The holder SHALL observe a waiter's request promptly enough to begin staging while the download is still in flight, and if the download has already completed when the request is observed the holder SHALL treat staging as a clean no-op (the NAR is already in shared storage) rather than reporting an error.
+
+#### Scenario: Cross-pod waiter triggers staging
+
+- **WHEN** replica A holds the download lock for hash `H` and is actively downloading
+- **AND** replica B fails to acquire the lock and records a staging request for `H`
+- **THEN** replica A SHALL observe the request promptly and begin staging the NAR to shared storage while the download is still in flight
+
+#### Scenario: Local locker never stages
+
+- **WHEN** ncps runs with the local (single-instance) locker and the feature is enabled
+- **THEN** no staging request can be recorded by another replica
+- **AND** the holder SHALL never begin staging
+
+#### Scenario: Request observed after the download completed is a clean no-op
+
+- **WHEN** a staging request for hash `H` is observed by the holder only at or after the download has completed (the in-flight temp file has already been committed to shared storage)
+- **THEN** the holder SHALL NOT attempt to stage from the absent temp file
+- **AND** it SHALL return without logging an error, because cross-pod waiters serve the completed NAR from shared storage

--- a/openspec/changes/archive/2026-06-08-fix-inflight-staging-producer-temp-race/tasks.md
+++ b/openspec/changes/archive/2026-06-08-fix-inflight-staging-producer-temp-race/tasks.md
@@ -1,0 +1,24 @@
+## 1. Reproduce in a unit test (red)
+
+- [x] 1.1 Add a failing `pkg/cache` internal test asserting `produceStagingParts` returns nil (no error, no WARN) when `ds.assetPath` points to a file that no longer exists (the download already completed and the post-completion cleanup removed the temp file). Model it on `inflight_staging_producer_internal_test.go`.
+
+## 2. Producer graceful no-op (green for 1.1)
+
+- [x] 2.1 In `produceStagingParts` (`pkg/cache/inflight_staging.go`), when `os.Open(ds.assetPath)` returns an `fs.ErrNotExist`, return nil — the temp file is only ever removed by the post-completion cleanup goroutine (`cache.go:3143`), so a not-exist error unambiguously means the download already completed and its NAR is in shared storage. Any other open error stays a real error.
+- [x] 2.2 Emit a single debug line for the no-op (download already completed before staging began), removing the spurious WARN for this case.
+
+## 3. Prompt activation (shorten the holder poll)
+
+- [x] 3.1 Lower `stagingActivationPollInterval` (`pkg/cache/inflight_staging.go`) from `1s` to `200ms`, matching the waiter's `pollInterval` (`cache.go:6517`) so the holder observes a cross-pod staging request while the download is still in flight. Update the now-stale "coarse on purpose" comment. (No per-hash local signal — staging requests are cross-pod-only, so there is nothing in-process to signal; see design D2.)
+- [x] 3.2 Confirm backfill-from-zero is unchanged: activation landing mid-download still backfills the already-downloaded prefix from offset zero (no code change expected; verify via the existing producer/late-waiter tests).
+
+## 4. Unit verification
+
+- [x] 4.1 `task test` green (race detector), including the new tests and the existing `inflight_staging_*` suite.
+- [x] 4.2 `task fmt` and `task lint` exit zero.
+
+## 5. Multi-process acceptance (the bug's real proof)
+
+- [x] 5.1 Ran `task test:inflight-staging-contention -- --storage local --window download` (gcc-unwrapped, ~277MB NAR, 2 replicas, 8 clients). PASS: staging ACTIVATED (4 activation log lines on the non-holder replica), all readers 200, byte-identical to canonical `nix-store --dump`, and `producer_error=[]` — the exact pre-fix failure (producer ENOENT WARN) is gone. This is the download-window (#660) proof.
+- [x] 5.2 `s3-download`: PASS (staging activated, same as local) — download window validated on both backends. Chunking window (`local-chunking`, `s3-chunking`) DESCOPED to a separate change: it fails on a distinct CDC serve-route bug (non-downloading replica 404s the `.nar.xz`, 4/8 readers, no producer error/no staging serve), which this fix neither causes nor addresses. Documented in [[project_cdc_window_nonholder_404]].
+- [x] 5.3 Evidence: `.e2e-results/inflight-staging/20260608-144032/` (local-download PASS, `activated_on:[8502]`, package `nixpkgs#gcc-unwrapped`) and `.../20260608-144129/summary.json` (matrix: local-download PASS, s3-download PASS, *-chunking FAIL on the separate CDC bug). Default `--package` set to `nixpkgs#gcc-unwrapped` (large + on cache.nixos.org + reliably activates; `nixpkgs#go` was local-store-only → upstream 404).

--- a/openspec/specs/inflight-nar-staging/spec.md
+++ b/openspec/specs/inflight-nar-staging/spec.md
@@ -24,19 +24,25 @@ The in-flight NAR staging feature SHALL be controlled by `--cache-inflight-stagi
 
 ### Requirement: Staging activates only on cross-pod contention
 
-When the feature is enabled, a replica holding the download lock SHALL begin staging only after it observes a cross-pod waiter for the same NAR hash, recorded as a request marker in the `staging_state` record. A replica using the local (non-distributed) locker SHALL never stage, because no cross-pod waiter can exist.
+When the feature is enabled, a replica holding the download lock SHALL begin staging only after it observes a cross-pod waiter for the same NAR hash, recorded as a request marker in the `staging_state` record. A replica using the local (non-distributed) locker SHALL never stage, because no cross-pod waiter can exist. The holder SHALL observe a waiter's request promptly enough to begin staging while the download is still in flight, and if the download has already completed when the request is observed the holder SHALL treat staging as a clean no-op (the NAR is already in shared storage) rather than reporting an error.
 
 #### Scenario: Cross-pod waiter triggers staging
 
 - **WHEN** replica A holds the download lock for hash `H` and is actively downloading
 - **AND** replica B fails to acquire the lock and records a staging request for `H`
-- **THEN** replica A SHALL observe the request within a bounded interval and begin staging the NAR to shared storage
+- **THEN** replica A SHALL observe the request promptly and begin staging the NAR to shared storage while the download is still in flight
 
 #### Scenario: Local locker never stages
 
 - **WHEN** ncps runs with the local (single-instance) locker and the feature is enabled
 - **THEN** no staging request can be recorded by another replica
 - **AND** the holder SHALL never begin staging
+
+#### Scenario: Request observed after the download completed is a clean no-op
+
+- **WHEN** a staging request for hash `H` is observed by the holder only at or after the download has completed (the in-flight temp file has already been committed to shared storage)
+- **THEN** the holder SHALL NOT attempt to stage from the absent temp file
+- **AND** it SHALL return without logging an error, because cross-pod waiters serve the completed NAR from shared storage
 
 ### Requirement: The in-flight NAR is staged as ordered immutable part-objects, backfilled from the start
 

--- a/pkg/cache/inflight_staging.go
+++ b/pkg/cache/inflight_staging.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"time"
 
@@ -238,7 +237,7 @@ func (c *Cache) produceStagingParts(ctx context.Context, hash string, ds *downlo
 		// the NAR is committed to shared storage and cross-pod waiters serve it
 		// from there. There is nothing to stage — a clean no-op, not a failure.
 		// Any other open error is a genuine fault and still propagates.
-		if errors.Is(err, fs.ErrNotExist) {
+		if errors.Is(err, os.ErrNotExist) {
 			zerolog.Ctx(ctx).Debug().
 				Str("hash", hash).
 				Msg("in-flight staging skipped: download completed before staging began")

--- a/pkg/cache/inflight_staging.go
+++ b/pkg/cache/inflight_staging.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"time"
 
@@ -16,10 +17,16 @@ import (
 )
 
 // stagingActivationPollInterval is how often the holder's staging producer reads
-// staging_state looking for a cross-pod waiter before staging activates (D10). It
-// is coarse on purpose: backfill-from-zero makes late activation harmless, so this
-// only needs to be cheap, not low-latency.
-const stagingActivationPollInterval = time.Second
+// staging_state looking for a cross-pod waiter before staging activates (D10).
+// Staging requests are recorded only by cross-pod waiters (markStagingRequested
+// is called solely from pollForDownloadOrTakeOver), so the holder learns of a
+// waiter only by this poll — there is no in-process signal to wake on. It must be
+// short enough that the holder observes the request while the download is still in
+// flight; otherwise a fast download finishes first and staging never engages (the
+// temp file is gone before the producer can tail it). It matches the waiter's own
+// 200ms pollInterval (see pollForDownloadOrTakeOver). The poll is holder-only and
+// stops on the first observed request, so the steady-state cost is near zero.
+const stagingActivationPollInterval = 200 * time.Millisecond
 
 // defaultInflightStagingPartSize is the fallback staging part size (8 MiB, the
 // conventional S3 multipart part size) used when the configured part size is unset
@@ -224,6 +231,21 @@ func (c *Cache) produceStagingParts(ctx context.Context, hash string, ds *downlo
 
 	f, err := os.Open(assetPath)
 	if err != nil {
+		// ds.assetPath is only ever removed by the post-completion cleanup
+		// goroutine (cache.go), which runs after the download and all readers
+		// finish. So a not-exist error here means the download already completed
+		// before staging began (the cross-pod request was observed at completion):
+		// the NAR is committed to shared storage and cross-pod waiters serve it
+		// from there. There is nothing to stage — a clean no-op, not a failure.
+		// Any other open error is a genuine fault and still propagates.
+		if errors.Is(err, fs.ErrNotExist) {
+			zerolog.Ctx(ctx).Debug().
+				Str("hash", hash).
+				Msg("in-flight staging skipped: download completed before staging began")
+
+			return nil
+		}
+
 		return fmt.Errorf("staging producer: open temp file %q: %w", assetPath, err)
 	}
 	defer f.Close()

--- a/pkg/cache/inflight_staging_producer_internal_test.go
+++ b/pkg/cache/inflight_staging_producer_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -253,20 +254,15 @@ func TestProduceStagingParts_NoOpWhenDownloadAlreadyCompleted(t *testing.T) {
 
 	const hash = "aaaabbbbccccddddeeeeffff22223333"
 
-	// Create then remove a temp file so ds.assetPath points at a path that no
-	// longer exists — exactly what the post-completion cleanup leaves behind.
-	f, err := os.CreateTemp(dir, "gone-*.nar")
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
-	require.NoError(t, os.Remove(f.Name()))
-
+	// A path under the temp dir that was never created — exactly what the
+	// post-completion cleanup leaves behind once it removes ds.assetPath.
 	ds := newDownloadState()
-	ds.assetPath = f.Name()
+	ds.assetPath = filepath.Join(dir, "gone.nar")
 	ds.finalSize = 10
 	ds.startOnce.Do(func() { close(ds.start) })
 	ds.doneOnce.Do(func() { close(ds.done) })
 
-	err = c.produceStagingParts(ctx, hash, ds)
+	err := c.produceStagingParts(ctx, hash, ds)
 	require.NoError(t, err,
 		"a missing temp file means the download already completed; staging must "+
 			"no-op, not error")

--- a/pkg/cache/inflight_staging_producer_internal_test.go
+++ b/pkg/cache/inflight_staging_producer_internal_test.go
@@ -234,3 +234,43 @@ func TestStageInflightNar_DisabledDoesNothing(t *testing.T) {
 	_, err = store.GetStagingPart(ctx, hash, 0)
 	assert.ErrorIs(t, err, storage.ErrNotFound)
 }
+
+// TestProduceStagingParts_NoOpWhenDownloadAlreadyCompleted verifies that when the
+// holder's temp file is already gone — the post-completion cleanup goroutine
+// (cache.go) removes ds.assetPath once the download and all readers finish — the
+// producer treats the missing temp file as a clean no-op rather than erroring.
+// This is the fast-download case the contention e2e surfaced: a cross-pod request
+// observed at completion led the producer to open an already-removed temp file.
+func TestProduceStagingParts_NoOpWhenDownloadAlreadyCompleted(t *testing.T) {
+	t.Parallel()
+
+	c, _, store, dir, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+
+	ctx := context.Background()
+
+	const hash = "aaaabbbbccccddddeeeeffff22223333"
+
+	// Create then remove a temp file so ds.assetPath points at a path that no
+	// longer exists — exactly what the post-completion cleanup leaves behind.
+	f, err := os.CreateTemp(dir, "gone-*.nar")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	require.NoError(t, os.Remove(f.Name()))
+
+	ds := newDownloadState()
+	ds.assetPath = f.Name()
+	ds.finalSize = 10
+	ds.startOnce.Do(func() { close(ds.start) })
+	ds.doneOnce.Do(func() { close(ds.done) })
+
+	err = c.produceStagingParts(ctx, hash, ds)
+	require.NoError(t, err,
+		"a missing temp file means the download already completed; staging must "+
+			"no-op, not error")
+
+	_, err = store.GetStagingPart(ctx, hash, 0)
+	assert.ErrorIs(t, err, storage.ErrNotFound, "no parts should be written on the no-op path")
+}


### PR DESCRIPTION
## Summary

- The in-flight NAR staging producer opened the holder's download temp file unconditionally; when a cross-pod staging request was observed at download completion, the temp file had already been removed by the post-completion cleanup, so the open failed with ENOENT and the producer logged a WARN error instead of staging — staging never served.
- `produceStagingParts` now treats `fs.ErrNotExist` as a clean no-op (the NAR is already committed to storage; waiters serve from there).
- `stagingActivationPollInterval` lowered 1s → 200ms to match the waiter's cadence, so the holder observes a request while the download is still in flight.

Proven green via the contention e2e in the **download window** across local and s3 (staging activates on the non-holder; byte-identical NARs; no producer WARN).

## Test plan

- [x] `task fmt` / `task lint` / `task test` (race) pass
- [x] New `pkg/cache` unit test (red→green)
- [x] Multi-process e2e: download window green (local + s3)