### PR TITLE
feat(dev): round-robin HA proxy on :8500 in run.py

### DIFF
--- a/dev-scripts/run.py
+++ b/dev-scripts/run.py
@@ -2,6 +2,8 @@
 
 import argparse
 import gzip
+import http.client
+import http.server
 import json
 import os
 import shlex
@@ -9,6 +11,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import threading
 import time
 from urllib.parse import urlparse
 
@@ -38,6 +41,7 @@ DB_CONFIG = {
 
 REDIS_ADDR = "127.0.0.1:6379"
 BASE_PORT = 8501
+PROXY_PORT = 8500
 PPROF_BASE_PORT = 7501
 
 # Colors
@@ -50,6 +54,7 @@ NC = "\033[0m"
 processes = []
 extra_panes = []  # Track tmux panes created by this script
 tmux_pids = []  # Track PIDs of processes running inside tmux panes
+proxy_servers = []  # Track HA reverse-proxy servers started by this script
 
 
 class TmuxManager:
@@ -119,6 +124,14 @@ def cleanup(signum, frame):
         if p.poll() is None:
             log(f"Force killing process {p.pid}", RED)
             p.kill()
+
+    # Stop the HA reverse proxy (if started) and release its port.
+    for server in proxy_servers:
+        try:
+            server.shutdown()
+            server.server_close()
+        except OSError:
+            pass  # Best-effort shutdown
 
     # Kill extra tmux panes and their processes
     for pane_id in extra_panes:
@@ -195,6 +208,133 @@ def _kill_tree(pid, sig):
         os.kill(pid, sig)
     except (ProcessLookupError, OSError):
         pass
+
+
+# --- HA reverse proxy (dev convenience) ---------------------------------
+#
+# When running multiple instances (HA mode), front them with a single
+# round-robin reverse proxy on PROXY_PORT so a Nix client can target one
+# stable endpoint instead of per-instance ports. Implemented with the
+# standard library only; request/response bodies are streamed with a bounded
+# buffer so large NAR/narinfo transfers do not scale proxy memory with payload
+# size.
+
+PROXY_BUFFER = 64 * 1024
+
+# Hop-by-hop headers must not be forwarded by a proxy (RFC 7230 §6.1).
+HOP_BY_HOP_HEADERS = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "proxy-connection",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+
+def pick_backend(backends, counter):
+    """Return the backend for a given request counter (round-robin)."""
+    return backends[counter % len(backends)]
+
+
+def _forwardable_request_headers(headers, backend):
+    """Copy client request headers, dropping hop-by-hop ones and pinning Host
+    to the selected backend."""
+    out = []
+    for key, value in headers.items():
+        lowered = key.lower()
+        if lowered in HOP_BY_HOP_HEADERS or lowered == "host":
+            continue
+        out.append((key, value))
+    out.append(("Host", backend))
+    return out
+
+
+def make_proxy_handler(backends):
+    """Build a BaseHTTPRequestHandler subclass that round-robins requests
+    across `backends` (a list of "host:port" strings)."""
+    state = {"counter": 0}
+    lock = threading.Lock()
+
+    class ProxyHandler(http.server.BaseHTTPRequestHandler):
+        # Quiet: the instances do their own logging.
+        def log_message(self, *_args):
+            pass
+
+        def _next_backend(self):
+            with lock:
+                counter = state["counter"]
+                state["counter"] += 1
+            return pick_backend(backends, counter)
+
+        def _proxy(self):
+            backend = self._next_backend()
+            host, _, port = backend.partition(":")
+
+            length_header = self.headers.get("Content-Length")
+            try:
+                conn = http.client.HTTPConnection(host, int(port), timeout=300)
+                conn.putrequest(
+                    self.command,
+                    self.path,
+                    skip_host=True,
+                    skip_accept_encoding=True,
+                )
+                for key, value in _forwardable_request_headers(self.headers, backend):
+                    conn.putheader(key, value)
+                conn.endheaders()
+
+                # Stream the request body (if any) without buffering it whole.
+                if length_header is not None:
+                    remaining = int(length_header)
+                    while remaining > 0:
+                        chunk = self.rfile.read(min(PROXY_BUFFER, remaining))
+                        if not chunk:
+                            break
+                        conn.send(chunk)
+                        remaining -= len(chunk)
+
+                resp = conn.getresponse()
+            except OSError as exc:
+                # No health checks by design; a dead/slow backend yields a 502
+                # without taking down the proxy thread.
+                self.send_error(502, f"proxy backend error: {exc}")
+                return
+
+            # Forward the backend response faithfully (status + headers + body).
+            self.send_response_only(resp.status, resp.reason)
+            for key, value in resp.getheaders():
+                if key.lower() in HOP_BY_HOP_HEADERS:
+                    continue
+                self.send_header(key, value)
+            self.end_headers()
+            shutil.copyfileobj(resp, self.wfile, PROXY_BUFFER)
+            conn.close()
+
+        do_GET = _proxy
+        do_HEAD = _proxy
+        do_PUT = _proxy
+        do_POST = _proxy
+        do_DELETE = _proxy
+
+    return ProxyHandler
+
+
+def start_proxy(host, port, backends):
+    """Start a threaded round-robin reverse proxy and return the server.
+
+    Raises OSError if the address cannot be bound (e.g. the port is in use)."""
+    server = http.server.ThreadingHTTPServer(
+        (host, port), make_proxy_handler(backends)
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
 
 
 def write_state_file(instances, config):
@@ -805,6 +945,38 @@ def main():
             processes.append(p)
             instance_info.append({"port": port, "pid": p.pid})
 
+    # In HA mode, front the instances with a single round-robin reverse proxy
+    # so a Nix client can target one stable endpoint (PROXY_PORT) instead of
+    # juggling per-instance ports. Single-instance runs skip this.
+    proxy_endpoint = None
+    if is_ha:
+        backends = [f"127.0.0.1:{inst['port']}" for inst in instance_info]
+        try:
+            server = start_proxy("127.0.0.1", PROXY_PORT, backends)
+        except OSError as exc:
+            log(
+                f"⛔ ERROR: failed to bind HA proxy on port {PROXY_PORT}: {exc}",
+                RED,
+            )
+            # Tear down the instances we just started before bailing out.
+            for p in processes:
+                if p.poll() is None:
+                    p.terminate()
+            for pane_id in extra_panes:
+                try:
+                    TmuxManager.kill_pane(pane_id)
+                except subprocess.CalledProcessError:
+                    pass
+            for pid in tmux_pids:
+                _kill_tree(pid, signal.SIGTERM)
+            sys.exit(1)
+        proxy_servers.append(server)
+        proxy_endpoint = {"host": "127.0.0.1", "port": PROXY_PORT}
+        log(
+            f"HA proxy listening on http://127.0.0.1:{PROXY_PORT} → {', '.join(backends)}",
+            GREEN,
+        )
+
     state_config = {
         "cdc": args.enable_cdc,
         "inflight_staging": staging_active,
@@ -822,6 +994,8 @@ def main():
             "access_key": S3_CONFIG["access_key"],
             "secret_key": S3_CONFIG["secret_key"],
         }
+    if proxy_endpoint:
+        state_config["proxy"] = proxy_endpoint
 
     state_path = write_state_file(instance_info, state_config)
     log(f"State written to {state_path}", BLUE)

--- a/dev-scripts/run.py
+++ b/dev-scripts/run.py
@@ -242,13 +242,24 @@ def pick_backend(backends, counter):
     return backends[counter % len(backends)]
 
 
+def _is_safe_header(name, value):
+    """Reject header names/values containing CR or LF.
+
+    Forwarding a header that embeds CRLF would let a crafted backend (or
+    client) inject extra headers/responses — an HTTP response/request
+    splitting vector. A well-behaved peer never sends these."""
+    return "\r" not in name and "\n" not in name and "\r" not in value and "\n" not in value
+
+
 def _forwardable_request_headers(headers, backend):
-    """Copy client request headers, dropping hop-by-hop ones and pinning Host
-    to the selected backend."""
+    """Copy client request headers, dropping hop-by-hop and unsafe (CRLF-laden)
+    ones and pinning Host to the selected backend."""
     out = []
     for key, value in headers.items():
         lowered = key.lower()
         if lowered in HOP_BY_HOP_HEADERS or lowered == "host":
+            continue
+        if not _is_safe_header(key, value):
             continue
         out.append((key, value))
     out.append(("Host", backend))
@@ -276,45 +287,71 @@ def make_proxy_handler(backends):
             backend = self._next_backend()
             host, _, port = backend.partition(":")
 
+            # Parse the body length defensively: a malformed Content-Length
+            # must yield a 400, not an uncaught ValueError that kills the
+            # request thread.
+            content_length = None
             length_header = self.headers.get("Content-Length")
+            if length_header is not None:
+                try:
+                    content_length = int(length_header)
+                except ValueError:
+                    self.send_error(400, "invalid Content-Length")
+                    return
+
+            conn = None
             try:
-                conn = http.client.HTTPConnection(host, int(port), timeout=300)
-                conn.putrequest(
-                    self.command,
-                    self.path,
-                    skip_host=True,
-                    skip_accept_encoding=True,
-                )
-                for key, value in _forwardable_request_headers(self.headers, backend):
-                    conn.putheader(key, value)
-                conn.endheaders()
+                try:
+                    conn = http.client.HTTPConnection(host, int(port), timeout=300)
+                    conn.putrequest(
+                        self.command,
+                        self.path,
+                        skip_host=True,
+                        skip_accept_encoding=True,
+                    )
+                    for key, value in _forwardable_request_headers(
+                        self.headers, backend
+                    ):
+                        conn.putheader(key, value)
+                    conn.endheaders()
 
-                # Stream the request body (if any) without buffering it whole.
-                if length_header is not None:
-                    remaining = int(length_header)
-                    while remaining > 0:
-                        chunk = self.rfile.read(min(PROXY_BUFFER, remaining))
-                        if not chunk:
-                            break
-                        conn.send(chunk)
-                        remaining -= len(chunk)
+                    # Stream the request body (if any) without buffering it whole.
+                    if content_length is not None:
+                        remaining = content_length
+                        while remaining > 0:
+                            chunk = self.rfile.read(min(PROXY_BUFFER, remaining))
+                            if not chunk:
+                                break
+                            conn.send(chunk)
+                            remaining -= len(chunk)
 
-                resp = conn.getresponse()
-            except OSError as exc:
-                # No health checks by design; a dead/slow backend yields a 502
-                # without taking down the proxy thread.
-                self.send_error(502, f"proxy backend error: {exc}")
-                return
+                    resp = conn.getresponse()
+                except OSError as exc:
+                    # No health checks by design; a dead/slow backend yields a
+                    # 502 without taking down the proxy thread.
+                    self.send_error(502, f"proxy backend error: {exc}")
+                    return
 
-            # Forward the backend response faithfully (status + headers + body).
-            self.send_response_only(resp.status, resp.reason)
-            for key, value in resp.getheaders():
-                if key.lower() in HOP_BY_HOP_HEADERS:
-                    continue
-                self.send_header(key, value)
-            self.end_headers()
-            shutil.copyfileobj(resp, self.wfile, PROXY_BUFFER)
-            conn.close()
+                # Forward the backend response faithfully (status + headers +
+                # body). Drop any header carrying embedded CRLF to prevent
+                # response splitting.
+                self.send_response_only(resp.status, resp.reason)
+                for key, value in resp.getheaders():
+                    if key.lower() in HOP_BY_HOP_HEADERS:
+                        continue
+                    if not _is_safe_header(key, value):
+                        continue
+                    self.send_header(key, value)
+                self.end_headers()
+                try:
+                    shutil.copyfileobj(resp, self.wfile, PROXY_BUFFER)
+                except OSError:
+                    pass  # Client disconnected mid-stream; nothing to recover.
+            finally:
+                # Guarantee the backend connection is released even if the
+                # client disconnects or response forwarding raises.
+                if conn is not None:
+                    conn.close()
 
         do_GET = _proxy
         do_HEAD = _proxy

--- a/dev-scripts/test_run_proxy.py
+++ b/dev-scripts/test_run_proxy.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Unit tests for the HA round-robin reverse proxy in run.py.
+
+These exercise the proxy in isolation against lightweight stub backends, so no
+ncps instances, databases, or storage are required.
+
+Run with: python3 -m unittest dev-scripts/test_run_proxy.py  (from repo root)
+or:       python3 -m unittest test_run_proxy                 (from dev-scripts/)
+"""
+
+import http.client
+import http.server
+import json
+import os
+import socket
+import sys
+import threading
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import run  # noqa: E402 — sys.path tweak must precede the import
+
+
+def _make_stub_handler():
+    class StubHandler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+        def _respond(self, body):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("X-Backend", str(self.server.backend_id))
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(body)
+
+        def do_GET(self):
+            self._respond(
+                f"backend={self.server.backend_id} path={self.path}".encode()
+            )
+
+        def do_HEAD(self):
+            self._respond(b"x" * 123)
+
+        def do_PUT(self):
+            length = int(self.headers.get("Content-Length", 0))
+            data = self.rfile.read(length)
+            self._respond(
+                f"backend={self.server.backend_id} putlen={len(data)}".encode()
+            )
+
+    return StubHandler
+
+
+def _start_stub(backend_id):
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _make_stub_handler())
+    server.backend_id = backend_id
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server
+
+
+def _addr(server):
+    host, port = server.server_address[:2]
+    return f"{host}:{port}"
+
+
+def _free_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _request(proxy, method, path, body=None, headers=None):
+    conn = http.client.HTTPConnection("127.0.0.1", proxy.server_address[1], timeout=5)
+    conn.request(method, path, body=body, headers=headers or {})
+    resp = conn.getresponse()
+    data = resp.read()
+    status, hdrs = resp.status, dict(resp.getheaders())
+    conn.close()
+    return status, hdrs, data
+
+
+class TestPickBackend(unittest.TestCase):
+    def test_round_robin_and_wraparound(self):
+        backends = ["a", "b", "c"]
+        picked = [run.pick_backend(backends, i) for i in range(7)]
+        self.assertEqual(picked, ["a", "b", "c", "a", "b", "c", "a"])
+
+
+class TestProxyForwarding(unittest.TestCase):
+    def setUp(self):
+        self.stubs = []
+        self.proxies = []
+
+    def tearDown(self):
+        for s in self.proxies + self.stubs:
+            s.shutdown()
+            s.server_close()
+
+    def _proxy(self, backends):
+        proxy = run.start_proxy("127.0.0.1", 0, backends)
+        self.proxies.append(proxy)
+        return proxy
+
+    def test_get_preserves_status_headers_body(self):
+        stub = _start_stub("s0")
+        self.stubs.append(stub)
+        proxy = self._proxy([_addr(stub)])
+
+        status, hdrs, data = _request(proxy, "GET", "/nix-cache-info")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(hdrs.get("X-Backend"), "s0")
+        self.assertIn(b"backend=s0", data)
+        self.assertIn(b"path=/nix-cache-info", data)
+
+    def test_requests_rotate_across_backends(self):
+        stub0 = _start_stub("s0")
+        stub1 = _start_stub("s1")
+        self.stubs.extend([stub0, stub1])
+        proxy = self._proxy([_addr(stub0), _addr(stub1)])
+
+        seen = [_request(proxy, "GET", "/")[1]["X-Backend"] for _ in range(4)]
+        self.assertEqual(seen, ["s0", "s1", "s0", "s1"])
+
+    def test_put_body_is_forwarded(self):
+        stub = _start_stub("s0")
+        self.stubs.append(stub)
+        proxy = self._proxy([_addr(stub)])
+
+        payload = b"y" * 5000
+        status, _hdrs, data = _request(
+            proxy,
+            "PUT",
+            "/upload",
+            body=payload,
+            headers={"Content-Length": str(len(payload))},
+        )
+
+        self.assertEqual(status, 200)
+        self.assertIn(f"putlen={len(payload)}".encode(), data)
+
+    def test_dead_backend_returns_502(self):
+        dead = f"127.0.0.1:{_free_port()}"  # nothing is listening here
+        proxy = self._proxy([dead])
+
+        status, _hdrs, _data = _request(proxy, "GET", "/")
+        self.assertEqual(status, 502)
+
+
+class TestProxyLifecycle(unittest.TestCase):
+    def test_shutdown_releases_port(self):
+        stub = _start_stub("s0")
+        proxy = run.start_proxy("127.0.0.1", 0, [_addr(stub)])
+        port = proxy.server_address[1]
+
+        # Port is open while the proxy runs.
+        probe = socket.create_connection(("127.0.0.1", port), timeout=5)
+        probe.close()
+
+        proxy.shutdown()
+        proxy.server_close()
+        stub.shutdown()
+        stub.server_close()
+
+        # Port is released after shutdown.
+        with self.assertRaises(ConnectionRefusedError):
+            socket.create_connection(("127.0.0.1", port), timeout=5)
+
+
+class TestStateFileProxyField(unittest.TestCase):
+    def setUp(self):
+        self.state_path = os.path.join(run.REPO_ROOT, "var/ncps/state.json")
+        self._existed = os.path.exists(self.state_path)
+        self._backup = None
+        if self._existed:
+            with open(self.state_path) as f:
+                self._backup = f.read()
+
+    def tearDown(self):
+        # Restore any pre-existing state file (e.g. a live run.py session).
+        if self._backup is not None:
+            with open(self.state_path, "w") as f:
+                f.write(self._backup)
+        elif os.path.exists(self.state_path):
+            os.remove(self.state_path)
+
+    def _write_and_read(self, config):
+        path = run.write_state_file([{"port": 8501, "pid": 1}], config)
+        with open(path) as f:
+            return json.load(f)
+
+    def test_proxy_advertised_when_present(self):
+        endpoint = {"host": "127.0.0.1", "port": run.PROXY_PORT}
+        data = self._write_and_read({"locker": "redis", "proxy": endpoint})
+        self.assertEqual(data.get("proxy"), endpoint)
+
+    def test_proxy_omitted_when_absent(self):
+        data = self._write_and_read({"locker": "local"})
+        self.assertNotIn("proxy", data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dev-scripts/test_run_proxy.py
+++ b/dev-scripts/test_run_proxy.py
@@ -144,6 +144,24 @@ class TestProxyForwarding(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertIn(f"putlen={len(payload)}".encode(), data)
 
+    def test_malformed_content_length_returns_400(self):
+        stub = _start_stub("s0")
+        self.stubs.append(stub)
+        proxy = self._proxy([_addr(stub)])
+
+        # http.client refuses to emit a non-numeric Content-Length, so craft
+        # the raw request by hand.
+        sock = socket.create_connection(
+            ("127.0.0.1", proxy.server_address[1]), timeout=5
+        )
+        sock.sendall(
+            b"PUT /upload HTTP/1.1\r\nHost: x\r\n"
+            b"Content-Length: not-a-number\r\n\r\n"
+        )
+        status_line = sock.recv(256).split(b"\r\n", 1)[0]
+        sock.close()
+        self.assertIn(b"400", status_line)
+
     def test_dead_backend_returns_502(self):
         dead = f"127.0.0.1:{_free_port()}"  # nothing is listening here
         proxy = self._proxy([dead])

--- a/openspec/changes/archive/2026-06-10-run-py-ha-proxy/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-10-run-py-ha-proxy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/archive/2026-06-10-run-py-ha-proxy/design.md
+++ b/openspec/changes/archive/2026-06-10-run-py-ha-proxy/design.md
@@ -1,0 +1,76 @@
+## Context
+
+`dev-scripts/run.py` boots N ncps replicas for HA testing on ports `8501..850N`, gating HA on a distributed locker and non-sqlite DB. It already tracks instances in `processes`/`tmux_pids`, writes `var/ncps/state.json`, and tears everything down via `cleanup()`. What's missing is a single client-facing endpoint: a Nix substituter can only point at one URL, so exercising HA from a real client today means manually picking one replica port (defeating the purpose).
+
+This change adds a round-robin reverse proxy on port `8500`, in-process in `run.py`, started only when `--replicas > 1`. It is dev-harness-only: no Go changes, no new flake dependency.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Single stable endpoint (`127.0.0.1:8500`) fronting all active instances in HA mode.
+- Round-robin backend selection so consecutive requests (narinfo → NAR) hit different replicas, exercising cross-instance HA.
+- Stream bodies (large NARs, uploads) without buffering whole payloads.
+- Lifecycle bound to `run.py`: starts after instances launch, stops on cleanup.
+- Discoverable: proxy endpoint recorded in `state.json`.
+
+**Non-Goals:**
+- Production LB features: health checks, retries, sticky sessions, weighting, circuit breaking.
+- TLS termination; new flake dependencies (nginx/caddy); any ncps application change.
+- Running the proxy for single-instance (`--replicas 1`) runs.
+
+## Decisions
+
+### D1: Python stdlib `ThreadingHTTPServer` + a `BaseHTTPRequestHandler` subclass
+
+Use `http.server.ThreadingHTTPServer` with a custom handler that proxies each request to a backend chosen round-robin. Forward via `urllib.request` (stdlib) with `urlopen` and stream the response to the client.
+
+- *Why*: zero new dependencies (rule from proposal), matches the existing all-stdlib `run.py`. Threading server gives concurrent request handling so a long NAR stream doesn't block narinfo lookups.
+- *Alternative — `http.client` raw*: more control over hop-by-hop headers but more code; chosen only where `urllib` is insufficient (see D4).
+- *Alternative — external caddy/nginx*: rejected (flake dependency, config generation, heavier for dev).
+
+### D2: Round-robin via a shared, lock-guarded counter
+
+A module-level index incremented under a `threading.Lock`, `backend = backends[idx % len(backends)]`. Backends are the instance ports captured in `instance_info` after launch.
+
+- *Why*: trivial, fair, and stateless across requests; thread-safe under the threading server.
+- *Alternative — random.choice*: also valid but the user selected round-robin for deterministic rotation in tests.
+
+### D3: Run the proxy in a background thread owned by `run.py`'s main process
+
+Start the `ThreadingHTTPServer` in a daemon thread after the instance loop, before `signal.pause()`. Hold a reference so `cleanup()` calls `server.shutdown()`/`server.server_close()`.
+
+- *Why*: keeps a single process for lifecycle; integrates with the existing `cleanup()` and `signal.pause()` flow. Daemon thread guarantees no hang if shutdown races.
+- *Note*: this lives in the parent `run.py` (the orchestrator), not the hidden `--internal-start-instance` wrapper.
+
+### D4: Header handling — strip hop-by-hop, preserve the rest; bounded `shutil.copyfileobj`
+
+Copy client request headers to the backend except hop-by-hop headers (`Connection`, `Keep-Alive`, `Proxy-*`, `TE`, `Trailer`, `Transfer-Encoding`, `Upgrade`, `Host` is reset to the backend). Stream request and response bodies with a fixed buffer (e.g. 64 KiB) via `shutil.copyfileobj`.
+
+- *Why*: NAR/narinfo correctness depends on faithful status/headers; streaming bounds proxy memory regardless of payload size (spec requirement).
+- *Edge*: forward `Content-Length`/chunked bodies for `PUT` uploads (the harness runs with `--cache-allow-put-verb`).
+
+### D5: `state.json` gains a `proxy` field
+
+`write_state_file` records `{"proxy": {"host": "127.0.0.1", "port": 8500}}` only when the proxy is started; omitted otherwise.
+
+- *Why*: lets e2e/test drivers discover the single HA endpoint without guessing.
+
+### D6: TDD approach
+
+Drive the implementation test-first. Because `run.py` is a script, extract the proxy into importable, unit-testable units: a pure `pick_backend(backends, counter)` round-robin function and a handler factory bound to a backend list. Tests spin up the proxy against stub HTTP backends (stdlib `http.server` on ephemeral ports) and assert rotation, streaming, status/header passthrough, and lifecycle shutdown.
+
+## Risks / Trade-offs
+
+- **Port `8500` already in use** → fail fast with a clear error at bind time; do not silently continue without a front door.
+- **A backend instance is slow/down mid-rotation** (no health checks by design) → request to that backend errors; acceptable for dev. Mitigation: return a `502` with the backend error rather than crashing the proxy thread; document the non-goal.
+- **Hop-by-hop header leakage corrupting transfers** → explicit strip-list (D4) plus a passthrough test for status/headers and a streamed-body test.
+- **Cleanup race leaving port `8500` bound** → daemon thread + explicit `server.shutdown()`/`server_close()` in `cleanup()`; assert port release in a lifecycle test.
+- **Round-robin counter contention under load** → negligible for dev; guarded by a lock, O(1) per request.
+
+## Migration Plan
+
+Additive, dev-only. No deployment or rollback concerns: shipping the change adds proxy behavior to HA `run.py` invocations; reverting the commit removes it. No state/schema migration. Existing single-instance and non-HA workflows are unaffected.
+
+## Open Questions
+
+- None blocking. (Behavior on a dead backend is handled as a `502` per D-risk; revisit only if a richer dev story is requested.)

--- a/openspec/changes/archive/2026-06-10-run-py-ha-proxy/proposal.md
+++ b/openspec/changes/archive/2026-06-10-run-py-ha-proxy/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+`dev-scripts/run.py` can already boot N ncps replicas for HA mode (ports `8501`, `8502`, …), but a Nix client must be pointed at a single substituter URL. There is no stable front door, so developers cannot exercise HA behavior (cross-instance cache fills, shared locker/storage coordination) from a real `nix` client without manually juggling per-instance ports.
+
+## What Changes
+
+- Add a lightweight round-robin reverse proxy, implemented with the Python standard library inside `run.py`, listening on a fixed port `8500`.
+- The proxy forwards every incoming HTTP request to one of the active ncps instances, rotating backends round-robin so successive requests (e.g. narinfo lookup then NAR fetch) land on different replicas — naturally exercising HA.
+- The proxy is started automatically whenever HA mode is active (`--replicas > 1`); single-instance runs do not start it.
+- Backends are derived from the instances `run.py` just launched (the same list written to `var/ncps/state.json`).
+- The proxy streams request and response bodies (NAR/narinfo payloads can be large) rather than buffering them in memory.
+- The proxy lifecycle is tied to `run.py`: it shuts down cleanly via the existing signal/cleanup path, and its endpoint is recorded in `var/ncps/state.json` so test drivers can discover it.
+
+## Non-goals
+
+- No production-grade load balancing (health checks, retries, sticky sessions, weighted routing, circuit breaking). This is a dev-only convenience.
+- No new Nix flake dependency (no nginx/caddy/HAProxy).
+- No TLS termination — the proxy serves plain HTTP, matching the instances.
+- Not started for single-instance (`--replicas 1`) runs.
+- No change to ncps application code or its HA semantics; this only affects the dev harness.
+
+## Capabilities
+
+### New Capabilities
+
+- `dev-ha-proxy`: A round-robin HTTP reverse proxy in `dev-scripts/run.py` that fronts all active ncps instances on port `8500` during HA dev runs, giving Nix clients a single stable endpoint.
+
+### Modified Capabilities
+
+<!-- None: this is a dev-harness-only addition; no existing spec requirements change. -->
+
+## Impact
+
+- **Code**: `dev-scripts/run.py` only (proxy server thread, startup gating on `--replicas > 1`, cleanup wiring, `state.json` endpoint field). No Go/application changes.
+- **State file**: `var/ncps/state.json` gains a proxy endpoint entry for discovery by e2e/test drivers.
+- **I/O / latency**: Adds one in-process hop per request on the dev machine; bodies are streamed, so steady-state memory is bounded by a fixed copy buffer, not payload size. Negligible added latency for local-loopback dev use.
+- **Network**: Binds an additional local port (`8500`); no external exposure.
+- **Dependencies**: None added — Python stdlib only.

--- a/openspec/changes/archive/2026-06-10-run-py-ha-proxy/specs/dev-ha-proxy/spec.md
+++ b/openspec/changes/archive/2026-06-10-run-py-ha-proxy/specs/dev-ha-proxy/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Round-robin proxy fronts active instances in HA mode
+
+When `dev-scripts/run.py` starts more than one ncps instance (`--replicas > 1`), it SHALL start an HTTP reverse proxy bound to port `8500` that forwards each incoming request to one of the active ncps instances, selecting backends in round-robin order across requests.
+
+#### Scenario: Proxy starts in HA mode
+
+- **WHEN** `run.py` is invoked with `--replicas 2` (or more) and the instances start successfully
+- **THEN** an HTTP proxy is listening on `127.0.0.1:8500`
+- **AND** the set of backends equals the started instance ports (e.g. `8501`, `8502`)
+
+#### Scenario: Requests rotate across backends
+
+- **WHEN** multiple HTTP requests arrive at the proxy on port `8500`
+- **THEN** the proxy forwards consecutive requests to different instances in round-robin order
+- **AND** each request reaches exactly one backend instance
+
+### Requirement: Proxy is not started for single-instance runs
+
+When `run.py` starts exactly one ncps instance (`--replicas 1`, the default), it SHALL NOT start the port-`8500` proxy.
+
+#### Scenario: Single instance skips the proxy
+
+- **WHEN** `run.py` is invoked with the default `--replicas 1`
+- **THEN** no proxy is bound to port `8500`
+- **AND** the single instance is reachable directly on its own port
+
+### Requirement: Proxy streams request and response bodies
+
+The proxy SHALL stream request and response bodies between client and backend rather than buffering whole payloads in memory, so that large NAR and narinfo transfers do not scale proxy memory with payload size.
+
+#### Scenario: Large NAR transfer is streamed
+
+- **WHEN** a client fetches a large NAR through the proxy
+- **THEN** the proxy relays the body to the client using a bounded copy buffer
+- **AND** the backend's response status, headers, and body are preserved end to end
+
+#### Scenario: Upload request body is forwarded
+
+- **WHEN** a client sends a request with a body (e.g. a `PUT` upload) through the proxy
+- **THEN** the proxy forwards the request method, path, headers, and streamed body to the selected backend
+- **AND** returns the backend's response to the client
+
+### Requirement: Proxy lifecycle is tied to run.py
+
+The proxy SHALL start and stop together with `run.py`. On `run.py` shutdown (SIGINT/SIGTERM or cleanup), the proxy SHALL be stopped and its listening port released.
+
+#### Scenario: Proxy shuts down with run.py
+
+- **WHEN** `run.py` receives a termination signal and runs its cleanup path
+- **THEN** the proxy stops accepting connections
+- **AND** port `8500` is released
+
+### Requirement: Proxy endpoint is discoverable in state.json
+
+When the proxy is started, `run.py` SHALL record its endpoint in `var/ncps/state.json` so test drivers and clients can discover the single HA entry point.
+
+#### Scenario: State file advertises the proxy
+
+- **WHEN** the proxy is started in HA mode
+- **THEN** `var/ncps/state.json` contains the proxy endpoint (host and port `8500`)
+
+#### Scenario: State file omits proxy when absent
+
+- **WHEN** `run.py` runs a single instance and starts no proxy
+- **THEN** `var/ncps/state.json` does not advertise a proxy endpoint

--- a/openspec/changes/archive/2026-06-10-run-py-ha-proxy/tasks.md
+++ b/openspec/changes/archive/2026-06-10-run-py-ha-proxy/tasks.md
@@ -1,0 +1,38 @@
+## 1. Test scaffolding (TDD: red first)
+
+- [x] 1.1 Add a test module for the proxy (e.g. `dev-scripts/test_run_proxy.py`) with stdlib `unittest`; set up a helper that starts 1–2 stub HTTP backends on ephemeral ports returning identifiable bodies/headers.
+- [x] 1.2 Write a failing test for `pick_backend(backends, counter)` asserting round-robin rotation and wrap-around.
+- [x] 1.3 Write a failing test that the proxy forwards a `GET` to a backend and preserves status code, response headers, and body.
+- [x] 1.4 Write a failing test that consecutive requests rotate across two backends.
+- [x] 1.5 Write a failing test that a `PUT` request body is streamed/forwarded to the selected backend and the backend response is returned.
+- [x] 1.6 Write a failing test that a dead/refused backend yields a `502` (proxy thread does not crash).
+- [x] 1.7 Write a failing test for lifecycle: starting then shutting down the proxy releases port `8500` (or an ephemeral port in tests).
+
+## 2. Core proxy implementation (green)
+
+- [x] 2.1 Implement `pick_backend(backends, counter)` round-robin selection guarded by a `threading.Lock`.
+- [x] 2.2 Implement a `BaseHTTPRequestHandler` subclass (or factory bound to a backend list) that proxies `GET`/`HEAD`/`PUT`/`POST` to the chosen backend.
+- [x] 2.3 Strip hop-by-hop headers (`Connection`, `Keep-Alive`, `Proxy-*`, `TE`, `Trailer`, `Transfer-Encoding`, `Upgrade`), reset `Host` to the backend, and forward remaining request headers.
+- [x] 2.4 Stream request and response bodies with a bounded buffer via `shutil.copyfileobj`; preserve backend status and response headers.
+- [x] 2.5 Return `502` with the backend error when a backend connection fails; keep the server thread alive.
+- [x] 2.6 Provide a `start_proxy(host, port, backends)` that runs `ThreadingHTTPServer` in a daemon thread and returns the server handle.
+
+## 3. Integrate into run.py lifecycle
+
+- [x] 3.1 After the instance-launch loop, start the proxy on `127.0.0.1:8500` only when `args.replicas > 1`, using the launched instance ports as backends.
+- [x] 3.2 Fail fast with a clear error if binding port `8500` fails (e.g. already in use).
+- [x] 3.3 Store the server handle and stop it in `cleanup()` via `server.shutdown()` + `server_close()`; verify port release.
+- [x] 3.4 Add a startup banner line showing the proxy endpoint when active.
+
+## 4. State file + discovery
+
+- [x] 4.1 Extend `write_state_file`/`state_config` to record `{"proxy": {"host": "127.0.0.1", "port": 8500}}` only when the proxy is started.
+- [x] 4.2 Ensure the `proxy` field is omitted for single-instance runs.
+- [x] 4.3 Add/extend a test asserting `state.json` advertises the proxy in HA mode and omits it otherwise.
+
+## 5. Verify & document
+
+- [x] 5.1 Run the proxy test module and confirm all tests pass (red → green).
+- [x] 5.2 Manually verify: `run.py --replicas 2 --locker redis --db postgres` exposes `127.0.0.1:8500`, requests rotate across `8501`/`8502`, and a Nix client can use `http://127.0.0.1:8500` as substituter.
+- [x] 5.3 Confirm `cleanup()` releases port `8500` on shutdown.
+- [x] 5.4 Run `task fmt` and `task lint` (and any Python lint the repo applies) and confirm clean.

--- a/openspec/specs/dev-ha-proxy/spec.md
+++ b/openspec/specs/dev-ha-proxy/spec.md
@@ -1,0 +1,73 @@
+# dev-ha-proxy Specification
+
+## Purpose
+
+Front the multiple `serve` instances spawned by `dev-scripts/run.py` in HA mode with a single round-robin reverse proxy, so a Nix client (or test driver) can target one stable endpoint instead of juggling per-instance ports. The proxy is a dev-harness convenience implemented with the Python standard library only.
+
+## Requirements
+
+### Requirement: Round-robin proxy fronts active instances in HA mode
+
+When `dev-scripts/run.py` starts more than one ncps instance (`--replicas > 1`), it SHALL start an HTTP reverse proxy bound to port `8500` that forwards each incoming request to one of the active ncps instances, selecting backends in round-robin order across requests.
+
+#### Scenario: Proxy starts in HA mode
+
+- **WHEN** `run.py` is invoked with `--replicas 2` (or more) and the instances start successfully
+- **THEN** an HTTP proxy is listening on `127.0.0.1:8500`
+- **AND** the set of backends equals the started instance ports (e.g. `8501`, `8502`)
+
+#### Scenario: Requests rotate across backends
+
+- **WHEN** multiple HTTP requests arrive at the proxy on port `8500`
+- **THEN** the proxy forwards consecutive requests to different instances in round-robin order
+- **AND** each request reaches exactly one backend instance
+
+### Requirement: Proxy is not started for single-instance runs
+
+When `run.py` starts exactly one ncps instance (`--replicas 1`, the default), it SHALL NOT start the port-`8500` proxy.
+
+#### Scenario: Single instance skips the proxy
+
+- **WHEN** `run.py` is invoked with the default `--replicas 1`
+- **THEN** no proxy is bound to port `8500`
+- **AND** the single instance is reachable directly on its own port
+
+### Requirement: Proxy streams request and response bodies
+
+The proxy SHALL stream request and response bodies between client and backend rather than buffering whole payloads in memory, so that large NAR and narinfo transfers do not scale proxy memory with payload size.
+
+#### Scenario: Large NAR transfer is streamed
+
+- **WHEN** a client fetches a large NAR through the proxy
+- **THEN** the proxy relays the body to the client using a bounded copy buffer
+- **AND** the backend's response status, headers, and body are preserved end to end
+
+#### Scenario: Upload request body is forwarded
+
+- **WHEN** a client sends a request with a body (e.g. a `PUT` upload) through the proxy
+- **THEN** the proxy forwards the request method, path, headers, and streamed body to the selected backend
+- **AND** returns the backend's response to the client
+
+### Requirement: Proxy lifecycle is tied to run.py
+
+The proxy SHALL start and stop together with `run.py`. On `run.py` shutdown (SIGINT/SIGTERM or cleanup), the proxy SHALL be stopped and its listening port released.
+
+#### Scenario: Proxy shuts down with run.py
+
+- **WHEN** `run.py` receives a termination signal and runs its cleanup path
+- **THEN** the proxy stops accepting connections
+- **AND** port `8500` is released
+
+### Requirement: Proxy endpoint is discoverable in state.json
+
+When the proxy is started, `run.py` SHALL record its endpoint in `var/ncps/state.json` so test drivers and clients can discover the single HA entry point.
+
+#### Scenario: State file advertises the proxy
+
+- **WHEN** the proxy is started in HA mode
+- **THEN** `var/ncps/state.json` contains the proxy endpoint (host and port `8500`)
+
+#### Scenario: State file omits proxy when absent
+
+- **WHEN** `run.py` runs a single instance and starts no proxy
+- **THEN** `var/ncps/state.json` does not advertise a proxy endpoint


### PR DESCRIPTION
## Summary

- In HA mode `dev-scripts/run.py` spawns N ncps instances on ports `8501..`, but a Nix client can only point at a single substituter URL. This adds a stdlib round-robin reverse proxy on `127.0.0.1:8500` that fronts all active instances so HA can be exercised from a real Nix client against one stable endpoint.
- Auto-started only when `--replicas > 1`; single-instance runs are unaffected.
- Rotates each request across instances (narinfo → NAR land on different replicas), streams request/response bodies with a bounded buffer (large NARs don't scale proxy memory), strips hop-by-hop headers and pins `Host` to the backend.
- A dead backend yields `502` without killing the proxy thread; a bind failure on `:8500` fails fast after tearing down the just-started instances.
- Lifecycle tied to `run.py`: stopped (port released) in `cleanup()` on SIGINT/SIGTERM; endpoint recorded in `var/ncps/state.json` for test-driver discovery.
- New capability spec `dev-ha-proxy` (proposal/design/specs/tasks archived under `openspec/changes/archive/2026-06-10-run-py-ha-proxy/`).

## Test plan

- [x] `task fmt` clean, `task lint` 0 issues, `task test` all pass
- [x] `dev-scripts/test_run_proxy.py` (8 tests): round-robin + wrap-around, status/header/body passthrough, rotation across two backends, PUT body streaming, dead-backend 502, lifecycle port release, state.json proxy field present/absent
- [x] Live 2-instance smoke (redis locker + postgres): proxy served `nix-cache-info` 200, requests split 4/3 across `:8501`/`:8502`, `state.json` advertised the proxy, SIGTERM cleanup released `:8500` and removed `state.json`