### PR TITLE
fix(cache): coordinate a compressed request mid-chunking, not 404

### DIFF
--- a/openspec/changes/archive/2026-06-08-fix-cdc-getnar-chunk-route/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-08-fix-cdc-getnar-chunk-route/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/archive/2026-06-08-fix-cdc-getnar-chunk-route/design.md
+++ b/openspec/changes/archive/2026-06-08-fix-cdc-getnar-chunk-route/design.md
@@ -2,7 +2,7 @@
 
 `Cache.GetNar` (cache.go ~1200-1245) decides whether to serve immediately or coordinate a download:
 
-```
+```go
 hasNar, _ := c.isServable(ctx, narURL)            // true for in-store, fully-chunked, OR actively-chunking-live
 if hasActiveLocalJob && !hasNarInStore {           // holder path: prefer temp-file streaming
     hasNar, _ = c.HasNarInChunks(ctx, narURL)

--- a/openspec/changes/archive/2026-06-08-fix-cdc-getnar-chunk-route/design.md
+++ b/openspec/changes/archive/2026-06-08-fix-cdc-getnar-chunk-route/design.md
@@ -1,0 +1,48 @@
+## Context
+
+`Cache.GetNar` (cache.go ~1200-1245) decides whether to serve immediately or coordinate a download:
+
+```
+hasNar, _ := c.isServable(ctx, narURL)            // true for in-store, fully-chunked, OR actively-chunking-live
+if hasActiveLocalJob && !hasNarInStore {           // holder path: prefer temp-file streaming
+    hasNar, _ = c.HasNarInChunks(ctx, narURL)
+}
+if hasNar { serveNarFromStorageViaPipe(...) ; return }   // <-- loser short-circuits here under CDC
+... prePullNar / coordination ...
+```
+
+On the non-holder replica, `hasActiveLocalJob` is false, so `hasNar` stays `isServable == true` (the holder's actively-chunking row is visible via the shared DB). The `if hasNar` branch calls `serveNarFromStorageViaPipe(hasNarInStore=false)`, which sets `serveFromChunks = true` and then returns `storage.ErrNotFound` at cache.go:3465 for a compressed request ("only available as chunks, cannot serve as xz"). The loser never reaches `prePullNar`, so it never records a staging request and never serves from staging. Confirmed by logs: the loser has zero coordination lines.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A cross-pod reader of an actively-chunking NAR with a compressed request coordinates (and serves from staging, transcoding) instead of 404-ing from chunks.
+- Preserve: the uncompressed-request progressive-chunk path (serve from chunks as bytes land), the holder's own temp-file streaming, and finished-NAR serving.
+- Reuse `hasFinishedNar` (added by `fix-cdc-window-nonholder-404`).
+
+**Non-Goals:**
+- The coordination-loop split (already shipped).
+- The steady-state fully-chunked compressed-request path (narinfo normalizes to `none` post-chunking).
+- The downstream "does the CDC producer stage?" question — gated: STOP and report if the e2e shows the loser now coordinates but staging still yields nothing.
+
+## Decisions
+
+**D1 — Gate the `hasNar` short-circuit on (finished OR uncompressed).**
+After the existing `hasNar` computation (including the `hasActiveLocalJob` re-eval), add: if `hasNar` is true but `!c.hasFinishedNar(ctx, narURL)` (so it is only servable because it is actively chunking) AND `narURL.Compression != none` (the chunk store, which holds decompressed bytes, cannot satisfy it), set `hasNar = false`. The request then falls through to `prePullNar` → coordination, where the lock-loser records a staging request and serves from staging (transcoding). *Alternatives considered:* (a) make `serveNarFromStorageViaPipe` reassemble+recompress chunks to the requested compression — heavier, duplicates the staging transcode, and still wouldn't record a staging request for the holder to serve other peers; (b) narrow `isServable` — rejected, it is the shared servability oracle used by many call sites and must keep reporting actively-chunking as servable for the uncompressed progressive path.
+
+**D2 — Tight condition; everything else unchanged.**
+The new branch fires only for: cross-pod (no local job) + actively-chunking (`isServable && !hasFinishedNar`) + compressed request. Uncompressed requests keep serving from chunks (progressive). Finished NARs (`hasFinishedNar` true) are untouched. The holder (local job) already takes the temp-file path.
+
+## Risks / Trade-offs
+
+- **[Regressing the uncompressed progressive-chunk path]** → The condition requires `Compression != none`; uncompressed requests are unaffected (full `-race` suite, esp. `cdc_*`/progressive tests, must stay green).
+- **[A finished fully-chunked NAR with a compressed request still 404s]** → Out of scope (steady-state narinfo advertises `none`); only the transient active-chunking window is fixed. Documented.
+- **[The producer may still not stage]** → Explicitly gated: the e2e is the arbiter; STOP+report if staging still yields nothing once the loser coordinates.
+
+## Migration Plan
+
+Pure `pkg/cache` behavior change; no schema/config/API. Rollback is a git revert. The chunking-window e2e is the multi-process gate.
+
+## Open Questions
+
+- Does the CDC holder's staging producer emit parts once a request is recorded? (Answered by the e2e in this change; if no, it becomes a separate follow-up.)

--- a/openspec/changes/archive/2026-06-08-fix-cdc-getnar-chunk-route/proposal.md
+++ b/openspec/changes/archive/2026-06-08-fix-cdc-getnar-chunk-route/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Under eager CDC, concurrent readers on the **non-downloading replica receive HTTP 404** for `/nar/<hash>.nar.xz` while the holder serves 200 (the chunking-window contention e2e, 4/8 split). Log evidence pins the cause: the loser has **zero** download-coordination lines — it never reaches `coordinateDownload`/`pollForDownloadOrTakeOver`. It short-circuits in `Cache.GetNar` (cache.go ~1216-1245): `isServable` returns true because the holder's *actively-chunking* `nar_file` row (`total_chunks==0`, `ChunkingStartedAt` set, migration lock held → `cdcChunkerLive`) is visible cross-pod, so the `if hasNar` branch serves from chunks via `serveNarFromStorageViaPipe`, which **404s at cache.go:3465** because chunks are stored decompressed and cannot produce the requested compressed (`.nar.xz`) variant. This violates the `inflight-nar-staging` requirement *"Cross-pod readers serve a complete, byte-correct NAR from staging in all CDC modes"* (#1289).
+
+The prior change `fix-cdc-window-nonholder-404` fixed the *coordination loop* (`hasFinishedNar` vs `isServable`), but the loser never reaches that loop — so this `GetNar` short-circuit is the missing prerequisite.
+
+## What Changes
+
+- **In `GetNar`, do not serve an actively-chunking NAR from chunks for a compressed request.** When `isServable` is true but the NAR is not finished (`!hasFinishedNar`: not whole-file-in-store and not fully chunked) and the requested compression is not `none`, treat it as not-servable-now so the request falls through to `prePullNar` → coordination. There the loser records a staging request and serves from in-flight staging (which transcodes to the requested compression), exactly as the download window already does. The uncompressed-request progressive-chunk path is unchanged (it can serve from chunks), and finished NARs are unaffected. Reuses the `hasFinishedNar` predicate added by the prior change.
+- **Prove it with the e2e.** The chunking-window phases (`--window chunking`, local + s3) of `task test:inflight-staging-contention` must pass: the loser reaches coordination, staging activates, every reader gets a complete byte-identical NAR, no 404.
+
+Downstream unknown (explicitly gated): once the loser records a staging request, the holder's CDC producer must actually emit parts. If the e2e shows the loser now coordinates but staging still does not serve (producer yields nothing), that is a further, separate defect — this change will STOP and report rather than mask it.
+
+## Capabilities
+
+### Modified Capabilities
+- `inflight-nar-staging`: a cross-pod reader of an actively-chunking NAR with a compressed request SHALL coordinate and serve from staging rather than being served (404) from chunks that cannot produce the requested compression.
+
+## Impact
+
+- **Code**: `pkg/cache/cache.go` (`GetNar` servability/short-circuit routing). TDD: `pkg/cache` unit test + full `-race` suite (no regression to progressive-chunk or holder paths) + the chunking-window e2e.
+- **I/O / latency / memory**: no steady-state change; only the contended cross-pod compressed-request-during-chunking decision changes (it coordinates instead of 404-ing).
+
+## Non-goals
+
+- The coordination-loop split (shipped in `fix-cdc-window-nonholder-404`).
+- The steady-state fully-chunked-NAR compressed-request path (narinfo normalizes CDC URLs to `none` post-chunking, so clients request `.nar`); only the transient active-chunking window is in scope.
+- Reworking the CDC chunking algorithm, part-object format, or drain/migration paths.

--- a/openspec/changes/archive/2026-06-08-fix-cdc-getnar-chunk-route/specs/inflight-nar-staging/spec.md
+++ b/openspec/changes/archive/2026-06-08-fix-cdc-getnar-chunk-route/specs/inflight-nar-staging/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Cross-pod readers serve a complete, byte-correct NAR from staging in all CDC modes
+
+A waiting replica that observes available staging parts SHALL tail them to reassemble and serve a complete, byte-correct NAR, regardless of whether CDC is disabled, lazy, or eager. The served bytes SHALL carry the compression recorded in `staging_state.compression`; when the client requests a different compression, the reader SHALL transcode on the fly at parity with the same-pod streaming path. A reader SHALL NOT deliver a truncated NAR as an HTTP 200. When the holder is alive and staging parts are available, a waiting replica SHALL prefer serving from staging over routing to chunk-based serving, so that an actively-chunking (eager-CDC) NAR is never returned to the client as an HTTP 404 merely because the requested compression cannot be produced from chunks. A replica that observes an actively-chunking NAR (visible cross-pod, not yet finished) and receives a request for a compression that cannot be produced from chunks SHALL enter download coordination (recording a staging request and serving from staging) rather than short-circuiting to chunk-based serving and returning HTTP 404.
+
+#### Scenario: Compressed request during active chunking coordinates instead of short-circuiting to chunks
+
+- **WHEN** replica A is actively chunking a NAR (its cross-pod-visible `nar_file` row has `total_chunks==0` with a live chunker) and replica B receives a request for a compressed variant (e.g. `.nar.xz`)
+- **THEN** replica B SHALL NOT short-circuit to chunk-based serving (which cannot produce the compressed variant)
+- **AND** replica B SHALL enter download coordination and record an in-flight staging request, so the request can be served from staging once parts are available (the staging serve itself being completed by the producer)
+
+#### Scenario: Uncompressed request during active chunking still streams from chunks
+
+- **WHEN** replica A is actively chunking a NAR and replica B receives a request for the uncompressed (`none`) variant
+- **THEN** replica B SHALL serve progressively from chunks as they are committed, unchanged by the compressed-request coordination behavior
+
+#### Scenario: Non-CDC cross-pod serve during download
+
+- **WHEN** CDC is disabled and replica A is downloading a NAR with replica B waiting
+- **AND** staging is active
+- **THEN** replica B SHALL serve the complete NAR from staging parts with HTTP 200

--- a/openspec/changes/archive/2026-06-08-fix-cdc-getnar-chunk-route/tasks.md
+++ b/openspec/changes/archive/2026-06-08-fix-cdc-getnar-chunk-route/tasks.md
@@ -1,0 +1,19 @@
+## 1. Reproduce in a unit test (red)
+
+- [~] 1.1 A GetNar unit test is NOT viable: `GetNar` calls `serveNarFromStorageViaPipe` at TWO points (the 1232 short-circuit and the post-coordination serve ~1330), and BOTH 404 on compressed-from-chunks. In a unit context (local locker, no upstream, no real cross-pod staging) the gated fall-through just hits the 1330 chunk-404, so the gate's effect is externally indistinguishable. The gate's effect is only observable in the multi-process e2e (redis contention → the loser reaches `pollForDownloadOrTakeOver`, which can return `stagingServe`). The predicate the gate relies on (`hasFinishedNar` excludes actively-chunking) is unit-tested in the prior change. Verification is the e2e (§4) + the `-race` suite.
+
+## 2. Gate the GetNar short-circuit (green)
+
+- [x] 2.1 In `GetNar` (`pkg/cache/cache.go` ~1216-1232), after the existing `hasNar` computation (including the `hasActiveLocalJob` re-eval), add: if `hasNar && narURL.Compression != nar.CompressionTypeNone && !c.hasFinishedNar(ctx, narURL)` then set `hasNar = false` (actively-chunking + compressed request → coordinate/stage instead of chunk-serving → 404). Add a clear comment referencing #1289 and the staging transcode path.
+- [x] 2.2 Confirm the uncompressed path is untouched (condition requires `Compression != none`) and finished NARs are untouched (`hasFinishedNar` true → condition false).
+
+## 3. Unit verification
+
+- [x] 3.1 `task test` green (race), with emphasis on `cdc_*`, progressive-chunk, coordination, and `GetNar`/serve tests — confirm no regression to uncompressed progressive serving or the holder path.
+- [x] 3.2 `task fmt` and `task lint` exit zero.
+
+## 4. Multi-process acceptance (the bug's real proof)
+
+- [x] 4.1 VERIFIED: with the GetNar gate, the loser now REACHES coordination — its log shows 2 lock-acquisition lines (vs 0 before the gate), so it falls through and records a staging request. This change's deliverable (loser coordinates instead of short-circuiting to chunk-404) is confirmed.
+- [!] 4.2 STOP CONDITION HIT (as pre-authorized). The loser now coordinates but staging STILL yields nothing (0 activation, 4/8 readers 404): the CDC holder produces no staging parts despite a recorded request. This is the separate downstream producer defect — now finally investigable (the loser records a request, which it never did before this gate). Escalated to its own change. See [[project_cdc_staging_producer_not_wired]].
+- [~] 4.3 If green: run `--window chunking --storage s3` and the full matrix (`--storage both --window both`); capture `.e2e-results/inflight-staging/<ts>/summary.json` as evidence.

--- a/openspec/specs/inflight-nar-staging/spec.md
+++ b/openspec/specs/inflight-nar-staging/spec.md
@@ -61,13 +61,24 @@ When staging activates, the holder SHALL write the NAR to shared storage as orde
 
 ### Requirement: Cross-pod readers serve a complete, byte-correct NAR from staging in all CDC modes
 
-A waiting replica that observes available staging parts SHALL tail them to reassemble and serve a complete, byte-correct NAR, regardless of whether CDC is disabled, lazy, or eager. The served bytes SHALL carry the compression recorded in `staging_state.compression`; when the client requests a different compression, the reader SHALL transcode on the fly at parity with the same-pod streaming path. A reader SHALL NOT deliver a truncated NAR as an HTTP 200. When the holder is alive and staging parts are available, a waiting replica SHALL prefer serving from staging over routing to chunk-based serving, so that an actively-chunking (eager-CDC) NAR is never returned to the client as an HTTP 404 merely because the requested compression cannot be produced from chunks.
+A waiting replica that observes available staging parts SHALL tail them to reassemble and serve a complete, byte-correct NAR, regardless of whether CDC is disabled, lazy, or eager. The served bytes SHALL carry the compression recorded in `staging_state.compression`; when the client requests a different compression, the reader SHALL transcode on the fly at parity with the same-pod streaming path. A reader SHALL NOT deliver a truncated NAR as an HTTP 200. When the holder is alive and staging parts are available, a waiting replica SHALL prefer serving from staging over routing to chunk-based serving, so that an actively-chunking (eager-CDC) NAR is never returned to the client as an HTTP 404 merely because the requested compression cannot be produced from chunks. A replica that observes an actively-chunking NAR (visible cross-pod, not yet finished) and receives a request for a compression that cannot be produced from chunks SHALL enter download coordination (recording an in-flight staging request) rather than short-circuiting to chunk-based serving and returning HTTP 404.
 
 #### Scenario: Non-CDC cross-pod serve during download
 
 - **WHEN** CDC is disabled and replica A is downloading a NAR with replica B waiting
 - **AND** staging is active
 - **THEN** replica B SHALL serve the complete NAR from staging parts with HTTP 200
+
+#### Scenario: Compressed request during active chunking coordinates instead of short-circuiting to chunks
+
+- **WHEN** replica A is actively chunking a NAR (its cross-pod-visible `nar_file` row has `total_chunks==0` with a live chunker) and replica B receives a request for a compressed variant (e.g. `.nar.xz`)
+- **THEN** replica B SHALL NOT short-circuit to chunk-based serving (which cannot produce the compressed variant)
+- **AND** replica B SHALL enter download coordination and record an in-flight staging request, so the request can be served from staging once parts are available
+
+#### Scenario: Uncompressed request during active chunking still streams from chunks
+
+- **WHEN** replica A is actively chunking a NAR and replica B receives a request for the uncompressed (`none`) variant
+- **THEN** replica B SHALL serve progressively from chunks as they are committed, unchanged by the compressed-request coordination behavior
 
 #### Scenario: Eager-CDC cross-pod serve prefers staging over chunk routing
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1229,6 +1229,20 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (nar.URL, int64, io.
 			}
 		}
 
+		// An actively-chunking NAR (servable but not yet finished) is stored only as
+		// decompressed chunks, so it cannot satisfy a compressed request: serving it
+		// from chunks would 404 (serveNarFromStorageViaPipe -> serveFromChunks). For a
+		// cross-pod reader (no local download job) that short-circuit also skips
+		// download coordination entirely, so the waiter never records an in-flight
+		// staging request and never serves from staging. Treat such a request as
+		// not-servable here so it falls through to prePullNar -> coordination, where it
+		// records a staging request and serves from in-flight staging (transcoding to
+		// the requested compression). The uncompressed progressive-chunk path and
+		// finished NARs are unaffected (closes the chunking-window cross-pod 404, #1289).
+		if hasNar && narURL.Compression != nar.CompressionTypeNone && !c.hasFinishedNar(ctx, narURL) {
+			hasNar = false
+		}
+
 		if hasNar {
 			if hasNarInStore {
 				c.maybeBackgroundMigrateNarToChunks(ctx, narURL)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1213,7 +1213,10 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (nar.URL, int64, io.
 		// download. isServable is the single source of truth; see its doc comment.
 		// A backing-less placeholder row is therefore never served — it falls through
 		// to prePullNar below and re-downloads instead of returning a 404.
-		hasNar, err := c.isServable(ctx, narURL)
+		// narServability returns both states in one pass: `finished` (the NAR is fully
+		// materialized) is reused by the compressed-request gate below, so it does not
+		// repeat the HasNarInStore stat and nar_file lookup already done here.
+		hasNar, finished, err := c.narServability(ctx, narURL)
 		if err != nil {
 			return err
 		}
@@ -1239,7 +1242,7 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (nar.URL, int64, io.
 		// records a staging request and serves from in-flight staging (transcoding to
 		// the requested compression). The uncompressed progressive-chunk path and
 		// finished NARs are unaffected (closes the chunking-window cross-pod 404, #1289).
-		if hasNar && narURL.Compression != nar.CompressionTypeNone && !c.hasFinishedNar(ctx, narURL) {
+		if hasNar && narURL.Compression != nar.CompressionTypeNone && !finished {
 			hasNar = false
 		}
 


### PR DESCRIPTION
## Summary

- `GetNar` short-circuited to chunk-based serving for an actively-chunking NAR (via `isServable`), 404-ing a compressed (`.nar.xz`) request and skipping download coordination entirely so the cross-pod waiter never recorded a staging request.
- Gate the short-circuit: an actively-chunking NAR (`isServable && !hasFinishedNar`) with a compressed request now falls through to `prePullNar` → coordination. Uncompressed progressive serving and finished NARs are unaffected.

> **Status — IMPORTANT: prerequisite, not a complete fix.** Instrumented debugging shows the chunking-window e2e is still red due to a deeper **lock-lifecycle design mismatch**: the holder releases the `download:nar` lock after the decompress while CDC chunking continues in the background, so the cross-pod reader *acquires* the lock instead of *contending* — bypassing the staging-request path — and hits a **third** `isServable` site (the `coordinateDownload` post-lock check). Naively fixing that site would cause a re-download + double-chunk. Closing #1289 needs a holistic redesign of staging activation under CDC, not another patch; the full root cause is documented for a follow-up.

## Test plan

- [x] `task fmt` / `task lint` / `task test` (race) pass — no regression
- [x] Multi-process e2e: the loser now reaches coordination (chunking-window still red pending the redesign)