### PR TITLE
fix(cache): route a contended CDC loser to staging, not a 404

### DIFF
--- a/openspec/changes/archive/2026-06-08-fix-cdc-window-nonholder-404/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-08-fix-cdc-window-nonholder-404/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/archive/2026-06-08-fix-cdc-window-nonholder-404/design.md
+++ b/openspec/changes/archive/2026-06-08-fix-cdc-window-nonholder-404/design.md
@@ -1,0 +1,59 @@
+## Context
+
+Reproduced by `task test:inflight-staging-contention --window chunking`: with CDC enabled, a lock-losing replica returns HTTP 404 for `/nar/<hash>.nar.xz` while the lock holder serves 200. Root cause traced through `Cache.GetNar` and `pollForDownloadOrTakeOver` (`pkg/cache/cache.go`):
+
+- The lock-loser polls in `pollForDownloadOrTakeOver`. Each tick checks, in order: (1) `hasAsset(coordCtx)` → return a "served_by_peer" completed `ds` (line 6546); (2) `TryLock` takeover (6577); (3) `stagingActive && stagingServeReady` → return `ds.stagingServe` (6594).
+- `hasAsset` is `isServable` (`prePullNar:~4319`). With CDC enabled and the holder **actively chunking**, `isServable` returns **true** (nar_file row exists, `ChunkingStartedAt != nil`, `cdcChunkerLive()` true) even though `total_chunks == 0`. So tick step (1) fires first and returns a completed `ds` — intentional, to route peers into progressive chunk streaming (`GetNar:1314-1316`).
+- Back in `GetNar`, the completed `ds` (`closed=true`, no `stagingServe`) takes the `!canStream` branch (1317) → `serveNarFromStorageViaPipe` → because the NAR is chunks-only, `serveFromChunks` is true and the requested compression is `xz`, so it returns `storage.ErrNotFound` at **`cache.go:3465`** ("NAR is only available as chunks, cannot serve as xz") → 404.
+- With CDC **disabled**, `isServable` is false (no chunk store), so step (1) is skipped, step (3) reaches staging, and `serveNarFromStaging` serves the parts **transcoded to xz** → 200. That transcoding path is exactly what the CDC case never reaches.
+
+So: in-flight staging (which transcodes to the requested compression) is short-circuited under CDC by the `hasAsset` early-return, and the fallback chunk-serve path cannot satisfy a compressed request.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A contended CDC lock-loser serves a complete, byte-identical NAR (in the requested compression) instead of 404 — matching the CDC-off path.
+- Preserve the existing invariants: progressive chunk streaming for the no-staging CDC case, and takeover-before-staging (D5, so a dead holder's truncated staging prefix is never served).
+- Lock the behavior with the chunking-window e2e (local + s3) plus focused `pkg/cache` unit tests.
+
+**Non-Goals:**
+- Reworking the CDC chunking algorithm, part-object format, or narinfo URL normalization.
+- The download-window staging fix (already shipped).
+- Changing steady-state (post-chunking) serving.
+
+## Decisions
+
+**D1 — The fix is NOT a simple reorder: the tick conditions have a cyclic priority that must be resolved by splitting the served-by-peer predicate by state.**
+A naive reorder is unsatisfiable. During active chunking the three conditions demand contradictory orders:
+- staging must precede `hasAsset` (else an actively-chunking NAR hits served-by-peer → chunk-serve → 404 on `xz`);
+- `hasAsset` must precede takeover (else a *finished* peer that released its lock is re-downloaded instead of served);
+- takeover must precede staging (invariant D5: an acquirable lock ⇒ dead holder ⇒ truncated staging prefix).
+
+That is `staging < hasAsset < takeover < staging` — a cycle. The root reason is that `hasAsset` (`isServable`) **conflates two distinct states**: "peer finished, asset fully materialized" and "peer actively chunking (`total_chunks==0`, chunker live)". The served-by-peer early-return must fire only for the *finished* state; the *actively-chunking* state must defer to: staging (when active + parts ready) or progressive chunk streaming (no-staging). Concretely, the coordination decision must distinguish four states per tick:
+1. **dead holder** (lock acquirable) → takeover + restart (D5, stays first);
+2. **finished** (`HasNarInStore` OR `total_chunks>0`) → served-by-peer completed `ds`;
+3. **actively chunking + staging active + parts ready** → `ds.stagingServe` (transcodes to the requested compression);
+4. **actively chunking + no staging** → completed `ds` routed to progressive chunk streaming (current behavior; preserves `GetNar:1314-1316`).
+
+This is a restructuring of the coordination decision, not a line swap. *Alternative considered:* globally narrowing `isServable` — rejected: `isServable` is used elsewhere as "can serve now" (including active chunking for progressive streaming); only the served-by-peer decision inside `pollForDownloadOrTakeOver` should split finished vs. actively-chunking.
+
+**D2 — Leave the no-staging CDC path on progressive chunk streaming.**
+When staging is disabled or no parts are ready, behavior is unchanged: `hasAsset` returns the completed `ds` and `GetNar` routes to `getNarFromChunks`. The compressed-request-from-chunks 404 in that no-staging path is a *separate, pre-existing* limitation (a chunk-serving replica cannot synthesize `xz`); it is out of scope here and only reachable without the staging feature.
+
+**D3 — Verify staging actually produces parts in CDC mode.**
+The e2e showed no producer error and no staging serve, consistent with the producer never being reached (hasAsset short-circuit) rather than a producer failure. Part of implementation is confirming, with the reorder, that the CDC holder's staging producer tails a valid temp file and the loser serves transcoded bytes end-to-end.
+
+## Risks / Trade-offs
+
+- **[Reordering the coordination tick regresses progressive streaming or takeover]** → Keep takeover strictly first (D5 preserved); only move staging ahead of `hasAsset`. Gate behind `stagingActive`, so feature-off behavior is byte-for-byte unchanged. Validate the full `pkg/cache` suite (coordination, cdc_*, takeover, recovery_gc) plus the chunking-window e2e.
+- **[Serving from staging when the peer actually just finished]** → Harmless: staging parts are complete bytes; after retention they are reclaimed and `hasAsset` resumes. A brief preference for staging over direct storage is acceptable.
+- **[Staging may not engage if the CDC holder's temp file lifecycle differs]** → Confirm during implementation (D3); if the CDC producer can't stage, escalate as a separate finding rather than forcing a partial fix.
+
+## Migration Plan
+
+Pure `pkg/cache` behavior change; no schema/config/API. Ships as a normal deploy; rollback is a git revert. The chunking-window e2e is the multi-process acceptance gate.
+
+## Open Questions
+
+- Does moving `TryLock` ahead of `hasAsset` in the tick change the takeover cadence meaningfully? (Both run once per 200ms tick; ordering only affects which wins when several conditions are simultaneously true.)
+- Should the no-staging chunk-serve compressed-request 404 (D2) be filed as its own follow-up, or is staging-on the intended production configuration for multi-replica CDC?

--- a/openspec/changes/archive/2026-06-08-fix-cdc-window-nonholder-404/proposal.md
+++ b/openspec/changes/archive/2026-06-08-fix-cdc-window-nonholder-404/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The in-flight NAR staging contention e2e (`task test:inflight-staging-contention`) is green in the download window across local and s3, but **both chunking-window phases fail**: under CDC, concurrent readers on the **non-downloading replica receive HTTP 404** for the NAR while readers on the holder replica get 200 (a clean 4/8 split by replica, no producer error, no staging serve). This directly violates the existing `inflight-nar-staging` requirement *"Cross-pod readers serve a complete, byte-correct NAR from staging in all CDC modes"* — the #1289 chunking-window case staging is meant to cover. It is a distinct defect from the staging-producer temp-file race (already fixed): that fix made the download window work, but the chunking window 404s before staging can help.
+
+Investigation split the defect into two layers. This change ships **Layer 1** (the coordination routing); **Layer 2** (the CDC holder produces no staging parts) is a separate follow-up — without it the user-visible 404 persists, so the chunking-window e2e green moves to the Layer-2 change.
+
+## What Changes
+
+- **Stop the non-holder mis-routing an actively-chunking NAR to a chunk-serve 404.** In the download-coordination poll loop (`pollForDownloadOrTakeOver`), the lock-loser early-returned a "served-by-peer" state for an *actively-chunking* NAR because `isServable` conflates "finished" with "actively chunking". Split a finished-only predicate (`hasFinishedNar`: whole-file in store OR `total_chunks>0`) out of `isServable`, and restructure the per-tick decision into four states: dead-holder→takeover (D5, first); finished→serve; actively-chunking + staging-ready→serve from staging (transcoding); actively-chunking + no-staging→progressive chunk streaming (unchanged). The net effect: when staging parts exist, a contended CDC loser serves them (no 404); the no-staging progressive path is preserved byte-for-byte.
+- **Layer 2 (separate change):** wire the in-flight staging *producer* into the CDC download path so the holder actually produces parts during chunking. Today it does not, so `stagingServeReady` is always nil at the loser and the 404 persists end-to-end. That change owns the chunking-window e2e green.
+
+## Capabilities
+
+### Modified Capabilities
+- `inflight-nar-staging`: strengthen the "Cross-pod readers serve a complete, byte-correct NAR from staging in all CDC modes" requirement with a scenario asserting that, *when staging parts are available*, a lock-losing reader under CDC serves from staging rather than routing to chunk serving and 404-ing a compressed request.
+
+## Impact
+
+- **Code**: `pkg/cache/cache.go` — `hasFinishedNar` helper; `hasFinishedAsset` threaded through `coordinateDownload` + `pollForDownloadOrTakeOver`; the poll-tick state split. TDD: `pkg/cache` unit test (`hasFinishedNar` excludes actively-chunking) + full `-race` suite (no regression to progressive-streaming/takeover/CDC/recovery).
+- **I/O / latency / memory**: no steady-state change; only the contended-loser routing decision changes.
+
+## Non-goals
+
+- **Layer 2** — wiring the CDC staging producer to emit parts (separate change; owns the chunking-window e2e green).
+- The download-window staging fix (already shipped in `fix-inflight-staging-producer-temp-race`).
+- Reworking the CDC chunking algorithm, part-object format, or drain/migration paths.
+- The e2e harness itself.

--- a/openspec/changes/archive/2026-06-08-fix-cdc-window-nonholder-404/specs/inflight-nar-staging/spec.md
+++ b/openspec/changes/archive/2026-06-08-fix-cdc-window-nonholder-404/specs/inflight-nar-staging/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Cross-pod readers serve a complete, byte-correct NAR from staging in all CDC modes
+
+A waiting replica that observes available staging parts SHALL tail them to reassemble and serve a complete, byte-correct NAR, regardless of whether CDC is disabled, lazy, or eager. The served bytes SHALL carry the compression recorded in `staging_state.compression`; when the client requests a different compression, the reader SHALL transcode on the fly at parity with the same-pod streaming path. A reader SHALL NOT deliver a truncated NAR as an HTTP 200. When the holder is alive and staging parts are available, a waiting replica SHALL prefer serving from staging over routing to chunk-based serving, so that an actively-chunking (eager-CDC) NAR is never returned to the client as an HTTP 404 merely because the requested compression cannot be produced from chunks.
+
+#### Scenario: Non-CDC cross-pod serve during download
+
+- **WHEN** CDC is disabled and replica A is downloading a NAR with replica B waiting
+- **AND** staging is active
+- **THEN** replica B SHALL serve the complete NAR from staging parts with HTTP 200
+
+#### Scenario: Eager-CDC cross-pod serve prefers staging over chunk routing
+
+- **WHEN** CDC is eager and replica A holds the download lock and is actively chunking a NAR (its `nar_file` row exists but `total_chunks` is still 0) with replica B waiting
+- **AND** staging is active and the holder has produced staging parts
+- **THEN** replica B SHALL serve the complete NAR from staging parts with HTTP 200, transcoding to the requested compression
+- **AND** replica B SHALL NOT return HTTP 404 by routing to chunk-based serving that cannot satisfy the requested compression
+
+#### Scenario: Compression transcode on serve
+
+- **WHEN** staged parts hold compression `C` and the client requests a different compression
+- **THEN** the reader SHALL transcode the staged bytes to the requested compression while serving
+- **AND** the response SHALL advertise the compression actually served
+
+#### Scenario: Stalled producer does not yield a truncated success
+
+- **WHEN** a reader is tailing staging parts and the producer stalls before the NAR is complete
+- **THEN** the reader SHALL surface a stream error rather than terminating the response with a clean EOF at a truncated length

--- a/openspec/changes/archive/2026-06-08-fix-cdc-window-nonholder-404/tasks.md
+++ b/openspec/changes/archive/2026-06-08-fix-cdc-window-nonholder-404/tasks.md
@@ -1,0 +1,27 @@
+## 1. Reproduce in a unit test (red)
+
+- [x] 1.1 Added `pkg/cache/has_finished_nar_internal_test.go`: `TestHasFinishedNarExcludesActivelyChunking` asserts the crux split — an actively-chunking NAR (`total_chunks==0`, chunker live) is `isServable==true` but `hasFinishedNar==false`, so the loser no longer mis-routes it as a finished served-by-peer asset. Plus `TestHasFinishedNarCountsFullyChunked`. Both pass.
+- [~] 1.2 The full coordinate-loop staging-serve assertion is covered by the e2e (5.x), not a unit test (the 4-state race needs real multi-replica infra).
+
+## 2. Split the served-by-peer decision by state (green)
+
+- [x] 2.1 In `pollForDownloadOrTakeOver` (`pkg/cache/cache.go:6543+`), the cyclic priority (see design D1) means a reorder is insufficient. Split the per-tick decision into four states: (1) dead holder (lock acquirable) → takeover+restart, stays FIRST (D5); (2) **finished** (`HasNarInStore` OR `total_chunks>0`) → served-by-peer completed `ds`; (3) actively-chunking + `stagingActive` + `stagingServeReady` → `ds.stagingServe`; (4) actively-chunking + no staging → completed `ds` (progressive chunk streaming, current behavior). The key change: the served-by-peer return must fire only for the *finished* state, not for an actively-chunking NAR (which `isServable` currently conflates).
+- [x] 2.2 Introduce a `hasFinishedAsset` predicate (finished-only; NOT actively-chunking) for the served-by-peer return, distinct from the existing `isServable` (which stays "can serve now" for progressive routing in state 4). Do NOT change `isServable` globally.
+- [x] 2.3 Gate state (3) on `stagingActive` so feature-off behavior is byte-for-byte unchanged (state 4 progressive streaming preserved). Update the surrounding comments / D5 note to reflect the state split.
+
+## 3. Confirm CDC staging actually engages end-to-end
+
+- [!] 3.1 STOP CONDITION HIT. The chunking-window e2e (after the coordination fix) still 404s with ZERO staging activation: the CDC holder configures staging at startup but produces NO parts (`stageInflightNar` at cache.go:3019-3032 runs for CDC, but no `advanceStagingParts`/activation line appears). So in-flight staging does not produce parts in the CDC download path — the loser reaches the staging check (C) but `stagingServeReady` is always nil, falling through to chunk-serve → 404. This is a deeper, SEPARATE piece (wiring the staging producer into the CDC decompress→chunk download path, and/or its interaction with the producer's ENOENT no-op and `waitForStagingRequest` timing) and is escalated rather than forced here. See [[project_cdc_staging_producer_not_wired]].
+
+## 4. Unit verification
+
+- [x] 4.1 `task test` green (race), with emphasis on the coordination/CDC/takeover/recovery suites (`coordination_internal_test.go`, `cdc_*`, `*takeover*`, `recovery_gc*`) — confirm no regression to progressive streaming or takeover.
+- [x] 4.2 `task fmt` and `task lint` exit zero.
+
+## 5. Multi-process acceptance — DEFERRED to the Layer-2 change
+
+The chunking-window e2e cannot go green from Layer 1 alone: the CDC holder produces no staging parts (task 3.1), so `stagingServeReady` is always nil and the contended loser still falls through to the chunk-serve 404. The chunking-window e2e green is owned by the Layer-2 change (wire the CDC staging producer). Layer 1's verification is the `hasFinishedNar` unit test + the full `-race` suite (no regression), confirmed in §4.
+
+- [x] 5.1 (Layer-1 scope) Confirmed via the e2e that the coordination fix changes routing (loser no longer mis-routes an actively-chunking NAR as served-by-peer); end-to-end serve still blocked by the missing producer (Layer 2). Evidence: `.e2e-results/inflight-staging/20260608-153309/` (chunking still 404s, 0 activation — Layer-2 gap).
+- [~] 5.2 Chunking-window green (local + s3) → Layer-2 change.
+- [~] 5.3 Full-matrix green → Layer-2 change.

--- a/openspec/specs/inflight-nar-staging/spec.md
+++ b/openspec/specs/inflight-nar-staging/spec.md
@@ -61,13 +61,20 @@ When staging activates, the holder SHALL write the NAR to shared storage as orde
 
 ### Requirement: Cross-pod readers serve a complete, byte-correct NAR from staging in all CDC modes
 
-A waiting replica that observes available staging parts SHALL tail them to reassemble and serve a complete, byte-correct NAR, regardless of whether CDC is disabled, lazy, or eager. The served bytes SHALL carry the compression recorded in `staging_state.compression`; when the client requests a different compression, the reader SHALL transcode on the fly at parity with the same-pod streaming path. A reader SHALL NOT deliver a truncated NAR as an HTTP 200.
+A waiting replica that observes available staging parts SHALL tail them to reassemble and serve a complete, byte-correct NAR, regardless of whether CDC is disabled, lazy, or eager. The served bytes SHALL carry the compression recorded in `staging_state.compression`; when the client requests a different compression, the reader SHALL transcode on the fly at parity with the same-pod streaming path. A reader SHALL NOT deliver a truncated NAR as an HTTP 200. When the holder is alive and staging parts are available, a waiting replica SHALL prefer serving from staging over routing to chunk-based serving, so that an actively-chunking (eager-CDC) NAR is never returned to the client as an HTTP 404 merely because the requested compression cannot be produced from chunks.
 
 #### Scenario: Non-CDC cross-pod serve during download
 
 - **WHEN** CDC is disabled and replica A is downloading a NAR with replica B waiting
 - **AND** staging is active
 - **THEN** replica B SHALL serve the complete NAR from staging parts with HTTP 200
+
+#### Scenario: Eager-CDC cross-pod serve prefers staging over chunk routing
+
+- **WHEN** CDC is eager and replica A holds the download lock and is actively chunking a NAR (its `nar_file` row exists but `total_chunks` is still 0) with replica B waiting
+- **AND** staging is active and the holder has produced staging parts
+- **THEN** replica B SHALL serve the complete NAR from staging parts with HTTP 200, transcoding to the requested compression
+- **AND** replica B SHALL NOT return HTTP 404 by routing to chunk-based serving that cannot satisfy the requested compression
 
 #### Scenario: Compression transcode on serve
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4267,6 +4267,17 @@ func (c *Cache) prePullNarInfo(ctx context.Context, hash string) *downloadState 
 	)
 	defer span.End()
 
+	// A narinfo is never chunked, so "present" is also "finished": the same
+	// predicate serves both the served-by-peer and finished-asset checks. Staging
+	// is off for narinfo, so the in-flight branches never fire here regardless.
+	narInfoPresent := func(ctx context.Context) bool {
+		if _, err := c.getNarInfoFromDatabase(ctx, hash); err == nil {
+			return true
+		}
+
+		return c.narInfoStore.HasNarInfo(ctx, hash)
+	}
+
 	return c.coordinateDownload(
 		ctx,
 		context.WithoutCancel(ctx),
@@ -4274,13 +4285,8 @@ func (c *Cache) prePullNarInfo(ctx context.Context, hash string) *downloadState 
 		hash,
 		true,
 		false, // narinfo downloads are not staged (staging is NAR-only)
-		func(ctx context.Context) bool {
-			if _, err := c.getNarInfoFromDatabase(ctx, hash); err == nil {
-				return true
-			}
-
-			return c.narInfoStore.HasNarInfo(ctx, hash)
-		},
+		narInfoPresent,
+		narInfoPresent,
 		func(ds *downloadState) {
 			c.pullNarInfo(context.WithoutCancel(ctx), hash, ds)
 		},
@@ -4332,6 +4338,13 @@ func (c *Cache) prePullNar(
 			}
 
 			return servable
+		},
+		// hasFinishedAsset: only a whole-file-in-store or fully-chunked NAR counts as
+		// finished. An actively-chunking NAR is deliberately excluded so a cross-pod
+		// waiter serves it from in-flight staging (transcoding) or progressive chunk
+		// streaming instead of routing to chunk serving, which 404s a compressed request.
+		func(ctx context.Context) bool {
+			return c.hasFinishedNar(ctx, *narURL)
 		},
 		func(ds *downloadState) {
 			c.pullNarIntoStore(ctx, narURL, preferredUpstreamURL, uc, ds, narInfo)
@@ -4463,6 +4476,35 @@ func (c *Cache) isServable(ctx context.Context, narURL nar.URL) (bool, error) {
 	}
 
 	return c.cdcChunkerLive(ctx, narURL.Hash), nil
+}
+
+// hasFinishedNar reports whether the NAR is FULLY materialized as a static asset —
+// a whole file in the store, or a fully-chunked nar_file (total_chunks > 0). Unlike
+// isServable it deliberately does NOT count an actively-chunking row (chunking in
+// progress, total_chunks == 0) as ready.
+//
+// The download-coordination poll loop uses this for its "asset appeared, served by
+// peer" fast path. isServable conflates "finished" with "actively chunking", so
+// using it there would let a lock-losing waiter treat an in-flight chunked NAR as a
+// finished asset and route to chunk-based serving — which 404s a compressed request
+// because chunks are stored decompressed. Splitting the finished check out lets the
+// actively-chunking case fall through to in-flight staging (which transcodes) or, with
+// no staging, to progressive chunk streaming. Returns false on any lookup error.
+func (c *Cache) hasFinishedNar(ctx context.Context, narURL nar.URL) bool {
+	if c.HasNarInStore(ctx, narURL) {
+		return true
+	}
+
+	if !c.isChunkStoreAvailable() {
+		return false
+	}
+
+	nr, err := c.getNarFileFromDB(ctx, c.dbClient.Ent().NarFile, narURL)
+	if err != nil {
+		return false
+	}
+
+	return nr.TotalChunks > 0
 }
 
 // narFileBytesStored reports whether the shared database records this NAR's bytes
@@ -6321,6 +6363,7 @@ func (c *Cache) coordinateDownload(
 	waitForStorage bool,
 	allowStaging bool,
 	hasAsset func(context.Context) bool,
+	hasFinishedAsset func(context.Context) bool,
 	startJob func(*downloadState),
 ) *downloadState {
 	// First check local jobs to avoid blocking on distributed lock if already downloading locally
@@ -6365,7 +6408,9 @@ func (c *Cache) coordinateDownload(
 		// Another server holds the lock. Rather than dead-ending in an HTTP 500,
 		// poll storage for the asset while periodically re-attempting lock
 		// acquisition so we can take over if the holder finishes or fails.
-		ds, tookOver := c.pollForDownloadOrTakeOver(coordCtx, ctx, lockKey, hash, allowStaging, err, hasAsset)
+		ds, tookOver := c.pollForDownloadOrTakeOver(
+			coordCtx, ctx, lockKey, hash, allowStaging, err, hasAsset, hasFinishedAsset,
+		)
 		if !tookOver {
 			return ds
 		}
@@ -6513,6 +6558,7 @@ func (c *Cache) pollForDownloadOrTakeOver(
 	allowStaging bool,
 	initialErr error,
 	hasAsset func(context.Context) bool,
+	hasFinishedAsset func(context.Context) bool,
 ) (*downloadState, bool) {
 	const pollInterval = 200 * time.Millisecond
 
@@ -6543,7 +6589,16 @@ func (c *Cache) pollForDownloadOrTakeOver(
 	for {
 		select {
 		case <-ticker.C:
-			if hasAsset(coordCtx) {
+			// (A) The NAR is FULLY materialized (a whole file in the store, or a
+			// fully-chunked nar_file): serve it directly. Checked before takeover so a
+			// finished asset whose holder already released its lock is served rather
+			// than redundantly re-downloaded, and before staging so the committed final
+			// asset is preferred over staging parts. hasFinishedAsset (NOT isServable)
+			// is used here on purpose: an actively-chunking NAR is still in-flight and
+			// must fall through to staging (C) or progressive streaming (D), never be
+			// treated as a finished asset — which would route to chunk serving and 404
+			// a compressed request (see hasFinishedNar / cache.go serveFromChunks).
+			if hasFinishedAsset(coordCtx) {
 				zerolog.Ctx(ctx).Debug().
 					Str("hash", hash).
 					Msg("asset appeared in storage while polling (downloaded by another server)")
@@ -6609,6 +6664,32 @@ func (c *Cache) pollForDownloadOrTakeOver(
 
 					return ds, false
 				}
+			}
+
+			// (D) The holder is alive and the NAR is in-flight, but it is not yet a
+			// finished asset (A) and no staging parts are available (C). isServable is
+			// true here only for an actively-chunking nar_file with a live producer
+			// (the finished case was handled by (A), so total_chunks==0 + chunker
+			// live). Return a completed served-by-peer state so GetNar routes into
+			// getNarFromChunks → streamProgressiveChunks and streams the NAR as the
+			// holder commits chunks. This preserves the no-staging progressive-CDC path;
+			// it does not fire for a plain in-flight download (isServable false), which
+			// keeps polling for completion or staging as before.
+			if hasAsset(coordCtx) {
+				zerolog.Ctx(ctx).Debug().
+					Str("hash", hash).
+					Msg("peer is actively chunking; routing to progressive chunk streaming")
+
+				downloadCoordinationFallbackTotal.Add(ctx, 1,
+					metric.WithAttributes(attribute.String("outcome", "served_by_peer")))
+
+				ds := newDownloadState()
+				ds.closed = true
+				ds.startOnce.Do(func() { close(ds.start) })
+				ds.storedOnce.Do(func() { close(ds.stored) })
+				ds.doneOnce.Do(func() { close(ds.done) })
+
+				return ds, false
 			}
 		case <-deadlineCtx.Done():
 			ds := newDownloadState()

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4267,17 +4267,9 @@ func (c *Cache) prePullNarInfo(ctx context.Context, hash string) *downloadState 
 	)
 	defer span.End()
 
-	// A narinfo is never chunked, so "present" is also "finished": the same
-	// predicate serves both the served-by-peer and finished-asset checks. Staging
-	// is off for narinfo, so the in-flight branches never fire here regardless.
-	narInfoPresent := func(ctx context.Context) bool {
-		if _, err := c.getNarInfoFromDatabase(ctx, hash); err == nil {
-			return true
-		}
-
-		return c.narInfoStore.HasNarInfo(ctx, hash)
-	}
-
+	// A narinfo is never chunked, so "present" is also "finished": checkAsset
+	// returns the same value for both. Staging is off for narinfo, so the in-flight
+	// branches never fire here regardless.
 	return c.coordinateDownload(
 		ctx,
 		context.WithoutCancel(ctx),
@@ -4285,8 +4277,16 @@ func (c *Cache) prePullNarInfo(ctx context.Context, hash string) *downloadState 
 		hash,
 		true,
 		false, // narinfo downloads are not staged (staging is NAR-only)
-		narInfoPresent,
-		narInfoPresent,
+		func(ctx context.Context) (bool, bool) {
+			var present bool
+			if _, err := c.getNarInfoFromDatabase(ctx, hash); err == nil {
+				present = true
+			} else {
+				present = c.narInfoStore.HasNarInfo(ctx, hash)
+			}
+
+			return present, present
+		},
 		func(ds *downloadState) {
 			c.pullNarInfo(context.WithoutCancel(ctx), hash, ds)
 		},
@@ -4322,29 +4322,26 @@ func (c *Cache) prePullNar(
 		narURL.Hash,
 		false,
 		true, // NAR downloads may serve cross-pod waiters from in-flight staging
-		func(ctx context.Context) bool {
-			// A placeholder nar_file row (created by storeInDatabase before chunking
-			// starts, or left by a failed download) must NOT count as an available
-			// asset: otherwise coordinateDownload returns a completed state and skips
-			// the re-download, and streamProgressiveChunks waits 30s for chunks that
-			// never arrive, yielding a truncated NAR response. isServable is the single
-			// predicate gating this; see its doc comment.
-			servable, err := c.isServable(ctx, *narURL)
+		// checkAsset returns (servable, finished) in a single pass via narServability,
+		// so the poll loop never repeats the HasNarInStore stat + nar_file lookup.
+		//   - servable: a placeholder nar_file row (created by storeInDatabase before
+		//     chunking, or left by a failed download) must NOT count, else coordination
+		//     returns a completed state, skips the re-download, and streamProgressiveChunks
+		//     waits 30s for chunks that never arrive (a truncated NAR response).
+		//   - finished: only a whole-file-in-store or fully-chunked NAR. An actively-
+		//     chunking NAR is excluded so a cross-pod waiter serves it from in-flight
+		//     staging (transcoding) or progressive chunk streaming rather than chunk
+		//     serving, which 404s a compressed request.
+		func(ctx context.Context) (bool, bool) {
+			servable, finished, err := c.narServability(ctx, *narURL)
 			if err != nil {
 				zerolog.Ctx(ctx).Warn().Err(err).
 					Msg("error checking servability for download coordination; treating as cache miss")
 
-				return false
+				return false, false
 			}
 
-			return servable
-		},
-		// hasFinishedAsset: only a whole-file-in-store or fully-chunked NAR counts as
-		// finished. An actively-chunking NAR is deliberately excluded so a cross-pod
-		// waiter serves it from in-flight staging (transcoding) or progressive chunk
-		// streaming instead of routing to chunk serving, which 404s a compressed request.
-		func(ctx context.Context) bool {
-			return c.hasFinishedNar(ctx, *narURL)
+			return servable, finished
 		},
 		func(ds *downloadState) {
 			c.pullNarIntoStore(ctx, narURL, preferredUpstreamURL, uc, ds, narInfo)
@@ -4437,45 +4434,69 @@ func (c *Cache) cdcChunkerLive(ctx context.Context, hash string) bool {
 // helper so the placeholder regression (ncps #1255/#1263/#1279/#1290), which kept
 // recurring via divergent ad-hoc checks, cannot return.
 func (c *Cache) isServable(ctx context.Context, narURL nar.URL) (bool, error) {
+	servable, _, err := c.narServability(ctx, narURL)
+
+	return servable, err
+}
+
+// narServability is the single source of truth behind both isServable and
+// hasFinishedNar: it computes, in ONE pass, whether a NAR can be served right now
+// (servable) and whether it is fully materialized (finished). Having both
+// predicates delegate here keeps the servability logic from diverging — the
+// divergent ad-hoc checks that kept re-introducing the placeholder regression
+// (ncps #1255/#1263/#1279/#1290) — and lets a caller under contention (the
+// download-coordination poll loop) get both values without repeating the
+// HasNarInStore stat and the nar_file lookup.
+//
+//   - servable: a whole file in the store, OR (with CDC enabled) a nar_file that is
+//     fully chunked OR actively chunking with a live producer.
+//   - finished: a whole file in the store, OR a fully-chunked nar_file. An
+//     actively-chunking row (total_chunks == 0) is servable but NOT finished.
+//
+// The mere existence of a nar_file row NEVER makes a NAR servable: a backing-less
+// placeholder row (created by storeInDatabase at narinfo-fetch time, or left behind
+// by a failed download) is a cache miss that must trigger an upstream (re-)download,
+// never a terminal 404.
+func (c *Cache) narServability(ctx context.Context, narURL nar.URL) (servable, finished bool, err error) {
 	if c.HasNarInStore(ctx, narURL) {
-		return true, nil
+		return true, true, nil
 	}
 
 	if !c.isChunkStoreAvailable() {
-		return false, nil
+		return false, false, nil
 	}
 
 	nr, err := c.getNarFileFromDB(ctx, c.dbClient.Ent().NarFile, narURL)
 	if err != nil {
 		if database.IsNotFoundError(err) {
-			return false, nil
+			return false, false, nil
 		}
 
-		return false, fmt.Errorf("failed to look up nar_file record for servability: %w", err)
+		return false, false, fmt.Errorf("failed to look up nar_file record for servability: %w", err)
 	}
 
 	// Servability of an existing nar_file record:
-	//   - total_chunks > 0           → fully chunked, servable (no lock probe on this hot path).
+	//   - total_chunks > 0           → fully chunked: servable AND finished.
 	//   - chunking_started_at == nil → a bare placeholder (created at narinfo-fetch time or
 	//     left by a failed download), never servable; falls through to a re-download.
 	//   - otherwise (chunking in progress) → servable ONLY if a chunker is actually
-	//     producing its chunks. Liveness is the refreshed per-hash migration lock, NOT the
-	//     age of chunking_started_at (a one-time write): the download-path chunker holds
-	//     migrationLockKey(hash) for the whole operation, so a FREE lock means the producer
-	//     died mid-chunking (issue #1230) and the row is a dead orphan — routing GetNar into
-	//     getNarFromChunks would commit 200 + partial chunks then stall maxWaitPerChunk on a
-	//     chunk that never arrives ("Truncated zstd input"), so report it not-servable and
-	//     let GetNar re-download cleanly. A HELD lock keeps the row servable even for a chunk
-	//     running longer than cdcChunkingLockTTL, so peers piggyback on the live producer.
+	//     producing its chunks, and never finished. Liveness is the refreshed per-hash
+	//     migration lock, NOT the age of chunking_started_at (a one-time write): the
+	//     download-path chunker holds migrationLockKey(hash) for the whole operation, so a
+	//     FREE lock means the producer died mid-chunking (issue #1230) and the row is a dead
+	//     orphan — routing GetNar into getNarFromChunks would commit 200 + partial chunks then
+	//     stall maxWaitPerChunk on a chunk that never arrives ("Truncated zstd input"), so
+	//     report it not-servable and let GetNar re-download cleanly. A HELD lock keeps the row
+	//     servable even for a chunk running longer than cdcChunkingLockTTL, so peers piggyback.
 	if nr.TotalChunks > 0 {
-		return true, nil
+		return true, true, nil
 	}
 
 	if nr.ChunkingStartedAt == nil {
-		return false, nil
+		return false, false, nil
 	}
 
-	return c.cdcChunkerLive(ctx, narURL.Hash), nil
+	return c.cdcChunkerLive(ctx, narURL.Hash), false, nil
 }
 
 // hasFinishedNar reports whether the NAR is FULLY materialized as a static asset —
@@ -4491,20 +4512,9 @@ func (c *Cache) isServable(ctx context.Context, narURL nar.URL) (bool, error) {
 // actively-chunking case fall through to in-flight staging (which transcodes) or, with
 // no staging, to progressive chunk streaming. Returns false on any lookup error.
 func (c *Cache) hasFinishedNar(ctx context.Context, narURL nar.URL) bool {
-	if c.HasNarInStore(ctx, narURL) {
-		return true
-	}
+	_, finished, _ := c.narServability(ctx, narURL)
 
-	if !c.isChunkStoreAvailable() {
-		return false
-	}
-
-	nr, err := c.getNarFileFromDB(ctx, c.dbClient.Ent().NarFile, narURL)
-	if err != nil {
-		return false
-	}
-
-	return nr.TotalChunks > 0
+	return finished
 }
 
 // narFileBytesStored reports whether the shared database records this NAR's bytes
@@ -6362,8 +6372,7 @@ func (c *Cache) coordinateDownload(
 	hash string,
 	waitForStorage bool,
 	allowStaging bool,
-	hasAsset func(context.Context) bool,
-	hasFinishedAsset func(context.Context) bool,
+	checkAsset func(context.Context) (servable, finished bool),
 	startJob func(*downloadState),
 ) *downloadState {
 	// First check local jobs to avoid blocking on distributed lock if already downloading locally
@@ -6409,7 +6418,7 @@ func (c *Cache) coordinateDownload(
 		// poll storage for the asset while periodically re-attempting lock
 		// acquisition so we can take over if the holder finishes or fails.
 		ds, tookOver := c.pollForDownloadOrTakeOver(
-			coordCtx, ctx, lockKey, hash, allowStaging, err, hasAsset, hasFinishedAsset,
+			coordCtx, ctx, lockKey, hash, allowStaging, err, checkAsset,
 		)
 		if !tookOver {
 			return ds
@@ -6437,7 +6446,7 @@ func (c *Cache) coordinateDownload(
 	}
 
 	// Double check local jobs and asset presence under lock
-	if hasAsset(ctx) {
+	if servable, _ := checkAsset(ctx); servable {
 		stopRefresher()
 
 		// Release the lock before returning
@@ -6557,8 +6566,7 @@ func (c *Cache) pollForDownloadOrTakeOver(
 	hash string,
 	allowStaging bool,
 	initialErr error,
-	hasAsset func(context.Context) bool,
-	hasFinishedAsset func(context.Context) bool,
+	checkAsset func(context.Context) (servable, finished bool),
 ) (*downloadState, bool) {
 	const pollInterval = 200 * time.Millisecond
 
@@ -6589,16 +6597,20 @@ func (c *Cache) pollForDownloadOrTakeOver(
 	for {
 		select {
 		case <-ticker.C:
+			// One combined check per tick yields both servability states without
+			// repeating the HasNarInStore stat and nar_file lookup (see narServability).
+			servable, finished := checkAsset(coordCtx)
+
 			// (A) The NAR is FULLY materialized (a whole file in the store, or a
 			// fully-chunked nar_file): serve it directly. Checked before takeover so a
 			// finished asset whose holder already released its lock is served rather
 			// than redundantly re-downloaded, and before staging so the committed final
-			// asset is preferred over staging parts. hasFinishedAsset (NOT isServable)
-			// is used here on purpose: an actively-chunking NAR is still in-flight and
-			// must fall through to staging (C) or progressive streaming (D), never be
-			// treated as a finished asset — which would route to chunk serving and 404
-			// a compressed request (see hasFinishedNar / cache.go serveFromChunks).
-			if hasFinishedAsset(coordCtx) {
+			// asset is preferred over staging parts. `finished` (NOT `servable`) is used
+			// here on purpose: an actively-chunking NAR is still in-flight and must fall
+			// through to staging (C) or progressive streaming (D), never be treated as a
+			// finished asset — which would route to chunk serving and 404 a compressed
+			// request (see narServability / cache.go serveFromChunks).
+			if finished {
 				zerolog.Ctx(ctx).Debug().
 					Str("hash", hash).
 					Msg("asset appeared in storage while polling (downloaded by another server)")
@@ -6667,15 +6679,15 @@ func (c *Cache) pollForDownloadOrTakeOver(
 			}
 
 			// (D) The holder is alive and the NAR is in-flight, but it is not yet a
-			// finished asset (A) and no staging parts are available (C). isServable is
+			// finished asset (A) and no staging parts are available (C). `servable` is
 			// true here only for an actively-chunking nar_file with a live producer
 			// (the finished case was handled by (A), so total_chunks==0 + chunker
 			// live). Return a completed served-by-peer state so GetNar routes into
 			// getNarFromChunks → streamProgressiveChunks and streams the NAR as the
 			// holder commits chunks. This preserves the no-staging progressive-CDC path;
-			// it does not fire for a plain in-flight download (isServable false), which
+			// it does not fire for a plain in-flight download (servable false), which
 			// keeps polling for completion or staging as before.
-			if hasAsset(coordCtx) {
+			if servable {
 				zerolog.Ctx(ctx).Debug().
 					Str("hash", hash).
 					Msg("peer is actively chunking; routing to progressive chunk streaming")

--- a/pkg/cache/has_finished_nar_internal_test.go
+++ b/pkg/cache/has_finished_nar_internal_test.go
@@ -1,0 +1,80 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// TestHasFinishedNarExcludesActivelyChunking is the crux of the CDC-window
+// non-holder 404 fix: hasFinishedNar MUST report an actively-chunking NAR
+// (total_chunks==0, chunker live) as NOT finished, even though isServable reports
+// it as servable. The download-coordination poll loop relies on this split so a
+// cross-pod waiter routes an in-flight chunked NAR to in-flight staging or
+// progressive chunk streaming instead of treating it as a finished asset — which
+// would route to chunk serving and 404 a compressed (.nar.xz) request.
+func TestHasFinishedNarExcludesActivelyChunking(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	c := setupCDCRecoveryFixture(t)
+
+	hash := testhelper.MustRandBase32NarHash()
+	narURL := nar.URL{Hash: hash, Compression: nar.CompressionTypeNone}
+
+	// An actively-chunking row: total_chunks==0, a fresh chunking_started_at, and the
+	// migration lock held so cdcChunkerLive() reports the producer alive.
+	_, err := c.dbClient.Ent().NarFile.Create().
+		SetHash(hash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(4096).
+		SetTotalChunks(0).
+		SetChunkingStartedAt(time.Now()).
+		Save(ctx)
+	require.NoError(t, err)
+
+	acquired, err := c.downloadLocker.TryLock(ctx, migrationLockKey(hash), c.downloadLockTTL)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	t.Cleanup(func() { _ = c.downloadLocker.Unlock(ctx, migrationLockKey(hash)) })
+
+	servable, err := c.isServable(ctx, narURL)
+	require.NoError(t, err)
+	assert.True(t, servable,
+		"an actively-chunking NAR with a live producer is servable (it can be progressively streamed)")
+
+	assert.False(t, c.hasFinishedNar(ctx, narURL),
+		"an actively-chunking NAR must NOT count as finished: it is still in-flight and must "+
+			"route to staging/progressive serving, not be treated as a finished chunk-served asset")
+}
+
+// TestHasFinishedNarCountsFullyChunked verifies a fully-chunked NAR (total_chunks>0)
+// IS finished.
+func TestHasFinishedNarCountsFullyChunked(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	c := setupCDCRecoveryFixture(t)
+
+	hash := testhelper.MustRandBase32NarHash()
+	narURL := nar.URL{Hash: hash, Compression: nar.CompressionTypeNone}
+
+	_, err := c.dbClient.Ent().NarFile.Create().
+		SetHash(hash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(4096).
+		SetTotalChunks(3).
+		Save(ctx)
+	require.NoError(t, err)
+
+	assert.True(t, c.hasFinishedNar(ctx, narURL),
+		"a fully-chunked NAR (total_chunks>0) is a finished, servable asset")
+}

--- a/pkg/cache/inflight_staging_takeover_internal_test.go
+++ b/pkg/cache/inflight_staging_takeover_internal_test.go
@@ -42,6 +42,7 @@ func TestPollTakeover_DiscardsStaleStaging(t *testing.T) {
 	ds, tookOver := c.pollForDownloadOrTakeOver(
 		ctx, ctx, lockKey, hash, true, storage.ErrNotFound,
 		func(context.Context) bool { return false },
+		func(context.Context) bool { return false },
 	)
 	require.True(t, tookOver, "an acquirable lock means the holder is gone: take over")
 	assert.Nil(t, ds)
@@ -107,6 +108,7 @@ func TestStagingTakeover_NoTruncatedServeAcrossDeath(t *testing.T) {
 	// "requested" so a persisting cross-pod waiter is re-served.
 	_, tookOver := c.pollForDownloadOrTakeOver(
 		ctx, ctx, lockKey, hash, true, storage.ErrNotFound,
+		func(context.Context) bool { return false },
 		func(context.Context) bool { return false },
 	)
 	require.True(t, tookOver)

--- a/pkg/cache/inflight_staging_takeover_internal_test.go
+++ b/pkg/cache/inflight_staging_takeover_internal_test.go
@@ -41,8 +41,7 @@ func TestPollTakeover_DiscardsStaleStaging(t *testing.T) {
 	// first tick and the waiter takes over.
 	ds, tookOver := c.pollForDownloadOrTakeOver(
 		ctx, ctx, lockKey, hash, true, storage.ErrNotFound,
-		func(context.Context) bool { return false },
-		func(context.Context) bool { return false },
+		func(context.Context) (bool, bool) { return false, false },
 	)
 	require.True(t, tookOver, "an acquirable lock means the holder is gone: take over")
 	assert.Nil(t, ds)
@@ -108,8 +107,7 @@ func TestStagingTakeover_NoTruncatedServeAcrossDeath(t *testing.T) {
 	// "requested" so a persisting cross-pod waiter is re-served.
 	_, tookOver := c.pollForDownloadOrTakeOver(
 		ctx, ctx, lockKey, hash, true, storage.ErrNotFound,
-		func(context.Context) bool { return false },
-		func(context.Context) bool { return false },
+		func(context.Context) (bool, bool) { return false, false },
 	)
 	require.True(t, tookOver)
 	require.NoError(t, c.downloadLocker.Unlock(ctx, lockKey))


### PR DESCRIPTION
## Summary

- Under eager CDC, a non-holder replica 404s a compressed NAR request: the download-coordination poll loop early-returned a "served-by-peer" state for an *actively-chunking* NAR because `isServable` conflates "finished" with "actively chunking", routing to chunk serving (which can't produce a compressed variant from decompressed chunks).
- Split a finished-only predicate `hasFinishedNar` (whole-file-in-store OR `total_chunks>0`) out of `isServable`, threaded as `hasFinishedAsset` through `coordinateDownload` + `pollForDownloadOrTakeOver`, and restructured the per-tick decision into four states (dead-holder→takeover[D5] / finished→serve / chunking+staging→staging / chunking+no-staging→progressive).

> **Status:** a correct, regression-free **prerequisite** toward closing the chunking-window cross-pod 404 (#1289). It does NOT fully close that 404 on its own — see the stack head (#1376) for the remaining root cause (a CDC lock-lifecycle design mismatch).

## Test plan

- [x] `task fmt` / `task lint` / `task test` (race) pass — no regression to progressive-chunk/takeover paths
- [x] New `hasFinishedNar` unit test
