### PR TITLE
feat(e2e): multi-scenario runs + nightly e2e workflow

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,90 @@
+name: e2e-nightly
+# Nightly run of the full unified e2e catalog against both modes. This is the
+# scheduled home for the harness (it stays out of the per-PR `nix flake check`).
+# A `gate` job records the last successfully-tested `main` SHA in an
+# `actions/cache` entry and short-circuits when `main` has not advanced, so the
+# same commit is never e2e-tested on two consecutive nights. A manual
+# `workflow_dispatch` bypasses the gate and forces a run against current `main`.
+on:
+  schedule:
+    - cron: "0 4 * * *" # 04:00 UTC nightly
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: e2e-nightly
+  cancel-in-progress: false
+jobs:
+  gate:
+    runs-on: ubuntu-24.04
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+      skip: ${{ steps.decide.outputs.skip }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          persist-credentials: false
+      - name: Resolve current main SHA
+        id: resolve
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Probe last-tested cache key
+        id: probe
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/cache/restore@v4
+        with:
+          path: .e2e-nightly
+          key: e2e-nightly-tested-${{ steps.resolve.outputs.sha }}
+          lookup-only: true
+      - name: Decide whether to skip
+        id: decide
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "manual dispatch: forcing a run"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.probe.outputs.cache-hit }}" = "true" ]; then
+            echo "main (${{ steps.resolve.outputs.sha }}) already tested; skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "main (${{ steps.resolve.outputs.sha }}) not yet tested; running"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+  e2e:
+    needs: gate
+    if: needs.gate.outputs.skip != 'true'
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [local, kubernetes]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Pin every leg to the exact SHA the gate resolved, so a mid-run push
+          # to main does not split the matrix across commits.
+          ref: ${{ needs.gate.outputs.sha }}
+          persist-credentials: false
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v17
+        with:
+          name: ncps
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Run e2e catalog (${{ matrix.mode }})
+        run: nix run .#e2e -- --mode ${{ matrix.mode }} --all
+  record:
+    needs: [gate, e2e]
+    # Only record the tested SHA after a fully successful matrix run, so a
+    # failure leaves the cache untouched and the next schedule retries the same
+    # commit.
+    if: ${{ needs.gate.outputs.skip != 'true' && needs.e2e.result == 'success' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Stamp the tested SHA
+        run: |
+          mkdir -p .e2e-nightly
+          echo "${{ needs.gate.outputs.sha }}" > .e2e-nightly/tested
+      - name: Save last-tested cache key
+        uses: actions/cache/save@v4
+        with:
+          path: .e2e-nightly
+          key: e2e-nightly-tested-${{ needs.gate.outputs.sha }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,9 +33,13 @@ tasks:
     cmds:
       - bash dev-scripts/test-auto.sh
   test:e2e:
-    desc: "Run a unified e2e harness scenario. Pass-through args, e.g. CLI_ARGS='--mode local --scenario cdc-lifecycle', CLI_ARGS='--mode kubernetes --scenario single-s3-postgres', or CLI_ARGS='--list'"
+    desc: "Run a unified e2e harness scenario. Pass-through args, e.g. CLI_ARGS='--mode local --scenario cdc-lifecycle', CLI_ARGS='--mode local --all', CLI_ARGS='--mode kubernetes --scenario single-s3-postgres', or CLI_ARGS='--list'"
     cmds:
       - nix run .#e2e -- {{.CLI_ARGS}}
+  test:e2e:unit:
+    desc: "Run the fast offline unit tests for the e2e harness (CLI/runner/catalog logic)"
+    cmds:
+      - python3 -m pytest nix/e2e-tests/tests -m "not catalog" -q
   test:deps:start:
     desc: Allocate random ports, start backing services in detached mode, write state file
     cmds:

--- a/nix/e2e-tests/README.md
+++ b/nix/e2e-tests/README.md
@@ -17,12 +17,22 @@ task test:e2e -- --list
 nix run .#e2e -- --mode local --scenario cdc-lifecycle
 task test:e2e -- --mode local --scenario staging-contention
 
+# Run several scenarios in one invocation (repeatable and/or comma-separated).
+nix run .#e2e -- --mode local --scenario cdc-lifecycle --scenario staging-contention
+nix run .#e2e -- --mode local --scenario cdc-lifecycle,staging-contention
+
+# Run every scenario supporting the chosen mode (unsupported ones are SKIPPED).
+nix run .#e2e -- --mode local --all
+nix run .#e2e -- --mode kubernetes --all
+
 # Run a scenario on a Kind cluster (Helm chart).
 nix run .#e2e -- --mode kubernetes --scenario single-s3-postgres
 ```
 
 `task test:e2e` forwards `{{.CLI_ARGS}}` to `nix run .#e2e`; the two entrypoints
-are equivalent.
+are equivalent. `--all` and `--scenario` are mutually exclusive. A multi-scenario
+run reports each scenario as PASS/FAIL/SKIP, prints an aggregate summary, and
+exits non-zero if **any** scenario FAILED (a SKIP alone never fails the run).
 
 ## Modes
 
@@ -70,11 +80,27 @@ In `kubernetes` mode the harness reuses the in-cluster `NCPSTester` validation
 
 ## CI
 
-This harness is **manual / opt-in** and is intentionally **not** part of
-`nix flake check` (Kind and network-NAR scenarios far exceed the per-PR budget).
-A scenario may only be promoted into `nix flake check` if it is proven to run in
-under 3 minutes. Automated coverage, if wanted, belongs on a scheduled (nightly)
-workflow, not on pull requests.
+The harness **scenarios** are **manual / opt-in** and are intentionally **not**
+part of `nix flake check` (Kind and network-NAR scenarios far exceed the per-PR
+budget). A scenario may only be promoted into `nix flake check` if it is proven
+to run in under 3 minutes.
+
+The fast, offline **unit tests** for the harness CLI/runner logic
+([`tests/`](./tests)) *are* in `nix flake check` as `e2e-harness-unit` (and
+`task test:e2e:unit`); they never touch the network or a cluster.
+
+Automated scenario coverage runs on a **nightly** schedule, not on pull requests
+— [`.github/workflows/e2e-nightly.yml`](../../.github/workflows/e2e-nightly.yml):
+
+- Triggers on `schedule` (04:00 UTC) and manual `workflow_dispatch`. Never on PRs.
+- Runs the full catalog as a matrix over both modes (`--mode local --all` and
+  `--mode kubernetes --all`, Kind on the ubuntu runner), `fail-fast: false` so
+  one mode failing does not cancel the other.
+- **Commit dedup:** a `gate` job records the last successfully-tested `main` SHA
+  in an `actions/cache` key (`e2e-nightly-tested-<sha>`) and skips the run when
+  `main` has not advanced, so the same commit is never tested two nights running.
+  The SHA is recorded only after a fully successful run, so a failure retries on
+  the next schedule. `workflow_dispatch` bypasses the gate and forces a run.
 
 ## Layout
 
@@ -83,9 +109,10 @@ nix/e2e-tests/
   flake-module.nix       packages.e2e + apps.e2e (writeShellApplication)
   config.nix             scenario catalog (shared by both modes)
   src/
-    cli.py               argument parsing (--mode / --scenario / --list)
+    cli.py               argument parsing (--mode / --scenario / --all / --list)
     catalog.py           load + normalize config.nix
-    runner.py            select adapter, manage deps, run phase, report
+    runner.py            select adapter, manage deps, run phase(s), report
+  tests/                 fast offline unit tests (checks.e2e-harness-unit)
     deployment.py        the mode-adapter Protocol
     local.py             LocalDeployment (run.py)
     kubernetes_mode.py   Kubernetes mode (delegates to the backend below)

--- a/nix/e2e-tests/flake-module.nix
+++ b/nix/e2e-tests/flake-module.nix
@@ -45,6 +45,11 @@ _: {
           exec python3 ${./src/cli.py} "$@"
         '';
       };
+      # Fast, offline unit tests for the harness CLI / runner / catalog logic.
+      # Excludes the `catalog` marker (those materialize config.nix via `nix
+      # eval`) and never touches the network or a cluster, so it is cheap enough
+      # to run in `nix flake check` even though the harness scenarios stay out.
+      pytestPython = pkgs.python3.withPackages (ps: with ps; [ pytest ]);
     in
     {
       packages.e2e = e2e;
@@ -53,5 +58,14 @@ _: {
         type = "app";
         program = "${e2e}/bin/e2e";
       };
+
+      checks.e2e-harness-unit = pkgs.runCommandLocal "e2e-harness-unit-tests" { } ''
+        cp -r ${./src} src
+        cp -r ${./tests} tests
+        cp ${./pytest.ini} pytest.ini
+        export PYTHONDONTWRITEBYTECODE=1
+        ${pytestPython}/bin/python -m pytest tests -m "not catalog" -q
+        touch $out
+      '';
     };
 }

--- a/nix/e2e-tests/pytest.ini
+++ b/nix/e2e-tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    catalog: tests that materialize the real config.nix via `nix eval` (slow)

--- a/nix/e2e-tests/src/cli.py
+++ b/nix/e2e-tests/src/cli.py
@@ -3,10 +3,13 @@
 
 Usage:
     e2e --list
-    e2e --mode local|kubernetes --scenario <name> [--verbose]
+    e2e --mode local|kubernetes --scenario <name> [--scenario <name> ...] [--verbose]
+    e2e --mode local|kubernetes --all [--verbose]
 
 ``--mode`` is required for a run and is validated up front. ``--list`` prints
-the scenario catalog and needs no mode.
+the scenario catalog and needs no mode. A run selects scenarios either with one
+or more ``--scenario`` values (repeatable and/or comma-separated) or with
+``--all`` (every catalog scenario); the two are mutually exclusive.
 """
 
 import argparse
@@ -19,8 +22,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="e2e",
         description=(
-            "Unified ncps end-to-end test harness. Runs a scenario from the "
-            "catalog against a local run.py deployment or a Kind/Helm cluster."
+            "Unified ncps end-to-end test harness. Runs one or more scenarios "
+            "from the catalog against a local run.py deployment or a Kind/Helm "
+            "cluster."
         ),
     )
     parser.add_argument(
@@ -30,7 +34,18 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--scenario",
-        help="Name of the catalog scenario to run.",
+        action="append",
+        metavar="NAME[,NAME...]",
+        help=(
+            "Catalog scenario to run. Repeatable, and each value may be a "
+            "comma-separated list. Mutually exclusive with --all."
+        ),
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Run every catalog scenario supporting the chosen mode. "
+        "Mutually exclusive with --scenario.",
     )
     parser.add_argument(
         "--list",
@@ -46,27 +61,42 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _split_scenarios(values):
+    """Flatten repeated/comma-separated --scenario values into a name list."""
+    names = []
+    for value in values or []:
+        names.extend(part.strip() for part in value.split(",") if part.strip())
+    return names
+
+
 def main(argv=None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    # --list short-circuits; it needs neither --mode nor --scenario.
+    # --list short-circuits; it needs neither --mode nor a selection.
     if args.list:
         from catalog import load_catalog, format_catalog_listing
 
         print(format_catalog_listing(load_catalog()))
         return 0
 
-    # A run requires both --mode and --scenario.
+    # A run requires --mode and exactly one of --all / --scenario.
     if args.mode is None:
         parser.error("--mode is required (choose 'local' or 'kubernetes') unless --list is given")
-    if args.scenario is None:
-        parser.error("--scenario is required unless --list is given")
+    if args.all and args.scenario:
+        parser.error("--all and --scenario are mutually exclusive")
+    if not args.all and not args.scenario:
+        parser.error("one of --scenario or --all is required unless --list is given")
 
-    from runner import run_scenario
+    # None means "every scenario"; otherwise the explicit, flattened list.
+    scenario_names = None if args.all else _split_scenarios(args.scenario)
 
-    return run_scenario(mode=args.mode, scenario_name=args.scenario, verbose=args.verbose)
+    import runner
+
+    return runner.run_scenarios(
+        mode=args.mode, scenario_names=scenario_names, verbose=args.verbose
+    )
 
 
 if __name__ == "__main__":

--- a/nix/e2e-tests/src/runner.py
+++ b/nix/e2e-tests/src/runner.py
@@ -1,15 +1,38 @@
 """Scenario runner: select adapter, manage deps, run the phase, report, teardown.
 
 Reports PASS / FAIL / SKIP uniformly and exits non-zero on any failure. SKIP is
-returned (exit 0) when the scenario's topology is unsupported in the chosen mode
-— never reported as PASS. Dependencies the harness starts are always torn down.
+reported (and does not fail the run) when a scenario's topology is unsupported in
+the chosen mode — never reported as PASS. A single invocation may run one
+scenario, an explicit set, or every catalog scenario (`run_scenarios`).
+Dependencies the harness starts are always torn down.
 """
 
 from __future__ import annotations
 
-from catalog import find_scenario
+from catalog import find_scenario, load_catalog
 from harness_config import AssertionFailure, G, R, Y, log, section
 from phases import get_phase
+
+
+def _execute(scenario, mode: str, verbose: bool) -> str:
+    """Run one scenario in one mode, returning 'PASS' | 'FAIL' | 'SKIP'."""
+    # SKIP (not FAIL, not PASS) when the topology can't be expressed in this mode.
+    if not scenario.supports(mode):
+        log(
+            f"SKIP {scenario.name} [{mode}]: topology unsupported in this mode "
+            f"(supported modes: {', '.join(scenario.modes)})",
+            Y,
+        )
+        return "SKIP"
+
+    if mode == "local":
+        rc = _run_local(scenario, verbose)
+    elif mode == "kubernetes":
+        rc = _run_kubernetes(scenario, verbose)
+    else:
+        log(f"unknown mode: {mode}", R)
+        return "FAIL"
+    return "PASS" if rc == 0 else "FAIL"
 
 
 def run_scenario(*, mode: str, scenario_name: str, verbose: bool = False) -> int:
@@ -19,21 +42,52 @@ def run_scenario(*, mode: str, scenario_name: str, verbose: bool = False) -> int
         log(str(e), R)
         return 2
 
-    # SKIP (not FAIL, not PASS) when the topology can't be expressed in this mode.
-    if not scenario.supports(mode):
-        log(
-            f"SKIP {scenario.name} [{mode}]: topology unsupported in this mode "
-            f"(supported modes: {', '.join(scenario.modes)})",
-            Y,
-        )
-        return 0
+    status = _execute(scenario, mode, verbose)
+    # SKIP and PASS both exit 0; only FAIL is non-zero.
+    return 1 if status == "FAIL" else 0
 
-    if mode == "local":
-        return _run_local(scenario, verbose)
-    if mode == "kubernetes":
-        return _run_kubernetes(scenario, verbose)
-    log(f"unknown mode: {mode}", R)
-    return 2
+
+def run_scenarios(*, mode: str, scenario_names, verbose: bool = False) -> int:
+    """Run a set of scenarios in one invocation and aggregate the result.
+
+    ``scenario_names`` is ``None`` to run every catalog scenario, or an explicit
+    list of names. Prints a per-scenario summary and returns non-zero iff any
+    selected scenario FAILED (a SKIP never fails the run).
+    """
+    catalog = load_catalog()
+
+    if scenario_names is None:
+        selected = list(catalog)
+    else:
+        selected = []
+        for name in scenario_names:
+            try:
+                selected.append(find_scenario(name, catalog))
+            except KeyError as e:
+                log(str(e), R)
+                return 2
+
+    results = []
+    for scenario in selected:
+        status = _execute(scenario, mode, verbose)
+        results.append((scenario.name, status))
+
+    _print_summary(mode, results)
+    return 1 if any(status == "FAIL" for _, status in results) else 0
+
+
+def _print_summary(mode: str, results) -> None:
+    section(f"SUMMARY [{mode}] — {len(results)} scenario(s)")
+    color = {"PASS": G, "FAIL": R, "SKIP": Y}
+    for name, status in results:
+        log(f"  {status:4} {name}", color.get(status, R))
+    passed = sum(1 for _, s in results if s == "PASS")
+    failed = sum(1 for _, s in results if s == "FAIL")
+    skipped = sum(1 for _, s in results if s == "SKIP")
+    log(
+        f"  totals: {passed} passed, {failed} failed, {skipped} skipped",
+        R if failed else G,
+    )
 
 
 def _run_local(scenario, verbose: bool) -> int:

--- a/nix/e2e-tests/tests/conftest.py
+++ b/nix/e2e-tests/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Pytest configuration for the unified e2e harness unit tests.
+
+Puts the harness ``src/`` on ``sys.path`` so tests import the harness modules
+(``cli``, ``runner``, ``catalog``) directly, and points ``CONFIG_FILE`` at the
+real scenario catalog so catalog tests materialize it via ``nix eval``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.join(os.path.dirname(_HERE), "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+# Default the catalog path for tests that load the real config.nix.
+os.environ.setdefault(
+    "CONFIG_FILE", os.path.join(os.path.dirname(_HERE), "config.nix")
+)

--- a/nix/e2e-tests/tests/test_cli.py
+++ b/nix/e2e-tests/tests/test_cli.py
@@ -1,0 +1,85 @@
+"""Unit tests for the harness CLI argument parsing and selection routing."""
+
+from __future__ import annotations
+
+import pytest
+
+import cli
+
+
+def test_scenario_is_repeatable():
+    args = cli.build_parser().parse_args(
+        ["--mode", "local", "--scenario", "a", "--scenario", "b"]
+    )
+    assert args.scenario == ["a", "b"]
+
+
+def test_scenario_comma_split():
+    args = cli.build_parser().parse_args(["--mode", "local", "--scenario", "a,b,c"])
+    assert cli._split_scenarios(args.scenario) == ["a", "b", "c"]
+
+
+def test_split_scenarios_flattens_and_trims():
+    assert cli._split_scenarios(["a, b", "c"]) == ["a", "b", "c"]
+    assert cli._split_scenarios(None) == []
+
+
+def test_all_flag_present():
+    args = cli.build_parser().parse_args(["--mode", "local", "--all"])
+    assert args.all is True
+
+
+def test_all_and_scenario_are_mutually_exclusive(capsys):
+    with pytest.raises(SystemExit):
+        cli.main(["--mode", "local", "--all", "--scenario", "a"])
+
+
+def test_run_requires_a_selection(capsys):
+    # --mode given but neither --scenario nor --all.
+    with pytest.raises(SystemExit):
+        cli.main(["--mode", "local"])
+
+
+def test_all_routes_to_run_scenarios_with_none(monkeypatch):
+    captured = {}
+
+    def fake_run_scenarios(*, mode, scenario_names, verbose=False):
+        captured["mode"] = mode
+        captured["names"] = scenario_names
+        return 0
+
+    import runner
+
+    monkeypatch.setattr(runner, "run_scenarios", fake_run_scenarios)
+    rc = cli.main(["--mode", "kubernetes", "--all"])
+    assert rc == 0
+    assert captured["mode"] == "kubernetes"
+    assert captured["names"] is None  # None == "every scenario"
+
+
+def test_explicit_scenarios_route_as_list(monkeypatch):
+    captured = {}
+
+    def fake_run_scenarios(*, mode, scenario_names, verbose=False):
+        captured["names"] = scenario_names
+        return 0
+
+    import runner
+
+    monkeypatch.setattr(runner, "run_scenarios", fake_run_scenarios)
+    cli.main(["--mode", "local", "--scenario", "a,b", "--scenario", "c"])
+    assert captured["names"] == ["a", "b", "c"]
+
+
+def test_single_scenario_still_works(monkeypatch):
+    captured = {}
+
+    def fake_run_scenarios(*, mode, scenario_names, verbose=False):
+        captured["names"] = scenario_names
+        return 0
+
+    import runner
+
+    monkeypatch.setattr(runner, "run_scenarios", fake_run_scenarios)
+    cli.main(["--mode", "local", "--scenario", "cdc-lifecycle"])
+    assert captured["names"] == ["cdc-lifecycle"]

--- a/nix/e2e-tests/tests/test_runner.py
+++ b/nix/e2e-tests/tests/test_runner.py
@@ -1,0 +1,89 @@
+"""Unit tests for multi-scenario aggregation in the runner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+import runner
+
+
+@dataclass
+class _FakeScenario:
+    name: str
+    modes: List[str]
+
+    def supports(self, mode: str) -> bool:
+        return mode in self.modes
+
+
+def _fake_catalog():
+    return [
+        _FakeScenario("alpha", ["local", "kubernetes"]),
+        _FakeScenario("bravo", ["local", "kubernetes"]),
+        _FakeScenario("charlie", ["kubernetes"]),  # local-unsupported
+    ]
+
+
+def _patch(monkeypatch, statuses):
+    """Patch catalog + per-scenario execution; statuses maps name -> result."""
+    monkeypatch.setattr(runner, "load_catalog", _fake_catalog)
+
+    def fake_execute(scenario, mode, verbose):
+        return statuses[scenario.name]
+
+    monkeypatch.setattr(runner, "_execute", fake_execute)
+
+
+def test_all_selects_every_scenario(monkeypatch):
+    seen = []
+    monkeypatch.setattr(runner, "load_catalog", _fake_catalog)
+
+    def fake_execute(scenario, mode, verbose):
+        seen.append(scenario.name)
+        return "PASS"
+
+    monkeypatch.setattr(runner, "_execute", fake_execute)
+    rc = runner.run_scenarios(mode="kubernetes", scenario_names=None)
+    assert rc == 0
+    assert seen == ["alpha", "bravo", "charlie"]
+
+
+def test_explicit_names_run_only_those(monkeypatch):
+    seen = []
+    monkeypatch.setattr(runner, "load_catalog", _fake_catalog)
+
+    def fake_execute(scenario, mode, verbose):
+        seen.append(scenario.name)
+        return "PASS"
+
+    monkeypatch.setattr(runner, "_execute", fake_execute)
+    rc = runner.run_scenarios(mode="local", scenario_names=["alpha", "bravo"])
+    assert rc == 0
+    assert seen == ["alpha", "bravo"]
+
+
+def test_any_failure_makes_exit_nonzero(monkeypatch):
+    _patch(monkeypatch, {"alpha": "PASS", "bravo": "FAIL", "charlie": "SKIP"})
+    rc = runner.run_scenarios(mode="kubernetes", scenario_names=None)
+    assert rc == 1
+
+
+def test_skip_alone_is_success(monkeypatch):
+    _patch(monkeypatch, {"alpha": "PASS", "bravo": "SKIP", "charlie": "SKIP"})
+    rc = runner.run_scenarios(mode="kubernetes", scenario_names=None)
+    assert rc == 0
+
+
+def test_unknown_name_fails_fast(monkeypatch):
+    monkeypatch.setattr(runner, "load_catalog", _fake_catalog)
+    rc = runner.run_scenarios(mode="local", scenario_names=["nope"])
+    assert rc == 2
+
+
+def test_summary_lists_each_result(monkeypatch, capsys):
+    _patch(monkeypatch, {"alpha": "PASS", "bravo": "FAIL", "charlie": "SKIP"})
+    runner.run_scenarios(mode="kubernetes", scenario_names=None)
+    out = capsys.readouterr().out
+    assert "alpha" in out and "bravo" in out and "charlie" in out
+    assert "PASS" in out and "FAIL" in out and "SKIP" in out

--- a/openspec/changes/archive/2026-06-09-e2e-multi-scenario-nightly/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-09-e2e-multi-scenario-nightly/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-09

--- a/openspec/changes/archive/2026-06-09-e2e-multi-scenario-nightly/design.md
+++ b/openspec/changes/archive/2026-06-09-e2e-multi-scenario-nightly/design.md
@@ -1,0 +1,113 @@
+## Context
+
+The unified e2e harness (`nix/e2e-tests/`) runs one scenario in one mode per
+invocation. Its two backends are asymmetric:
+
+- **local mode** drives ncps through `dev-scripts/run.py` behind a clean
+  `Deployment` protocol (`replica_urls`, `client`, `restart`, `run_subcommand`,
+  `db`, `logs`). The feature phases (`serve`, `cdc-lifecycle`,
+  `staging-contention`) are written against this protocol only.
+- **kubernetes mode** (`kubernetes_mode.py`) does *not* use that protocol. It
+  delegates to `K8sTestsCLI` + `NCPSTester` (`k8s_tests_tester.py`), a separate
+  validation body that port-forwards, asserts serve + DB/storage invariants, and
+  runs an in-cluster CDC-lifecycle topology check for HA permutations.
+
+Because the phase drivers bind to `Deployment` and no `KubernetesDeployment`
+exists, `cdc-lifecycle` and `staging-contention` are pinned `modes = ["local"]`
+in `config.nix`. Nothing runs the catalog on a schedule.
+
+This change adds multi-scenario selection, lifts those pins by giving the phase
+drivers a kubernetes substrate, and adds a nightly CI workflow with
+commit-dedup.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One invocation can run many scenarios (`--all`, repeatable/comma `--scenario`)
+  with per-scenario PASS/FAIL/SKIP and an aggregate non-zero-on-any-failure exit.
+- A nightly workflow runs the full catalog as a `local`+`kubernetes` matrix and
+  skips when `main` is unchanged since the last successful run.
+
+**Non-Goals:**
+- Lifting the `cdc-lifecycle` / `staging-contention` local-only pins — **deferred
+  to a follow-up change** (see D2; it needs new k8s plumbing out of scope here).
+- Intra-process scenario parallelism (the CI matrix parallelizes at job level).
+- Promoting any scenario into `nix flake check` (only a fast offline harness unit
+  check is added).
+- New scenarios or changed phase assertions.
+
+## Decisions
+
+### D1 — Multi-scenario selection in the runner, not per scenario
+`--scenario` becomes `action="append"` and each value is comma-split; add
+`--all`. `--all` and `--scenario` are mutually exclusive. A new
+`run_scenarios(mode, names, …)` resolves the set (for `--all`: every catalog
+scenario; unknown names still fail fast), runs each via the existing
+single-scenario path, prints a final summary table, and returns `0` only if
+none FAILED (SKIP is not a failure). Single `--scenario <name>` is unchanged.
+*Alternative rejected:* a shell `for` loop in the Nix wrapper — loses unified
+reporting and the shared catalog load.
+
+### D2 — Lift the pins with a real `KubernetesDeployment` adapter — DEFERRED
+**Status: carved out into a follow-up change.** The intended approach is a
+`KubernetesDeployment(Deployment)` so the **same** phase drivers run on Kind,
+with the seams mapped onto `K8sTestsCLI` + the kubernetes client:
+- `provision()` → `cmd_cluster_create` + `cmd_generate` + `cmd_install`.
+- `replica_urls()` → per-pod `kubectl port-forward` (the tester only forwards the
+  Service; staging-contention needs per-replica addressing).
+- `logs(i)` → `kubectl logs` of replica `i`.
+- `restart()/stop()/start()` → ConfigMap CDC enable/disable toggle + `kubectl
+  rollout restart` + wait-ready.
+- `run_subcommand()` → `kubectl exec` (drain).
+- `db()` → a new per-dialect in-cluster path: **sqlite via `kubectl exec`** and
+  pg/mysql via port-forward.
+
+*Why deferred:* implementation discovery showed the seams are **not** all already
+present. NCPSTester can only *disable* CDC (no enable/lazy toggle), forwards only
+the Service (no per-pod addressing), and has no direct `db()` the phase drivers
+can call — the single-instance `cdc-lifecycle` is sqlite-in-a-pod-PVC, so its DB
+invariants need a sqlite-via-exec path that does not exist. That is substantial
+new plumbing plus long Kind verification cycles (the `staging-contention`
+scenario pulls `gcc-unwrapped`, several hundred MiB, per window). Splitting it
+out lets the verified multi-scenario + nightly work ship now. When the follow-up
+lands it will drop the `modes = ["local"]` pins in `config.nix`; until then the
+nightly `--mode kubernetes --all` leg SKIPs those two scenarios.
+
+### D3 — Nightly workflow with cache-keyed commit dedup
+New `.github/workflows/e2e-nightly.yml`: `schedule` (cron, nightly) +
+`workflow_dispatch`. A `gate` job resolves the current `main` SHA and probes an
+`actions/cache` entry keyed by that SHA (`e2e-nightly-tested-<sha>`); on a cache
+**hit** it sets `skip=true` and the matrix jobs are skipped. After a fully
+successful matrix run, a final job *writes* that cache key, recording the tested
+SHA so the next night short-circuits. `workflow_dispatch` can force a run
+(bypass the gate).
+*Alternatives rejected:* committing a SHA file back to the repo (needs write
+perms, noisy history); a git tag/note (same perms); querying `gh run list` for
+the last green SHA (works, but cache is simpler and needs no token scope).
+*Matrix:* over `mode ∈ {local, kubernetes}`; each leg runs `nix run .#e2e --
+--mode <mode> --all`. Kind runs on the `ubuntu` runner.
+
+## Risks / Trade-offs
+
+- **Kind flake/runtime on CI** → matrix isolates the kubernetes leg; a failing
+  k8s leg does not mask the local leg; nightly cadence absorbs slowness.
+- **`actions/cache` eviction (7-day / size LRU) re-runs an already-tested SHA**
+  → acceptable: worst case is one redundant run, never a missed regression.
+- **port-forward flakiness for `replica_urls()`** → bounded retries/readiness
+  waits, mirroring the tester's existing port-forward handling.
+- **Scope creep building the k8s adapter** → reuse `NCPSTester` helpers as the
+  implementation of each seam instead of new code paths.
+- **`--all` masking individual failures** → explicit per-scenario lines plus a
+  summary table; aggregate exit is non-zero if any FAILED.
+
+## Migration Plan
+
+Additive only. CLI change is backward-compatible (single `--scenario` still
+works). No production code, schema, or migration touched. Rollback = revert the
+harness/workflow commits; no deployed state to unwind.
+
+## Open Questions
+
+- Nightly cron hour (pick a low-traffic UTC slot; default 04:00 UTC).
+- Whether to also matrix the kubernetes leg per-scenario if `--all` in one job
+  exceeds the runner time budget — deferred until first nightly timings exist.

--- a/openspec/changes/archive/2026-06-09-e2e-multi-scenario-nightly/proposal.md
+++ b/openspec/changes/archive/2026-06-09-e2e-multi-scenario-nightly/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+The unified e2e harness runs exactly one scenario in one mode per invocation, so
+validating the whole catalog means dozens of manual runs, and the harness has no
+automated coverage at all. Nothing runs the catalog on a schedule, so
+regressions in serving correctness surface only when a developer happens to run a
+scenario.
+
+## What Changes
+
+- Add **multi-scenario selection**: a repeatable/comma-separated `--scenario`
+  and an `--all` flag that runs every catalog scenario supporting the chosen
+  mode. The runner executes each selected scenario, reports per-scenario
+  PASS/FAIL/SKIP, and exits non-zero if any fails. Single `--scenario <name>`
+  behavior is unchanged.
+- Add the harness's **first unit-test net**: fast offline pytest coverage of the
+  CLI/runner logic, wired as a `nix flake check` (`e2e-harness-unit`) and a
+  `task test:e2e:unit` target. (The harness had no tests before.)
+- Add a **nightly GitHub Actions workflow** that runs the full catalog as a
+  matrix over both modes (`local`, `kubernetes` via Kind on the ubuntu runner),
+  using `--all` so every supported scenario is exercised.
+- **Skip redundant runs**: the workflow records the `main` commit SHA it last
+  tested and exits early when `main` is unchanged since the previous run, so the
+  same commit is never e2e-tested two days running.
+
+> **Deferred (follow-up change):** lifting the local-only pins on
+> `cdc-lifecycle` and `staging-contention` so they run in `--mode kubernetes`.
+> Investigation (see `design.md` D2) showed this needs substantial new
+> plumbing — per-pod port-forwarding, a per-dialect in-cluster DB-access path
+> (sqlite-via-exec, pg/mysql-via-port-forward), and a CDC enable/disable
+> ConfigMap toggle — plus long Kind verification cycles. It is carved out so the
+> verified, high-value work here can ship now. The nightly matrix still runs
+> `--mode kubernetes --all`; the two pinned scenarios simply SKIP there until the
+> follow-up lands.
+
+## Capabilities
+
+### New Capabilities
+- `e2e-nightly-ci`: scheduled (nightly) execution of the full e2e catalog as a
+  mode matrix, with last-tested-commit deduplication and manual dispatch.
+
+### Modified Capabilities
+- `unified-e2e-harness`: multi-scenario / `--all` selection across one
+  invocation, with per-scenario PASS/FAIL/SKIP and an aggregate exit code.
+
+## Impact
+
+- **Code**: `nix/e2e-tests/src/cli.py` (arg parsing), `runner.py`
+  (`run_scenarios` loop + aggregate exit code), `nix/e2e-tests/tests/` (new unit
+  tests), `flake-module.nix` (new `e2e-harness-unit` check), `Taskfile.yml` (new
+  unit target). New `.github/workflows/e2e-nightly.yml`.
+- **CI**: net-new nightly job plus a fast offline harness unit check added to
+  `nix flake check`; no change to the per-PR hot path for the harness *scenarios*
+  (those stay opt-in/scheduled). The commit-SHA skip bounds nightly cost to one
+  full run per new `main` commit.
+- **I/O / network / memory**: no change to ncps runtime behavior — this is
+  test-harness and CI orchestration only. Nightly runs pull NARs from upstream
+  and provision Kind, but that load is confined to CI runners, off the per-PR
+  path.
+
+## Non-goals
+
+- Lifting the local-only pins on `cdc-lifecycle` / `staging-contention`
+  (deferred to a follow-up change, per the note above).
+- Promoting any harness *scenario* into `nix flake check` (the sub-3-minute bar
+  is unchanged; the scenarios stay manual/scheduled — only the new offline unit
+  check is added to flake check).
+- Parallelizing scenarios within a single harness process (the matrix
+  parallelizes at the GitHub Actions job level).
+- Adding new test scenarios or changing what any existing phase asserts.
+- Changing ncps production behavior, storage, or database semantics.

--- a/openspec/changes/archive/2026-06-09-e2e-multi-scenario-nightly/specs/e2e-nightly-ci/spec.md
+++ b/openspec/changes/archive/2026-06-09-e2e-multi-scenario-nightly/specs/e2e-nightly-ci/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Scheduled nightly e2e execution
+
+The repository SHALL provide a GitHub Actions workflow that runs the full unified e2e catalog on a nightly schedule. The workflow MUST be triggered by `schedule` (cron) and MUST run the harness with `--all` so every catalog scenario supporting the leg's mode is exercised. It MUST NOT run on pull requests and MUST NOT be part of `nix flake check`, keeping the harness off the per-PR hot path.
+
+#### Scenario: Nightly cron triggers the full catalog
+
+- **WHEN** the nightly schedule fires
+- **THEN** the workflow runs `nix run .#e2e -- --mode <mode> --all` for each matrix leg, reporting per-scenario PASS/FAIL/SKIP
+
+#### Scenario: The workflow never runs on pull requests
+
+- **WHEN** a pull request is opened or updated
+- **THEN** the nightly e2e workflow does not run and `nix flake check` does not invoke it
+
+### Requirement: Mode matrix coverage
+
+The workflow SHALL run the catalog as a matrix over the harness modes `local` and `kubernetes`. Each leg MUST run independently so a failure in one mode does not prevent the other mode's results from being produced, and the kubernetes leg MUST provision its Kind cluster on the runner.
+
+#### Scenario: Both modes run as independent legs
+
+- **WHEN** the nightly workflow executes
+- **THEN** it runs a `local` leg and a `kubernetes` leg as separate matrix jobs, each reporting its own result
+
+#### Scenario: One mode failing does not cancel the other
+
+- **WHEN** the `kubernetes` leg fails
+- **THEN** the `local` leg still runs to completion and reports its own PASS/FAIL
+
+### Requirement: Commit-tested deduplication
+
+The workflow SHALL record the `main` commit SHA it last successfully tested and SHALL skip a scheduled run when `main` has not advanced since that recorded SHA, so the same commit is never e2e-tested on two consecutive scheduled runs. The recorded SHA MUST only be written after a fully successful run, so a failed run does not suppress a retry on the next schedule.
+
+#### Scenario: Unchanged main skips the run
+
+- **WHEN** the scheduled workflow resolves the current `main` SHA and finds it equals the last successfully-tested SHA
+- **THEN** the matrix legs are skipped and the run records no new test work
+
+#### Scenario: Advanced main runs and records the new SHA
+
+- **WHEN** `main` has advanced since the last recorded SHA and the matrix legs all pass
+- **THEN** the workflow runs the catalog and records the newly-tested SHA for the next schedule to compare against
+
+#### Scenario: A failed run does not record the SHA
+
+- **WHEN** a scheduled run executes but at least one matrix leg fails
+- **THEN** the last-tested SHA is left unchanged so the next schedule re-attempts the same commit
+
+### Requirement: Manual dispatch override
+
+The workflow SHALL be manually triggerable via `workflow_dispatch`, and a manual trigger MUST bypass the commit-tested deduplication so an operator can force a full run against the current `main` regardless of whether it changed.
+
+#### Scenario: Manual dispatch forces a run
+
+- **WHEN** an operator triggers the workflow via `workflow_dispatch`
+- **THEN** the matrix legs run even if `main` is unchanged since the last recorded SHA

--- a/openspec/changes/archive/2026-06-09-e2e-multi-scenario-nightly/specs/unified-e2e-harness/spec.md
+++ b/openspec/changes/archive/2026-06-09-e2e-multi-scenario-nightly/specs/unified-e2e-harness/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Multi-scenario selection in one invocation
+
+The harness SHALL run more than one scenario from a single invocation. It MUST accept `--scenario` more than once and MUST accept a comma-separated list as a single value; it MUST also accept an `--all` flag that selects every catalog scenario. `--all` and an explicit `--scenario` set MUST be mutually exclusive. For each selected scenario the harness MUST report PASS, FAIL, or SKIP individually, print an aggregate summary, and exit non-zero if any selected scenario FAILED. A SKIP (topology unsupported in the chosen mode) MUST NOT, on its own, cause a non-zero exit. A single `--scenario <name>` invocation MUST behave exactly as before.
+
+#### Scenario: --all runs every catalog scenario for the mode
+
+- **WHEN** the harness is invoked with `--mode <mode> --all`
+- **THEN** it runs every catalog scenario, reporting each as PASS/FAIL/SKIP, where scenarios whose topology the mode cannot express are SKIPPED rather than run
+
+#### Scenario: Multiple --scenario values run each selected scenario
+
+- **WHEN** the harness is invoked with `--mode <mode> --scenario a --scenario b` (or `--scenario a,b`)
+- **THEN** it runs scenarios `a` and `b` and no others, reporting a result for each
+
+#### Scenario: Aggregate exit reflects any failure
+
+- **WHEN** a multi-scenario run completes with at least one scenario reporting FAIL
+- **THEN** the harness prints a summary listing each scenario's result and exits non-zero
+
+#### Scenario: --all and explicit --scenario together is rejected
+
+- **WHEN** the harness is invoked with both `--all` and one or more `--scenario` values
+- **THEN** it exits non-zero with a usage error and runs nothing

--- a/openspec/changes/archive/2026-06-09-e2e-multi-scenario-nightly/tasks.md
+++ b/openspec/changes/archive/2026-06-09-e2e-multi-scenario-nightly/tasks.md
@@ -1,0 +1,34 @@
+## 1. Multi-scenario selection (CLI + runner)
+
+- [x] 1.1 Write failing tests for `cli.build_parser`: `--scenario` is repeatable (`action="append"`), comma values split, `--all` flag present, and `--all` + `--scenario` together is a usage error
+- [x] 1.2 Write failing tests for a new `runner.run_scenarios(mode, names, verbose)`: resolves `--all` to every catalog scenario, runs each, aggregates exit code (non-zero iff any FAIL, SKIP alone is zero), and prints a per-scenario summary
+- [x] 1.3 Update `cli.py`: make `--scenario` `action="append"`, add `--all`, comma-split values, enforce mutual exclusion, and route to `run_scenarios`
+- [x] 1.4 Add `runner.run_scenarios` wrapping the existing single-scenario path; keep `run_scenario` for the single case; emit the summary table
+- [x] 1.5 Confirm single `--scenario <name>` behavior is unchanged (regression test) and `--list` still works
+- [x] 1.6 Update `nix/e2e-tests/README.md` usage section with `--all` and repeatable `--scenario`
+
+Note: also added `checks.e2e-harness-unit` (flake check) and `task test:e2e:unit` so the harness now has a reproducible offline unit-test net (it had none).
+
+## 2. Nightly workflow with commit dedup
+
+- [x] 2.1 Add `.github/workflows/e2e-nightly.yml` with `schedule` (04:00 UTC cron) and `workflow_dispatch` triggers; no `pull_request`/`push` triggers
+- [x] 2.2 Add a `gate` job: resolve current `main` SHA, probe an `actions/cache` key `e2e-nightly-tested-<sha>`; output `skip=true` on cache hit, `skip=false` on miss or `workflow_dispatch`
+- [x] 2.3 Add the matrix job over `mode ∈ {local, kubernetes}` gated on `needs.gate.outputs.skip != 'true'`, with `fail-fast: false`, each leg running `nix run .#e2e -- --mode <mode> --all` (Cachix/Nix setup mirroring `ci.yml`)
+- [x] 2.4 Add a final `record` job (needs all matrix legs, runs only if all succeeded) that writes the `e2e-nightly-tested-<sha>` cache key so the next schedule short-circuits
+- [x] 2.5 Validate the workflow YAML with `actionlint`
+- [x] 2.6 Document the nightly workflow and the commit-dedup behavior in `nix/e2e-tests/README.md` (CI section)
+
+## 3. Verification
+
+- [x] 3.1 `task fmt` and `task lint` clean (including the harness Python and workflow YAML)
+- [x] 3.2 `task test` (Go unit tests) green — no production code touched, confirm no regressions
+- [x] 3.3 Harness unit check green: `nix build .#checks.<system>.e2e-harness-unit`
+- [x] 3.4 Local-mode smoke: `nix run .#e2e -- --list` and a single-scenario run still behave; multi-scenario selection parses (covered by unit tests)
+- [x] 3.5 `openspec validate e2e-multi-scenario-nightly --strict` passes
+
+## Deferred (follow-up change)
+
+The kubernetes pin-lift (`KubernetesDeployment` adapter; running `cdc-lifecycle`
+and `staging-contention` in `--mode kubernetes`) is carved out — see `design.md`
+D2 and the proposal's deferred note. Tracked for a dedicated follow-up where the
+slow Kind verification can iterate.

--- a/openspec/specs/e2e-nightly-ci/spec.md
+++ b/openspec/specs/e2e-nightly-ci/spec.md
@@ -1,0 +1,67 @@
+# e2e-nightly-ci
+
+## Purpose
+
+Scheduled (nightly) automated coverage of the unified e2e harness catalog,
+keeping the harness scenarios off the per-PR hot path while still exercising them
+regularly. Runs the full catalog as a matrix over both harness modes and skips
+runs for a `main` commit that has already been tested, so the same commit is
+never e2e-tested on two consecutive scheduled runs.
+
+## Requirements
+
+### Requirement: Scheduled nightly e2e execution
+
+The repository SHALL provide a GitHub Actions workflow that runs the full unified e2e catalog on a nightly schedule. The workflow MUST be triggered by `schedule` (cron) and MUST run the harness with `--all` so every catalog scenario supporting the leg's mode is exercised. It MUST NOT run on pull requests and MUST NOT be part of `nix flake check`, keeping the harness off the per-PR hot path.
+
+#### Scenario: Nightly cron triggers the full catalog
+
+- **WHEN** the nightly schedule fires
+- **THEN** the workflow runs `nix run .#e2e -- --mode <mode> --all` for each matrix leg, reporting per-scenario PASS/FAIL/SKIP
+
+#### Scenario: The workflow never runs on pull requests
+
+- **WHEN** a pull request is opened or updated
+- **THEN** the nightly e2e workflow does not run and `nix flake check` does not invoke it
+
+### Requirement: Mode matrix coverage
+
+The workflow SHALL run the catalog as a matrix over the harness modes `local` and `kubernetes`. Each leg MUST run independently so a failure in one mode does not prevent the other mode's results from being produced, and the kubernetes leg MUST provision its Kind cluster on the runner.
+
+#### Scenario: Both modes run as independent legs
+
+- **WHEN** the nightly workflow executes
+- **THEN** it runs a `local` leg and a `kubernetes` leg as separate matrix jobs, each reporting its own result
+
+#### Scenario: One mode failing does not cancel the other
+
+- **WHEN** the `kubernetes` leg fails
+- **THEN** the `local` leg still runs to completion and reports its own PASS/FAIL
+
+### Requirement: Commit-tested deduplication
+
+The workflow SHALL record the `main` commit SHA it last successfully tested and SHALL skip a scheduled run when `main` has not advanced since that recorded SHA, so the same commit is never e2e-tested on two consecutive scheduled runs. The recorded SHA MUST only be written after a fully successful run, so a failed run does not suppress a retry on the next schedule.
+
+#### Scenario: Unchanged main skips the run
+
+- **WHEN** the scheduled workflow resolves the current `main` SHA and finds it equals the last successfully-tested SHA
+- **THEN** the matrix legs are skipped and the run records no new test work
+
+#### Scenario: Advanced main runs and records the new SHA
+
+- **WHEN** `main` has advanced since the last recorded SHA and the matrix legs all pass
+- **THEN** the workflow runs the catalog and records the newly-tested SHA for the next schedule to compare against
+
+#### Scenario: A failed run does not record the SHA
+
+- **WHEN** a scheduled run executes but at least one matrix leg fails
+- **THEN** the last-tested SHA is left unchanged so the next schedule re-attempts the same commit
+
+### Requirement: Manual dispatch override
+
+The workflow SHALL be manually triggerable via `workflow_dispatch`, and a manual trigger MUST bypass the commit-tested deduplication so an operator can force a full run against the current `main` regardless of whether it changed.
+
+#### Scenario: Manual dispatch forces a run
+
+- **WHEN** an operator triggers the workflow via `workflow_dispatch`
+- **THEN** the matrix legs run even if `main` is unchanged since the last recorded SHA

--- a/openspec/specs/unified-e2e-harness/spec.md
+++ b/openspec/specs/unified-e2e-harness/spec.md
@@ -55,6 +55,30 @@ The harness SHALL define its scenarios declaratively in a single catalog. Each s
 - **WHEN** `--scenario <name>` names an entry absent from the catalog
 - **THEN** the harness exits non-zero with an error listing valid scenario names
 
+### Requirement: Multi-scenario selection in one invocation
+
+The harness SHALL run more than one scenario from a single invocation. It MUST accept `--scenario` more than once and MUST accept a comma-separated list as a single value; it MUST also accept an `--all` flag that selects every catalog scenario. `--all` and an explicit `--scenario` set MUST be mutually exclusive. For each selected scenario the harness MUST report PASS, FAIL, or SKIP individually, print an aggregate summary, and exit non-zero if any selected scenario FAILED. A SKIP (topology unsupported in the chosen mode) MUST NOT, on its own, cause a non-zero exit. A single `--scenario <name>` invocation MUST behave exactly as before.
+
+#### Scenario: --all runs every catalog scenario for the mode
+
+- **WHEN** the harness is invoked with `--mode <mode> --all`
+- **THEN** it runs every catalog scenario, reporting each as PASS/FAIL/SKIP, where scenarios whose topology the mode cannot express are SKIPPED rather than run
+
+#### Scenario: Multiple --scenario values run each selected scenario
+
+- **WHEN** the harness is invoked with `--mode <mode> --scenario a --scenario b` (or `--scenario a,b`)
+- **THEN** it runs scenarios `a` and `b` and no others, reporting a result for each
+
+#### Scenario: Aggregate exit reflects any failure
+
+- **WHEN** a multi-scenario run completes with at least one scenario reporting FAIL
+- **THEN** the harness prints a summary listing each scenario's result and exits non-zero
+
+#### Scenario: --all and explicit --scenario together is rejected
+
+- **WHEN** the harness is invoked with both `--all` and one or more `--scenario` values
+- **THEN** it exits non-zero with a usage error and runs nothing
+
 ### Requirement: Dependency lifecycle and result reporting
 
 The harness SHALL own the lifecycle of the backing dependencies for the selected mode and report results uniformly. In `local` mode it MUST start the fixed-port backends (`nix run .#deps`: S3/Garage, PostgreSQL, MariaDB, Redis) when they are not already running and stop the ones it started on exit. In `kubernetes` mode it MUST provision the cluster dependencies. It MUST report per-scenario and per-phase PASS/FAIL and MUST exit non-zero if any scenario or phase fails.


### PR DESCRIPTION
## Summary

The unified e2e harness ran exactly one scenario per invocation and had **no automated coverage at all**. This adds multi-scenario selection, the harness's first unit-test net, and a nightly workflow.

- **Multi-scenario selection** — `--scenario` is now repeatable and comma-separated, and a new `--all` runs every catalog scenario supporting the chosen mode. `runner.run_scenarios` reports per-scenario PASS/FAIL/SKIP with an aggregate summary and exits non-zero iff any scenario FAILED (a SKIP alone never fails the run). Single `--scenario <name>` is unchanged.
- **First test net** — fast offline pytest coverage of the CLI/runner logic, wired as the `e2e-harness-unit` flake check and a `task test:e2e:unit` target (the harness had no tests before).
- **Nightly workflow** — `.github/workflows/e2e-nightly.yml` runs the full catalog as a `local`+`kubernetes` matrix (`fail-fast: false`) at 04:00 UTC, plus manual `workflow_dispatch`. A `gate` job records the last successfully-tested `main` SHA in an `actions/cache` key and skips when `main` hasn't advanced, so the same commit is never e2e-tested two nights running. The SHA is recorded only after a fully successful run; manual dispatch bypasses the gate.

## Deferred (follow-up change)

Lifting the `cdc-lifecycle` / `staging-contention` local-only pins onto kubernetes is **carved out**: it needs substantial new k8s plumbing (per-pod port-forward, in-cluster per-dialect DB access, a CDC enable/disable ConfigMap toggle) and long Kind verification cycles. Until then the nightly kubernetes leg SKIPs those two scenarios. See the archived change's `design.md` D2.

## Test plan

- [x] `task fmt`, `task lint`, `task test` (Go, race) all green
- [x] `nix build .#checks.<system>.e2e-harness-unit` green (15 pytest cases)
- [x] `actionlint` clean on the nightly workflow
- [x] `nix run .#e2e -- --list` works via the wrapper
- [ ] First live nightly proves the cache-keyed dedup / matrix / record wiring (can't fire a scheduled workflow pre-merge)

OpenSpec change `e2e-multi-scenario-nightly` archived; main specs `unified-e2e-harness` + new `e2e-nightly-ci` updated.