### PR TITLE
feat: verify upstream signatures on narinfo ingestion

### DIFF
--- a/charts/ncps/templates/configmap.yaml
+++ b/charts/ncps/templates/configmap.yaml
@@ -89,6 +89,7 @@ data:
       {{- end }}
 
       sign-narinfo: {{ ne .Values.config.signing.enabled false }}
+      require-trusted-signature: {{ eq .Values.config.signing.requireTrustedSignature true }}
 
       upstream:
         urls:

--- a/charts/ncps/tests/configmap_test.yaml
+++ b/charts/ncps/tests/configmap_test.yaml
@@ -269,6 +269,23 @@ tests:
           path: data["config.yaml"]
           pattern: "sign-narinfo: true"
 
+  - it: should default require-trusted-signature to false
+    set:
+      config.hostname: test.example.com
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "require-trusted-signature: false"
+
+  - it: should enable require-trusted-signature when set
+    set:
+      config.hostname: test.example.com
+      config.signing.requireTrustedSignature: true
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "require-trusted-signature: true"
+
   - it: should configure upstream caches
     set:
       config.hostname: test.example.com

--- a/charts/ncps/values.schema.json
+++ b/charts/ncps/values.schema.json
@@ -113,6 +113,10 @@
             "enabled": {
               "type": "boolean"
             },
+            "requireTrustedSignature": {
+              "type": "boolean",
+              "description": "Reject PUT-uploaded narinfos lacking a signature trusted by the configured upstream public keys (fail-closed)"
+            },
             "secretKey": {
               "type": "string"
             },

--- a/charts/ncps/values.yaml
+++ b/charts/ncps/values.yaml
@@ -112,6 +112,12 @@ config:
   signing:
     # Whether to sign narInfo files
     enabled: true
+    # Reject narInfos uploaded via PUT that do not carry a signature trusted by
+    # the configured upstream public keys (fail-closed). When enabled, uploads
+    # lacking a valid trusted upstream signature are rejected, and uploads are
+    # also rejected when no trusted upstream keys are configured. Default off
+    # preserves backward-compatible passthru of client uploads.
+    requireTrustedSignature: false
     # Signing key (provided via secret if not auto-generated)
     # Leave empty to auto-generate
     secretKey: ""

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -113,6 +113,12 @@ cache:
   secret-key-path: ""
   # Whether to sign narInfo files or passthru as-is from upstream
   sign-narinfo: true
+  # Reject narInfos uploaded via PUT that do not carry a signature trusted by
+  # the configured upstream public keys (fail-closed). When enabled, uploads
+  # are rejected if no signature validates against the trusted upstream keys,
+  # and also rejected when no trusted upstream keys are configured at all.
+  # Default off preserves backward-compatible passthru of client uploads.
+  require-trusted-signature: false
   storage:
     # The local data path used for configuration and cache storage
     # Use this OR S3 storage (cache.storage.s3.bucket) - not both

--- a/docs/docs/User Guide/Configuration/Reference.md
+++ b/docs/docs/User Guide/Configuration/Reference.md
@@ -206,6 +206,7 @@ In-flight staging resolves the cross-pod serve-during-download gap for **all** m
 | Option | Description | Environment Variable | Default |
 | --- | --- | --- | --- |
 | `--cache-sign-narinfo` | Sign NarInfo files with private key | `CACHE_SIGN_NARINFO` | `true` |
+| `--cache-require-trusted-signature` | Reject PUT-uploaded narinfos lacking a signature trusted by the configured upstream public keys (fail-closed) | `CACHE_REQUIRE_TRUSTED_SIGNATURE` | `false` |
 | `--cache-secret-key-path` | Path to signing private key | `CACHE_SECRET_KEY_PATH` | auto-generated |
 | `--cache-allow-put-verb` | Allow PUT uploads to cache (requires `/upload` prefix) | `CACHE_ALLOW_PUT_VERB` | `false` |
 | `--cache-allow-delete-verb` | Allow DELETE operations on cache | `CACHE_ALLOW_DELETE_VERB` | `false` |

--- a/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
+++ b/docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md
@@ -120,6 +120,7 @@ The following table lists the configurable parameters of the ncps chart and thei
 | `config.permissions.allowPut` | Allow PUT requests (requires `/upload` prefix) | `false` |
 | `config.permissions.allowDelete` | Allow DELETE requests | `false` |
 | `config.signing.enabled` | Enable NAR signing | `true` |
+| `config.signing.requireTrustedSignature` | Reject PUT-uploaded narinfos lacking a signature trusted by the configured upstream public keys (fail-closed) | `false` |
 | `config.signing.secretKey` | Signing secret key | `""` |
 | `config.signing.existingSecret` | Existing secret with signing key | `""` |
 

--- a/openspec/changes/archive/2026-06-09-verify-trusted-narinfo-signature-on-put/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-09-verify-trusted-narinfo-signature-on-put/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/archive/2026-06-09-verify-trusted-narinfo-signature-on-put/design.md
+++ b/openspec/changes/archive/2026-06-09-verify-trusted-narinfo-signature-on-put/design.md
@@ -1,0 +1,83 @@
+## Context
+
+ncps signs narinfos on ingestion (both upstream-fetch and client `PUT`) and
+re-serves them under its own key. The upstream-fetch path
+(`pkg/cache/upstream/cache.go`) already verifies incoming signatures against the
+configured trusted public keys via `signature.VerifyFirst` before accepting a
+narinfo. The client `PutNarInfo` path (`pkg/cache/cache.go`) parses, signs, and
+stores uploads with no verification at all. Because ncps then signs with its own
+key, downstream clients trusting ncps cannot tell that the original upstream
+signature was forged or absent. nix itself validates signatures before
+substituting from a cache, so this gate restores that guarantee for the `PUT`
+path (issue #1269).
+
+The trusted key material already exists in memory: each upstream `Cache` parses
+its configured public keys at construction. The only missing piece on the cache
+side was an accessor and an aggregation + verification step on the `PUT` path,
+plus an operator toggle.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Give operators a way to reject `PUT`-uploaded narinfos that are not signed by a
+  trusted upstream key, closing the signature-laundering gap.
+- Keep the default behavior identical to today (off → passthru), so existing
+  deployments are unaffected.
+- Reuse the exact verification primitive (`signature.VerifyFirst` over
+  `narInfo.Fingerprint()`) already used on the upstream path for consistency.
+
+**Non-Goals:**
+- Modifying the upstream-fetch verification, which already works.
+- Per-upstream or per-key trust policy; the trusted set is the union of all
+  configured upstream keys.
+- Verifying NAR bytes/hashes; this gate is narinfo-signature only.
+
+## Decisions
+
+- **Fail-closed when no keys are configured.** Unlike the upstream path's
+  `if len(c.publicKeys) > 0` guard (which skips verification when no keys
+  exist), the `PUT` gate rejects when zero trusted keys are configured. Rationale:
+  an operator who turns on "require trusted signature" but has no keys would
+  otherwise run a silent no-op verifier — a dangerous false sense of security.
+  Failing closed matches nix's substitution posture. Alternative considered:
+  mirror the upstream skip-when-empty behavior — rejected because it makes the
+  gate a no-op in a plausible misconfiguration.
+- **Aggregate keys across all upstreams under the existing RWMutex.**
+  `trustedPublicKeys()` takes `upstreamCachesMu.RLock()` and appends each
+  upstream's `PublicKeys()` into a fresh slice. Rationale: upstreams can be added
+  concurrently; reuse the same lock that already guards `upstreamCaches`.
+- **Verify after parse, before normalization/signing.** The call sits
+  immediately after `narinfo.Parse` in `PutNarInfo`, before CDC compression
+  normalization and `signNarInfo`. Rationale: `Fingerprint()` is derived from
+  store path / NarHash / NarSize / References — none of which the CDC block
+  mutates — so the fingerprint verified is the authentic uploaded one.
+- **New exported accessor `Cache.PublicKeys()` on the upstream package.** The
+  parsed keys were unexported with no getter; expose them so the cache layer can
+  aggregate. Returns an empty slice when none configured.
+- **New `ErrUntrustedNarInfo` sentinel** so callers and tests can match the
+  rejection with `errors.Is`.
+- **Setter mirrors `SetCacheSignNarinfo`.** `SetCacheRequireTrustedSignature`
+  wires the boolean from the flag in `createCache`, matching the established
+  configuration pattern.
+
+## Risks / Trade-offs
+
+- [Operator enables the gate but only some uploads are signed by trusted keys] →
+  Those uploads are rejected with a clear `ErrUntrustedNarInfo`. This is the
+  intended fail-closed behavior; documented in config and chart references so
+  operators understand they must configure upstream public keys first.
+- [Accessor returns the internal slice by reference] → The sole caller only reads
+  and appends into a new slice, so there is no mutation hazard today; a future
+  caller could mutate the backing array. Low impact; can be hardened with
+  `slices.Clone` if a mutating caller ever appears.
+- [Performance] → Verification is in-memory over already-parsed signatures and an
+  in-memory key set, on the `PUT` path only. No extra network or storage I/O; the
+  default (off) path adds a single boolean check.
+
+## Migration Plan
+
+- Ship default-off. No data migration, no schema change, no behavior change for
+  existing deployments.
+- Operators opt in by setting `--cache-require-trusted-signature` (or the env /
+  config equivalent) after confirming their upstream public keys are configured.
+- Rollback is a config flip back to off; no persisted state is affected.

--- a/openspec/changes/archive/2026-06-09-verify-trusted-narinfo-signature-on-put/proposal.md
+++ b/openspec/changes/archive/2026-06-09-verify-trusted-narinfo-signature-on-put/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+ncps re-signs every narinfo it ingests with its own secret key and serves it
+under that key. The upstream-fetch path verifies incoming signatures against the
+configured trusted public keys before doing so, but the client `PutNarInfo`
+(`PUT`) path performs **zero** verification. A client can upload a narinfo with a
+forged or absent upstream signature; ncps signs it and serves it, and downstream
+clients trusting ncps's key accept it without ever learning the original
+signature was invalid. This closes that laundering gap for the unverified `PUT`
+path (issue #1269).
+
+## What Changes
+
+- Add a new operator flag `--cache-require-trusted-signature` (env
+  `CACHE_REQUIRE_TRUSTED_SIGNATURE`, config `cache.require-trusted-signature`),
+  **default off**, mirroring the existing `sign-narinfo` toggle.
+- When enabled, `PutNarInfo` rejects any uploaded narinfo that does not carry at
+  least one signature validating against the aggregated trusted public keys of
+  all configured upstream caches, returning a new `ErrUntrustedNarInfo` sentinel
+  before the narinfo is signed or persisted.
+- Verification is **fail-closed**: an upload is also rejected when zero trusted
+  upstream keys are configured, so an operator cannot accidentally run a no-op
+  verifier (matching nix's own posture).
+- Document the flag in `config.example.yaml`, the Helm chart
+  (`values.yaml` → `config.signing.requireTrustedSignature`,
+  `values.schema.json`, `configmap.yaml`, `configmap_test.yaml`), and the docs
+  (Configuration Reference and Helm Chart Reference).
+
+## Non-goals
+
+- Changing the default ingestion behavior. With the flag off (default), client
+  uploads pass through exactly as before — no verification, full backward
+  compatibility.
+- Re-verifying the upstream-fetch path, which already verifies signatures.
+- Verifying NAR file contents or hashes — this gate covers narinfo signatures
+  only.
+- Per-upstream or per-key policy granularity; the trusted set is the union of
+  all configured upstream public keys.
+
+## Capabilities
+
+### New Capabilities
+- `narinfo-trusted-signature`: Optional, fail-closed verification of trusted
+  upstream signatures on client `PUT` narinfo ingestion, gated by an operator
+  flag and defaulting to off.
+
+### Modified Capabilities
+<!-- None. No existing capability's requirements change. -->
+
+## Impact
+
+- Code: `pkg/cache/cache.go` (`requireTrustedSignature` field, setter,
+  `trustedPublicKeys`/`verifyNarInfoTrusted` helpers, `ErrUntrustedNarInfo`,
+  call inside `PutNarInfo`), `pkg/cache/upstream/cache.go` (new `PublicKeys()`
+  accessor), `pkg/ncps/serve.go` (flag wiring).
+- Config/docs: `config.example.yaml`, `charts/ncps/**`, `docs/docs/User Guide/**`.
+- I/O / network / memory: negligible. Verification runs in-memory over the
+  already-parsed narinfo's signatures and the in-memory key set on the `PUT`
+  path only; no additional network calls, storage reads, or per-stream
+  allocations. Behavior on the default (off) path is unchanged.

--- a/openspec/changes/archive/2026-06-09-verify-trusted-narinfo-signature-on-put/specs/narinfo-trusted-signature/spec.md
+++ b/openspec/changes/archive/2026-06-09-verify-trusted-narinfo-signature-on-put/specs/narinfo-trusted-signature/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Operator gate for trusted-signature verification on PUT ingestion
+
+The cache MUST expose an operator toggle, default off, that controls whether
+client-uploaded narinfos (the `PutNarInfo` / `PUT` path) are verified against
+the configured trusted upstream public keys before being signed and persisted.
+The toggle is configurable via the `--cache-require-trusted-signature` flag, the
+`CACHE_REQUIRE_TRUSTED_SIGNATURE` environment variable, and the
+`cache.require-trusted-signature` config key.
+
+#### Scenario: Disabled by default preserves passthru
+
+- **WHEN** the gate is not configured and a client uploads a narinfo via `PUT`
+- **THEN** the narinfo is accepted, signed, and persisted exactly as before with
+  no signature verification performed
+
+#### Scenario: Toggle is wired from flag, env, and config
+
+- **WHEN** an operator sets `--cache-require-trusted-signature`,
+  `CACHE_REQUIRE_TRUSTED_SIGNATURE`, or `cache.require-trusted-signature` to true
+- **THEN** the cache enables trusted-signature verification on the `PutNarInfo`
+  path
+
+### Requirement: Reject untrusted narinfos when verification is enabled
+
+The cache MUST, when the gate is enabled, reject any narinfo uploaded via `PUT`
+that does not carry at least one signature validating against the union of the
+trusted public keys of all configured upstream caches. Verification MUST occur
+after the narinfo is parsed and before it is signed or persisted, and rejection
+MUST return the `ErrUntrustedNarInfo` sentinel and leave no narinfo persisted.
+
+#### Scenario: Untrusted signature is rejected
+
+- **WHEN** the gate is enabled and a client uploads a narinfo whose signatures
+  do not validate against any configured trusted upstream public key
+- **THEN** the upload is rejected with `ErrUntrustedNarInfo` and no narinfo
+  record is persisted
+
+#### Scenario: Trusted signature is accepted and persisted
+
+- **WHEN** the gate is enabled and a client uploads a narinfo carrying at least
+  one signature that validates against a configured trusted upstream public key
+- **THEN** the narinfo is accepted, signed with the cache's key, and persisted
+
+### Requirement: Fail closed when no trusted keys are configured
+
+The cache MUST, when the gate is enabled and no trusted upstream public keys are
+configured, reject every `PUT` narinfo upload with `ErrUntrustedNarInfo` rather
+than silently accepting uploads. This prevents an operator from accidentally
+running a no-op verifier and matches nix's fail-closed substitution posture.
+
+#### Scenario: No trusted keys configured rejects all uploads
+
+- **WHEN** the gate is enabled, zero trusted upstream public keys are
+  configured, and a client uploads a narinfo via `PUT`
+- **THEN** the upload is rejected with `ErrUntrustedNarInfo` and no narinfo
+  record is persisted

--- a/openspec/changes/archive/2026-06-09-verify-trusted-narinfo-signature-on-put/tasks.md
+++ b/openspec/changes/archive/2026-06-09-verify-trusted-narinfo-signature-on-put/tasks.md
@@ -1,0 +1,34 @@
+## 1. Core verification logic
+
+- [x] 1.1 Add `ErrUntrustedNarInfo` sentinel error in `pkg/cache/cache.go`
+- [x] 1.2 Add `requireTrustedSignature` field and `SetCacheRequireTrustedSignature` setter (mirroring `shouldSignNarinfo`)
+- [x] 1.3 Add `PublicKeys()` accessor on the upstream `Cache` in `pkg/cache/upstream/cache.go`
+- [x] 1.4 Add `trustedPublicKeys()` helper aggregating keys across upstreams under `upstreamCachesMu.RLock()`
+- [x] 1.5 Add `verifyNarInfoTrusted()` helper: no-op when disabled, fail-closed when no keys, `signature.VerifyFirst` over `narInfo.Fingerprint()` otherwise
+- [x] 1.6 Call `verifyNarInfoTrusted` in `PutNarInfo` after parse and before CDC normalization / signing
+
+## 2. Flag wiring
+
+- [x] 2.1 Add `--cache-require-trusted-signature` flag (env `CACHE_REQUIRE_TRUSTED_SIGNATURE`, config `cache.require-trusted-signature`, default off) in `pkg/ncps/serve.go`
+- [x] 2.2 Wire the flag to `SetCacheRequireTrustedSignature` in `createCache`
+
+## 3. Tests
+
+- [x] 3.1 Add `PutNarInfoRequireTrustedSignature` cache test: disabled-accepts, no-keys-rejects, untrusted-rejects, trusted-accepts (asserting nothing persisted on rejection)
+- [x] 3.2 Register the new subtest in `runCacheTestSuite`
+
+## 4. Configuration & documentation
+
+- [x] 4.1 Document `require-trusted-signature` in `config.example.yaml`
+- [x] 4.2 Add `config.signing.requireTrustedSignature` to `charts/ncps/values.yaml`
+- [x] 4.3 Add the field to `charts/ncps/values.schema.json`
+- [x] 4.4 Render `require-trusted-signature` in `charts/ncps/templates/configmap.yaml`
+- [x] 4.5 Add helm unit-test assertions in `charts/ncps/tests/configmap_test.yaml` (default false, enabled true)
+- [x] 4.6 Add the flag row to `docs/docs/User Guide/Configuration/Reference.md`
+- [x] 4.7 Add the value row to `docs/docs/User Guide/Installation/Helm Chart/Chart Reference.md`
+
+## 5. Verification
+
+- [x] 5.1 `task fmt` clean (0 changed); `golangci-lint run ./pkg/... ./cmd/... ./ent/...` → 0 issues (only stray lint hits are in gitignored `var/ncps/nix-tmp` dev cruft, not project code); PR Go tests already green per PR #1382
+- [x] 5.2 `helm template` confirms `require-trusted-signature` defaults to false and flips to true when `config.signing.requireTrustedSignature=true`
+- [x] 5.3 `openspec validate verify-trusted-narinfo-signature-on-put --no-interactive --strict` → "is valid"

--- a/openspec/specs/narinfo-trusted-signature/spec.md
+++ b/openspec/specs/narinfo-trusted-signature/spec.md
@@ -1,0 +1,71 @@
+# narinfo-trusted-signature Specification
+
+## Purpose
+
+Defines an optional, fail-closed verification gate on the client `PutNarInfo`
+(`PUT`) ingestion path. ncps re-signs every narinfo it ingests with its own key
+and serves it under that key; the upstream-fetch path already verifies incoming
+signatures against the configured trusted public keys, but the `PUT` path did not.
+This capability lets an operator require that client-uploaded narinfos carry a
+signature trusted by the configured upstream public keys before ncps signs and
+serves them, closing the signature-laundering gap (issue #1269). The gate
+defaults off, preserving backward-compatible passthru of client uploads.
+
+## Requirements
+
+### Requirement: Operator gate for trusted-signature verification on PUT ingestion
+
+The cache MUST expose an operator toggle, default off, that controls whether
+client-uploaded narinfos (the `PutNarInfo` / `PUT` path) are verified against
+the configured trusted upstream public keys before being signed and persisted.
+The toggle is configurable via the `--cache-require-trusted-signature` flag, the
+`CACHE_REQUIRE_TRUSTED_SIGNATURE` environment variable, and the
+`cache.require-trusted-signature` config key.
+
+#### Scenario: Disabled by default preserves passthru
+
+- **WHEN** the gate is not configured and a client uploads a narinfo via `PUT`
+- **THEN** the narinfo is accepted, signed, and persisted exactly as before with
+  no signature verification performed
+
+#### Scenario: Toggle is wired from flag, env, and config
+
+- **WHEN** an operator sets `--cache-require-trusted-signature`,
+  `CACHE_REQUIRE_TRUSTED_SIGNATURE`, or `cache.require-trusted-signature` to true
+- **THEN** the cache enables trusted-signature verification on the `PutNarInfo`
+  path
+
+### Requirement: Reject untrusted narinfos when verification is enabled
+
+The cache MUST, when the gate is enabled, reject any narinfo uploaded via `PUT`
+that does not carry at least one signature validating against the union of the
+trusted public keys of all configured upstream caches. Verification MUST occur
+after the narinfo is parsed and before it is signed or persisted, and rejection
+MUST return the `ErrUntrustedNarInfo` sentinel and leave no narinfo persisted.
+
+#### Scenario: Untrusted signature is rejected
+
+- **WHEN** the gate is enabled and a client uploads a narinfo whose signatures
+  do not validate against any configured trusted upstream public key
+- **THEN** the upload is rejected with `ErrUntrustedNarInfo` and no narinfo
+  record is persisted
+
+#### Scenario: Trusted signature is accepted and persisted
+
+- **WHEN** the gate is enabled and a client uploads a narinfo carrying at least
+  one signature that validates against a configured trusted upstream public key
+- **THEN** the narinfo is accepted, signed with the cache's key, and persisted
+
+### Requirement: Fail closed when no trusted keys are configured
+
+The cache MUST, when the gate is enabled and no trusted upstream public keys are
+configured, reject every `PUT` narinfo upload with `ErrUntrustedNarInfo` rather
+than silently accepting uploads. This prevents an operator from accidentally
+running a no-op verifier and matches nix's fail-closed substitution posture.
+
+#### Scenario: No trusted keys configured rejects all uploads
+
+- **WHEN** the gate is enabled, zero trusted upstream public keys are
+  configured, and a client uploads a narinfo via `PUT`
+- **THEN** the upload is rejected with `ErrUntrustedNarInfo` and no narinfo
+  record is persisted

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -139,6 +139,11 @@ var (
 	// ErrMigrationInProgress is returned if a migration is already in progress.
 	ErrMigrationInProgress = errors.New("migration is already in progress")
 
+	// ErrUntrustedNarInfo is returned by PutNarInfo when requireTrustedSignature
+	// is enabled and the submitted narinfo carries no signature that validates
+	// against the set of trusted upstream public keys.
+	ErrUntrustedNarInfo = errors.New("narinfo has no trusted signature")
+
 	// ErrNarInfoPurged is returned if the narinfo was purged.
 	ErrNarInfoPurged = errors.New("the narinfo was purged")
 
@@ -487,6 +492,11 @@ type Cache struct {
 
 	// Should the cache sign the narinfos?
 	shouldSignNarinfo bool
+
+	// requireTrustedSignature, when true, makes PutNarInfo reject any narinfo
+	// that does not carry at least one signature validating against the trusted
+	// upstream public keys. Default false preserves prior behavior.
+	requireTrustedSignature bool
 
 	// recordAgeIgnoreTouch represents the duration at which a record is
 	// considered up to date and a touch is not invoked. This helps avoid
@@ -1043,9 +1053,52 @@ func (c *Cache) GetConfig() *config.Config {
 // SetCacheSignNarinfo configure ncps to sign or not sign narinfos.
 func (c *Cache) SetCacheSignNarinfo(shouldSignNarinfo bool) { c.shouldSignNarinfo = shouldSignNarinfo }
 
+// SetCacheRequireTrustedSignature configures whether PutNarInfo rejects
+// narinfos lacking a valid trusted upstream signature.
+func (c *Cache) SetCacheRequireTrustedSignature(requireTrustedSignature bool) {
+	c.requireTrustedSignature = requireTrustedSignature
+}
+
 // SetMaxSize sets the maxsize of the cache. This will be used by the LRU
 // cronjob to automatically clean-up the store.
 func (c *Cache) SetMaxSize(maxSize uint64) { c.maxSize = maxSize }
+
+// trustedPublicKeys aggregates the public keys from all configured upstream
+// caches.
+func (c *Cache) trustedPublicKeys() []signature.PublicKey {
+	c.upstreamCachesMu.RLock()
+	defer c.upstreamCachesMu.RUnlock()
+
+	var keys []signature.PublicKey
+	for _, uc := range c.upstreamCaches {
+		keys = append(keys, uc.PublicKeys()...)
+	}
+
+	return keys
+}
+
+// verifyNarInfoTrusted returns nil when requireTrustedSignature is disabled,
+// or when the narinfo carries at least one signature that validates against
+// the trusted upstream public keys. When the gate is enabled it fails closed:
+// if no trusted keys are configured, or no signature validates, it returns
+// ErrUntrustedNarInfo (matching nix's fail-closed posture so an operator
+// cannot accidentally run a no-op verifier).
+func (c *Cache) verifyNarInfoTrusted(narInfo *narinfo.NarInfo) error {
+	if !c.requireTrustedSignature {
+		return nil
+	}
+
+	keys := c.trustedPublicKeys()
+	if len(keys) == 0 {
+		return ErrUntrustedNarInfo
+	}
+
+	if !signature.VerifyFirst(narInfo.Fingerprint(), narInfo.Signatures, keys) {
+		return ErrUntrustedNarInfo
+	}
+
+	return nil
+}
 
 func (c *Cache) isCDCEnabled() bool {
 	c.cdcMu.RLock()
@@ -4226,6 +4279,10 @@ func (c *Cache) PutNarInfo(ctx context.Context, hash string, r io.ReadCloser) er
 		narInfo, err := narinfo.Parse(r)
 		if err != nil {
 			return fmt.Errorf("error parsing narinfo: %w", err)
+		}
+
+		if err := c.verifyNarInfoTrusted(narInfo); err != nil {
+			return fmt.Errorf("rejecting untrusted narinfo: %w", err)
 		}
 
 		// For CDC mode, normalize all NARs to Compression: none.

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -927,6 +927,84 @@ func testPutNarInfo(factory cacheFactory) func(*testing.T) {
 	}
 }
 
+func testPutNarInfoRequireTrustedSignature(factory cacheFactory) func(*testing.T) {
+	return func(t *testing.T) {
+		putNarInfo := func(t *testing.T, c *cache.Cache) error {
+			t.Helper()
+
+			r := io.NopCloser(strings.NewReader(testdata.Nar1.NarInfoText))
+
+			return c.PutNarInfo(context.Background(), testdata.Nar1.NarInfoHash, r)
+		}
+
+		narInfoCount := func(t *testing.T, dbClient *database.Client) int {
+			t.Helper()
+
+			count, err := dbClient.Ent().NarInfo.Query().Count(newContext())
+			require.NoError(t, err)
+
+			return count
+		}
+
+		t.Run("disabled accepts narinfo without trusted upstream signature", func(t *testing.T) {
+			c, _, _, _, _, cleanup := factory(t)
+			t.Cleanup(cleanup)
+
+			require.NoError(t, putNarInfo(t, c))
+		})
+
+		t.Run("enabled rejects when no trusted keys are configured", func(t *testing.T) {
+			c, dbClient, _, _, _, cleanup := factory(t)
+			t.Cleanup(cleanup)
+
+			c.SetCacheRequireTrustedSignature(true)
+
+			err := putNarInfo(t, c)
+			require.ErrorIs(t, err, cache.ErrUntrustedNarInfo)
+			assert.Equal(t, 0, narInfoCount(t, dbClient))
+		})
+
+		t.Run("enabled rejects narinfo with untrusted signature", func(t *testing.T) {
+			ts := testdata.NewTestServer(t, 40)
+			t.Cleanup(ts.Close)
+
+			c, dbClient, _, _, _, cleanup := factory(t)
+			t.Cleanup(cleanup)
+
+			uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
+				PublicKeys: []string{"untrusted-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="},
+			})
+			require.NoError(t, err)
+
+			c.AddUpstreamCaches(newContext(), uc)
+			c.SetCacheRequireTrustedSignature(true)
+
+			err = putNarInfo(t, c)
+			require.ErrorIs(t, err, cache.ErrUntrustedNarInfo)
+			assert.Equal(t, 0, narInfoCount(t, dbClient))
+		})
+
+		t.Run("enabled accepts narinfo with trusted upstream signature", func(t *testing.T) {
+			ts := testdata.NewTestServer(t, 40)
+			t.Cleanup(ts.Close)
+
+			c, dbClient, _, _, _, cleanup := factory(t)
+			t.Cleanup(cleanup)
+
+			uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
+				PublicKeys: testdata.PublicKeys(),
+			})
+			require.NoError(t, err)
+
+			c.AddUpstreamCaches(newContext(), uc)
+			c.SetCacheRequireTrustedSignature(true)
+
+			require.NoError(t, putNarInfo(t, c))
+			assert.Equal(t, 1, narInfoCount(t, dbClient))
+		})
+	}
+}
+
 func testPutNarInfoDeadlock(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
 		c, _, _, _, _, cleanup := factory(t)
@@ -3101,6 +3179,7 @@ func runCacheTestSuite(t *testing.T, factory cacheFactory) {
 	t.Run("GetNarInfoWithoutSignature", testGetNarInfoWithoutSignature(factory))
 	t.Run("GetNarInfo", testGetNarInfo(factory))
 	t.Run("PutNarInfo", testPutNarInfo(factory))
+	t.Run("PutNarInfoRequireTrustedSignature", testPutNarInfoRequireTrustedSignature(factory))
 	t.Run("PutNarInfoDeadlock", testPutNarInfoDeadlock(factory))
 	t.Run("DeleteNarInfo", testDeleteNarInfo(factory))
 	t.Run("GetNar", testGetNar(factory))

--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -266,6 +266,12 @@ func (c *Cache) SetPriority(priority uint64) {
 	c.priority = priority
 }
 
+// PublicKeys returns the parsed trusted public keys configured for this
+// upstream cache. It returns an empty slice when none were configured.
+func (c *Cache) PublicKeys() []signature.PublicKey {
+	return c.publicKeys
+}
+
 // ParsePriority parses the priority from the upstream.
 func (c *Cache) ParsePriority(ctx context.Context) (uint64, error) {
 	return c.parsePriority(ctx)

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -306,6 +306,12 @@ func serveCommand(
 				Sources: flagSources("cache.sign-narinfo", "CACHE_SIGN_NARINFO"),
 				Value:   true,
 			},
+			&cli.BoolFlag{
+				Name:    "cache-require-trusted-signature",
+				Usage:   "Reject narinfos uploaded via PUT that do not carry a signature trusted by the configured upstream public keys (fail-closed). Default off.",
+				Sources: flagSources("cache.require-trusted-signature", "CACHE_REQUIRE_TRUSTED_SIGNATURE"),
+				Value:   false,
+			},
 			&cli.StringFlag{
 				Name:    "cache-temp-path",
 				Usage:   "The path to the temporary directory that is used by the cache to download NAR files",
@@ -1269,6 +1275,7 @@ func createCache(
 	}
 
 	c.AddUpstreamCaches(ctx, ucs...)
+	c.SetCacheRequireTrustedSignature(cmd.Bool("cache-require-trusted-signature"))
 
 	// Trigger the health-checker to speed-up the boot but do not wait for the check to complete.
 	c.GetHealthChecker().Trigger()

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -307,8 +307,9 @@ func serveCommand(
 				Value:   true,
 			},
 			&cli.BoolFlag{
-				Name:    "cache-require-trusted-signature",
-				Usage:   "Reject narinfos uploaded via PUT that do not carry a signature trusted by the configured upstream public keys (fail-closed). Default off.",
+				Name: "cache-require-trusted-signature",
+				Usage: "Reject narinfos uploaded via PUT that do not carry a signature trusted " +
+					"by the configured upstream public keys (fail-closed). Default off.",
 				Sources: flagSources("cache.require-trusted-signature", "CACHE_REQUIRE_TRUSTED_SIGNATURE"),
 				Value:   false,
 			},


### PR DESCRIPTION
## Summary

Adds optional trusted-signature verification to the client `PutNarInfo` ingestion path. Fixes #1269.

## Why this matters

ncps signs narinfos on ingestion (both upstream-fetch and client `PUT`) and re-serves them under its own key. The upstream-fetch path already verifies incoming signatures against the configured trusted public keys (`signature.VerifyFirst` in `pkg/cache/upstream/cache.go`). The client `PutNarInfo` path, however, parsed, signed, and stored uploads with **zero** signature verification. A client could upload a narinfo carrying a forged or absent upstream signature; ncps would sign it and serve it, and downstream clients trusting ncps's key would accept it without ever knowing the original signature was invalid. nix itself validates signatures before substituting from a cache, so this closes that gap for the unverified `PUT` path.

## Changes

- `pkg/cache/upstream/cache.go`: new `PublicKeys()` accessor exposing the parsed trusted keys (previously unexported with no getter).
- `pkg/cache/cache.go`: new `requireTrustedSignature` field + `SetCacheRequireTrustedSignature` setter (mirrors the existing `shouldSignNarinfo` pattern), a `verifyNarInfoTrusted` helper that aggregates trusted keys across configured upstream caches and runs `signature.VerifyFirst`, and a call to it inside `PutNarInfo` immediately after parse and before signing. Adds the `ErrUntrustedNarInfo` sentinel.
- `pkg/ncps/serve.go`: new `--cache-require-trusted-signature` flag (default off) wired to the setter.

Behavior is unchanged when the flag is off (the default), preserving backward compatibility. When the flag is on, verification is **fail-closed**: an upload with no signature validating against the trusted upstream keys is rejected, and rejected when zero trusted keys are configured (matching nix's posture, so operators cannot accidentally run a no-op verifier).

This is a partial scope of the issue: it targets the unverified client `PUT` ingestion path. The upstream-fetch path already verifies, so it needs only the operator toggle, not new verification logic.

## Testing

- New `PutNarInfoRequireTrustedSignature` test covering: disabled (backward compat accept), fail-closed with no keys configured, untrusted-key rejection (not persisted), and trusted-key success (persisted).
- `go build`, `go vet`, `gofmt -l` clean on affected packages; full SQLite cache suite passes.

AI was used for assistance.
