### PR TITLE
fix(e2e): make the e2e-nightly workflow reliable on both modes

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -77,7 +77,19 @@ jobs:
           name: ncps
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Run e2e catalog (${{ matrix.mode }})
-        run: nix run .#e2e -- --mode ${{ matrix.mode }} --all
+        run: |
+          if [ "${{ matrix.mode }}" = "local" ]; then
+            # Local mode drives dev-scripts/run.py, which launches each ncps
+            # replica via watchexec + `direnv exec` + `go run` and therefore
+            # needs the dev-shell toolchain. Run it inside `nix develop` (which
+            # now bundles direnv) with the repo's .envrc allowed so `direnv
+            # exec` can load the flake env. The kubernetes leg is self-contained
+            # in the `nix run .#e2e` wrapper (kubectl/helm/kind) and needs none
+            # of this.
+            nix develop --command bash -c 'direnv allow . && nix run .#e2e -- --mode local --all'
+          else
+            nix run .#e2e -- --mode kubernetes --all
+          fi
   record:
     needs: [gate, e2e]
     # Only record the tested SHA after a fully successful matrix run, so a

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -9,6 +9,11 @@ on:
   schedule:
     - cron: "0 4 * * *" # 04:00 UTC nightly
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (branch/tag/SHA) to check out and test. Defaults to main."
+        required: false
+        default: main
 permissions:
   contents: read
 concurrency:
@@ -23,9 +28,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: main
+          # Scheduled runs and the default dispatch test `main`; a manual dispatch
+          # may override `ref` to test a branch/tag/SHA (e.g. a PR branch).
+          ref: ${{ inputs.ref || 'main' }}
           persist-credentials: false
-      - name: Resolve current main SHA
+      - name: Resolve tested SHA
         id: resolve
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Probe last-tested cache key

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -80,14 +80,12 @@ jobs:
         run: |
           if [ "${{ matrix.mode }}" = "local" ]; then
             # Local mode drives dev-scripts/run.py, which launches each ncps
-            # replica via watchexec + `direnv exec` + `go run` and therefore
-            # needs the dev-shell toolchain. Run it inside `nix develop` (which
-            # now bundles direnv) with the repo's .envrc allowed so `direnv
-            # exec` can load the flake env. The kubernetes leg is self-contained
-            # in the `nix run .#e2e` wrapper (kubectl/helm/kind) and needs none
-            # of this.
-            nix develop --command bash -c 'direnv allow . && nix run .#e2e -- --mode local --all'
+            # replica via watchexec + `direnv exec` + `go run` (cgo needs gcc).
+            # Run it inside the CI dev shell (default toolchain + direnv) so the
+            # leg is self-contained; local.py runs `direnv allow` itself.
+            nix develop .#ci-e2e-local --command bash -c 'nix run .#e2e -- --mode local --all'
           else
+            # Kubernetes mode is self-contained in the e2e wrapper (kubectl/helm/kind).
             nix run .#e2e -- --mode kubernetes --all
           fi
   record:

--- a/nix/dev-packages.nix
+++ b/nix/dev-packages.nix
@@ -8,6 +8,11 @@ pkgs: with pkgs; [
   sqlc
   sqlfluff
   watchexec
+  # direnv: dev-scripts/run.py launches each ncps replica via `direnv exec` to
+  # load the flake env. Bundling it makes the dev shell self-contained (CI runs
+  # local-mode e2e via `nix develop` and must not rely on a host-installed
+  # direnv).
+  direnv
   xz
   delve
   awscli2

--- a/nix/dev-packages.nix
+++ b/nix/dev-packages.nix
@@ -8,11 +8,6 @@ pkgs: with pkgs; [
   sqlc
   sqlfluff
   watchexec
-  # direnv: dev-scripts/run.py launches each ncps replica via `direnv exec` to
-  # load the flake env. Bundling it makes the dev shell self-contained (CI runs
-  # local-mode e2e via `nix develop` and must not rely on a host-installed
-  # direnv).
-  direnv
   xz
   delve
   awscli2

--- a/nix/devshells/flake-module.nix
+++ b/nix/devshells/flake-module.nix
@@ -6,8 +6,8 @@
       pkgs,
       ...
     }:
-    {
-      devShells.default = pkgs.mkShell {
+    let
+      defaultShell = pkgs.mkShell {
         buildInputs =
           (import ../dev-packages.nix pkgs)
           ++ [
@@ -182,5 +182,19 @@
           echo ""
         '';
       };
+    in
+    {
+      devShells.default = defaultShell;
+
+      # CI-only shell for the local-mode e2e nightly. dev-scripts/run.py
+      # launches each ncps replica via `direnv exec <repo>`, so direnv must be
+      # on PATH. It is deliberately NOT in the default shell: developers use
+      # their host direnv (with their own shellrc hooks/config), and bundling it
+      # in the default shell would shadow that. This sibling layers only direnv
+      # on top of the default toolchain so `nix develop .#ci-e2e-local` is
+      # self-contained for CI without affecting local development.
+      devShells.ci-e2e-local = defaultShell.overrideAttrs (old: {
+        buildInputs = old.buildInputs ++ [ pkgs.direnv ];
+      });
     };
 }

--- a/nix/e2e-tests/flake-module.nix
+++ b/nix/e2e-tests/flake-module.nix
@@ -23,7 +23,10 @@ _: {
           kind
           skopeo
           docker
-          # Shared.
+          # Shared. Local mode additionally needs the dev-shell toolchain
+          # (go, gcc/cgo, watchexec, direnv, dbmate); the nightly provides it by
+          # running the local leg inside the `ci-e2e-local` devShell rather than
+          # bundling a partial toolchain here.
           git
           nix # `nix eval` (catalog) and `nix run .#deps` (local-mode backends)
           (pkgs.python3.withPackages (

--- a/nix/e2e-tests/src/deps.py
+++ b/nix/e2e-tests/src/deps.py
@@ -60,7 +60,10 @@ class Deps:
         ]
         self._started = False
 
-    def ensure_up(self, timeout: int = 120) -> None:
+    # 300s (not 120s): a cold all-backend boot — postgres `initdb`, mariadb
+    # `mariadb-install-db`, garage layout, each into a fresh `mktemp` data dir —
+    # can exceed two minutes on a resource-constrained CI runner.
+    def ensure_up(self, timeout: int = 300) -> None:
         if _all_ports_ready(self.ports):
             log("deps: backends already reachable; leaving them as-is", Y)
             return
@@ -87,7 +90,44 @@ class Deps:
                 log("deps: all services ready", G)
                 return
             time.sleep(2)
+        # Surface which backend is unhealthy instead of an opaque timeout, so a
+        # CI failure is diagnosable from the logs alone.
+        self._dump_diagnostics()
         raise RuntimeError(f"deps: services not ready within {timeout}s")
+
+    def _dump_diagnostics(self) -> None:
+        """Best-effort dump of process-compose state + per-process logs.
+
+        Never raises: a diagnostics failure must not mask the readiness error.
+        """
+        log("deps: services not ready — process-compose state follows:", R)
+        names: List[str] = []
+        try:
+            listing = subprocess.run(
+                ["nix", "run", ".#deps", "--", "process", "list", "-p", str(PC_PORT)],
+                cwd=REPO_ROOT,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            log((listing.stdout or "") + (listing.stderr or ""), R)
+            names = [ln.strip() for ln in (listing.stdout or "").splitlines() if ln.strip()]
+        except Exception as e:  # noqa: BLE001 — diagnostics are best-effort
+            log(f"deps: could not list processes: {e}", R)
+        for name in names:
+            try:
+                logs = subprocess.run(
+                    ["nix", "run", ".#deps", "--", "process", "logs", name, "--tail", "100", "-p", str(PC_PORT)],
+                    cwd=REPO_ROOT,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=20,
+                )
+                log(f"deps: --- {name} logs ---\n{(logs.stdout or '')}{(logs.stderr or '')}", R)
+            except Exception as e:  # noqa: BLE001 — diagnostics are best-effort
+                log(f"deps: could not fetch logs for {name}: {e}", R)
 
     def teardown(self) -> None:
         if not self._started:

--- a/nix/e2e-tests/src/deps.py
+++ b/nix/e2e-tests/src/deps.py
@@ -8,6 +8,7 @@ reachable, an externally-managed stack is assumed and left untouched.
 
 from __future__ import annotations
 
+import json
 import os
 import socket
 import subprocess
@@ -46,6 +47,23 @@ def _port_open(port: int, host: str = "127.0.0.1") -> bool:
 
 def _all_ports_ready(ports: List[int]) -> bool:
     return all(_port_open(p) for p in ports)
+
+
+def _parse_process_names(raw: str) -> List[str]:
+    """Extract process names from `process list -o json`.
+
+    Tolerates both a top-level JSON array and a ``{"data": [...]}`` envelope, and
+    returns ``[]`` on any malformed/empty input (diagnostics are best-effort).
+    """
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        return []
+    if isinstance(data, dict):
+        data = data.get("data", [])
+    if not isinstance(data, list):
+        return []
+    return [p["name"] for p in data if isinstance(p, dict) and "name" in p]
 
 
 class Deps:
@@ -103,8 +121,11 @@ class Deps:
         log("deps: services not ready — process-compose state follows:", R)
         names: List[str] = []
         try:
+            # `-o json`: the default `process list` prints a formatted table whose
+            # header/border rows would be mis-parsed as process names; JSON is the
+            # stable machine-readable form.
             listing = subprocess.run(
-                ["nix", "run", ".#deps", "--", "process", "list", "-p", str(PC_PORT)],
+                ["nix", "run", ".#deps", "--", "process", "list", "-o", "json", "-p", str(PC_PORT)],
                 cwd=REPO_ROOT,
                 check=False,
                 capture_output=True,
@@ -112,7 +133,7 @@ class Deps:
                 timeout=30,
             )
             log((listing.stdout or "") + (listing.stderr or ""), R)
-            names = [ln.strip() for ln in (listing.stdout or "").splitlines() if ln.strip()]
+            names = _parse_process_names(listing.stdout or "")
         except Exception as e:  # noqa: BLE001 — diagnostics are best-effort
             log(f"deps: could not list processes: {e}", R)
         for name in names:

--- a/nix/e2e-tests/src/http_retry.py
+++ b/nix/e2e-tests/src/http_retry.py
@@ -26,6 +26,8 @@ def get_with_retry(do_get, *, attempts: int = 5, backoff: float = 1.0, sleep=tim
     every attempt raised, re-raises the last exception. Backoff is exponential
     and capped at 10s between attempts.
     """
+    if attempts < 1:
+        raise ValueError("attempts must be >= 1")
     last_exc: BaseException | None = None
     resp = None
     for i in range(attempts):

--- a/nix/e2e-tests/src/http_retry.py
+++ b/nix/e2e-tests/src/http_retry.py
@@ -1,0 +1,44 @@
+"""Bounded retry for transient HTTP failures during kubernetes validation.
+
+Dependency-injected (no ``requests`` import) so it stays unit-testable under the
+pytest-only harness check: the caller passes a ``do_get`` thunk that performs the
+request and returns a response object exposing ``status_code``.
+
+Rationale: right after a deploy ncps can be up (``/healthz`` passes) yet a
+narinfo/NAR fetch transiently 5xxes during warm-up or seeding. A single no-retry
+GET turns that transient blip into a whole-scenario failure (the observed
+``single-local-mariadb`` HTTP 500). Retrying connection errors and 5xx absorbs
+the blip; a persistent failure still surfaces (the final 5xx response is
+returned, or the last connection error is raised).
+"""
+
+from __future__ import annotations
+
+import time
+
+
+def get_with_retry(do_get, *, attempts: int = 5, backoff: float = 1.0, sleep=time.sleep):
+    """Call ``do_get`` until it returns a non-5xx response or attempts run out.
+
+    Retries on a raised exception (connection-level failure) or a >= 500 status.
+    Returns the first response with ``status_code < 500``; if every attempt was a
+    5xx, returns the last response so the caller can still fail the check; if
+    every attempt raised, re-raises the last exception. Backoff is exponential
+    and capped at 10s between attempts.
+    """
+    last_exc: BaseException | None = None
+    resp = None
+    for i in range(attempts):
+        try:
+            resp = do_get()
+        except Exception as e:  # noqa: BLE001 — any connection-level error is retryable
+            last_exc = e
+            resp = None
+        else:
+            if resp.status_code < 500:
+                return resp
+        if i < attempts - 1:
+            sleep(min(backoff * (2**i), 10))
+    if resp is not None:
+        return resp
+    raise last_exc  # type: ignore[misc]  # only reached when every attempt raised

--- a/nix/e2e-tests/src/k8s_tests_tester.py
+++ b/nix/e2e-tests/src/k8s_tests_tester.py
@@ -35,6 +35,8 @@ try:
 except ImportError:
     boto3 = None
 
+from http_retry import get_with_retry
+
 HTTP_TIMEOUT = 60
 
 
@@ -564,9 +566,13 @@ class NCPSTester:
             # Test first 3 hashes
             for narinfo_hash in test_hashes[:3]:
                 try:
-                    # Fetch narinfo
-                    resp = requests.get(
-                        f"{base_url}/{narinfo_hash}.narinfo", timeout=HTTP_TIMEOUT
+                    # Fetch narinfo. Retry transient post-deploy 5xx/connection
+                    # errors: ncps can be up (healthz ok) yet briefly 5xx a
+                    # narinfo during warm-up/seeding.
+                    resp = get_with_retry(
+                        lambda: requests.get(
+                            f"{base_url}/{narinfo_hash}.narinfo", timeout=HTTP_TIMEOUT
+                        )
                     )
                     if resp.status_code != 200:
                         return TestResult(
@@ -591,10 +597,12 @@ class NCPSTester:
 
                     nar_url = url_match.group(1).strip()
 
-                    # Fetch the NAR file
+                    # Fetch the NAR file (same transient-error tolerance).
                     if self.verbose:
                         print(f"      ✓ Fetching {nar_url}")
-                    resp = requests.get(f"{base_url}/{nar_url}", timeout=HTTP_TIMEOUT)
+                    resp = get_with_retry(
+                        lambda: requests.get(f"{base_url}/{nar_url}", timeout=HTTP_TIMEOUT)
+                    )
                     if resp.status_code != 200:
                         return TestResult(
                             "HTTP Endpoints",

--- a/nix/e2e-tests/src/k8s_tests_tester.py
+++ b/nix/e2e-tests/src/k8s_tests_tester.py
@@ -570,8 +570,8 @@ class NCPSTester:
                     # errors: ncps can be up (healthz ok) yet briefly 5xx a
                     # narinfo during warm-up/seeding.
                     resp = get_with_retry(
-                        lambda: requests.get(
-                            f"{base_url}/{narinfo_hash}.narinfo", timeout=HTTP_TIMEOUT
+                        lambda h=narinfo_hash: requests.get(
+                            f"{base_url}/{h}.narinfo", timeout=HTTP_TIMEOUT
                         )
                     )
                     if resp.status_code != 200:
@@ -601,7 +601,7 @@ class NCPSTester:
                     if self.verbose:
                         print(f"      ✓ Fetching {nar_url}")
                     resp = get_with_retry(
-                        lambda: requests.get(f"{base_url}/{nar_url}", timeout=HTTP_TIMEOUT)
+                        lambda u=nar_url: requests.get(f"{base_url}/{u}", timeout=HTTP_TIMEOUT)
                     )
                     if resp.status_code != 200:
                         return TestResult(

--- a/nix/e2e-tests/src/k8s_tests_tester.py
+++ b/nix/e2e-tests/src/k8s_tests_tester.py
@@ -677,14 +677,24 @@ class NCPSTester:
             # When using debug with --target, access target's filesystem via /proc/1/root
             target_db_path = f"/proc/1/root{db_path}"
 
-            # Snapshot the live DB with SQLite's online backup, which yields a
-            # WAL-consistent copy. The previous approach copied ncps.db,
-            # ncps.db-wal and ncps.db-shm as three separate files; a checkpoint
-            # landing between the copies (main file copied pre-checkpoint without
-            # the table, WAL then truncated) produced a snapshot missing freshly
-            # written tables — a flaky "nar_files not found" even though the live
-            # DB clearly has it (the HTTP narinfo probe, which reads nar_files,
-            # passes). `.backup` coordinates with WAL and concurrent writers.
+            # Copy the DB to writable /tmp and query the copy. We cannot open the
+            # live DB in place: with WAL mode sqlite needs to write the directory
+            # (-shm/locks) to open it, but the ephemeral debug container sees the
+            # target fs via /proc/1/root read-only, so a direct open (or
+            # `.backup`) fails with "unable to open database file". cp only reads
+            # bytes, which works.
+            #
+            # Copy order matters: copy -wal FIRST and the main DB LAST, so the
+            # main file is the newest in the snapshot. If a checkpoint lands
+            # mid-copy, the DB copied last already has the table (and the now
+            # stale -wal is ignored on a salt mismatch); if none does, the copied
+            # -wal still matches the DB and sqlite replays it. The reverse order
+            # (DB first) was the flaky bug — a checkpoint between `cp db` and
+            # `cp wal` left an old DB plus a truncated WAL, so the table went
+            # missing even though the live DB had it. We deliberately do NOT copy
+            # -shm (the volatile wal-index); sqlite rebuilds it in /tmp, and a
+            # stale -shm could otherwise make it trust an inconsistent wal index.
+            #
             # nouchka/sqlite3 ships sqlite3; no --profile=restricted because it
             # sets runAsNonRoot, which the kubelet rejects for that root image
             # (the debug container never starts and the probe times out).
@@ -703,7 +713,9 @@ class NCPSTester:
                         "--",
                         "sh",
                         "-c",
-                        f"sqlite3 {target_db_path} \".backup '/tmp/test.db'\" "
+                        "rm -f /tmp/test.db /tmp/test.db-wal /tmp/test.db-shm; "
+                        f"cp {target_db_path}-wal /tmp/test.db-wal 2>/dev/null; "
+                        f"cp {target_db_path} /tmp/test.db "
                         f"&& sqlite3 /tmp/test.db {query_arg}",
                     ],
                     capture_output=True,

--- a/nix/e2e-tests/src/k8s_tests_tester.py
+++ b/nix/e2e-tests/src/k8s_tests_tester.py
@@ -677,84 +677,68 @@ class NCPSTester:
             # When using debug with --target, access target's filesystem via /proc/1/root
             target_db_path = f"/proc/1/root{db_path}"
 
-            # Copy the database and its WAL files to /tmp before querying.
-            # With WAL mode enabled, recent writes live in ncps.db-wal and are not yet
-            # checkpointed into the main ncps.db file. Copying only the .db file would
-            # show empty tables. Copying all three files (-wal and -shm may not exist if
-            # nothing is pending, hence the || true) gives SQLite a consistent view.
-            # Using nouchka/sqlite3 image which has sqlite pre-installed
-            result = subprocess.run(
-                [
-                    "kubectl",
-                    "debug",
-                    "-n",
-                    namespace,
-                    pod_name,
-                    "--target=ncps",
-                    "--image=nouchka/sqlite3:latest",
-                    "-it=false",
-                    "--quiet",
-                    # No --profile=restricted: it sets runAsNonRoot on the
-                    # ephemeral container, which the kubelet rejects because the
-                    # nouchka/sqlite3 image runs as root ("container has
-                    # runAsNonRoot and image will run as root" -> the debug
-                    # container never starts and the probe times out). Match the
-                    # storage probe, which uses the default profile.
-                    "--",
-                    "sh",
-                    "-c",
-                    f"cp {target_db_path} /tmp/test.db && cp {target_db_path}-wal /tmp/test.db-wal 2>/dev/null || true && cp {target_db_path}-shm /tmp/test.db-shm 2>/dev/null || true && sqlite3 /tmp/test.db '.tables'",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=60,
-            )
-
-            if result.returncode != 0:
-                return TestResult(
-                    "Database",
-                    False,
-                    f"Failed to access SQLite database at {db_path}",
-                    details=f"Return code: {result.returncode}\nstderr: {result.stderr}\nstdout: {result.stdout}",
+            # Snapshot the live DB with SQLite's online backup, which yields a
+            # WAL-consistent copy. The previous approach copied ncps.db,
+            # ncps.db-wal and ncps.db-shm as three separate files; a checkpoint
+            # landing between the copies (main file copied pre-checkpoint without
+            # the table, WAL then truncated) produced a snapshot missing freshly
+            # written tables — a flaky "nar_files not found" even though the live
+            # DB clearly has it (the HTTP narinfo probe, which reads nar_files,
+            # passes). `.backup` coordinates with WAL and concurrent writers.
+            # nouchka/sqlite3 ships sqlite3; no --profile=restricted because it
+            # sets runAsNonRoot, which the kubelet rejects for that root image
+            # (the debug container never starts and the probe times out).
+            def _sqlite(query_arg: str) -> subprocess.CompletedProcess:
+                return subprocess.run(
+                    [
+                        "kubectl",
+                        "debug",
+                        "-n",
+                        namespace,
+                        pod_name,
+                        "--target=ncps",
+                        "--image=nouchka/sqlite3:latest",
+                        "-it=false",
+                        "--quiet",
+                        "--",
+                        "sh",
+                        "-c",
+                        f"sqlite3 {target_db_path} \".backup '/tmp/test.db'\" "
+                        f"&& sqlite3 /tmp/test.db {query_arg}",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
                 )
 
-            tables_output = result.stdout.strip()
-
-            if "nar_files" not in tables_output:
+            # Retry the table check: a snapshot taken in the brief window before
+            # a migration/write commits can miss the table. The data is present
+            # once serving has begun, so a few attempts converge.
+            last = None
+            tables_output = ""
+            for _attempt in range(5):
+                last = _sqlite("'.tables'")
+                if last.returncode == 0 and "nar_files" in last.stdout:
+                    tables_output = last.stdout.strip()
+                    break
+                time.sleep(3)
+            else:
+                if last is not None and last.returncode != 0:
+                    return TestResult(
+                        "Database",
+                        False,
+                        f"Failed to access SQLite database at {db_path}",
+                        details=f"Return code: {last.returncode}\nstderr: {last.stderr}\nstdout: {last.stdout}",
+                    )
                 return TestResult(
                     "Database",
                     False,
-                    f"Expected 'nar_files' table not found in SQLite database",
-                    details=f"Tables found: '{tables_output}'",
+                    "Expected 'nar_files' table not found in SQLite database",
+                    details=f"Tables found: '{(last.stdout if last else '').strip()}'",
                 )
 
             # Count rows
-            result = subprocess.run(
-                [
-                    "kubectl",
-                    "debug",
-                    "-n",
-                    namespace,
-                    pod_name,
-                    "--target=ncps",
-                    "--image=nouchka/sqlite3:latest",
-                    "-it=false",
-                    "--quiet",
-                    # No --profile=restricted: it sets runAsNonRoot on the
-                    # ephemeral container, which the kubelet rejects because the
-                    # nouchka/sqlite3 image runs as root ("container has
-                    # runAsNonRoot and image will run as root" -> the debug
-                    # container never starts and the probe times out). Match the
-                    # storage probe, which uses the default profile.
-                    "--",
-                    "sh",
-                    "-c",
-                    f"cp {target_db_path} /tmp/test.db && cp {target_db_path}-wal /tmp/test.db-wal 2>/dev/null || true && cp {target_db_path}-shm /tmp/test.db-shm 2>/dev/null || true && sqlite3 /tmp/test.db 'SELECT COUNT(*) FROM nar_files;'",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=60,
-            )
+            result = _sqlite("'SELECT COUNT(*) FROM nar_files;'")
 
             if result.returncode != 0:
                 return TestResult(

--- a/nix/e2e-tests/src/local.py
+++ b/nix/e2e-tests/src/local.py
@@ -35,6 +35,25 @@ from harness_config import (
 )
 
 
+_direnv_allowed = False
+
+
+def _allow_direnv_once() -> None:
+    """Allow the repo's ``.envrc`` once so run.py's ``direnv exec`` can load the
+    flake env on a fresh checkout (e.g. CI). Best-effort and idempotent; a
+    developer's already-allowed repo just gets a harmless refresh."""
+    global _direnv_allowed
+    if _direnv_allowed:
+        return
+    _direnv_allowed = True
+    try:
+        subprocess.run(
+            ["direnv", "allow", REPO_ROOT], cwd=REPO_ROOT, check=False, timeout=30
+        )
+    except Exception as e:  # noqa: BLE001 — best-effort
+        log(f"local: 'direnv allow' failed (ignored): {e}", Y)
+
+
 class LocalDeployment:
     """A run.py-backed deployment of one scenario."""
 
@@ -57,6 +76,8 @@ class LocalDeployment:
         return [BASE_PORT + i for i in range(self.replicas)]
 
     def _start(self, *, clean: bool, cdc: bool, lazy: bool) -> None:
+        # run.py launches ncps via `direnv exec`; ensure the .envrc is allowed.
+        _allow_direnv_once()
         args = [
             PYTHON,
             RUN_PY,

--- a/nix/e2e-tests/src/local.py
+++ b/nix/e2e-tests/src/local.py
@@ -45,11 +45,17 @@ def _allow_direnv_once() -> None:
     global _direnv_allowed
     if _direnv_allowed:
         return
-    _direnv_allowed = True
     try:
-        subprocess.run(
+        result = subprocess.run(
             ["direnv", "allow", REPO_ROOT], cwd=REPO_ROOT, check=False, timeout=30
         )
+        # Latch only on success so a transient failure is retried on the next
+        # start (e.g. a restart within a scenario) rather than wedging the rest
+        # of the run.
+        if result.returncode == 0:
+            _direnv_allowed = True
+        else:
+            log("local: 'direnv allow' returned non-zero (will retry later)", Y)
     except Exception as e:  # noqa: BLE001 — best-effort
         log(f"local: 'direnv allow' failed (ignored): {e}", Y)
 

--- a/nix/e2e-tests/src/local.py
+++ b/nix/e2e-tests/src/local.py
@@ -103,6 +103,7 @@ class LocalDeployment:
         pending = set(self._ports())
         while time.time() < deadline:
             if self._proc.poll() is not None:
+                self._dump_logs()
                 raise RuntimeError(
                     f"local: run.py exited with code {self._proc.returncode} "
                     "before all replicas became ready (see var/log/e2e-run.py.log)"
@@ -119,7 +120,26 @@ class LocalDeployment:
                 log(f"local: all {self.replicas} replica(s) ready", G)
                 return
             time.sleep(1)
+        self._dump_logs()
         raise RuntimeError(f"local: replicas not ready within {timeout}s: {sorted(pending)}")
+
+    def _dump_logs(self) -> None:
+        """Best-effort: echo run.py's harness log and each replica's ncps log so
+        a CI failure shows *why* ncps did not come up. Never raises."""
+        try:
+            if self._harness_log is not None:
+                self._harness_log.flush()
+        except Exception:  # noqa: BLE001 — diagnostics are best-effort
+            pass
+        paths = [os.path.join(LOG_DIR, "e2e-run.py.log")]
+        paths += [os.path.join(LOG_DIR, f"ncps-{p}.log") for p in self._ports()]
+        for path in paths:
+            try:
+                with open(path, encoding="utf-8", errors="replace") as f:
+                    content = f.read().strip()
+            except OSError:
+                content = "(no log file)"
+            log(f"local: --- {os.path.basename(path)} ---\n{content or '(empty)'}", R)
 
     def _stop(self) -> None:
         if self._proc is not None and self._proc.poll() is None:

--- a/nix/e2e-tests/src/runner.py
+++ b/nix/e2e-tests/src/runner.py
@@ -14,8 +14,13 @@ from harness_config import AssertionFailure, G, R, Y, log, section
 from phases import get_phase
 
 
-def _execute(scenario, mode: str, verbose: bool) -> str:
-    """Run one scenario in one mode, returning 'PASS' | 'FAIL' | 'SKIP'."""
+def _execute(scenario, mode: str, verbose: bool, shared_deps=None) -> str:
+    """Run one scenario in one mode, returning 'PASS' | 'FAIL' | 'SKIP'.
+
+    ``shared_deps`` is the run-scoped local backends started once by
+    ``run_scenarios``; when provided, ``_run_local`` reuses them instead of
+    starting/stopping its own.
+    """
     # SKIP (not FAIL, not PASS) when the topology can't be expressed in this mode.
     if not scenario.supports(mode):
         log(
@@ -26,7 +31,7 @@ def _execute(scenario, mode: str, verbose: bool) -> str:
         return "SKIP"
 
     if mode == "local":
-        rc = _run_local(scenario, verbose)
+        rc = _run_local(scenario, verbose, shared_deps=shared_deps)
     elif mode == "kubernetes":
         rc = _run_kubernetes(scenario, verbose)
     else:
@@ -67,13 +72,56 @@ def run_scenarios(*, mode: str, scenario_names, verbose: bool = False) -> int:
                 log(str(e), R)
                 return 2
 
+    # In local mode start the managed backends ONCE for the whole run (not per
+    # scenario): each backend boots cold into a fresh `mktemp` data dir, so a
+    # per-scenario restart pays a full cold boot every time and races the
+    # readiness timeout on a slow runner. The single startup includes Redis if
+    # any selected scenario needs it.
+    shared_deps = _shared_local_deps(mode, selected)
     results = []
-    for scenario in selected:
-        status = _execute(scenario, mode, verbose)
-        results.append((scenario.name, status))
+    try:
+        if shared_deps is not None:
+            try:
+                shared_deps.ensure_up()
+            except Exception as e:  # noqa: BLE001 — report as a run failure, not a traceback
+                log(f"ERROR [local]: backing services not ready: {e}", R)
+                return 1
+        for scenario in selected:
+            status = _execute(scenario, mode, verbose, shared_deps=shared_deps)
+            results.append((scenario.name, status))
+    finally:
+        if shared_deps is not None:
+            shared_deps.teardown()
 
     _print_summary(mode, results)
     return 1 if any(status == "FAIL" for _, status in results) else 0
+
+
+def _shared_local_deps(mode: str, selected):
+    """Build the run-scoped backends for a local run, or None.
+
+    Returns None for non-local mode or when no selected scenario can run locally.
+    """
+    if mode != "local":
+        return None
+    local_selected = [s for s in selected if s.supports("local")]
+    if not local_selected:
+        return None
+    return _make_local_deps(local_selected)
+
+
+def _make_local_deps(scenarios):
+    """Construct the shared ``Deps`` for the given local-supported scenarios.
+
+    Redis is included if ANY scenario needs it (staging or multi-replica), since
+    one shared backend set serves every scenario in the run.
+    """
+    from deps import Deps
+
+    needs_redis = any(
+        getattr(s, "staging", False) or getattr(s, "replicas", 1) > 1 for s in scenarios
+    )
+    return Deps(needs_redis=needs_redis)
 
 
 def _print_summary(mode: str, results) -> None:
@@ -90,18 +138,26 @@ def _print_summary(mode: str, results) -> None:
     )
 
 
-def _run_local(scenario, verbose: bool) -> int:
+def _run_local(scenario, verbose: bool, shared_deps=None) -> int:
     from deps import Deps
     from local import LocalDeployment
 
-    needs_redis = scenario.staging or scenario.replicas > 1
-    deps = Deps(needs_redis=needs_redis)
+    # When the caller (a multi-scenario run) already started the backends, reuse
+    # them and leave their lifecycle to the caller. Only the single-scenario path
+    # owns (starts and stops) its own backends.
+    owns_deps = shared_deps is None
+    if owns_deps:
+        needs_redis = scenario.staging or scenario.replicas > 1
+        deps = Deps(needs_redis=needs_redis)
+    else:
+        deps = shared_deps
     deployment = LocalDeployment(scenario)
     phase = get_phase(scenario.phase)
 
     rc = 0
     try:
-        deps.ensure_up()
+        if owns_deps:
+            deps.ensure_up()
         deployment.provision()
         phase(deployment, scenario)
         section(f"PASS {scenario.name} [local]")
@@ -114,7 +170,8 @@ def _run_local(scenario, verbose: bool) -> int:
         rc = 1
     finally:
         deployment.teardown()
-        deps.teardown()
+        if owns_deps:
+            deps.teardown()
     return rc
 
 

--- a/nix/e2e-tests/tests/test_deps.py
+++ b/nix/e2e-tests/tests/test_deps.py
@@ -1,0 +1,48 @@
+"""Unit tests for the backing-services readiness lifecycle.
+
+``deps`` imports only stdlib + ``harness_config`` (light), so these run under the
+pytest-only ``e2e-harness-unit`` check without ``nix``/network.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+import deps as deps_mod
+
+
+def test_ensure_up_timeout_tolerates_cold_ci_boot():
+    """A cold all-backend boot on a constrained runner can exceed 120s; the
+    default readiness timeout must allow at least 300s."""
+    default = inspect.signature(deps_mod.Deps.ensure_up).parameters["timeout"].default
+    assert default >= 300
+
+
+def test_readiness_timeout_dumps_process_compose_diagnostics(monkeypatch):
+    """On a readiness timeout the harness must surface which backend is unready
+    (process list at minimum), not just an opaque 'not ready' message."""
+    commands = []
+
+    class _R:
+        returncode = 0
+        stdout = "garage-server\npostgres-server\nmariadb-server\n"
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        commands.append(list(cmd))
+        return _R()
+
+    # Ports never become ready -> force the timeout path.
+    monkeypatch.setattr(deps_mod, "_all_ports_ready", lambda ports: False)
+    monkeypatch.setattr(deps_mod.subprocess, "run", fake_run)
+
+    d = deps_mod.Deps()
+    with pytest.raises(RuntimeError):
+        d.ensure_up(timeout=0)
+
+    joined = [" ".join(str(p) for p in c) for c in commands]
+    assert any("process" in j and "list" in j for j in joined), (
+        "diagnostics must include a process-compose process list"
+    )

--- a/nix/e2e-tests/tests/test_deps.py
+++ b/nix/e2e-tests/tests/test_deps.py
@@ -27,7 +27,8 @@ def test_readiness_timeout_dumps_process_compose_diagnostics(monkeypatch):
 
     class _R:
         returncode = 0
-        stdout = "garage-server\npostgres-server\nmariadb-server\n"
+        # `process list -o json` emits a JSON array of process objects.
+        stdout = '[{"name": "garage-server"}, {"name": "postgres-server"}, {"name": "mariadb-server"}]'
         stderr = ""
 
     def fake_run(cmd, **kwargs):
@@ -43,6 +44,20 @@ def test_readiness_timeout_dumps_process_compose_diagnostics(monkeypatch):
         d.ensure_up(timeout=0)
 
     joined = [" ".join(str(p) for p in c) for c in commands]
-    assert any("process" in j and "list" in j for j in joined), (
-        "diagnostics must include a process-compose process list"
+    assert any("process" in j and "list" in j and "json" in j for j in joined), (
+        "diagnostics must include a process-compose process list as JSON"
     )
+    # The parsed names must drive per-process log fetches.
+    assert any("process" in j and "logs" in j and "garage-server" in j for j in joined), (
+        "diagnostics must fetch per-process logs for each parsed process"
+    )
+
+
+def test_parse_process_names_handles_shapes():
+    assert deps_mod._parse_process_names('[{"name": "a"}, {"name": "b"}]') == ["a", "b"]
+    # `{"data": [...]}` envelope is also accepted.
+    assert deps_mod._parse_process_names('{"data": [{"name": "a"}]}') == ["a"]
+    # Malformed / empty / wrong-shape input degrades to [].
+    assert deps_mod._parse_process_names("not json") == []
+    assert deps_mod._parse_process_names("") == []
+    assert deps_mod._parse_process_names('{"nope": 1}') == []

--- a/nix/e2e-tests/tests/test_http_retry.py
+++ b/nix/e2e-tests/tests/test_http_retry.py
@@ -1,0 +1,95 @@
+"""Unit tests for the bounded transient-failure retry helper.
+
+The helper is dependency-injected (it calls a ``do_get`` thunk and an injected
+``sleep``) so these tests need no ``requests``/network and run under the
+pytest-only ``e2e-harness-unit`` check.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import http_retry
+
+
+class _Resp:
+    def __init__(self, code: int) -> None:
+        self.status_code = code
+
+
+def test_returns_first_2xx_without_retrying():
+    seq = [_Resp(200), _Resp(500)]
+    calls = {"n": 0}
+
+    def do_get():
+        r = seq[calls["n"]]
+        calls["n"] += 1
+        return r
+
+    out = http_retry.get_with_retry(do_get, attempts=5, backoff=0, sleep=lambda _s: None)
+    assert out.status_code == 200
+    assert calls["n"] == 1, "stops as soon as a non-5xx response arrives"
+
+
+def test_recovers_after_transient_5xx():
+    seq = [_Resp(500), _Resp(503), _Resp(200)]
+    calls = {"n": 0}
+
+    def do_get():
+        r = seq[calls["n"]]
+        calls["n"] += 1
+        return r
+
+    out = http_retry.get_with_retry(do_get, attempts=5, backoff=0, sleep=lambda _s: None)
+    assert out.status_code == 200
+    assert calls["n"] == 3
+
+
+def test_recovers_after_connection_error():
+    calls = {"n": 0}
+
+    def do_get():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ConnectionError("connection refused")
+        return _Resp(200)
+
+    out = http_retry.get_with_retry(do_get, attempts=5, backoff=0, sleep=lambda _s: None)
+    assert out.status_code == 200
+    assert calls["n"] == 3
+
+
+def test_persistent_5xx_returns_last_response():
+    """A reproducible 5xx is NOT masked — the final 5xx response is returned so
+    the caller still fails the check."""
+    calls = {"n": 0}
+
+    def do_get():
+        calls["n"] += 1
+        return _Resp(500)
+
+    out = http_retry.get_with_retry(do_get, attempts=3, backoff=0, sleep=lambda _s: None)
+    assert out.status_code == 500
+    assert calls["n"] == 3, "all attempts used"
+
+
+def test_persistent_connection_error_raises():
+    def do_get():
+        raise ConnectionError("down")
+
+    with pytest.raises(ConnectionError):
+        http_retry.get_with_retry(do_get, attempts=3, backoff=0, sleep=lambda _s: None)
+
+
+def test_backoff_is_bounded_and_sleeps_between_attempts():
+    slept = []
+
+    def do_get():
+        return _Resp(500)
+
+    http_retry.get_with_retry(
+        do_get, attempts=4, backoff=1.0, sleep=slept.append
+    )
+    # One sleep between each of the 4 attempts -> 3 sleeps, each capped at 10s.
+    assert len(slept) == 3
+    assert all(s <= 10 for s in slept)

--- a/nix/e2e-tests/tests/test_http_retry.py
+++ b/nix/e2e-tests/tests/test_http_retry.py
@@ -81,6 +81,12 @@ def test_persistent_connection_error_raises():
         http_retry.get_with_retry(do_get, attempts=3, backoff=0, sleep=lambda _s: None)
 
 
+def test_invalid_attempts_raises_valueerror():
+    """attempts < 1 would skip the loop and `raise None`; guard it up front."""
+    with pytest.raises(ValueError):
+        http_retry.get_with_retry(lambda: _Resp(200), attempts=0)
+
+
 def test_backoff_is_bounded_and_sleeps_between_attempts():
     slept = []
 

--- a/nix/e2e-tests/tests/test_runner.py
+++ b/nix/e2e-tests/tests/test_runner.py
@@ -12,6 +12,8 @@ import runner
 class _FakeScenario:
     name: str
     modes: List[str]
+    staging: bool = False
+    replicas: int = 1
 
     def supports(self, mode: str) -> bool:
         return mode in self.modes
@@ -28,8 +30,11 @@ def _fake_catalog():
 def _patch(monkeypatch, statuses):
     """Patch catalog + per-scenario execution; statuses maps name -> result."""
     monkeypatch.setattr(runner, "load_catalog", _fake_catalog)
+    # Neutralize the shared local-deps lifecycle so these aggregation tests never
+    # touch real backends.
+    monkeypatch.setattr(runner, "_make_local_deps", lambda scenarios: None)
 
-    def fake_execute(scenario, mode, verbose):
+    def fake_execute(scenario, mode, verbose, shared_deps=None):
         return statuses[scenario.name]
 
     monkeypatch.setattr(runner, "_execute", fake_execute)
@@ -146,7 +151,7 @@ def test_all_selects_every_scenario(monkeypatch):
     seen = []
     monkeypatch.setattr(runner, "load_catalog", _fake_catalog)
 
-    def fake_execute(scenario, mode, verbose):
+    def fake_execute(scenario, mode, verbose, shared_deps=None):
         seen.append(scenario.name)
         return "PASS"
 
@@ -159,8 +164,10 @@ def test_all_selects_every_scenario(monkeypatch):
 def test_explicit_names_run_only_those(monkeypatch):
     seen = []
     monkeypatch.setattr(runner, "load_catalog", _fake_catalog)
+    # Neutralize the shared local-deps lifecycle for this local-mode aggregation.
+    monkeypatch.setattr(runner, "_make_local_deps", lambda scenarios: None)
 
-    def fake_execute(scenario, mode, verbose):
+    def fake_execute(scenario, mode, verbose, shared_deps=None):
         seen.append(scenario.name)
         return "PASS"
 
@@ -168,6 +175,56 @@ def test_explicit_names_run_only_those(monkeypatch):
     rc = runner.run_scenarios(mode="local", scenario_names=["alpha", "bravo"])
     assert rc == 0
     assert seen == ["alpha", "bravo"]
+
+
+def test_local_multi_scenario_starts_deps_once(monkeypatch):
+    """A local --all run starts the managed backends once before the loop and
+    tears them down once after — not per scenario — and includes Redis when any
+    selected scenario needs it."""
+    counts = {"created": 0, "ensure_up": 0, "teardown": 0, "needs_redis": None}
+
+    class _SpyDeps:
+        def __init__(self, *, needs_redis=False):
+            counts["created"] += 1
+            counts["needs_redis"] = needs_redis
+
+        def ensure_up(self, timeout=300):
+            counts["ensure_up"] += 1
+
+        def teardown(self):
+            counts["teardown"] += 1
+
+    import deps as deps_mod
+
+    monkeypatch.setattr(deps_mod, "Deps", _SpyDeps)
+
+    def _catalog():
+        return [
+            _FakeScenario("alpha", ["local", "kubernetes"]),
+            _FakeScenario("bravo", ["local", "kubernetes"], replicas=2),  # needs redis
+            _FakeScenario("charlie", ["kubernetes"]),  # local-unsupported
+        ]
+
+    monkeypatch.setattr(runner, "load_catalog", _catalog)
+
+    seen_shared = []
+
+    def fake_run_local(scenario, verbose, shared_deps=None):
+        seen_shared.append(shared_deps)
+        return 0
+
+    monkeypatch.setattr(runner, "_run_local", fake_run_local)
+
+    rc = runner.run_scenarios(mode="local", scenario_names=None)
+    assert rc == 0
+    assert counts["created"] == 1, "deps constructed exactly once"
+    assert counts["ensure_up"] == 1, "backends started exactly once"
+    assert counts["teardown"] == 1, "backends torn down exactly once"
+    assert counts["needs_redis"] is True, "redis included because a scenario needs it"
+    # Both local-supported scenarios received the shared deps (so _run_local does
+    # not start its own); charlie skipped before reaching _run_local.
+    assert len(seen_shared) == 2
+    assert all(s is not None for s in seen_shared)
 
 
 def test_any_failure_makes_exit_nonzero(monkeypatch):

--- a/nix/process-compose/start-mysql.sh
+++ b/nix/process-compose/start-mysql.sh
@@ -5,7 +5,13 @@ set -euo pipefail
 DATA_DIR=$(mktemp -d)
 
 echo "Storing ephemeral MariaDB data in $DATA_DIR"
-mariadb-install-db --datadir="$DATA_DIR" --auth-root-authentication-method=normal
+# --user="$(id -un)": mariadb-install-db otherwise defaults to the 'mysql'
+# system user and tries to chown the datadir to it. That chown fails with
+# EPERM for an unprivileged user that cannot change file ownership (e.g. the
+# `runner` user on GitHub-hosted CI), aborting install so mariadbd never binds
+# its port. Targeting the current user makes the chown a no-op and lets the
+# install proceed rootless.
+mariadb-install-db --datadir="$DATA_DIR" --user="$(id -un)" --auth-root-authentication-method=normal
 
 exec mariadbd \
   --datadir="$DATA_DIR" \

--- a/nix/process-compose/start-mysql.sh
+++ b/nix/process-compose/start-mysql.sh
@@ -5,15 +5,18 @@ set -euo pipefail
 DATA_DIR=$(mktemp -d)
 
 echo "Storing ephemeral MariaDB data in $DATA_DIR"
-# --user="$(id -un)": mariadb-install-db otherwise defaults to the 'mysql'
-# system user and tries to chown the datadir to it. That chown fails with
-# EPERM for an unprivileged user that cannot change file ownership (e.g. the
-# `runner` user on GitHub-hosted CI), aborting install so mariadbd never binds
-# its port. Targeting the current user makes the chown a no-op and lets the
-# install proceed rootless.
-mariadb-install-db --datadir="$DATA_DIR" --user="$(id -un)" --auth-root-authentication-method=normal
+# --no-defaults: ignore the system option files (/etc/mysql/my.cnf etc.). A
+# GitHub-hosted runner ships a pre-installed MySQL whose my.cnf sets
+# `user=mysql` and the MySQL-only `mysqlx-bind-address`. MariaDB reads those by
+# default, so it both tries to chown the datadir to the (unwritable) `mysql`
+# user and then aborts on the unknown `mysqlx-bind-address` variable, leaving
+# mariadbd unable to bind its port. Ignoring the system config lets the install
+# and server run rootless as the current user; every option we rely on is
+# passed explicitly here.
+mariadb-install-db --no-defaults --datadir="$DATA_DIR" --auth-root-authentication-method=normal
 
 exec mariadbd \
+  --no-defaults \
   --datadir="$DATA_DIR" \
   --bind-address="$MYSQL_HOST" \
   --port="$MYSQL_TCP_PORT" \

--- a/openspec/changes/archive/2026-06-09-fix-e2e-nightly-failures/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-09-fix-e2e-nightly-failures/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/archive/2026-06-09-fix-e2e-nightly-failures/design.md
+++ b/openspec/changes/archive/2026-06-09-fix-e2e-nightly-failures/design.md
@@ -1,0 +1,41 @@
+## Context
+
+The `e2e-nightly` workflow (added in #1383) first ran on 2026-06-10 (run 27252786882) and failed on both matrix legs:
+
+- **local: 0/9 passed.** Every scenario aborted before any test with `deps: services not ready within 120s`. Reproduced locally: `nix/e2e-tests/src/runner.py::_run_local` calls `Deps.ensure_up()` and `Deps.teardown()` *inside* the per-scenario loop of `run_scenarios`. Each backend's start script (`nix/process-compose/start-{postgres,mysql,garage,redis}.sh`) provisions an ephemeral `mktemp -d` data dir, so every scenario pays a full cold boot (`initdb`, `mariadb-install-db`, garage layout). On a dev box this cold boot is ~70s; on a hosted `ubuntu-24.04` runner it exceeds the 120s readiness timeout (`deps.py`), so all 9 local scenarios time out identically. The harness emits no backend logs, so CI shows only the opaque timeout.
+- **kubernetes: 13/15 passed, 1 skipped, 1 failed.** The `already exists` lines are non-fatal idempotent re-provisioning noise. Only `single-local-mariadb` failed, on one check: `HTTP Endpoints: Failed to fetch narinfo … HTTP 500` — while `healthz` passed and Database (2 NAR entries) and Storage (2 NAR files) passed, and the same hashes fetched fine in an adjacent mariadb scenario. `k8s_tests_tester.test_http_endpoints` does `port-forward` → `sleep 3` → one `healthz` probe → a **single, no-retry** narinfo GET; a transient post-deploy 5xx (readiness/seeding race, consistent with known MariaDB-on-Kind flakiness) fails the whole scenario.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the `local` leg reliable on a hosted runner: 0/9 → all-pass.
+- Make the `kubernetes` validation robust to a transient post-deploy error.
+- Make readiness failures self-diagnosing in CI.
+
+**Non-Goals:**
+- No ncps production code changes — harness reliability only.
+- Not investigating whether the MariaDB 500 is a genuine ncps bug; the transient, single-occurrence signal is treated as flakiness and absorbed by a bounded retry. A persistent 5xx still fails.
+- Not switching backends to persistent (warm) data dirs — start-once removes the redundant cold boots without changing the ephemeral-dir design.
+
+## Decisions
+
+- **Start backends once per multi-scenario local run.** Hoist the deps lifecycle out of `_run_local` into `run_scenarios` for `local` mode: start once before the loop, tear down once after. `_run_local` keeps managing deps for the single-scenario `run_scenario` path. `needs_redis` for the shared startup is the OR across all selected local-supported scenarios.
+  - *Alternative considered:* persistent/named data dirs so scenario 2+ boot warm. Rejected — larger blast radius, leaves a race on the 120s timeout for scenario 1's cold boot, and complicates cleanup.
+  - *Alternative considered:* rely only on `ensure_up`'s "ports already reachable → leave as-is" short-circuit by not tearing down between scenarios. This is effectively what start-once formalizes; doing it explicitly keeps teardown ownership unambiguous.
+- **Raise the readiness timeout to 300s.** A single cold boot on a slow runner must fit even in the single-scenario path. 300s is comfortably above the observed ~70s dev cost with headroom for a constrained runner.
+- **Emit diagnostics on readiness timeout.** Before raising, dump `process-compose process list` and per-process logs (via the process-compose API/CLI on the control port) so CI identifies the unready backend.
+- **Bounded retry on kubernetes validation fetches.** Wrap the narinfo and NAR GETs in a small retry (e.g. up to ~5 attempts, short backoff) that retries connection errors and 5xx. A persistent failure still fails the check.
+
+## Risks / Trade-offs
+
+- [Start-once changes deps ownership] → Keep teardown in a `finally` around the whole loop so backends are always stopped even if a scenario raises; the single-scenario path is unchanged.
+- [Retry could mask a real, reproducible 5xx] → Bound attempts and only retry connection errors / 5xx; a deterministic failure still surfaces. If `single-local-mariadb` 500s persistently after this, that is a separate, real ncps bug to be filed.
+- [Longer timeout hides a genuinely hung backend] → Mitigated by the new diagnostics: a timeout now prints which backend was unready and its logs.
+
+## Migration Plan
+
+Harness-only change; no deployment or rollback concerns. Validate with `nix run .#e2e -- --mode local --all` (expect all-pass) and a manual re-dispatch of the `e2e-nightly` workflow.
+
+## Open Questions
+
+- None blocking. Whether the MariaDB-local narinfo 500 is ever reproducible deterministically is deferred; if the retry stops absorbing it, file a dedicated ncps serve bug.

--- a/openspec/changes/archive/2026-06-09-fix-e2e-nightly-failures/proposal.md
+++ b/openspec/changes/archive/2026-06-09-fix-e2e-nightly-failures/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The first run of the new `e2e-nightly` workflow failed on both legs (run 27252786882). `local` failed systemically (0/9 scenarios) and `kubernetes` failed on a single flaky check (13/15 passed). The nightly is the only automated coverage for the unified e2e harness, so it must be made reliable.
+
+## What Changes
+
+- **Local deps lifecycle — start once per run, not per scenario.** `runner._run_local` currently calls `Deps.ensure_up()`/`teardown()` for *every* scenario. Because each backend (`nix/process-compose/start-*.sh`) uses an ephemeral `mktemp -d` data dir, every scenario pays a full cold boot (`initdb` + `mariadb-install-db` + garage layout). On a hosted runner that cold boot exceeds the 120s readiness timeout, so all 9 local scenarios time out identically. In a multi-scenario (`run_scenarios`) local run the harness will start the backends **once** before the loop (including Redis if any selected scenario needs it) and tear them down **once** after.
+- **Tolerate cold hosted-runner boots.** Raise the `ensure_up` readiness timeout (`nix/e2e-tests/src/deps.py`) from 120s to ~300s.
+- **Diagnose readiness failures.** On timeout, `ensure_up` MUST surface process-compose state (`process list`) and per-process logs, instead of the current blind "services not ready within 120s".
+- **Harden the kubernetes HTTP-endpoint check against transient post-deploy 5xx.** `k8s_tests_tester.test_http_endpoints` does a single, no-retry narinfo GET right after `port-forward` + `sleep 3`; a transient 5xx during ncps warm-up/seeding fails the whole scenario (the `single-local-mariadb` 500). Add a bounded retry (a few attempts with short backoff, retrying connection errors and 5xx) around the narinfo and NAR fetches.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `unified-e2e-harness`: The "Dependency lifecycle and result reporting" requirement is refined — in a local multi-scenario run the harness starts/stops backends once per invocation (not per scenario), waits for readiness with a cold-boot-tolerant timeout, emits backend diagnostics on readiness failure, and the kubernetes validation probes tolerate transient post-deploy 5xx via bounded retry.
+
+## Impact
+
+- Code (harness only, no ncps production code): `nix/e2e-tests/src/runner.py`, `nix/e2e-tests/src/deps.py`, `nix/e2e-tests/src/k8s_tests_tester.py`.
+- No change to ncps behavior, APIs, I/O, network latency, or memory usage — this is test-harness reliability only.
+- Validation: `nix run .#e2e -- --mode local --all` must go from 0/9 to all-pass; re-dispatch the `e2e-nightly` workflow.

--- a/openspec/changes/archive/2026-06-09-fix-e2e-nightly-failures/specs/unified-e2e-harness/spec.md
+++ b/openspec/changes/archive/2026-06-09-fix-e2e-nightly-failures/specs/unified-e2e-harness/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Dependency lifecycle and result reporting
+
+The harness SHALL own the lifecycle of the backing dependencies for the selected mode and report results uniformly. In `local` mode it MUST start the fixed-port backends (`nix run .#deps`: S3/Garage, PostgreSQL, MariaDB, Redis) when they are not already running and stop the ones it started on exit. In `kubernetes` mode it MUST provision the cluster dependencies. It MUST report per-scenario and per-phase PASS/FAIL and MUST exit non-zero if any scenario or phase fails.
+
+When a single `local`-mode invocation runs more than one scenario (a multi-scenario or "all" run), the harness MUST start the backends it manages **once** before running the scenarios and stop them **once** after the last scenario, rather than starting and stopping them per scenario. The single shared startup MUST include Redis whenever any selected scenario requires it. This avoids paying a full cold backend boot (ephemeral `mktemp` data dirs: `initdb`, `mariadb-install-db`, garage layout) for every scenario.
+
+The readiness wait MUST tolerate a cold backend boot on a resource-constrained CI runner: the timeout MUST be at least 300 seconds. When the backends do not become ready within the timeout, the harness MUST emit diagnostics identifying which backend(s) were not ready — at minimum the process-compose process list and the per-process logs — before failing, instead of reporting only an opaque "services not ready" message.
+
+The kubernetes validation HTTP probes MUST tolerate a transient post-deploy server error: the narinfo and NAR fetches MUST retry a bounded number of times with short backoff on connection errors and 5xx responses, so that a transient error during ncps warm-up or seeding does not fail an otherwise-healthy scenario.
+
+#### Scenario: Dependencies are started and torn down
+
+- **WHEN** the harness runs a scenario that needs backends it had to start
+- **THEN** the required services are confirmed reachable before the scenario runs, and the services the harness started are stopped on exit (success or failure)
+
+#### Scenario: Multi-scenario local run starts backends once
+
+- **WHEN** a single `local`-mode invocation runs more than one scenario (e.g. `--all`)
+- **THEN** the harness starts the backends it manages once before the first scenario and stops them once after the last scenario, not once per scenario, and includes Redis if any selected scenario needs it
+
+#### Scenario: Readiness wait tolerates a cold CI boot
+
+- **WHEN** the managed backends are starting cold on a resource-constrained runner
+- **THEN** the harness waits at least 300 seconds for all required ports to become reachable before declaring a readiness failure
+
+#### Scenario: Readiness failure surfaces backend diagnostics
+
+- **WHEN** the managed backends do not become ready within the readiness timeout
+- **THEN** the harness emits the process-compose process list and per-process logs identifying the unready backend(s) before failing, not just an opaque "services not ready" message
+
+#### Scenario: Kubernetes validation retries a transient post-deploy error
+
+- **WHEN** a narinfo or NAR fetch during kubernetes validation returns a connection error or a 5xx response shortly after deploy
+- **THEN** the harness retries the fetch a bounded number of times with short backoff and only fails the check if the error persists
+
+#### Scenario: Failure produces a non-zero exit
+
+- **WHEN** any scenario phase asserts a failure (incomplete NAR, wrong DB invariant, missing activation, etc.)
+- **THEN** the harness reports that phase as FAILED and the overall process exits non-zero
+
+#### Scenario: Resources are cleaned up on failure
+
+- **WHEN** a scenario aborts mid-run
+- **THEN** the harness still tears down the ncps instances and the dependencies it started, leaving no orphaned processes (local) or installs (kubernetes)

--- a/openspec/changes/archive/2026-06-09-fix-e2e-nightly-failures/tasks.md
+++ b/openspec/changes/archive/2026-06-09-fix-e2e-nightly-failures/tasks.md
@@ -1,0 +1,24 @@
+## 1. Local: start backends once per multi-scenario run
+
+- [x] 1.1 Add a failing pytest in `nix/e2e-tests/tests/test_runner.py` asserting that a `run_scenarios` local run over multiple scenarios calls deps startup once and teardown once (not per scenario), with Redis included when any selected scenario needs it
+- [x] 1.2 Hoist the deps lifecycle in `nix/e2e-tests/src/runner.py`: start the managed backends once before the `run_scenarios` local loop and tear them down once after; `_run_local` no longer starts/stops deps when a shared deps instance is provided, but still manages them for the single-scenario `run_scenario` path
+- [x] 1.3 Compute `needs_redis` for the shared startup as the OR across all selected local-supported scenarios
+- [x] 1.4 Ensure teardown runs in a `finally` around the whole loop so backends stop even if a scenario raises
+
+## 2. Local: cold-boot-tolerant readiness + diagnostics
+
+- [x] 2.1 Add a failing pytest asserting `Deps.ensure_up` default timeout is at least 300s and that a readiness-timeout path emits process-compose state/logs
+- [x] 2.2 Raise the `ensure_up` readiness timeout in `nix/e2e-tests/src/deps.py` from 120s to 300s
+- [x] 2.3 On readiness timeout, dump the process-compose process list and per-process logs (via the control port) before raising, identifying the unready backend(s)
+
+## 3. Kubernetes: retry transient validation fetches
+
+- [x] 3.1 Add a failing pytest (or extend `nix/e2e-tests/tests/`) asserting the HTTP-endpoint narinfo/NAR fetch retries on connection errors and 5xx and succeeds when a later attempt returns 200
+- [x] 3.2 Wrap the narinfo and NAR GETs in `nix/e2e-tests/src/k8s_tests_tester.py::test_http_endpoints` with a bounded retry (≈5 attempts, short backoff) that retries connection errors and 5xx; a persistent failure still fails the check
+
+## 4. Verify
+
+- [x] 4.1 Run the harness pytest suite (`e2e-harness-unit`) and confirm green — 52 passed
+- [x] 4.2 Validate the local start-once path end-to-end with a multi-scenario run (`nix run .#e2e -- --mode local --scenario single-local-sqlite --scenario single-local-postgres`): deps boot once and tear down once after the loop, both scenarios PASS with byte-identical NAR serving (2/2). Full `--all` and CI re-dispatch covered by 4.4.
+- [x] 4.3 Run `task fmt`, `task lint` and confirm clean
+- [ ] 4.4 After merge, re-dispatch the `e2e-nightly` workflow and confirm both legs pass (post-merge)

--- a/openspec/specs/unified-e2e-harness/spec.md
+++ b/openspec/specs/unified-e2e-harness/spec.md
@@ -88,10 +88,36 @@ The harness SHALL run more than one scenario from a single invocation. It MUST a
 
 The harness SHALL own the lifecycle of the backing dependencies for the selected mode and report results uniformly. In `local` mode it MUST start the fixed-port backends (`nix run .#deps`: S3/Garage, PostgreSQL, MariaDB, Redis) when they are not already running and stop the ones it started on exit. In `kubernetes` mode it MUST provision the cluster dependencies. It MUST report per-scenario and per-phase PASS/FAIL and MUST exit non-zero if any scenario or phase fails.
 
+When a single `local`-mode invocation runs more than one scenario (a multi-scenario or "all" run), the harness MUST start the backends it manages **once** before running the scenarios and stop them **once** after the last scenario, rather than starting and stopping them per scenario. The single shared startup MUST include Redis whenever any selected scenario requires it. This avoids paying a full cold backend boot (ephemeral `mktemp` data dirs: `initdb`, `mariadb-install-db`, garage layout) for every scenario.
+
+The readiness wait MUST tolerate a cold backend boot on a resource-constrained CI runner: the timeout MUST be at least 300 seconds. When the backends do not become ready within the timeout, the harness MUST emit diagnostics identifying which backend(s) were not ready — at minimum the process-compose process list and the per-process logs — before failing, instead of reporting only an opaque "services not ready" message.
+
+The kubernetes validation HTTP probes MUST tolerate a transient post-deploy server error: the narinfo and NAR fetches MUST retry a bounded number of times with short backoff on connection errors and 5xx responses, so that a transient error during ncps warm-up or seeding does not fail an otherwise-healthy scenario.
+
 #### Scenario: Dependencies are started and torn down
 
 - **WHEN** the harness runs a scenario that needs backends it had to start
 - **THEN** the required services are confirmed reachable before the scenario runs, and the services the harness started are stopped on exit (success or failure)
+
+#### Scenario: Multi-scenario local run starts backends once
+
+- **WHEN** a single `local`-mode invocation runs more than one scenario (e.g. `--all`)
+- **THEN** the harness starts the backends it manages once before the first scenario and stops them once after the last scenario, not once per scenario, and includes Redis if any selected scenario needs it
+
+#### Scenario: Readiness wait tolerates a cold CI boot
+
+- **WHEN** the managed backends are starting cold on a resource-constrained runner
+- **THEN** the harness waits at least 300 seconds for all required ports to become reachable before declaring a readiness failure
+
+#### Scenario: Readiness failure surfaces backend diagnostics
+
+- **WHEN** the managed backends do not become ready within the readiness timeout
+- **THEN** the harness emits the process-compose process list and per-process logs identifying the unready backend(s) before failing, not just an opaque "services not ready" message
+
+#### Scenario: Kubernetes validation retries a transient post-deploy error
+
+- **WHEN** a narinfo or NAR fetch during kubernetes validation returns a connection error or a 5xx response shortly after deploy
+- **THEN** the harness retries the fetch a bounded number of times with short backoff and only fails the check if the error persists
 
 #### Scenario: Failure produces a non-zero exit
 


### PR DESCRIPTION
## Summary

The first `e2e-nightly` run failed on both legs. Investigation turned up several independent issues — most surfaced one after another only once CI could get far enough to hit the next one. This makes both legs reliably green. **The harness changes only; no ncps production code is touched.**

### Local leg (was 0/9 passed)
- **Start backing services once per run.** `runner._run_local` started *and* tore down deps per scenario; each backend boots cold into an ephemeral `mktemp` dir, so every scenario paid a full cold boot and raced the readiness timeout. A multi-scenario local run now starts them once and tears down once.
- **Cold-boot-tolerant readiness + diagnostics.** Raise the readiness timeout 120s → 300s, and on timeout dump process-compose state + per-process logs (this is what surfaced every subsequent layer).
- **MariaDB starts on a hosted runner.** `mariadb-install-db` read the runner's pre-installed MySQL `/etc/mysql/my.cnf` (which sets `user=mysql` and the MySQL-only `mysqlx-bind-address`), tried to chown the datadir to an unwritable user and then aborted on the unknown variable, so 3306 never bound. Run MariaDB with `--no-defaults`.
- **ncps actually launches in CI.** `dev-scripts/run.py` launches each replica via `watchexec` + `direnv exec` + `go run` (cgo needs gcc), so the local leg needs the dev-shell toolchain. The nightly ran bare `nix run .#e2e` outside the dev shell, and `direnv` wasn't even in the flake. The local leg now runs inside a **CI-only `ci-e2e-local` devShell** (the default dev shell + `direnv`), so the default devShell / docker-dev image / a developer's host `direnv` are all untouched.

### Kubernetes leg (was 13/15; flaky)
- **Tolerate a transient post-deploy 5xx.** The HTTP-endpoint validation did a single, no-retry narinfo/NAR GET; a transient warm-up 5xx failed the scenario. Added a small dependency-injected retry helper.
- **Consistent SQLite snapshot.** The DB probe copied `ncps.db` + `-wal` + `-shm` as separate files; a WAL checkpoint between the copies produced a torn snapshot missing `nar_files` (while HTTP served narinfo from that very table). Copy `-wal` first and the main DB last, omit the volatile `-shm`, and retry.

### Workflow
- `workflow_dispatch` gains an optional `ref` input (default `main`) so the nightly can be run against a branch: `gh workflow run e2e-nightly.yml --ref <branch> -f ref=<branch>`.

## Test plan

- [x] `task fmt` / `task lint` clean; 54 harness unit tests pass (`e2e-harness-unit`), including new `test_http_retry`, `test_deps`, and a start-once `test_runner` case.
- [x] Local validated in a stripped env (`env -i`, host tools removed) via the exact CI invocation — toolchain resolves from the nix store and scenarios pass.
- [x] **Full `e2e-nightly` run against the branch is green on both legs** (`--mode local` and `--mode kubernetes`).
- [x] OpenSpec change `fix-e2e-nightly-failures` archived; `unified-e2e-harness` spec updated.