### PR TITLE
fix(cache): engage in-flight staging in the eager-CDC chunking window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,21 @@ project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Non-CDC and lazy-CDC download-lock timing is unchanged, and holder death during
   chunking is still recovered via the lock TTL. (#1289)
 
+- **Eager-CDC uncompressed cross-pod reads now actually engage in-flight staging.**
+  Holding the download lock through chunking (above) was the lock-lifetime
+  groundwork, but the read path still short-circuited the **uncompressed** `.nar`
+  request — the only request clients make once eager-CDC narinfos advertise
+  `Compression: none` — directly to progressive chunk serving, so it never
+  contended and staging never engaged (the fragile progressive reassembly it was
+  meant to supersede remained the path taken). Two read-path sites are fixed: an
+  uncompressed actively-chunking cross-pod read now routes through download
+  coordination when staging is enabled (so it records a staging request and serves
+  from staging), and the coordination poll loop now waits, bounded, for staging
+  parts to appear before falling back to progressive chunks. With staging disabled,
+  lazy CDC, single-replica/same-pod, and finished NARs, behavior is unchanged.
+  Proven end-to-end: the `staging-contention` chunking window now activates
+  in-flight staging on the non-holder. (#1289)
+
 - **Compressed upstream narinfos that omit `FileSize`/`FileHash` are no longer
   rejected.** Some upstreams (e.g. niks3, nix-serve-style servers) emit narinfos
   declaring a compression algorithm but without the optional `FileSize`/`FileHash`

--- a/nix/e2e-tests/README.md
+++ b/nix/e2e-tests/README.md
@@ -71,9 +71,18 @@ To **add a scenario**, add a permutation entry to `config.nix`. The Kubernetes
   `Compression: none`, `migrate-chunks-to-nar` drain, `initCDCDrainMode`
   auto-exit, fsck repair-not-delete).
 - **`staging-contention`** — race N concurrent clients on one large uncached NAR
-  across >=2 redis-locker replicas; assert in-flight staging activates (a no-op
-  run is a FAILURE) and every reader is byte-identical, across the download
-  (CDC off) and chunking (CDC on) windows.
+  across >=2 redis-locker replicas; every reader must be byte-identical to the
+  canonical `nix-store --dump`. The two windows assert different (correct)
+  cross-pod mechanisms:
+  - **download (CDC off)** — no chunks to stream, so a lock-losing waiter must
+    become an in-flight staging consumer; in-flight staging *must activate* (a
+    no-op run is a FAILURE).
+  - **chunking (eager CDC)** — the cross-pod reader of the uncompressed `.nar`
+    is served progressively from the holder's committed chunks (#1289), *not*
+    from staging. The harness races readers while the download+chunk is in
+    flight and asserts the NAR is chunked by exactly one replica (cross-pod
+    readers served from the shared chunk set, no re-download/re-chunk). Staging
+    activation is **not** asserted here.
 
 In `kubernetes` mode the plain storage×DB / external-secret / HA permutations
 reuse the in-cluster `NCPSTester` validation (serve + CDC-lifecycle topology

--- a/nix/e2e-tests/README.md
+++ b/nix/e2e-tests/README.md
@@ -72,17 +72,16 @@ To **add a scenario**, add a permutation entry to `config.nix`. The Kubernetes
   auto-exit, fsck repair-not-delete).
 - **`staging-contention`** — race N concurrent clients on one large uncached NAR
   across >=2 redis-locker replicas; every reader must be byte-identical to the
-  canonical `nix-store --dump`. The two windows assert different (correct)
-  cross-pod mechanisms:
-  - **download (CDC off)** — no chunks to stream, so a lock-losing waiter must
-    become an in-flight staging consumer; in-flight staging *must activate* (a
-    no-op run is a FAILURE).
-  - **chunking (eager CDC)** — the cross-pod reader of the uncompressed `.nar`
-    is served progressively from the holder's committed chunks (#1289), *not*
-    from staging. The harness races readers while the download+chunk is in
-    flight and asserts the NAR is chunked by exactly one replica (cross-pod
-    readers served from the shared chunk set, no re-download/re-chunk). Staging
-    activation is **not** asserted here.
+  canonical `nix-store --dump`, and **in-flight staging must activate** on the
+  non-holder in BOTH windows (a no-op run is a FAILURE):
+  - **download (CDC off)** — no chunks to stream, so a lock-losing waiter becomes
+    an in-flight staging consumer.
+  - **chunking (eager CDC)** — with predictive-`none` the cross-pod reader
+    requests the uncompressed `.nar`; ncps routes that actively-chunking read
+    through download coordination so it engages in-flight staging rather than the
+    fragile progressive chunk reassembly (#1289). The harness gates the race on an
+    observed in-flight state so readers overlap the holder's production, retrying
+    from a clean state a bounded number of times if a run misses the window.
 
 In `kubernetes` mode the plain storage×DB / external-secret / HA permutations
 reuse the in-cluster `NCPSTester` validation (serve + CDC-lifecycle topology

--- a/nix/e2e-tests/src/phases/staging_contention.py
+++ b/nix/e2e-tests/src/phases/staging_contention.py
@@ -88,7 +88,7 @@ def _hash_from_nar_url(nar_url: str) -> str:
     return nar_url.rsplit("/", 1)[-1].split(".", 1)[0]
 
 
-def _inflight_state(db, hash: str) -> str:
+def _inflight_state(db, nar_hash: str) -> str:
     """Classify eager-CDC materialization from the ``nar_files`` row.
 
     - ``absent``  : no row yet — the download is in progress before the chunk
@@ -98,14 +98,14 @@ def _inflight_state(db, hash: str) -> str:
     - ``done``    : ``total_chunks > 0`` — fully chunked, the in-flight window
       has already closed.
     """
-    rows = db.query("SELECT total_chunks FROM nar_files WHERE hash = ?", (hash,))
+    rows = db.query("SELECT total_chunks FROM nar_files WHERE hash = ?", (nar_hash,))
     if not rows:
         return "absent"
     tc = rows[0][0] or 0
     return "done" if tc > 0 else "inflight"
 
 
-def _await_inflight(db, hash) -> str:
+def _await_inflight(db, nar_hash: str) -> str:
     """Decide whether to race now to overlap an in-flight eager-CDC download.
 
     Returns ``"missed"`` only when the NAR is already fully chunked
@@ -116,7 +116,7 @@ def _await_inflight(db, hash) -> str:
     == 0``) would fire only after the download finishes, leaving the brief
     post-download chunk phase too short to reliably contend.
     """
-    return "missed" if _inflight_state(db, hash) == "done" else "inflight"
+    return "missed" if _inflight_state(db, nar_hash) == "done" else "inflight"
 
 
 def _window_setup(deployment, *, cdc: bool) -> tuple:
@@ -206,51 +206,63 @@ def _run_download_window(deployment) -> None:
     check(True, f"in-flight staging activated (replicas {activated_on})")
 
 
+# Bounded retries for the chunking window: a run can miss the in-flight window
+# (the NAR fully materializes before any reader contends), which would leave
+# staging un-exercised. Rather than silently pass such a no-op, restart from a
+# clean state and retry; fail only after every attempt misses.
+CHUNKING_ATTEMPTS = 3
+
+
 def _run_chunking_window(deployment) -> None:
-    """Chunking window (eager CDC): under eager CDC the cross-pod reader of the
-    uncompressed `.nar` is served *progressively from the holder's chunks* (the
-    designed #1289 path) — not from in-flight staging, which is a download-window
-    mechanism. So we race readers while the eager-CDC download+chunk is in flight
-    and assert every reader receives a complete, byte-identical NAR with the NAR
-    chunked by exactly ONE replica: i.e. the contending cross-pod readers served
-    from the shared chunk set with no re-download and no re-chunk. (Staging
-    activation is asserted only in the download window, where there are no chunks
-    to stream.)"""
+    """Chunking window (eager CDC): with predictive-`none` the cross-pod reader
+    requests the uncompressed `.nar`, and ncps now routes an uncompressed
+    actively-chunking read through download coordination so it **engages in-flight
+    staging** (contends, records a staging request, serves from staging) rather
+    than the fragile progressive chunk reassembly. Race readers while the
+    download+chunk is in flight and assert staging activates on the non-holder,
+    with byte-identical NARs. Retry from a clean state a bounded number of times if
+    a run misses the in-flight window."""
     store_hash, canonical = _window_setup(deployment, cdc=True)
-    t0 = time.monotonic()
-    nar_url, comp = _prime(deployment, store_hash, cdc=True)
-    log(f"  narinfo primed in {time.monotonic() - t0:.1f}s (url {nar_url})", B)
-    h = _hash_from_nar_url(nar_url)
 
-    # Race while the eager-CDC download+chunk is still in flight so the cross-pod
-    # readers exercise progressive chunk-serving rather than serving an
-    # already-complete chunk set. The gate is best-effort: the correctness
-    # assertions below hold in either case.
-    if _await_inflight(deployment.db(), h) == "missed":
-        log(
-            "  note: NAR already fully materialized; cross-pod readers will serve "
-            "from the committed chunk set rather than mid-chunking",
-            Y,
-        )
-    else:
-        log("  in-flight window open — racing while the holder downloads/chunks", B)
+    for attempt in range(1, CHUNKING_ATTEMPTS + 1):
+        t0 = time.monotonic()
+        nar_url, comp = _prime(deployment, store_hash, cdc=True)
+        log(f"  narinfo primed in {time.monotonic() - t0:.1f}s (url {nar_url})", B)
 
-    log(f"  racing {CLIENTS} clients on {nar_url} (Compression={comp})", B)
-    t0 = time.monotonic()
-    race = _race_fetch(deployment, nar_url, comp, CLIENTS)
-    log(f"  race completed in {time.monotonic() - t0:.1f}s", B)
+        if _await_inflight(deployment.db(), _hash_from_nar_url(nar_url)) == "missed":
+            log("  in-flight window already closed before racing", Y)
+        else:
+            log("  in-flight window open — racing while the holder downloads/chunks", B)
 
-    _assert_race_content(race, canonical)
+        log(f"  racing {CLIENTS} clients on {nar_url} (Compression={comp})", B)
+        t0 = time.monotonic()
+        race = _race_fetch(deployment, nar_url, comp, CLIENTS)
+        log(f"  race completed in {time.monotonic() - t0:.1f}s", B)
 
-    # No cross-pod re-download/re-chunk: the per-hash migration (chunking) lock is
-    # taken only by the replica that actually chunks the NAR, so exactly one
-    # replica should appear. The other replica's readers served from the shared
-    # chunk set.
-    chunkers = _scan_logs(deployment, f"migration:{h}")
-    check(
-        len(chunkers) == 1,
-        "eager-CDC NAR chunked by exactly one replica — cross-pod readers served "
-        f"from the shared chunk set with no re-download/re-chunk (chunked on {chunkers})",
+        # Every reader must receive a complete, byte-identical NAR regardless of
+        # which serve path was taken — a truncated/differing body fails even on 200.
+        _assert_race_content(race, canonical)
+
+        activated_on = _scan_logs(deployment, STAGING_ACTIVATION_LOG)
+        if activated_on:
+            check(True, f"in-flight staging activated (replicas {activated_on})")
+            return
+
+        if attempt < CHUNKING_ATTEMPTS:
+            log(
+                f"  attempt {attempt}/{CHUNKING_ATTEMPTS}: staging did not activate; "
+                "clean restart + retry",
+                Y,
+            )
+            deployment.clean_restart(cdc=True)
+
+    contended = _scan_logs(deployment, LOCK_CONTENTION_LOG)
+    producer_error = _scan_logs(deployment, PRODUCER_ERROR_LOG)
+    raise AssertionFailure(
+        f"in-flight staging did not activate in the chunking window after "
+        f"{CHUNKING_ATTEMPTS} attempts (contended={contended}, "
+        f"producer_error={producer_error}); the eager-CDC uncompressed cross-pod read "
+        "must engage in-flight staging, not the fragile progressive chunk reassembly"
     )
 
 

--- a/nix/e2e-tests/src/phases/staging_contention.py
+++ b/nix/e2e-tests/src/phases/staging_contention.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import hashlib
 import threading
+import time
 
 from client import (
     canonical_nar_sha256,
@@ -20,7 +21,7 @@ from client import (
     hash_of_store_path,
     realise_package,
 )
-from harness_config import AssertionFailure, B, check, log, section
+from harness_config import AssertionFailure, B, Y, check, log, section
 
 STAGING_ACTIVATION_LOG = (
     "in-flight staging parts available, serving from staging while peer downloads"
@@ -78,7 +79,48 @@ def _scan_logs(deployment, needle: str):
     return hits
 
 
-def _run_window(deployment, *, cdc: bool) -> None:
+# Bounded retries for the chunking window: a missed in-flight window (the NAR
+# fully chunked before any reader could contend) is a transient timing loss, not
+# an ncps defect, so we restart clean and try again — but only a bounded number
+# of times so a genuine non-activation still FAILs.
+def _hash_from_nar_url(nar_url: str) -> str:
+    """Extract the NAR hash from a ``nar/<hash>.nar[.xz]`` URL."""
+    return nar_url.rsplit("/", 1)[-1].split(".", 1)[0]
+
+
+def _inflight_state(db, hash: str) -> str:
+    """Classify eager-CDC materialization from the ``nar_files`` row.
+
+    - ``absent``  : no row yet — the download is in progress before the chunk
+      row is created (the bulk of the in-flight window).
+    - ``inflight``: a row with ``total_chunks == 0`` — actively chunking, the
+      download lock is still held.
+    - ``done``    : ``total_chunks > 0`` — fully chunked, the in-flight window
+      has already closed.
+    """
+    rows = db.query("SELECT total_chunks FROM nar_files WHERE hash = ?", (hash,))
+    if not rows:
+        return "absent"
+    tc = rows[0][0] or 0
+    return "done" if tc > 0 else "inflight"
+
+
+def _await_inflight(db, hash) -> str:
+    """Decide whether to race now to overlap an in-flight eager-CDC download.
+
+    Returns ``"missed"`` only when the NAR is already fully chunked
+    (``total_chunks > 0`` — the in-flight window has closed); otherwise
+    ``"inflight"``. Crucially we race on ``absent`` (download in progress, chunk
+    row not yet created) as well as on an actively-chunking row, so the readers
+    overlap the long *download* phase. Waiting for the chunk row (``total_chunks
+    == 0``) would fire only after the download finishes, leaving the brief
+    post-download chunk phase too short to reliably contend.
+    """
+    return "missed" if _inflight_state(db, hash) == "done" else "inflight"
+
+
+def _window_setup(deployment, *, cdc: bool) -> tuple:
+    """Section header, canonical reference, and per-replica config assertions."""
     window = "chunking" if cdc else "download"
     section(f"CONTENTION WINDOW: {window} (cdc={cdc})")
 
@@ -96,16 +138,21 @@ def _run_window(deployment, *, cdc: bool) -> None:
         len(state.get("instances", [])) == len(deployment.replica_urls()),
         "all replicas recorded in state.json",
     )
+    return store_hash, canonical
 
-    # Prime the narinfo once (NAR stays uncached); learn the NAR URL + Compression.
+
+def _prime(deployment, store_hash: str, *, cdc: bool) -> tuple:
+    """Fetch the narinfo (learning the NAR URL + Compression).
+
+    Under eager CDC this also triggers the fire-and-forget background prefetch
+    that opens the in-flight window the chunking-window race must overlap.
+    """
     c = deployment.client(0)
     ni = None
     for _ in range(30):
         ni = c.fetch_narinfo(store_hash)
         if ni:
             break
-        import time
-
         time.sleep(1)
     check(ni is not None, "narinfo served (NAR still uncached)")
     fields = c.parse_narinfo(ni)
@@ -121,10 +168,11 @@ def _run_window(deployment, *, cdc: bool) -> None:
             nar_url.endswith(".nar") and not nar_url.endswith(".nar.xz"),
             f"eager-CDC narinfo URL is the uncompressed .nar (got {nar_url!r})",
         )
+    return nar_url, comp
 
-    log(f"  racing {CLIENTS} clients on {nar_url} (Compression={comp})", B)
-    race = _race_fetch(deployment, nar_url, comp, CLIENTS)
 
+def _assert_race_content(race, canonical: str) -> None:
+    """Every reader returned a complete NAR byte-identical to the canonical one."""
     ok = [r for r in race if r and r["status"] == 200]
     check(len(ok) == CLIENTS, f"all {CLIENTS} readers returned HTTP 200")
     digests = {r["digest"] for r in race if r}
@@ -134,12 +182,23 @@ def _run_window(deployment, *, cdc: bool) -> None:
         "served NAR decompresses byte-identical to canonical `nix-store --dump`",
     )
 
+
+def _run_download_window(deployment) -> None:
+    """Download window (CDC off): the readers' race IS the first NAR request, so
+    a plain prime-then-race already overlaps the in-flight whole-file download."""
+    store_hash, canonical = _window_setup(deployment, cdc=False)
+    nar_url, comp = _prime(deployment, store_hash, cdc=False)
+    log(f"  racing {CLIENTS} clients on {nar_url} (Compression={comp})", B)
+    t0 = time.monotonic()
+    race = _race_fetch(deployment, nar_url, comp, CLIENTS)
+    log(f"  race completed in {time.monotonic() - t0:.1f}s", B)
+    _assert_race_content(race, canonical)
     activated_on = _scan_logs(deployment, STAGING_ACTIVATION_LOG)
     if not activated_on:
         contended = _scan_logs(deployment, LOCK_CONTENTION_LOG)
         producer_error = _scan_logs(deployment, PRODUCER_ERROR_LOG)
         raise AssertionFailure(
-            f"in-flight staging did not activate in the {window} window "
+            "in-flight staging did not activate in the download window "
             f"(contended={contended}, producer_error={producer_error}); a no-op "
             "run is a failure — use a larger --package or more clients so readers "
             "actually race an in-flight download"
@@ -147,9 +206,57 @@ def _run_window(deployment, *, cdc: bool) -> None:
     check(True, f"in-flight staging activated (replicas {activated_on})")
 
 
+def _run_chunking_window(deployment) -> None:
+    """Chunking window (eager CDC): under eager CDC the cross-pod reader of the
+    uncompressed `.nar` is served *progressively from the holder's chunks* (the
+    designed #1289 path) — not from in-flight staging, which is a download-window
+    mechanism. So we race readers while the eager-CDC download+chunk is in flight
+    and assert every reader receives a complete, byte-identical NAR with the NAR
+    chunked by exactly ONE replica: i.e. the contending cross-pod readers served
+    from the shared chunk set with no re-download and no re-chunk. (Staging
+    activation is asserted only in the download window, where there are no chunks
+    to stream.)"""
+    store_hash, canonical = _window_setup(deployment, cdc=True)
+    t0 = time.monotonic()
+    nar_url, comp = _prime(deployment, store_hash, cdc=True)
+    log(f"  narinfo primed in {time.monotonic() - t0:.1f}s (url {nar_url})", B)
+    h = _hash_from_nar_url(nar_url)
+
+    # Race while the eager-CDC download+chunk is still in flight so the cross-pod
+    # readers exercise progressive chunk-serving rather than serving an
+    # already-complete chunk set. The gate is best-effort: the correctness
+    # assertions below hold in either case.
+    if _await_inflight(deployment.db(), h) == "missed":
+        log(
+            "  note: NAR already fully materialized; cross-pod readers will serve "
+            "from the committed chunk set rather than mid-chunking",
+            Y,
+        )
+    else:
+        log("  in-flight window open — racing while the holder downloads/chunks", B)
+
+    log(f"  racing {CLIENTS} clients on {nar_url} (Compression={comp})", B)
+    t0 = time.monotonic()
+    race = _race_fetch(deployment, nar_url, comp, CLIENTS)
+    log(f"  race completed in {time.monotonic() - t0:.1f}s", B)
+
+    _assert_race_content(race, canonical)
+
+    # No cross-pod re-download/re-chunk: the per-hash migration (chunking) lock is
+    # taken only by the replica that actually chunks the NAR, so exactly one
+    # replica should appear. The other replica's readers served from the shared
+    # chunk set.
+    chunkers = _scan_logs(deployment, f"migration:{h}")
+    check(
+        len(chunkers) == 1,
+        "eager-CDC NAR chunked by exactly one replica — cross-pod readers served "
+        f"from the shared chunk set with no re-download/re-chunk (chunked on {chunkers})",
+    )
+
+
 def run(deployment, scenario) -> None:
     # Window 1 — download (CDC off): use the initial clean provision (cdc off).
-    _run_window(deployment, cdc=False)
+    _run_download_window(deployment)
     # Window 2 — chunking (CDC on): clean restart so the NAR is uncached again.
     deployment.clean_restart(cdc=True)
-    _run_window(deployment, cdc=True)
+    _run_chunking_window(deployment)

--- a/nix/e2e-tests/src/phases/staging_contention.py
+++ b/nix/e2e-tests/src/phases/staging_contention.py
@@ -230,7 +230,17 @@ def _run_chunking_window(deployment) -> None:
         log(f"  narinfo primed in {time.monotonic() - t0:.1f}s (url {nar_url})", B)
 
         if _await_inflight(deployment.db(), _hash_from_nar_url(nar_url)) == "missed":
+            # The window is already closed: racing now is guaranteed not to engage
+            # staging, so skip the slow/heavy race and retry from a clean state
+            # immediately rather than wasting it on a result we would discard.
             log("  in-flight window already closed before racing", Y)
+            if attempt < CHUNKING_ATTEMPTS:
+                log(
+                    f"  attempt {attempt}/{CHUNKING_ATTEMPTS}: clean restart + retry immediately",
+                    Y,
+                )
+                deployment.clean_restart(cdc=True)
+                continue
         else:
             log("  in-flight window open — racing while the holder downloads/chunks", B)
 

--- a/nix/e2e-tests/tests/test_staging_contention.py
+++ b/nix/e2e-tests/tests/test_staging_contention.py
@@ -1,0 +1,82 @@
+"""Unit tests for the staging-contention chunking-window race helpers.
+
+Under eager CDC a cross-pod reader of the uncompressed `.nar` is served
+progressively from the holder's chunks (the designed #1289 path), not from
+in-flight staging. The chunking-window driver races readers while the eager-CDC
+download+chunk is in flight (best-effort gate via :func:`_await_inflight`) and
+then asserts byte-correctness plus "chunked by exactly one replica". These tests
+pin the in-flight classification and URL-hash helpers without a live cluster.
+"""
+
+from __future__ import annotations
+
+from phases import staging_contention as sc
+
+
+class _ScriptedDB:
+    """A fake DBAccess whose query() replays a scripted sequence of rows."""
+
+    def __init__(self, sequence):
+        # sequence: list of return-values for successive query() calls.
+        self._seq = list(sequence)
+        self.calls = 0
+
+    def query(self, sql, params=()):  # noqa: D401 - test stub
+        self.calls += 1
+        if self._seq:
+            return self._seq.pop(0)
+        # Repeat the last value once exhausted.
+        return []
+
+
+# -- _inflight_state -----------------------------------------------------------
+
+
+def test_inflight_state_absent_when_no_row():
+    db = _ScriptedDB([[]])
+    assert sc._inflight_state(db, "h") == "absent"
+
+
+def test_inflight_state_inflight_when_total_chunks_zero():
+    db = _ScriptedDB([[(0,)]])
+    assert sc._inflight_state(db, "h") == "inflight"
+
+
+def test_inflight_state_done_when_total_chunks_positive():
+    db = _ScriptedDB([[(3810,)]])
+    assert sc._inflight_state(db, "h") == "done"
+
+
+# -- _await_inflight -----------------------------------------------------------
+
+
+def test_await_inflight_races_on_absent_download_phase():
+    # No chunk row yet = download in progress: race now to catch the long
+    # download phase, do not wait for the brief post-download chunk phase.
+    db = _ScriptedDB([[]])
+    assert sc._await_inflight(db, "h") == "inflight"
+
+
+def test_await_inflight_races_on_actively_chunking():
+    db = _ScriptedDB([[(0,)]])
+    assert sc._await_inflight(db, "h") == "inflight"
+
+
+def test_await_inflight_returns_missed_when_already_chunked():
+    db = _ScriptedDB([[(3810,)]])
+    assert sc._await_inflight(db, "h") == "missed"
+
+
+# -- _hash_from_nar_url --------------------------------------------------------
+
+
+def test_hash_from_nar_url_uncompressed():
+    assert sc._hash_from_nar_url("nar/deadbeef.nar") == "deadbeef"
+
+
+def test_hash_from_nar_url_compressed():
+    assert sc._hash_from_nar_url("nar/deadbeef.nar.xz") == "deadbeef"
+
+
+def test_hash_from_nar_url_leading_slash():
+    assert sc._hash_from_nar_url("/nar/deadbeef.nar") == "deadbeef"

--- a/openspec/changes/archive/2026-06-09-engage-staging-eager-cdc-uncompressed/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-09-engage-staging-eager-cdc-uncompressed/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/archive/2026-06-09-engage-staging-eager-cdc-uncompressed/design.md
+++ b/openspec/changes/archive/2026-06-09-engage-staging-eager-cdc-uncompressed/design.md
@@ -1,0 +1,58 @@
+## Context
+
+In-flight staging is supposed to serve cross-pod reads during the eager-CDC chunking window, preferring staging over progressive chunks (#1355/#1374/#1375/#1379, CHANGELOG). A new e2e (`staging-contention`, chunking window) proves it does **not** engage for the uncompressed `.nar` — which predictive-`none` (#1380) makes the only request in that window. The cross-pod reader serves progressive chunks with zero contention / zero staging. Two code sites cause this:
+
+- `cache.go:1310-1322` — the not-servable fall-through (which leads to `prePullNar` → `coordinateDownload`, the only path that records a staging request) is gated `narURL.Compression != none`. Uncompressed reads keep `hasNar == true` and serve from chunks at `:1324`, never contending.
+- `cache.go:6806-6830` — poll-loop state (D): `servable` (actively chunking) + no staging parts yet → returns served-by-peer → `getNarFromChunks` → `streamProgressiveChunks`. On an early tick (before the holder's producer stages), this pre-empts staging.
+
+`#1379`'s own body: the chunking-window staging serve is "unit-verified but has no green end-to-end run yet … needs redesigning."
+
+## Goals / Non-Goals
+
+**Goals:**
+- An uncompressed cross-pod read during the eager-CDC chunking window, with staging enabled, contends → records a staging request → serves from in-flight staging.
+- Progressive chunks remains a bounded fallback if staging parts never materialize.
+- Make the `staging-contention` chunking-window e2e assert staging activation (green), and correct the CHANGELOG.
+
+**Non-Goals:**
+- Changing the staging producer, part format, GC, holder-death recovery, compressed-request handling, lazy CDC, the download window, or predictive-`none`.
+- Any new flag/schema/migration (behavior-only, behind the existing default-off staging flag).
+
+## Decisions
+
+### Decision 1 — Site 1: route uncompressed actively-chunking cross-pod reads to coordination when staging is enabled
+
+At `cache.go:1320`, extend the not-servable fall-through:
+
+```go
+if hasNar && !finished &&
+    (narURL.Compression != nar.CompressionTypeNone || c.InflightStagingEnabled()) {
+    hasNar = false
+}
+```
+
+Rationale: only fires for actively-chunking (`!finished`) reads. The existing compressed case is unchanged. The new uncompressed case fires only when staging is enabled; the holder (`hasActiveLocalJob`) was already excluded at `:1303`. Staging-disabled → unchanged (progressive chunks). Alternative rejected: record the staging request inside `getNarFromChunks` — duplicates the coordination machinery and races the producer worse.
+
+### Decision 2 — Site 2: poll-loop state (D) waits for staging parts before falling to progressive
+
+At `cache.go:6815`, when `stagingActive` (a request was recorded at `:6703`), state (D) MUST NOT immediately return progressive. Instead keep polling (subsequent ticks re-check (C) `stagingServeReady`) until staging parts appear, the holder finishes/dies, or a **bounded** staging-wait deadline elapses — only then fall back to progressive. The bound keeps the progressive safety net for a producer that errors/stalls (consistent with the "stalled producer" requirement). Staging-disabled (`!stagingActive`) → state (D) unchanged (immediate progressive).
+
+### Decision 3 — Flip the e2e assertion + correct CHANGELOG
+
+`staging-contention` chunking window reverts to asserting staging activation (the `inflight-nar-staging` log line on the non-holder). The interim "chunked by exactly one replica / progressive" assertion from PR #1386 is removed. CHANGELOG: keep the staging description but attribute the *actually-working* chunking-window engagement to this change (the prior entries described intended-but-unverified behavior).
+
+## Risks / Trade-offs
+
+- **[State (D) wait → hang/latency]** → Mitigation: bounded staging-wait (a few 200 ms ticks) inside the existing `deadlineCtx`; falls back to progressive on timeout. Never unbounded.
+- **[Truncation if staging serves an incomplete prefix]** → Mitigation: unchanged — `serveNarFromStaging` already tails to completion and the "stalled producer surfaces a stream error, not a truncated 200" requirement holds.
+- **[Regressing the progressive path / staging-disabled]** → Mitigation: every change gated on `InflightStagingEnabled()`; unit tests assert the disabled path is byte-for-byte the old behavior.
+- **[Same-pod / single-replica]** → Unaffected: `hasActiveLocalJob` short-circuit at `:1303` keeps the holder on its temp-file path.
+
+## Migration Plan
+
+Behavior-only, behind the default-off staging flag. No deploy/rollback concerns. Verified by `pkg/cache` race unit tests + `staging-contention` e2e (chunking window now activates staging) + `task fmt/lint/test`.
+
+## Open Questions
+
+- The exact staging-wait bound in state (D): start at ~10 ticks (2 s) and tune from the e2e (the producer stages within a tick or two once it sees the request); must stay well under the poll give-up bound.
+- Whether `prefer staging over progressive chunks` (#1355, inside `getNarFromChunks`) becomes redundant once site-1/site-2 route through coordination — likely keep it as defense-in-depth; confirm no double-serve.

--- a/openspec/changes/archive/2026-06-09-engage-staging-eager-cdc-uncompressed/proposal.md
+++ b/openspec/changes/archive/2026-06-09-engage-staging-eager-cdc-uncompressed/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+In-flight NAR staging is documented (CHANGELOG; #1355/#1374/#1375/#1379) as serving cross-pod reads during the eager-CDC chunking window — *"preferring staging over the fragile progressive-chunk reassembly."* But it never actually engages for the **uncompressed `.nar`** request, which — since predictive-`none` (#1380) — is the **only** request clients make in that window. A new e2e proves it: the cross-pod reader is served by progressive chunks with zero contention and zero staging. The gap is two-site:
+
+- `cache.go:1320` routes an actively-chunking read to download coordination (the path that records a staging request and serves from staging) **only when `Compression != none`** — so the uncompressed read short-circuits to progressive chunk serving and never contends.
+- Poll-loop state (D) at `cache.go:6815` returns "served-by-peer → progressive chunks" as soon as the NAR is actively-chunking with no staging parts *yet*, pre-empting staging before the holder's producer can stage.
+
+`#1379` itself flagged this path as unit-verified but with "no green end-to-end run yet." This change closes the gap so the documented behavior is real.
+
+## What Changes
+
+- **Route uncompressed actively-chunking cross-pod reads to coordination when staging is enabled** (`cache.go:1320`): extend the not-servable fall-through to `Compression == none` under `InflightStagingEnabled()`, so the reader contends, records a staging request, and serves from in-flight staging instead of progressive chunks.
+- **Let poll-loop state (D) wait briefly for staging parts** (`cache.go:6815`): when staging is enabled and a staging request was recorded, keep polling (bounded) for staging parts so (C) "serve from staging" can win, before falling back to progressive chunks as the safety net.
+- Both behind `InflightStagingEnabled()` (default off); staging-disabled, lazy-CDC, single-replica/same-pod, and finished-NAR paths are unchanged.
+- Flip the `staging-contention` e2e chunking-window assertion to require **staging activation** (the design intent), reverting the interim progressive-chunk assertion.
+- Correct the CHANGELOG to reflect that this is the change that actually makes chunking-window staging engage.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `inflight-nar-staging`: clarify that an **uncompressed** cross-pod read during the eager-CDC chunking window engages in-flight staging (contends, records a request, serves from staging), preferring staging over progressive chunks; progressive chunks remains the bounded fallback only when staging parts never materialize.
+- `unified-e2e-harness`: the `staging-contention` chunking window asserts staging activation again (not progressive-chunk serving).
+
+## Impact
+
+- **Code**: `pkg/cache/cache.go` (GetNar routing at ~1320; `pollForDownloadOrTakeOver` state D at ~6815). Hot serve path — concurrency-critical.
+- **Tests**: new `pkg/cache` internal unit tests (red→green) for both sites; `nix/e2e-tests/src/phases/staging_contention.py` chunking-window assertion flipped to staging activation.
+- **I/O / latency / memory**: when staging engages, a contending cross-pod reader tails staging part-objects (existing mechanism) instead of progressive chunks — comparable I/O, more robust (no truncation). Bounded extra poll latency (≤ a few 200 ms ticks) before the staging fallback. No change when staging is disabled.
+- **Non-goals**: not changing the staging producer, part-object format, GC, or holder-death recovery; not touching compressed-request handling (already coordinates), lazy CDC, or the download window; not altering predictive-`none`.

--- a/openspec/changes/archive/2026-06-09-engage-staging-eager-cdc-uncompressed/specs/inflight-nar-staging/spec.md
+++ b/openspec/changes/archive/2026-06-09-engage-staging-eager-cdc-uncompressed/specs/inflight-nar-staging/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Cross-pod readers serve a complete, byte-correct NAR from staging in all CDC modes
+
+A waiting replica that observes available staging parts SHALL tail them to reassemble and serve a complete, byte-correct NAR, regardless of whether CDC is disabled, lazy, or eager. The served bytes carry the compression recorded in `staging_state.compression`; when the client requests the uncompressed (`none`) variant of compressed staged bytes, the reader SHALL decompress on the fly at parity with the same-pod streaming path. A reader SHALL NOT deliver a truncated NAR as an HTTP 200.
+
+For the **eager-CDC chunking window** the staged bytes are uncompressed (the temp is decompressed for chunking, so there is no whole-file copy in any compressed form). A request for the **uncompressed** variant SHALL be served the complete NAR from staging, preferring staging over progressive chunk reassembly. A request for a **compressed** variant cannot be reconstructed from uncompressed staged bytes, so the staging serve SHALL return a not-found and the client SHALL fall back to an upstream that has the original compressed file.
+
+When in-flight staging is enabled, an **uncompressed** cross-pod read arriving during the eager-CDC chunking window (the holder is actively chunking; the NAR is servable-from-chunks but not finished) SHALL enter download coordination — contending for the holder's retained download lock and recording an in-flight staging request — rather than short-circuiting directly to progressive chunk serving. The coordinating reader SHALL wait, bounded, for the holder's producer to make staging parts available and then serve from staging. Progressive chunk serving from the holder's committed chunks remains the fallback only when in-flight staging is disabled, or when staging parts do not materialize within that bound (e.g. a stalled or errored producer). This relies on the holder retaining the NAR download lock through the chunking window (see the `cdc-chunking` capability).
+
+#### Scenario: Non-CDC cross-pod serve during download
+
+- **WHEN** CDC is disabled and replica A is downloading a NAR with replica B waiting
+- **AND** staging is active
+- **THEN** replica B SHALL serve the complete NAR from staging parts with HTTP 200
+
+#### Scenario: Uncompressed request during active chunking prefers staging
+
+- **WHEN** in-flight staging is enabled, replica A is actively chunking an eager-CDC NAR (its `nar_file` row has `total_chunks == 0` with a live chunker, no whole-file copy in shared storage), and replica B receives a request for the uncompressed (`none`) variant
+- **THEN** replica B SHALL enter download coordination, contend for the held download lock, and record an in-flight staging request rather than short-circuiting to progressive chunk serving
+- **AND** replica B SHALL serve the complete, byte-identical NAR from staging once parts are available
+- **AND** replica B SHALL NOT re-download or re-chunk the NAR
+
+#### Scenario: Progressive chunks remain the fallback when staging cannot serve
+
+- **WHEN** an uncompressed cross-pod read is coordinating during active chunking but in-flight staging is disabled, OR staging parts do not become available within the bounded staging wait (a stalled/errored producer)
+- **THEN** replica B SHALL fall back to serving progressively from the holder's committed chunks
+- **AND** replica B SHALL surface a stream error rather than a truncated HTTP 200 if reassembly cannot complete
+
+#### Scenario: Compressed request during active chunking coordinates, then falls back to upstream
+
+- **WHEN** replica A is actively chunking a NAR and replica B receives a request for a compressed variant (e.g. `.nar.xz`)
+- **THEN** replica B SHALL enter download coordination rather than acquiring a free lock and short-circuiting to chunk-based serving
+- **AND** because the in-flight bytes are uncompressed, the staging serve SHALL return a not-found so the client falls back to an upstream that has the original compressed file
+
+#### Scenario: Compression transcode on serve (decompression only)
+
+- **WHEN** staged parts hold a compressed form and the client requests the uncompressed (`none`) variant
+- **THEN** the reader SHALL decompress the staged bytes on the fly while serving and advertise `none`
+- **AND** a request for a compressed variant backed only by uncompressed staged bytes SHALL instead return a not-found, so the client falls back to upstream
+
+#### Scenario: Stalled producer does not yield a truncated success
+
+- **WHEN** a reader is tailing staging parts and the producer stalls before the NAR is complete
+- **THEN** the reader SHALL surface a stream error rather than terminating the response with a clean EOF at a truncated length

--- a/openspec/changes/archive/2026-06-09-engage-staging-eager-cdc-uncompressed/specs/unified-e2e-harness/spec.md
+++ b/openspec/changes/archive/2026-06-09-engage-staging-eager-cdc-uncompressed/specs/unified-e2e-harness/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: In-flight staging contention scenario
+
+The harness SHALL provide a `staging-contention` scenario that proves in-flight NAR staging activates under real multi-replica contention and delivers complete, byte-identical NARs. The scenario MUST launch at least two replicas with a Redis distributed locker and staging enabled, race concurrent clients fetching the same uncached NAR so that lock-losing waiters become staging consumers, and cover both the download window (CDC off) and the chunking window (eager CDC) as independently-scored runs.
+
+For **both** windows the harness MUST race readers while the NAR is still in flight and MUST assert that in-flight staging **activates** on the non-holder replica (the staging-activation log line) — a no-op run (staging never activates) is a FAILURE, not a pass. For the chunking window the harness gates the race on an observed in-flight state (a `nar_files` row with `total_chunks == 0`, or no row yet) so the readers overlap the holder's production; every reader MUST receive a NAR byte-identical to the canonical `nix-store --dump`.
+
+This scenario SHALL remain `local`-mode only: in-flight staging *activation* is a single-shot timing event, and reaching `kubernetes` replicas through `kubectl port-forward` introduces per-request latency jitter that de-synchronizes the race so the lock-holder caches the NAR before cross-pod waiters can contend on an in-flight piece; activation therefore cannot be reliably forced on Kind. The harness MUST report the scenario as SKIPPED (never PASSED) when requested in `kubernetes` mode.
+
+#### Scenario: Concurrent same-NAR fetch activates staging in both windows
+
+- **WHEN** at least two replicas run with `--locker redis` and staging enabled and N clients race to fetch the same large uncached NAR, in either the download window (CDC off) or the chunking window (eager CDC)
+- **THEN** at least one lock-losing waiter serves from committed staging parts, evidenced by the staging-activation log line on the non-holder replica
+
+#### Scenario: All racing readers receive identical complete NARs
+
+- **WHEN** the racing clients complete their fetches in either window
+- **THEN** every reader receives a NAR whose decompressed content is byte-identical to the canonical store-path NAR and to every other reader, with a truncated or differing body failing even on HTTP 200
+
+#### Scenario: Non-activation is a failure, not a pass
+
+- **WHEN** a run completes without staging ever activating in a window
+- **THEN** the harness reports the scenario as FAILED with diagnostics, not as PASSED
+
+#### Scenario: Both protected windows are covered
+
+- **WHEN** the scenario is run
+- **THEN** it exercises the download window (CDC off, whole-file NARs) and the chunking window (eager CDC) as separate runs each with its own pass/fail, each asserting staging activation
+
+#### Scenario: Kubernetes mode skips the scenario rather than running it unreliably
+
+- **WHEN** the `staging-contention` scenario is requested with `--mode kubernetes`
+- **THEN** the harness reports it as SKIPPED (topology/timing unsupported in that mode), never PASSED, because port-forward jitter makes single-shot in-flight activation unreliable on Kind

--- a/openspec/changes/archive/2026-06-09-engage-staging-eager-cdc-uncompressed/tasks.md
+++ b/openspec/changes/archive/2026-06-09-engage-staging-eager-cdc-uncompressed/tasks.md
@@ -1,0 +1,35 @@
+## 1. Site 1 — route uncompressed actively-chunking cross-pod reads to coordination (TDD)
+
+- [x] 1.1 RED→GREEN: `TestShouldCoordinateInflightUncompressedRequiresStaging` — uncompressed coordinates only when staging enabled
+- [x] 1.2 RED→GREEN: same test asserts staging-disabled → no coordination (progressive preserved); `TestShouldCoordinateInflightCompressedAlways` guards compressed
+- [x] 1.3 GREEN: `cache.go:1320` now `!finished && c.shouldCoordinateInflight(narURL.Compression)`; added `shouldCoordinateInflight` predicate
+
+## 2. Site 2 — poll-loop state (D) waits for staging parts before progressive (TDD)
+
+- [x] 2.1 RED→GREEN: `TestPollDStateWaitsForStagingPartsBeforeProgressive` — (D) waits for staging parts (staged 300ms after polling) and serves from staging
+- [x] 2.2 RED→GREEN: `TestPollDStateFallsBackToProgressiveWhenStagingStalls` — bounded wait → progressive fallback, no hang
+- [x] 2.3 GREEN: `TestPollDStateProgressiveWhenStagingDisabled` — `!stagingActive` unchanged (immediate progressive)
+- [x] 2.4 GREEN: `cache.go:6815` gates progressive on staging-wait exhaustion (`maxStagingWaitTicks=15`); `stagingActive` keeps polling
+
+## 3. Verify ncps unit + integration
+
+- [x] 3.1 `go test -race ./pkg/cache/` green (33.8s) + full `task test` green — no regression
+- [x] 3.2 Covered by the e2e (real 2-replica postgres+s3+redis multi-process run), stronger than unit integration
+
+## 4. Flip the e2e assertion + harness tests
+
+- [x] 4.1 `_run_chunking_window` reverted to assert staging activation (removed chunked-by-one); kept the in-flight gate; added bounded clean-restart retry (addresses CodeRabbit #1386 review)
+- [x] 4.2 `tests/test_staging_contention.py` green (43/43); kept `_inflight_state`/`_await_inflight`/`_hash_from_nar_url`; applied Gemini `hash`→`nar_hash` rename
+- [x] 4.3 `nix/e2e-tests/README.md` reverted to staging-activation for both windows; `unified-e2e-harness` main spec corrected via /opsx:sync below
+
+## 5. End-to-end validation
+
+- [x] 5.1 `task test:e2e ... staging-contention` — BOTH windows PASS with staging activation; chunking-window race 143s→4.5s (staging replaced progressive)
+- [x] 5.2 Determinism confirmed: runs #6 and #7 both PASS both windows with staging activation [1] (~4.5s each)
+
+## 6. CHANGELOG + finalize
+
+- [x] 6.1 CHANGELOG entry added: eager-CDC uncompressed cross-pod reads now actually engage staging (two-site read-path fix)
+- [x] 6.2 `task fmt` clean; `task lint` clean (0 issues) after `golangci-lint cache clean` + removing `var/ncps/nix-tmp`; `task lint:fix` resolved 4 wsl/nlreturn nits in the test
+- [x] 6.3 `openspec validate --all` → 41 passed, 0 failed (incl. corrected unified-e2e-harness + inflight-nar-staging main specs)
+- [ ] 6.4 Cannibalize PR #1386: same branch, update PR title/description once landed

--- a/openspec/changes/archive/2026-06-09-fix-staging-contention-e2e-race/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-09-fix-staging-contention-e2e-race/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/archive/2026-06-09-fix-staging-contention-e2e-race/design.md
+++ b/openspec/changes/archive/2026-06-09-fix-staging-contention-e2e-race/design.md
@@ -1,0 +1,57 @@
+## Context
+
+The `staging-contention` scenario races N clients at the same uncached NAR. The **download window** (CDC off) passes; the **chunking window** (eager CDC) always FAILed locally with `in-flight staging did not activate`.
+
+Investigation (live runs + `var/log/ncps-*.log` + `pkg/cache/cache.go`) established, in order of discovery:
+
+1. The download lock is already held through the eager-CDC chunking window (`<-ds.done`, `cache.go:6660`; closes post-chunk at `3304/3424`). ncps is correct; the lock-lifecycle was already fixed.
+2. Under eager CDC the **narinfo prime** fires a fire-and-forget background prefetch (`prePullNar`, `cache.go:4136-4151`) that downloads+chunks the whole NAR within seconds. `GetNarInfo` returns the narinfo in ~0.1s; the prefetch holds `download:nar` ~11s. The harness then raced the readers minutes later, after materialization. Fixing this with an in-flight gate (race while a download/chunk is observable) made the readers overlap the in-flight window — confirmed live: `download:nar` held 18:51:37→49, readers fired inside it.
+3. **Even with the readers racing in-flight, staging still did not activate** — because the cross-pod reader (replica B) serves the uncompressed `.nar` *progressively from the holder's committed chunks* (a DB lookup then a chunk-stream; replica B logged no upstream pull, no lock contention, no chunking). This is the designed eager-CDC behavior (#1289) and matches the `cdc-chunking` / `inflight-nar-staging` "streams from chunks" scenario. In-flight staging is a *download-window* mechanism (used when there are no chunks to stream). The chunking window's "staging must activate" assertion therefore tested the wrong mechanism.
+
+The maintainer chose to assert the actual designed behavior for the chunking window (fork A), not to change ncps.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Download window: keep asserting in-flight staging activation (FAIL if it never activates).
+- Chunking window: race readers while the eager-CDC download+chunk is in flight, then assert every reader receives a complete byte-identical NAR AND the NAR is chunked by exactly one replica (cross-pod readers served from the shared chunk set, no re-download/re-chunk).
+- Harness-only; no ncps production change.
+
+**Non-Goals:**
+- Changing ncps download-lock lifecycle, staging activation, or eager-CDC progressive chunk-serving.
+- Reconciling the `inflight-nar-staging` "serve from staging" vs "stream from chunks" scenarios for the chunking window (ncps implements chunks; spec cleanup deferred).
+- Lifting the `local`-only pin; touching the download-window path.
+
+## Decisions
+
+### Decision 1 — Chunking window asserts progressive chunk-serving, not staging
+
+The correctness property for the eager-CDC chunking window is: contending cross-pod readers get the complete, byte-identical NAR **without re-downloading or re-chunking** — they serve from the holder's shared chunk set. Staging activation is asserted only in the download window (no chunks to stream there). Rejected: keep asserting staging in the chunking window — ncps deliberately serves from chunks there, so it could never pass.
+
+### Decision 2 — "No re-download/re-chunk" via the per-hash chunking lock
+
+The assertion uses `_scan_logs(deployment, f"migration:{hash}")` and requires exactly one replica. The per-hash migration (chunking) lock is taken only by the replica that actually chunks the NAR; a cross-pod re-download would re-chunk and appear as a second replica. Empirically (run logs) the lock appears on the holder only (8501=present, 8502=0), and the cross-pod's progressive serve never touches it. Rejected alternatives: counting `download:nar` acquisitions (a coordinating reader may acquire the freed lock without re-downloading — false positive); scanning the upstream-pull log (less hash-specific).
+
+### Decision 3 — Best-effort in-flight gate, no retry
+
+`_await_inflight` reads the `nar_files` row once: `total_chunks > 0` → `missed` (already materialized, logged as a note), else `inflight` (race now). We race immediately after the 0.1s prime so readers overlap the long download phase. Because the correctness assertions (byte-identical + chunked-once) hold whether the readers race mid-production or against the committed chunk set, no bounded retry / clean-restart loop is needed — it was removed.
+
+### Decision 4 — Harness unit test for the pure helpers
+
+`_inflight_state`, `_await_inflight`, and `_hash_from_nar_url` are covered by `tests/test_staging_contention.py` with a scripted fake DB, under `e2e-harness-unit` in `nix flake check`. The race + chunk-serve assertions are integration-only (exercised by the e2e run).
+
+## Risks / Trade-offs
+
+- **[`migration:<hash>` also touched by a non-chunking replica]** → Mitigation: empirically holder-only; the progressive chunk-serve path does not acquire the per-hash migration lock. If a future ncps change makes a reader take it, the assertion would over-count — revisit with a writer-specific needle (`recordChunkBatch`) then.
+- **[Readers race after materialization (gate "missed")]** → Accepted: the byte-identical + chunked-once assertions still hold; the gate is best-effort and only logs the case. The download phase (~10s for gcc) makes a mid-production race the common case.
+- **[Spec tension between staging vs chunks scenarios]** → Out of scope: documented as a deferred `inflight-nar-staging` spec reconciliation; ncps implements the chunks path and this harness asserts it.
+
+## Migration Plan
+
+Pure test-harness change. No deploy/runtime impact, no rollback concerns. Verified by `nix run .#e2e -- --mode local --scenario staging-contention` green (both windows) and `nix flake check` (`e2e-harness-unit`).
+
+## Open Questions
+
+- **Resolved — cause of the original late firing**: the narinfo prime returns in ~0.1s but the harness raced minutes later; the in-flight gate now fires the race immediately after prime, confirmed overlapping the held `download:nar` window.
+- **Resolved — why staging never activated**: eager-CDC uncompressed cross-pod reads are served progressively from chunks, not staging.
+- **Deferred (ncps/spec)**: whether the `inflight-nar-staging` spec's "reader contends and serves from staging mid-chunking" scenario should be reconciled with the "streams from chunks" scenario. ncps implements chunks; this is a spec-cleanup item, not part of this harness change.

--- a/openspec/changes/archive/2026-06-09-fix-staging-contention-e2e-race/proposal.md
+++ b/openspec/changes/archive/2026-06-09-fix-staging-contention-e2e-race/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The `staging-contention` e2e scenario's **chunking window** (eager CDC) always FAILs locally with `in-flight staging did not activate`. Investigation (live runs + ncps logs) showed this is **not** an ncps bug and **not** merely a race-timing bug in the harness: under eager CDC the cross-pod reader of the uncompressed `.nar` is served *progressively from the holder's committed chunks* — the designed behavior (#1289) — and never uses in-flight staging. In-flight staging is a download-window mechanism (for the case where there are no chunks to stream). So the chunking window's assertion that "staging must activate" tests for a mechanism ncps deliberately does not use there; the window can never pass as written.
+
+Separately, the harness raced the readers long after the eager-CDC NAR had fully materialized (the narinfo prime fire-and-forget background-prefetches and chunks the whole NAR within seconds), so the readers never even overlapped the holder's production.
+
+## What Changes
+
+- Split the scenario into two correctly-scoped windows:
+  - **Download window (CDC off)** — unchanged in intent: a lock-losing waiter must become an in-flight staging consumer; FAIL if staging never activates.
+  - **Chunking window (eager CDC)** — assert the *actual designed behavior*: race readers while the eager-CDC download+chunk is in flight, then assert every reader gets a complete byte-identical NAR AND the NAR is downloaded+chunked by **exactly one replica** (cross-pod readers served from the shared chunk set, no re-download/no re-chunk). Drop the staging-activation assertion for this window.
+- Gate the chunking-window race on an observed in-flight state (a `nar_files` row with `total_chunks == 0`, or no row yet) so the readers overlap the holder's production instead of an already-materialized NAR.
+- No ncps production-code change. The download-lock lifecycle, staging activation, and eager-CDC progressive chunk-serving are all already correct.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `unified-e2e-harness`: the `staging-contention` scenario requirement — the chunking window asserts byte-correct cross-pod chunk-serving with no re-download/re-chunk (chunked by exactly one replica) instead of in-flight staging activation; staging activation remains asserted only for the download window.
+
+## Impact
+
+- **Code**: `nix/e2e-tests/src/phases/staging_contention.py` (window split, in-flight gate, chunk-serve assertion). Harness-side only.
+- **Tests**: `nix/e2e-tests/tests/test_staging_contention.py` covers the in-flight classification + URL-hash helpers under `e2e-harness-unit` (`nix flake check`); the e2e scenario itself becomes deterministic and meaningful under `--mode local`.
+- **I/O / latency / memory**: none on ncps. The scenario continues to download one large NAR (gcc-unwrapped) once per window from the configured upstream; no change to ncps request handling, network, or memory.
+- **Non-goals**: not changing ncps download-lock lifecycle, staging activation, or eager-CDC progressive chunk-serving; not reconciling the `inflight-nar-staging` spec's "serve from staging" vs "stream from chunks" scenarios for the chunking window (deferred — ncps implements the chunks path); not lifting the scenario's `local`-only pin to kubernetes; not touching the download-window path.

--- a/openspec/changes/archive/2026-06-09-fix-staging-contention-e2e-race/specs/unified-e2e-harness/spec.md
+++ b/openspec/changes/archive/2026-06-09-fix-staging-contention-e2e-race/specs/unified-e2e-harness/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: In-flight staging contention scenario
+
+The harness SHALL provide a `staging-contention` scenario that proves correct cross-pod NAR serving under real multi-replica contention and delivers complete, byte-identical NARs. The scenario MUST launch at least two replicas with a Redis distributed locker and staging enabled, race concurrent clients fetching the same uncached NAR, and cover both the download window (CDC off) and the chunking window (eager CDC) as independently-scored runs.
+
+For the **download window (CDC off)** there are no chunks to stream, so a lock-losing waiter MUST become an in-flight staging consumer. This window MUST FAIL if in-flight staging never activates (a no-op run is a failure).
+
+For the **chunking window (eager CDC)** the cross-pod reader of the uncompressed `.nar` is served *progressively from the holder's committed chunks* — the designed behavior (#1289) — rather than from in-flight staging, which is a download-window mechanism. The harness MUST race readers while the eager-CDC download+chunk is still in flight (gating the race on an observed in-flight state — a `nar_files` row with `total_chunks == 0` or no row yet — so the readers overlap the holder's production rather than serving an already-complete chunk set). It MUST then assert that every reader received a complete NAR byte-identical to the canonical `nix-store --dump`, AND that the NAR was downloaded and chunked by **exactly one replica** — i.e. the contending cross-pod readers served from the shared chunk set with no re-download and no re-chunk. The harness MUST NOT assert in-flight staging activation for the chunking window, because eager-CDC uncompressed cross-pod reads are correctly served from chunks, not staging.
+
+This scenario SHALL remain `local`-mode only: in-flight staging *activation* (the download window) is a single-shot timing event, and reaching `kubernetes` replicas through `kubectl port-forward` introduces per-request latency jitter that de-synchronizes the race so the lock-holder caches the NAR before cross-pod waiters can contend on an in-flight piece; activation therefore cannot be reliably forced on Kind. The harness MUST report the scenario as SKIPPED (never PASSED) when requested in `kubernetes` mode.
+
+#### Scenario: Download-window concurrent fetch activates staging
+
+- **WHEN** at least two replicas run with `--locker redis` and staging enabled, CDC is off, and N clients race to fetch the same large uncached NAR
+- **THEN** at least one lock-losing waiter serves from committed staging parts, evidenced by the staging-activation log line
+- **AND** the window FAILS if staging never activates (a no-op run is a failure, not a pass)
+
+#### Scenario: All racing readers receive identical complete NARs
+
+- **WHEN** the racing clients complete their fetches in either window
+- **THEN** every reader receives a NAR whose decompressed content is byte-identical to the canonical store-path NAR and to every other reader, with a truncated or differing body failing even on HTTP 200
+
+#### Scenario: Both protected windows are covered
+
+- **WHEN** the scenario is run
+- **THEN** it exercises the download window (CDC off, whole-file NARs) and the chunking window (eager CDC) as separate runs each with its own pass/fail
+
+#### Scenario: Chunking-window readers race an in-flight eager-CDC download
+
+- **WHEN** the chunking window runs and the narinfo prime has triggered the background eager-CDC download+chunk
+- **THEN** the harness gates the reader race on an observed in-flight state (a `nar_files` row with `total_chunks == 0`, or no row yet because the download is still in progress) and fires the readers while the holder is producing the NAR
+- **AND** if the NAR is already fully materialized before the race, the harness still runs the race against the committed chunk set and the correctness assertions below still apply
+
+#### Scenario: Chunking-window cross-pod readers serve from chunks with no re-download or re-chunk
+
+- **WHEN** the chunking-window readers race the uncompressed `.nar` across two replicas while one replica holds and produces the eager-CDC NAR
+- **THEN** every reader receives a complete NAR byte-identical to the canonical `nix-store --dump`
+- **AND** the NAR is downloaded and chunked by exactly one replica (the per-hash chunking lock appears on a single replica), proving the cross-pod readers served from the shared chunk set rather than re-downloading or re-chunking
+- **AND** the harness does NOT require in-flight staging to activate in this window
+
+#### Scenario: Kubernetes mode skips the scenario rather than running it unreliably
+
+- **WHEN** the `staging-contention` scenario is requested with `--mode kubernetes`
+- **THEN** the harness reports it as SKIPPED (topology/timing unsupported in that mode), never PASSED, because port-forward jitter makes single-shot in-flight activation unreliable on Kind

--- a/openspec/changes/archive/2026-06-09-fix-staging-contention-e2e-race/tasks.md
+++ b/openspec/changes/archive/2026-06-09-fix-staging-contention-e2e-race/tasks.md
@@ -1,0 +1,31 @@
+## 1. Confirm the timing mechanism (instrumented run)
+
+- [x] 1.1 Ran `task test:e2e CLI_ARGS='--mode local --scenario staging-contention'`; captured `var/log/ncps-850{1,2}.log` + live DB/redis state during the chunking race
+- [x] 1.2 CONFIRMED (live): during the chunking race the `nar_files` row already had `total_chunks=3810` (chunked) — readers race a fully-materialized NAR. narinfo prime returns fast (handled 200 in ~1s); bg prefetch holds `download:nar` ~11s; race readers' `.nar` GETs land ~2min later. Exact source of the prime→race gap still to be revealed by in-harness timestamp logging in the validation run (Open Question #1, non-blocking)
+- [x] 1.3 Signal chosen: `nar_files` row for the hash with `total_chunks == 0` = in-flight (downloading/actively chunking); `total_chunks > 0` = done/missed. Queried via `deployment.db()` (postgres). URL taken from the narinfo response (nix-base32 hand-derivation is unreliable — do NOT construct it)
+
+## 2. Harness unit test (red)
+
+- [x] 2.1 Added `tests/test_staging_contention.py`: `_inflight_state` (absent/inflight/done) + `_await_inflight` (race unless already chunked) classification tests
+- [x] 2.2 Added `_hash_from_nar_url` tests (uncompressed / `.nar.xz` / leading-slash)
+- [x] 2.3 NOTE: live runs revealed eager-CDC cross-pod reads serve from chunks, not staging → fork A. Dropped the staging-activation/bounded-retry tests; the chunking window now asserts chunk-serve correctness (integration-only)
+
+## 3. Implement the corrected chunking-window race (green)
+
+- [x] 3.1 `_await_inflight` reads `nar_files` via `deployment.db()` once: `total_chunks>0` → missed (logged), else race now (overlap the in-flight download)
+- [x] 3.2 `_run_chunking_window` gates on `_await_inflight` then fires `_race_fetch`; no slow work between prime and race (timestamp-instrumented)
+- [x] 3.3 Chunking window asserts byte-identical content + NAR chunked by exactly one replica (`migration:<hash>` on a single replica) = cross-pod served from shared chunks, no re-download/re-chunk. Removed `_race_until_activated`/bounded-retry (not needed under fork A)
+- [x] 3.4 URL from narinfo response; hash via `_hash_from_nar_url`; reused `DBAccess`; download-window path keeps staging-activation assertion (`_run_download_window`)
+- [x] 3.5 Existing content assertions preserved in `_assert_race_content`; 43/43 unit tests green
+
+## 4. Verify end to end
+
+- [x] 4.1 Ran `task test:e2e CLI_ARGS='--mode local --scenario staging-contention'`: download window PASS (staging activated [1]); chunking window PASS (all 8 readers 200, byte-identical to canonical, chunked by exactly one replica [0]). SUMMARY: 1 passed, 0 failed
+- [x] 4.2 Determinism confirmed: runs #4 and #5 both PASS both windows identically (download staging [1]; chunking chunked-once [0])
+- [x] 4.3 `task test:e2e:unit` green (43/43)
+
+## 5. Finalize
+
+- [x] 5.1 `task fmt` clean (exit 0, no changes to my files — no Python formatter in treefmt; nix/Go untouched)
+- [x] 5.2 Updated `nix/e2e-tests/README.md` staging-contention description: download=staging activation, chunking=byte-identical + chunked-by-one-replica (no staging)
+- [x] 5.3 `openspec validate fix-staging-contention-e2e-race --no-interactive` → valid

--- a/openspec/specs/inflight-nar-staging/spec.md
+++ b/openspec/specs/inflight-nar-staging/spec.md
@@ -72,9 +72,9 @@ When staging activates, the holder SHALL write the NAR to shared storage as orde
 
 A waiting replica that observes available staging parts SHALL tail them to reassemble and serve a complete, byte-correct NAR, regardless of whether CDC is disabled, lazy, or eager. The served bytes carry the compression recorded in `staging_state.compression`; when the client requests the uncompressed (`none`) variant of compressed staged bytes, the reader SHALL decompress on the fly at parity with the same-pod streaming path. A reader SHALL NOT deliver a truncated NAR as an HTTP 200.
 
-For the **eager-CDC chunking window** the staged bytes are uncompressed (the temp is decompressed for chunking, so there is no whole-file copy in any compressed form). A request for the **uncompressed** variant SHALL be served the complete NAR from staging. A request for a **compressed** variant cannot be reconstructed from uncompressed staged bytes (ncps has no NAR compressor, and a re-compressed file would not match the narinfo `FileHash`/`FileSize`), so the staging serve SHALL return a not-found and the client SHALL fall back to an upstream that has the original compressed file — never the uncompressed bytes mislabeled as the requested compression.
+For the **eager-CDC chunking window** the staged bytes are uncompressed (the temp is decompressed for chunking, so there is no whole-file copy in any compressed form). A request for the **uncompressed** variant SHALL be served the complete NAR from staging, preferring staging over progressive chunk reassembly. A request for a **compressed** variant cannot be reconstructed from uncompressed staged bytes, so the staging serve SHALL return a not-found and the client SHALL fall back to an upstream that has the original compressed file.
 
-This relies on the download holder retaining the NAR download lock through the eager-CDC chunking window (see the `cdc-chunking` capability). A cross-pod reader arriving mid-chunking therefore **contends** for the held lock and enters the staging-request path, rather than acquiring a free lock and short-circuiting to chunk-based serving. The reader SHALL NOT re-download or re-chunk the NAR while the holder's chunking is live.
+When in-flight staging is enabled, an **uncompressed** cross-pod read arriving during the eager-CDC chunking window (the holder is actively chunking; the NAR is servable-from-chunks but not finished) SHALL enter download coordination — contending for the holder's retained download lock and recording an in-flight staging request — rather than short-circuiting directly to progressive chunk serving. The coordinating reader SHALL wait, bounded, for the holder's producer to make staging parts available and then serve from staging. Progressive chunk serving from the holder's committed chunks remains the fallback only when in-flight staging is disabled, or when staging parts do not materialize within that bound (e.g. a stalled or errored producer). This relies on the holder retaining the NAR download lock through the chunking window (see the `cdc-chunking` capability).
 
 #### Scenario: Non-CDC cross-pod serve during download
 
@@ -82,35 +82,30 @@ This relies on the download holder retaining the NAR download lock through the e
 - **AND** staging is active
 - **THEN** replica B SHALL serve the complete NAR from staging parts with HTTP 200
 
-#### Scenario: Compressed request during active chunking coordinates, then falls back to upstream
+#### Scenario: Uncompressed request during active chunking prefers staging
 
-- **WHEN** replica A is actively chunking a NAR (its cross-pod-visible `nar_file` row has `total_chunks==0` with a live chunker) and replica B receives a request for a compressed variant (e.g. `.nar.xz`)
-- **THEN** replica B SHALL enter download coordination rather than acquiring a free lock and short-circuiting to chunk-based serving
-- **AND** because the in-flight bytes are uncompressed, the staging serve SHALL return a not-found so the client falls back to an upstream that has the original compressed file
-
-#### Scenario: Uncompressed request during active chunking still streams from chunks
-
-- **WHEN** replica A is actively chunking a NAR and replica B receives a request for the uncompressed (`none`) variant
-- **THEN** replica B SHALL serve progressively from chunks as they are committed, unchanged by the compressed-request coordination behavior
-
-#### Scenario: Reader contends for the held lock mid-chunking and serves an uncompressed request from staging
-
-- **WHEN** the holder retains the download lock while it continues chunking an eager-CDC NAR for hash `H` (no whole-file copy in shared storage)
-- **AND** replica B contends for the held lock and receives a request for the uncompressed (`none`) variant of `H`
-- **THEN** replica B SHALL enter download coordination, record an in-flight staging request, and serve the complete NAR from staging once parts are available
+- **WHEN** in-flight staging is enabled, replica A is actively chunking an eager-CDC NAR (its `nar_file` row has `total_chunks == 0` with a live chunker, no whole-file copy in shared storage), and replica B receives a request for the uncompressed (`none`) variant
+- **THEN** replica B SHALL enter download coordination, contend for the held download lock, and record an in-flight staging request rather than short-circuiting to progressive chunk serving
+- **AND** replica B SHALL serve the complete, byte-identical NAR from staging once parts are available
 - **AND** replica B SHALL NOT re-download or re-chunk the NAR
 
-#### Scenario: Eager-CDC compressed cross-pod request falls back to upstream
+#### Scenario: Progressive chunks remain the fallback when staging cannot serve
 
-- **WHEN** CDC is eager and replica A is actively chunking a NAR (its `nar_file` row exists but `total_chunks` is still 0), the staged bytes are uncompressed, and replica B requests a compressed variant
-- **THEN** replica B SHALL return a not-found from the staging serve path so the client falls back to an upstream that has the original compressed file
-- **AND** replica B SHALL NOT serve the uncompressed staged bytes mislabeled as the requested compression
+- **WHEN** an uncompressed cross-pod read is coordinating during active chunking but in-flight staging is disabled, OR staging parts do not become available within the bounded staging wait (a stalled/errored producer)
+- **THEN** replica B SHALL fall back to serving progressively from the holder's committed chunks
+- **AND** replica B SHALL surface a stream error rather than a truncated HTTP 200 if reassembly cannot complete
+
+#### Scenario: Compressed request during active chunking coordinates, then falls back to upstream
+
+- **WHEN** replica A is actively chunking a NAR and replica B receives a request for a compressed variant (e.g. `.nar.xz`)
+- **THEN** replica B SHALL enter download coordination rather than acquiring a free lock and short-circuiting to chunk-based serving
+- **AND** because the in-flight bytes are uncompressed, the staging serve SHALL return a not-found so the client falls back to an upstream that has the original compressed file
 
 #### Scenario: Compression transcode on serve (decompression only)
 
 - **WHEN** staged parts hold a compressed form and the client requests the uncompressed (`none`) variant
 - **THEN** the reader SHALL decompress the staged bytes on the fly while serving and advertise `none`
-- **AND** a request for a compressed variant backed only by uncompressed staged bytes SHALL instead return a not-found (ncps cannot re-compress to a `FileHash`/`FileSize`-matching file), so the client falls back to upstream
+- **AND** a request for a compressed variant backed only by uncompressed staged bytes SHALL instead return a not-found, so the client falls back to upstream
 
 #### Scenario: Stalled producer does not yield a truncated success
 

--- a/openspec/specs/unified-e2e-harness/spec.md
+++ b/openspec/specs/unified-e2e-harness/spec.md
@@ -153,27 +153,42 @@ The harness SHALL drive the full content-defined-chunking lifecycle `non-CDC →
 
 ### Requirement: In-flight staging contention scenario
 
-The harness SHALL provide a `staging-contention` scenario that proves in-flight NAR staging activates under real multi-replica contention and delivers complete, byte-identical NARs. The scenario MUST launch at least two replicas with a Redis distributed locker and staging enabled, race concurrent clients fetching the same uncached NAR so that lock-losing waiters become staging consumers, and FAIL if staging never activates. It MUST cover both the download window (CDC off) and the chunking window (CDC on) as independently-scored runs. This scenario SHALL remain `local`-mode only: in-flight staging *activation* is a single-shot timing event, and reaching `kubernetes` replicas through `kubectl port-forward` introduces per-request latency jitter that de-synchronizes the race so the lock-holder caches the NAR before cross-pod waiters can contend on an in-flight piece; activation therefore cannot be reliably forced on Kind. The harness MUST report the scenario as SKIPPED (never PASSED) when requested in `kubernetes` mode.
+The harness SHALL provide a `staging-contention` scenario that proves correct cross-pod NAR serving under real multi-replica contention and delivers complete, byte-identical NARs. The scenario MUST launch at least two replicas with a Redis distributed locker and staging enabled, race concurrent clients fetching the same uncached NAR, and cover both the download window (CDC off) and the chunking window (eager CDC) as independently-scored runs.
 
-#### Scenario: Concurrent same-NAR fetch activates staging
+For the **download window (CDC off)** there are no chunks to stream, so a lock-losing waiter MUST become an in-flight staging consumer. This window MUST FAIL if in-flight staging never activates (a no-op run is a failure).
 
-- **WHEN** at least two replicas run with `--locker redis` and staging enabled and N clients race to fetch the same large uncached NAR
+For the **chunking window (eager CDC)** the cross-pod reader of the uncompressed `.nar` is served *progressively from the holder's committed chunks* — the designed behavior (#1289) — rather than from in-flight staging, which is a download-window mechanism. The harness MUST race readers while the eager-CDC download+chunk is still in flight (gating the race on an observed in-flight state — a `nar_files` row with `total_chunks == 0` or no row yet — so the readers overlap the holder's production rather than serving an already-complete chunk set). It MUST then assert that every reader received a complete NAR byte-identical to the canonical `nix-store --dump`, AND that the NAR was downloaded and chunked by **exactly one replica** — i.e. the contending cross-pod readers served from the shared chunk set with no re-download and no re-chunk. The harness MUST NOT assert in-flight staging activation for the chunking window, because eager-CDC uncompressed cross-pod reads are correctly served from chunks, not staging.
+
+This scenario SHALL remain `local`-mode only: in-flight staging *activation* (the download window) is a single-shot timing event, and reaching `kubernetes` replicas through `kubectl port-forward` introduces per-request latency jitter that de-synchronizes the race so the lock-holder caches the NAR before cross-pod waiters can contend on an in-flight piece; activation therefore cannot be reliably forced on Kind. The harness MUST report the scenario as SKIPPED (never PASSED) when requested in `kubernetes` mode.
+
+#### Scenario: Download-window concurrent fetch activates staging
+
+- **WHEN** at least two replicas run with `--locker redis` and staging enabled, CDC is off, and N clients race to fetch the same large uncached NAR
 - **THEN** at least one lock-losing waiter serves from committed staging parts, evidenced by the staging-activation log line
+- **AND** the window FAILS if staging never activates (a no-op run is a failure, not a pass)
 
 #### Scenario: All racing readers receive identical complete NARs
 
-- **WHEN** the racing clients complete their fetches
+- **WHEN** the racing clients complete their fetches in either window
 - **THEN** every reader receives a NAR whose decompressed content is byte-identical to the canonical store-path NAR and to every other reader, with a truncated or differing body failing even on HTTP 200
-
-#### Scenario: Non-activation is a failure, not a pass
-
-- **WHEN** a run completes without staging ever activating
-- **THEN** the harness reports the scenario as FAILED with diagnostics, not as PASSED
 
 #### Scenario: Both protected windows are covered
 
 - **WHEN** the scenario is run
-- **THEN** it exercises the download window (CDC off, whole-file NARs) and the chunking window (CDC on) as separate runs each with its own pass/fail
+- **THEN** it exercises the download window (CDC off, whole-file NARs) and the chunking window (eager CDC) as separate runs each with its own pass/fail
+
+#### Scenario: Chunking-window readers race an in-flight eager-CDC download
+
+- **WHEN** the chunking window runs and the narinfo prime has triggered the background eager-CDC download+chunk
+- **THEN** the harness gates the reader race on an observed in-flight state (a `nar_files` row with `total_chunks == 0`, or no row yet because the download is still in progress) and fires the readers while the holder is producing the NAR
+- **AND** if the NAR is already fully materialized before the race, the harness still runs the race against the committed chunk set and the correctness assertions below still apply
+
+#### Scenario: Chunking-window cross-pod readers serve from chunks with no re-download or re-chunk
+
+- **WHEN** the chunking-window readers race the uncompressed `.nar` across two replicas while one replica holds and produces the eager-CDC NAR
+- **THEN** every reader receives a complete NAR byte-identical to the canonical `nix-store --dump`
+- **AND** the NAR is downloaded and chunked by exactly one replica (the per-hash chunking lock appears on a single replica), proving the cross-pod readers served from the shared chunk set rather than re-downloading or re-chunking
+- **AND** the harness does NOT require in-flight staging to activate in this window
 
 #### Scenario: Kubernetes mode skips the scenario rather than running it unreliably
 

--- a/openspec/specs/unified-e2e-harness/spec.md
+++ b/openspec/specs/unified-e2e-harness/spec.md
@@ -153,42 +153,31 @@ The harness SHALL drive the full content-defined-chunking lifecycle `non-CDC →
 
 ### Requirement: In-flight staging contention scenario
 
-The harness SHALL provide a `staging-contention` scenario that proves correct cross-pod NAR serving under real multi-replica contention and delivers complete, byte-identical NARs. The scenario MUST launch at least two replicas with a Redis distributed locker and staging enabled, race concurrent clients fetching the same uncached NAR, and cover both the download window (CDC off) and the chunking window (eager CDC) as independently-scored runs.
+The harness SHALL provide a `staging-contention` scenario that proves in-flight NAR staging activates under real multi-replica contention and delivers complete, byte-identical NARs. The scenario MUST launch at least two replicas with a Redis distributed locker and staging enabled, race concurrent clients fetching the same uncached NAR so that lock-losing waiters become staging consumers, and cover both the download window (CDC off) and the chunking window (eager CDC) as independently-scored runs.
 
-For the **download window (CDC off)** there are no chunks to stream, so a lock-losing waiter MUST become an in-flight staging consumer. This window MUST FAIL if in-flight staging never activates (a no-op run is a failure).
+For **both** windows the harness MUST race readers while the NAR is still in flight and MUST assert that in-flight staging **activates** on the non-holder replica (the staging-activation log line) — a no-op run (staging never activates) is a FAILURE, not a pass. For the chunking window the harness gates the race on an observed in-flight state (a `nar_files` row with `total_chunks == 0`, or no row yet) so the readers overlap the holder's production; every reader MUST receive a NAR byte-identical to the canonical `nix-store --dump`.
 
-For the **chunking window (eager CDC)** the cross-pod reader of the uncompressed `.nar` is served *progressively from the holder's committed chunks* — the designed behavior (#1289) — rather than from in-flight staging, which is a download-window mechanism. The harness MUST race readers while the eager-CDC download+chunk is still in flight (gating the race on an observed in-flight state — a `nar_files` row with `total_chunks == 0` or no row yet — so the readers overlap the holder's production rather than serving an already-complete chunk set). It MUST then assert that every reader received a complete NAR byte-identical to the canonical `nix-store --dump`, AND that the NAR was downloaded and chunked by **exactly one replica** — i.e. the contending cross-pod readers served from the shared chunk set with no re-download and no re-chunk. The harness MUST NOT assert in-flight staging activation for the chunking window, because eager-CDC uncompressed cross-pod reads are correctly served from chunks, not staging.
+This scenario SHALL remain `local`-mode only: in-flight staging *activation* is a single-shot timing event, and reaching `kubernetes` replicas through `kubectl port-forward` introduces per-request latency jitter that de-synchronizes the race so the lock-holder caches the NAR before cross-pod waiters can contend on an in-flight piece; activation therefore cannot be reliably forced on Kind. The harness MUST report the scenario as SKIPPED (never PASSED) when requested in `kubernetes` mode.
 
-This scenario SHALL remain `local`-mode only: in-flight staging *activation* (the download window) is a single-shot timing event, and reaching `kubernetes` replicas through `kubectl port-forward` introduces per-request latency jitter that de-synchronizes the race so the lock-holder caches the NAR before cross-pod waiters can contend on an in-flight piece; activation therefore cannot be reliably forced on Kind. The harness MUST report the scenario as SKIPPED (never PASSED) when requested in `kubernetes` mode.
+#### Scenario: Concurrent same-NAR fetch activates staging in both windows
 
-#### Scenario: Download-window concurrent fetch activates staging
-
-- **WHEN** at least two replicas run with `--locker redis` and staging enabled, CDC is off, and N clients race to fetch the same large uncached NAR
-- **THEN** at least one lock-losing waiter serves from committed staging parts, evidenced by the staging-activation log line
-- **AND** the window FAILS if staging never activates (a no-op run is a failure, not a pass)
+- **WHEN** at least two replicas run with `--locker redis` and staging enabled and N clients race to fetch the same large uncached NAR, in either the download window (CDC off) or the chunking window (eager CDC)
+- **THEN** at least one lock-losing waiter serves from committed staging parts, evidenced by the staging-activation log line on the non-holder replica
 
 #### Scenario: All racing readers receive identical complete NARs
 
 - **WHEN** the racing clients complete their fetches in either window
 - **THEN** every reader receives a NAR whose decompressed content is byte-identical to the canonical store-path NAR and to every other reader, with a truncated or differing body failing even on HTTP 200
 
+#### Scenario: Non-activation is a failure, not a pass
+
+- **WHEN** a run completes without staging ever activating in a window
+- **THEN** the harness reports the scenario as FAILED with diagnostics, not as PASSED
+
 #### Scenario: Both protected windows are covered
 
 - **WHEN** the scenario is run
-- **THEN** it exercises the download window (CDC off, whole-file NARs) and the chunking window (eager CDC) as separate runs each with its own pass/fail
-
-#### Scenario: Chunking-window readers race an in-flight eager-CDC download
-
-- **WHEN** the chunking window runs and the narinfo prime has triggered the background eager-CDC download+chunk
-- **THEN** the harness gates the reader race on an observed in-flight state (a `nar_files` row with `total_chunks == 0`, or no row yet because the download is still in progress) and fires the readers while the holder is producing the NAR
-- **AND** if the NAR is already fully materialized before the race, the harness still runs the race against the committed chunk set and the correctness assertions below still apply
-
-#### Scenario: Chunking-window cross-pod readers serve from chunks with no re-download or re-chunk
-
-- **WHEN** the chunking-window readers race the uncompressed `.nar` across two replicas while one replica holds and produces the eager-CDC NAR
-- **THEN** every reader receives a complete NAR byte-identical to the canonical `nix-store --dump`
-- **AND** the NAR is downloaded and chunked by exactly one replica (the per-hash chunking lock appears on a single replica), proving the cross-pod readers served from the shared chunk set rather than re-downloading or re-chunking
-- **AND** the harness does NOT require in-flight staging to activate in this window
+- **THEN** it exercises the download window (CDC off, whole-file NARs) and the chunking window (eager CDC) as separate runs each with its own pass/fail, each asserting staging activation
 
 #### Scenario: Kubernetes mode skips the scenario rather than running it unreliably
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -875,6 +875,22 @@ func (c *Cache) InflightStagingEnabled() bool {
 	return c.inflightStagingFlag && c.lockerIsDistributed
 }
 
+// shouldCoordinateInflight reports whether an actively-chunking (servable but not
+// finished) read must fall through to download coordination — where it contends,
+// records an in-flight staging request, and serves from in-flight staging — rather
+// than being served directly from the holder's chunks. A compressed request always
+// must, because decompressed chunks cannot satisfy it. An uncompressed request must
+// too when in-flight staging is enabled, so it engages staging instead of the
+// fragile progressive chunk reassembly (#1289); with staging disabled it keeps
+// serving progressively from chunks (unchanged behavior).
+func (c *Cache) shouldCoordinateInflight(compression nar.CompressionType) bool {
+	if compression != nar.CompressionTypeNone {
+		return true
+	}
+
+	return c.InflightStagingEnabled()
+}
+
 // InflightStagingRetention returns the grace period before staging part-objects
 // are reclaimed after the final representation is committed.
 func (c *Cache) InflightStagingRetention() time.Duration {
@@ -1308,16 +1324,17 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (nar.URL, int64, io.
 		}
 
 		// An actively-chunking NAR (servable but not yet finished) is stored only as
-		// decompressed chunks, so it cannot satisfy a compressed request: serving it
-		// from chunks would 404 (serveNarFromStorageViaPipe -> serveFromChunks). For a
-		// cross-pod reader (no local download job) that short-circuit also skips
-		// download coordination entirely, so the waiter never records an in-flight
-		// staging request and never serves from staging. Treat such a request as
-		// not-servable here so it falls through to prePullNar -> coordination, where it
-		// records a staging request and serves from in-flight staging (transcoding to
-		// the requested compression). The uncompressed progressive-chunk path and
-		// finished NARs are unaffected (closes the chunking-window cross-pod 404, #1289).
-		if hasNar && narURL.Compression != nar.CompressionTypeNone && !finished {
+		// decompressed chunks. Serving it directly from chunks short-circuits download
+		// coordination, so a cross-pod reader (no local download job) never records an
+		// in-flight staging request and never serves from staging. Treat such a request
+		// as not-servable here so it falls through to prePullNar -> coordination, where
+		// it records a staging request and serves from in-flight staging. A compressed
+		// request always must (decompressed chunks cannot satisfy it); an uncompressed
+		// request must too when in-flight staging is enabled, so it engages staging
+		// instead of the fragile progressive reassembly (closes the chunking-window
+		// cross-pod staging gap, #1289). With staging disabled the uncompressed read
+		// keeps serving progressively from chunks. Finished NARs are unaffected.
+		if hasNar && !finished && c.shouldCoordinateInflight(narURL.Compression) {
 			hasNar = false
 		}
 
@@ -6695,6 +6712,16 @@ func (c *Cache) pollForDownloadOrTakeOver(
 ) (*downloadState, bool) {
 	const pollInterval = 200 * time.Millisecond
 
+	// When staging is active, state (D) below gives the holder's producer a bounded
+	// number of ticks to publish in-flight staging parts before falling back to
+	// progressive chunk serving, so the (C) staging serve wins the common eager-CDC
+	// chunking-window case instead of being pre-empted by (D) on an early tick. The
+	// bound keeps progressive as the safety net for a stalled or errored producer
+	// and stays well under giveUpBound. (#1289)
+	const maxStagingWaitTicks = 15
+
+	stagingWaitTicks := 0
+
 	// Signal the holder that a cross-pod waiter wants the NAR staged so it can be
 	// served during the active-download window (closes #660 / #1289). Idempotent
 	// and free of churn: it is a one-shot marker the holder reads on its own loop.
@@ -6813,6 +6840,22 @@ func (c *Cache) pollForDownloadOrTakeOver(
 			// it does not fire for a plain in-flight download (servable false), which
 			// keeps polling for completion or staging as before.
 			if servable {
+				// Prefer in-flight staging over progressive chunk reassembly: when
+				// staging is active, keep polling (bounded) so the holder's producer
+				// can publish parts and (C) above can serve them. Only once the
+				// bounded staging wait is exhausted (a stalled/errored producer) — or
+				// when staging is disabled — fall back to progressive serving. (#1289)
+				if stagingActive && stagingWaitTicks < maxStagingWaitTicks {
+					stagingWaitTicks++
+
+					zerolog.Ctx(ctx).Debug().
+						Str("hash", hash).
+						Int("staging_wait_tick", stagingWaitTicks).
+						Msg("peer is actively chunking; waiting for in-flight staging parts before progressive fallback")
+
+					continue
+				}
+
 				zerolog.Ctx(ctx).Debug().
 					Str("hash", hash).
 					Msg("peer is actively chunking; routing to progressive chunk streaming")

--- a/pkg/cache/engage_staging_uncompressed_internal_test.go
+++ b/pkg/cache/engage_staging_uncompressed_internal_test.go
@@ -87,7 +87,12 @@ func TestPollDStateWaitsForStagingPartsBeforeProgressive(t *testing.T) {
 	go func() {
 		time.Sleep(300 * time.Millisecond)
 
-		_ = c.markStagingRequested(ctx, hash)
+		if e := c.markStagingRequested(ctx, hash); e != nil {
+			staged <- e
+
+			return
+		}
+
 		if e := c.advanceStagingParts(ctx, hash, 1, nar.CompressionTypeNone.String()); e != nil {
 			staged <- e
 

--- a/pkg/cache/engage_staging_uncompressed_internal_test.go
+++ b/pkg/cache/engage_staging_uncompressed_internal_test.go
@@ -1,0 +1,189 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
+)
+
+// TestShouldCoordinateInflightUncompressedRequiresStaging pins the read-path half
+// of closing the eager-CDC chunking-window staging gap (#1289): an uncompressed
+// (none) request for an actively-chunking NAR (servable but not finished) must be
+// routed to download coordination — so it contends, records an in-flight staging
+// request, and serves from staging — rather than served directly from progressive
+// chunks, but ONLY when in-flight staging is enabled. With staging disabled it
+// must keep serving progressively (unchanged behavior).
+func TestShouldCoordinateInflightUncompressedRequiresStaging(t *testing.T) {
+	t.Parallel()
+
+	c := setupCDCRecoveryFixture(t)
+
+	// Staging disabled (default): an uncompressed read serves from chunks, no
+	// coordination — the progressive-chunk path is preserved.
+	assert.False(t, c.shouldCoordinateInflight(nar.CompressionTypeNone),
+		"uncompressed read must NOT coordinate when staging is disabled (progressive chunks preserved)")
+
+	// Staging enabled: the uncompressed read coordinates so it engages in-flight
+	// staging instead of the fragile progressive reassembly.
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+	assert.True(t, c.shouldCoordinateInflight(nar.CompressionTypeNone),
+		"uncompressed read must coordinate when staging is enabled (prefer staging over progressive chunks)")
+}
+
+// TestShouldCoordinateInflightCompressedAlways verifies a compressed (.nar.xz)
+// request for an actively-chunking NAR always routes to coordination — decompressed
+// chunks cannot satisfy it — independent of the staging flag.
+func TestShouldCoordinateInflightCompressedAlways(t *testing.T) {
+	t.Parallel()
+
+	c := setupCDCRecoveryFixture(t)
+
+	assert.True(t, c.shouldCoordinateInflight(nar.CompressionTypeXz),
+		"compressed read always coordinates (chunks can't satisfy it) with staging disabled")
+
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+	assert.True(t, c.shouldCoordinateInflight(nar.CompressionTypeXz),
+		"compressed read always coordinates with staging enabled too")
+}
+
+// TestPollDStateWaitsForStagingPartsBeforeProgressive pins the poll-loop half of
+// closing the gap: when in-flight staging is enabled and the holder is actively
+// chunking (servable, not finished) but staging parts are not yet available on the
+// first poll tick, state (D) MUST keep polling for staging parts (so the staging
+// serve wins) instead of immediately returning a served-by-peer state that routes
+// the reader to progressive chunk reassembly.
+func TestPollDStateWaitsForStagingPartsBeforeProgressive(t *testing.T) {
+	t.Parallel()
+
+	c, _, _, _, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+
+	ctx := context.Background()
+
+	const (
+		hash    = "deadbeefdeadbeefdeadbeefdeadbeef"
+		lockKey = "dstate-staging-wait-lock"
+	)
+
+	// Holder is alive: hold the lock so TryLock fails on every tick (no takeover),
+	// forcing the waiter to choose between staging and progressive.
+	acquired, err := c.downloadLocker.TryLock(ctx, lockKey, c.downloadLockTTL)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	t.Cleanup(func() { _ = c.downloadLocker.Unlock(ctx, lockKey) })
+
+	// The holder's producer stages a complete part set shortly AFTER the waiter
+	// begins polling — i.e. parts are not yet available on the first (D) tick.
+	staged := make(chan error, 1)
+
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+
+		_ = c.markStagingRequested(ctx, hash)
+		if e := c.advanceStagingParts(ctx, hash, 1, nar.CompressionTypeNone.String()); e != nil {
+			staged <- e
+
+			return
+		}
+
+		staged <- c.markStagingComplete(ctx, hash)
+	}()
+
+	// Actively chunking: servable, not finished.
+	ds, tookOver := c.pollForDownloadOrTakeOver(
+		ctx, ctx, lockKey, hash, true, storage.ErrNotFound,
+		func(context.Context) (bool, bool) { return true, false },
+	)
+
+	require.NoError(t, <-staged)
+	require.False(t, tookOver, "the holder is alive (lock held); there is no takeover")
+	require.NotNil(t, ds)
+	assert.NotNil(t, ds.stagingServe,
+		"poll-loop state (D) must wait for staging parts and serve from staging, "+
+			"not fall back to progressive chunks on the first tick")
+}
+
+// TestPollDStateProgressiveWhenStagingDisabled guards the gate: with in-flight
+// staging disabled, an actively-chunking servable NAR must still route immediately
+// to progressive chunk serving (a served-by-peer state with no stagingServe) — the
+// existing behavior is unchanged.
+func TestPollDStateProgressiveWhenStagingDisabled(t *testing.T) {
+	t.Parallel()
+
+	c, _, _, _, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+	// Staging left disabled (default).
+
+	ctx := context.Background()
+
+	const (
+		hash    = "cafecafecafecafecafecafecafecafe"
+		lockKey = "dstate-no-staging-lock"
+	)
+
+	acquired, err := c.downloadLocker.TryLock(ctx, lockKey, c.downloadLockTTL)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	t.Cleanup(func() { _ = c.downloadLocker.Unlock(ctx, lockKey) })
+
+	ds, tookOver := c.pollForDownloadOrTakeOver(
+		ctx, ctx, lockKey, hash, true, storage.ErrNotFound,
+		func(context.Context) (bool, bool) { return true, false },
+	)
+
+	require.False(t, tookOver)
+	require.NotNil(t, ds)
+	assert.Nil(t, ds.stagingServe,
+		"with staging disabled, state (D) must route to progressive chunk serving immediately")
+	assert.True(t, ds.closed, "served-by-peer state is a completed downloadState")
+}
+
+// TestPollDStateFallsBackToProgressiveWhenStagingStalls verifies the safety net:
+// when staging is active but the producer never publishes parts, state (D) must
+// not wait forever — after the bounded staging wait it falls back to progressive
+// chunk serving (a served-by-peer state) rather than hanging until the give-up
+// bound.
+func TestPollDStateFallsBackToProgressiveWhenStagingStalls(t *testing.T) {
+	t.Parallel()
+
+	c, _, _, _, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	c.SetInflightStaging(true, 5*time.Minute, 4, true)
+
+	ctx := context.Background()
+
+	const (
+		hash    = "f00df00df00df00df00df00df00df00d"
+		lockKey = "dstate-staging-stall-lock"
+	)
+
+	// Holder alive, but its producer never stages any parts (a stall).
+	acquired, err := c.downloadLocker.TryLock(ctx, lockKey, c.downloadLockTTL)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	t.Cleanup(func() { _ = c.downloadLocker.Unlock(ctx, lockKey) })
+
+	start := time.Now()
+	ds, tookOver := c.pollForDownloadOrTakeOver(
+		ctx, ctx, lockKey, hash, true, storage.ErrNotFound,
+		func(context.Context) (bool, bool) { return true, false },
+	)
+	elapsed := time.Since(start)
+
+	require.False(t, tookOver)
+	require.NotNil(t, ds)
+	assert.Nil(t, ds.stagingServe,
+		"with no staging parts ever published, the bounded wait must fall back to progressive")
+	assert.True(t, ds.closed, "served-by-peer state is a completed downloadState")
+	assert.Less(t, elapsed, 30*time.Second,
+		"the staging wait must be bounded (well under the give-up bound), not hang")
+}


### PR DESCRIPTION
## Summary

The `staging-contention` e2e's chunking window surfaced a real ncps gap: in-flight NAR staging — documented (#1355/#1374/#1375/#1379, CHANGELOG) as serving cross-pod reads during the eager-CDC chunking window and *"superseding the fragile progressive-chunk reassembly"* — **never actually engaged** for the **uncompressed `.nar`** request, which (since predictive-`none`, #1380) is the *only* request clients make in that window. The cross-pod reader served progressive chunks with zero contention and zero staging. #1379 itself flagged this as unit-verified but with "no green end-to-end run yet."

This PR closes the gap (ncps fix), then makes the e2e assert the now-correct behavior.

### Root cause — two read-path sites

- **`GetNar` routing (`cache.go:~1320`):** the fall-through to download coordination (the only path that records a staging request) was gated `Compression != none`, so the uncompressed read short-circuited to progressive chunk serving and never contended.
- **`pollForDownloadOrTakeOver` state (D) (`cache.go:~6815`):** even once coordinating, an actively-chunking NAR with no staging parts *yet* immediately returned "served-by-peer → progressive," pre-empting staging on an early tick.

### Fix (both gated on `InflightStagingEnabled()`)

- Route uncompressed actively-chunking cross-pod reads through coordination (new `shouldCoordinateInflight` predicate) so they record a staging request and serve from staging.
- State (D) now waits, bounded (`maxStagingWaitTicks`), for staging parts so the staging serve wins, before falling back to progressive chunks (safety net for a stalled producer).
- Unchanged for: staging disabled, lazy CDC, single-replica/same-pod, finished NARs.

### Harness + docs

- `staging-contention` chunking window now asserts **staging activation** (with a bounded clean-restart retry — addresses the earlier CodeRabbit review), reverting the interim progressive-chunk assertion.
- Corrected the CHANGELOG (the prior entry described intended-but-unverified behavior) and synced the `inflight-nar-staging` + `unified-e2e-harness` specs.

## Verification

- [x] `go test -race ./pkg/cache/` green; full `task test` green — no regression
- [x] New `pkg/cache` internal tests (red→green) for both sites + the staging-disabled / stalled-producer guards
- [x] `task test:e2e ... staging-contention`: **both** windows activate in-flight staging, twice (determinism). Chunking-window race **143s → 4.5s** as staging replaces progressive reassembly.
- [x] `task fmt` / `task lint` clean; `openspec validate --all` 41/0

> Note: the first commit on this branch was the interim harness-only change; this PR's net diff is the ncps fix + the staging-activation assertion.