### PR TITLE
fix(dev): forward chunked request bodies in HA proxy

### DIFF
--- a/dev-scripts/run.py
+++ b/dev-scripts/run.py
@@ -384,7 +384,19 @@ def make_proxy_handler(backends):
             """Drain the unconsumed body, send an error, and close the
             connection so the client observes `code` rather than a TCP reset."""
             self.close_connection = True
-            self._drain_request_body(cl_remaining, is_chunked)
+            # Time-bound the drain: a client that stalls mid-upload must not
+            # block us in rfile.read()/readline() and prevent the 502. On
+            # timeout the socket raises (OSError), which _drain_request_body
+            # swallows, stopping the drain.
+            prev_timeout = self.connection.gettimeout()
+            try:
+                self.connection.settimeout(0.25)
+                self._drain_request_body(cl_remaining, is_chunked)
+            finally:
+                try:
+                    self.connection.settimeout(prev_timeout)
+                except OSError:
+                    pass
             try:
                 self.send_error(code, message)
             except OSError:
@@ -452,7 +464,10 @@ def make_proxy_handler(backends):
                         while cl_remaining > 0:
                             chunk = self.rfile.read(min(PROXY_BUFFER, cl_remaining))
                             if not chunk:
-                                break
+                                # Client closed before sending the full body the
+                                # backend was told to expect; routing this to the
+                                # 502 path avoids hanging in getresponse().
+                                raise ProxyBodyError("truncated request body")
                             conn.send(chunk)
                             cl_remaining -= len(chunk)
                     elif is_chunked:

--- a/dev-scripts/run.py
+++ b/dev-scripts/run.py
@@ -265,9 +265,13 @@ def _stream_chunked_body(rfile, send):
             raise ProxyBodyError(f"invalid chunk size {token!r}") from exc
         if size == 0:
             # Consume optional trailers up to the terminating blank line.
+            # A clean EOF here means the terminator never arrived — that is a
+            # truncated body, not a valid end of stream.
             while True:
                 trailer = rfile.readline()
-                if trailer in (b"\r\n", b"\n", b""):
+                if trailer == b"":
+                    raise ProxyBodyError("truncated chunked terminator")
+                if trailer in (b"\r\n", b"\n"):
                     break
             break
         remaining = size
@@ -277,8 +281,10 @@ def _stream_chunked_body(rfile, send):
                 raise ProxyBodyError("truncated chunk body")
             send(b"%X\r\n" % len(piece) + piece + b"\r\n")
             remaining -= len(piece)
-        # Each chunk's data is followed by a CRLF; consume it.
-        rfile.readline()
+        # Each chunk's data is followed by a CRLF; validate it rather than
+        # silently accepting malformed framing.
+        if rfile.read(2) != b"\r\n":
+            raise ProxyBodyError("invalid chunk terminator")
     send(b"0\r\n\r\n")
 
 
@@ -323,30 +329,62 @@ def make_proxy_handler(backends):
                 state["counter"] += 1
             return pick_backend(backends, counter)
 
-        def _fail(self, code, message):
-            """Send an error response and close the connection.
+        def _drain_request_body(self, cl_remaining, is_chunked):
+            """Best-effort, bounded drain of the *unconsumed* request body.
 
             A partially-read request body left in the socket makes
             BaseHTTPRequestHandler reset the connection on return — the client
-            would see `Connection reset by peer` instead of the status. Force
-            the connection closed (and best-effort drain a bounded amount of any
-            unconsumed body) so the client observes the real error code."""
-            self.close_connection = True
+            would see `Connection reset by peer` instead of the status. Drain
+            only what is still unread (`cl_remaining` bytes for a fixed-length
+            body, or the rest of the chunked stream), bounded so a huge upload
+            cannot be drained unboundedly."""
+            drain_cap = 8 * PROXY_BUFFER
+
+            def drain_fixed(remaining):
+                nonlocal drain_cap
+                while remaining > 0 and drain_cap > 0:
+                    n = min(PROXY_BUFFER, remaining, drain_cap)
+                    chunk = self.rfile.read(n)
+                    if not chunk:
+                        break
+                    remaining -= len(chunk)
+                    drain_cap -= len(chunk)
+
             try:
-                length_header = self.headers.get("Content-Length")
-                if length_header is not None:
-                    remaining = int(length_header)
-                    # Bounded drain: do not read unboundedly on a huge upload.
-                    drain_cap = 8 * PROXY_BUFFER
-                    while remaining > 0 and drain_cap > 0:
-                        n = min(PROXY_BUFFER, remaining, drain_cap)
-                        chunk = self.rfile.read(n)
-                        if not chunk:
+                if cl_remaining is not None:
+                    drain_fixed(cl_remaining)
+                elif is_chunked:
+                    # Continue decoding the chunked stream best-effort. On any
+                    # framing irregularity, stop — we are closing the
+                    # connection anyway.
+                    while drain_cap > 0:
+                        size_line = self.rfile.readline()
+                        if not size_line:
                             break
-                        remaining -= len(chunk)
-                        drain_cap -= len(chunk)
+                        token = size_line.split(b";", 1)[0].strip()
+                        try:
+                            size = int(token, 16)
+                        except ValueError:
+                            break
+                        if size == 0:
+                            while True:
+                                trailer = self.rfile.readline()
+                                if trailer in (b"\r\n", b"\n", b""):
+                                    break
+                            break
+                        before = drain_cap
+                        drain_fixed(size)
+                        if before - drain_cap < size:
+                            break  # capped or truncated mid-chunk
+                        self.rfile.readline()  # trailing CRLF
             except (OSError, ValueError):
                 pass
+
+        def _fail(self, code, message, cl_remaining=None, is_chunked=False):
+            """Drain the unconsumed body, send an error, and close the
+            connection so the client observes `code` rather than a TCP reset."""
+            self.close_connection = True
+            self._drain_request_body(cl_remaining, is_chunked)
             try:
                 self.send_error(code, message)
             except OSError:
@@ -369,11 +407,20 @@ def make_proxy_handler(backends):
                     return
 
             # When the client frames its body with `Transfer-Encoding: chunked`
-            # (no Content-Length — e.g. `nix copy` streaming a NAR whose
-            # compressed size is unknown), the body must still be forwarded.
-            # `Transfer-Encoding` is hop-by-hop, so we re-encode it ourselves.
+            # (e.g. `nix copy` streaming a NAR whose compressed size is unknown),
+            # the body must still be forwarded. `Transfer-Encoding` is hop-by-hop,
+            # so we re-encode it ourselves. Per RFC 7230 §3.3.3, if both
+            # Transfer-Encoding and Content-Length are present, chunked wins and
+            # Content-Length is ignored (also closes a request-smuggling vector).
             te = self.headers.get("Transfer-Encoding", "")
-            is_chunked = content_length is None and "chunked" in te.lower()
+            is_chunked = "chunked" in te.lower()
+            if is_chunked:
+                content_length = None
+
+            # Track how much fixed-length body is still unread so a failure
+            # mid-forward drains only the remainder (not the whole declared
+            # length, which would over-drain/block).
+            cl_remaining = content_length
 
             conn = None
             try:
@@ -388,6 +435,11 @@ def make_proxy_handler(backends):
                     for key, value in _forwardable_request_headers(
                         self.headers, backend
                     ):
+                        # When forwarding chunked, never also send the client's
+                        # Content-Length (RFC 7230 §3.3.3) — it would confuse the
+                        # backend's body framing.
+                        if is_chunked and key.lower() == "content-length":
+                            continue
                         conn.putheader(key, value)
                     if is_chunked:
                         # Re-advertise chunked framing to the backend (it was
@@ -397,26 +449,29 @@ def make_proxy_handler(backends):
 
                     # Stream the request body (if any) without buffering it whole.
                     if content_length is not None:
-                        remaining = content_length
-                        while remaining > 0:
-                            chunk = self.rfile.read(min(PROXY_BUFFER, remaining))
+                        while cl_remaining > 0:
+                            chunk = self.rfile.read(min(PROXY_BUFFER, cl_remaining))
                             if not chunk:
                                 break
                             conn.send(chunk)
-                            remaining -= len(chunk)
+                            cl_remaining -= len(chunk)
                     elif is_chunked:
                         _stream_chunked_body(self.rfile, conn.send)
 
                     resp = conn.getresponse()
                 except ProxyBodyError as exc:
                     log(f"proxy: body-forward error to {backend}: {exc}", RED)
-                    self._fail(502, f"proxy body error: {exc}")
+                    self._fail(
+                        502, f"proxy body error: {exc}", cl_remaining, is_chunked
+                    )
                     return
                 except OSError as exc:
                     # No health checks by design; a dead/slow backend yields a
                     # 502 without taking down the proxy thread.
                     log(f"proxy: backend error to {backend}: {exc}", RED)
-                    self._fail(502, f"proxy backend error: {exc}")
+                    self._fail(
+                        502, f"proxy backend error: {exc}", cl_remaining, is_chunked
+                    )
                     return
 
                 # Forward the backend response faithfully (status + headers +

--- a/dev-scripts/run.py
+++ b/dev-scripts/run.py
@@ -237,9 +237,49 @@ HOP_BY_HOP_HEADERS = frozenset(
 )
 
 
+class ProxyBodyError(Exception):
+    """Raised when the client request body cannot be read/forwarded intact
+    (e.g. malformed or truncated chunked framing). Turned into a 502 so the
+    client gets a real status instead of a silently dropped body."""
+
+
 def pick_backend(backends, counter):
     """Return the backend for a given request counter (round-robin)."""
     return backends[counter % len(backends)]
+
+
+def _stream_chunked_body(rfile, send):
+    """Decode a `Transfer-Encoding: chunked` request body from `rfile` and
+    re-emit it, chunk-framed, via `send` (bounded by PROXY_BUFFER so proxy
+    memory never scales with payload size). Ends with the zero-length
+    terminator. Raises ProxyBodyError on malformed/truncated framing."""
+    while True:
+        size_line = rfile.readline()
+        if not size_line:
+            raise ProxyBodyError("client closed before chunked terminator")
+        # Ignore any chunk extensions (the part after ';').
+        token = size_line.split(b";", 1)[0].strip()
+        try:
+            size = int(token, 16)
+        except ValueError as exc:
+            raise ProxyBodyError(f"invalid chunk size {token!r}") from exc
+        if size == 0:
+            # Consume optional trailers up to the terminating blank line.
+            while True:
+                trailer = rfile.readline()
+                if trailer in (b"\r\n", b"\n", b""):
+                    break
+            break
+        remaining = size
+        while remaining > 0:
+            piece = rfile.read(min(PROXY_BUFFER, remaining))
+            if not piece:
+                raise ProxyBodyError("truncated chunk body")
+            send(b"%X\r\n" % len(piece) + piece + b"\r\n")
+            remaining -= len(piece)
+        # Each chunk's data is followed by a CRLF; consume it.
+        rfile.readline()
+    send(b"0\r\n\r\n")
 
 
 def _is_safe_header(name, value):
@@ -283,6 +323,35 @@ def make_proxy_handler(backends):
                 state["counter"] += 1
             return pick_backend(backends, counter)
 
+        def _fail(self, code, message):
+            """Send an error response and close the connection.
+
+            A partially-read request body left in the socket makes
+            BaseHTTPRequestHandler reset the connection on return — the client
+            would see `Connection reset by peer` instead of the status. Force
+            the connection closed (and best-effort drain a bounded amount of any
+            unconsumed body) so the client observes the real error code."""
+            self.close_connection = True
+            try:
+                length_header = self.headers.get("Content-Length")
+                if length_header is not None:
+                    remaining = int(length_header)
+                    # Bounded drain: do not read unboundedly on a huge upload.
+                    drain_cap = 8 * PROXY_BUFFER
+                    while remaining > 0 and drain_cap > 0:
+                        n = min(PROXY_BUFFER, remaining, drain_cap)
+                        chunk = self.rfile.read(n)
+                        if not chunk:
+                            break
+                        remaining -= len(chunk)
+                        drain_cap -= len(chunk)
+            except (OSError, ValueError):
+                pass
+            try:
+                self.send_error(code, message)
+            except OSError:
+                pass
+
         def _proxy(self):
             backend = self._next_backend()
             host, _, port = backend.partition(":")
@@ -299,6 +368,13 @@ def make_proxy_handler(backends):
                     self.send_error(400, "invalid Content-Length")
                     return
 
+            # When the client frames its body with `Transfer-Encoding: chunked`
+            # (no Content-Length — e.g. `nix copy` streaming a NAR whose
+            # compressed size is unknown), the body must still be forwarded.
+            # `Transfer-Encoding` is hop-by-hop, so we re-encode it ourselves.
+            te = self.headers.get("Transfer-Encoding", "")
+            is_chunked = content_length is None and "chunked" in te.lower()
+
             conn = None
             try:
                 try:
@@ -313,6 +389,10 @@ def make_proxy_handler(backends):
                         self.headers, backend
                     ):
                         conn.putheader(key, value)
+                    if is_chunked:
+                        # Re-advertise chunked framing to the backend (it was
+                        # dropped as hop-by-hop above).
+                        conn.putheader("Transfer-Encoding", "chunked")
                     conn.endheaders()
 
                     # Stream the request body (if any) without buffering it whole.
@@ -324,12 +404,19 @@ def make_proxy_handler(backends):
                                 break
                             conn.send(chunk)
                             remaining -= len(chunk)
+                    elif is_chunked:
+                        _stream_chunked_body(self.rfile, conn.send)
 
                     resp = conn.getresponse()
+                except ProxyBodyError as exc:
+                    log(f"proxy: body-forward error to {backend}: {exc}", RED)
+                    self._fail(502, f"proxy body error: {exc}")
+                    return
                 except OSError as exc:
                     # No health checks by design; a dead/slow backend yields a
                     # 502 without taking down the proxy thread.
-                    self.send_error(502, f"proxy backend error: {exc}")
+                    log(f"proxy: backend error to {backend}: {exc}", RED)
+                    self._fail(502, f"proxy backend error: {exc}")
                     return
 
                 # Forward the backend response faithfully (status + headers +

--- a/nix/e2e-tests/flake-module.nix
+++ b/nix/e2e-tests/flake-module.nix
@@ -63,6 +63,11 @@ _: {
         cp -r ${./src} src
         cp -r ${./tests} tests
         cp ${./pytest.ini} pytest.ini
+        # The dev-proxy regression test drives the real dev-scripts/run.py
+        # proxy code, so make it available and point the test at it.
+        mkdir -p dev-scripts
+        cp ${../../dev-scripts/run.py} dev-scripts/run.py
+        export NCPS_RUN_PY="$PWD/dev-scripts/run.py"
         export PYTHONDONTWRITEBYTECODE=1
         ${pytestPython}/bin/python -m pytest tests -m "not catalog" -q
         touch $out

--- a/nix/e2e-tests/tests/test_dev_proxy.py
+++ b/nix/e2e-tests/tests/test_dev_proxy.py
@@ -18,6 +18,7 @@ import socket
 import threading
 import time
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
 
@@ -55,10 +56,18 @@ def _free_port() -> int:
     return port
 
 
+@pytest.fixture(autouse=True)
+def _clear_capture_state():
+    """Reset the shared capture dict before each test so per-test body-length
+    records never leak across tests in the same process."""
+    _CaptureHandler.received.clear()
+    yield
+
+
 class _CaptureHandler(http.server.BaseHTTPRequestHandler):
     """Backend that records the request-body length per X-Test-Case."""
 
-    received: dict = {}
+    received: ClassVar[dict] = {}
 
     def log_message(self, *_args):
         pass
@@ -151,15 +160,17 @@ def test_chunked_put_forwards_full_body():
         backend.shutdown()
 
 
-def test_unreachable_backend_returns_502_not_reset():
+@pytest.mark.parametrize("chunked", [False, True])
+def test_unreachable_backend_returns_502_not_reset(chunked):
     # Point the proxy at a port with nothing listening.
     dead_port = _free_port()
     proxy = run.start_proxy("127.0.0.1", _free_port(), [f"127.0.0.1:{dead_port}"])
     proxy_port = proxy.server_address[1]
     try:
         time.sleep(0.2)
-        # The client must observe a clean 502, not a ConnectionResetError.
-        status = _put(proxy_port, "dead_case", b"Y" * 4096, chunked=False)
+        # The client must observe a clean 502, not a ConnectionResetError, for
+        # both Content-Length and Transfer-Encoding: chunked uploads.
+        status = _put(proxy_port, "dead_case", b"Y" * 4096, chunked=chunked)
         assert status == 502
     finally:
         proxy.shutdown()

--- a/nix/e2e-tests/tests/test_dev_proxy.py
+++ b/nix/e2e-tests/tests/test_dev_proxy.py
@@ -1,0 +1,165 @@
+"""Regression tests for the dev HA round-robin reverse proxy in
+``dev-scripts/run.py``.
+
+These drive the *actual* proxy code (`make_proxy_handler`/`start_proxy`) in
+front of an in-test capture backend that records how many request-body bytes it
+actually receives. They guard the bug where a `Transfer-Encoding: chunked`
+upload had its body silently dropped (backend received 0 bytes), which `nix
+copy` saw as ``curl error 56: Connection reset by peer`` on large NAR uploads.
+"""
+
+from __future__ import annotations
+
+import http.client
+import http.server
+import importlib.util
+import os
+import socket
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+
+def _load_run_py():
+    """Import dev-scripts/run.py as a module.
+
+    Resolves the path from ``NCPS_RUN_PY`` if set, else walks up from this test
+    file looking for ``dev-scripts/run.py`` (works both in-repo and inside the
+    nix flake-check sandbox where dev-scripts is copied next to tests/)."""
+    override = os.environ.get("NCPS_RUN_PY")
+    candidates = []
+    if override:
+        candidates.append(Path(override))
+    here = Path(__file__).resolve()
+    for parent in [here.parent, *here.parents]:
+        candidates.append(parent / "dev-scripts" / "run.py")
+    run_py = next((p for p in candidates if p.is_file()), None)
+    if run_py is None:
+        pytest.skip("could not locate dev-scripts/run.py")
+    spec = importlib.util.spec_from_file_location("ncps_run_py", run_py)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+run = _load_run_py()
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class _CaptureHandler(http.server.BaseHTTPRequestHandler):
+    """Backend that records the request-body length per X-Test-Case."""
+
+    received: dict = {}
+
+    def log_message(self, *_args):
+        pass
+
+    def do_PUT(self):
+        cl = self.headers.get("Content-Length")
+        te = self.headers.get("Transfer-Encoding")
+        body = b""
+        if cl is not None:
+            body = self.rfile.read(int(cl))
+        elif te and "chunked" in te.lower():
+            while True:
+                line = self.rfile.readline().strip()
+                if not line:
+                    break
+                size = int(line.split(b";", 1)[0], 16)
+                if size == 0:
+                    self.rfile.readline()  # trailing CRLF after terminator
+                    break
+                body += self.rfile.read(size)
+                self.rfile.readline()  # CRLF after each chunk
+        type(self).received[self.headers.get("X-Test-Case")] = len(body)
+        self.send_response(204)
+        self.end_headers()
+
+
+def _start_capture_backend():
+    port = _free_port()
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", port), _CaptureHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, port
+
+
+def _put(proxy_port, case, body, *, chunked: bool):
+    conn = http.client.HTTPConnection("127.0.0.1", proxy_port, timeout=10)
+    try:
+        path = f"/upload/nar/{case}.nar.zst"
+        if chunked:
+            conn.putrequest("PUT", path, skip_accept_encoding=True)
+            conn.putheader("X-Test-Case", case)
+            conn.putheader("Transfer-Encoding", "chunked")
+            conn.endheaders()
+            conn.send(b"%X\r\n" % len(body) + body + b"\r\n0\r\n\r\n")
+        else:
+            conn.request(
+                "PUT",
+                path,
+                body=body,
+                headers={"X-Test-Case": case, "Content-Length": str(len(body))},
+            )
+        resp = conn.getresponse()
+        resp.read()
+        return resp.status
+    finally:
+        conn.close()
+
+
+PAYLOAD = b"X" * 200_000
+
+
+def test_content_length_put_forwards_full_body():
+    backend, backend_port = _start_capture_backend()
+    proxy = run.start_proxy("127.0.0.1", _free_port(), [f"127.0.0.1:{backend_port}"])
+    proxy_port = proxy.server_address[1]
+    try:
+        time.sleep(0.2)
+        status = _put(proxy_port, "cl_case", PAYLOAD, chunked=False)
+        time.sleep(0.1)
+        assert status == 204
+        assert _CaptureHandler.received.get("cl_case") == len(PAYLOAD)
+    finally:
+        proxy.shutdown()
+        backend.shutdown()
+
+
+def test_chunked_put_forwards_full_body():
+    backend, backend_port = _start_capture_backend()
+    proxy = run.start_proxy("127.0.0.1", _free_port(), [f"127.0.0.1:{backend_port}"])
+    proxy_port = proxy.server_address[1]
+    try:
+        time.sleep(0.2)
+        status = _put(proxy_port, "chunked_case", PAYLOAD, chunked=True)
+        time.sleep(0.1)
+        assert status == 204
+        # The bug: backend received 0 bytes because the proxy dropped the
+        # chunked body. The full payload must reach the backend.
+        assert _CaptureHandler.received.get("chunked_case") == len(PAYLOAD)
+    finally:
+        proxy.shutdown()
+        backend.shutdown()
+
+
+def test_unreachable_backend_returns_502_not_reset():
+    # Point the proxy at a port with nothing listening.
+    dead_port = _free_port()
+    proxy = run.start_proxy("127.0.0.1", _free_port(), [f"127.0.0.1:{dead_port}"])
+    proxy_port = proxy.server_address[1]
+    try:
+        time.sleep(0.2)
+        # The client must observe a clean 502, not a ConnectionResetError.
+        status = _put(proxy_port, "dead_case", b"Y" * 4096, chunked=False)
+        assert status == 502
+    finally:
+        proxy.shutdown()

--- a/nix/e2e-tests/tests/test_dev_proxy.py
+++ b/nix/e2e-tests/tests/test_dev_proxy.py
@@ -174,3 +174,35 @@ def test_unreachable_backend_returns_502_not_reset(chunked):
         assert status == 502
     finally:
         proxy.shutdown()
+
+
+def test_truncated_content_length_body_returns_502_not_hang():
+    # A client that promises a Content-Length but closes early must not leave
+    # the proxy hanging in conn.getresponse() waiting on a backend that still
+    # expects the full body — it must surface a 502.
+    backend, backend_port = _start_capture_backend()
+    proxy = run.start_proxy("127.0.0.1", _free_port(), [f"127.0.0.1:{backend_port}"])
+    proxy_port = proxy.server_address[1]
+    try:
+        time.sleep(0.2)
+        sock = socket.create_connection(("127.0.0.1", proxy_port), timeout=10)
+        try:
+            # Declare 200000 bytes but send only 10, then half-close.
+            sock.sendall(
+                b"PUT /upload/nar/truncated.nar.zst HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Content-Length: 200000\r\n"
+                b"\r\n"
+                b"XXXXXXXXXX"
+            )
+            sock.shutdown(socket.SHUT_WR)
+            # Read the status line; timeout (not hang) if the fix regresses.
+            sock.settimeout(10)
+            status_line = sock.recv(64)
+            assert status_line.startswith(b"HTTP/"), status_line
+            assert b" 502 " in status_line, status_line
+        finally:
+            sock.close()
+    finally:
+        proxy.shutdown()
+        backend.shutdown()

--- a/openspec/changes/archive/2026-06-10-fix-dev-proxy-chunked-body/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-10-fix-dev-proxy-chunked-body/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/archive/2026-06-10-fix-dev-proxy-chunked-body/design.md
+++ b/openspec/changes/archive/2026-06-10-fix-dev-proxy-chunked-body/design.md
@@ -1,0 +1,90 @@
+## Context
+
+`dev-scripts/run.py` runs an in-process, stdlib-only round-robin reverse proxy (`make_proxy_handler` / `start_proxy`, a `ThreadingHTTPServer` of `BaseHTTPRequestHandler`) on port `8500` to front the HA `serve` instances (PR #1389). Its `_proxy()` handler forwards the client request to a backend via `http.client.HTTPConnection`.
+
+The request-body forwarding is gated on `Content-Length`:
+
+```python
+content_length = None
+length_header = self.headers.get("Content-Length")
+if length_header is not None:
+    content_length = int(length_header)
+...
+if content_length is not None:        # run.py ~319
+    remaining = content_length
+    while remaining > 0:
+        chunk = self.rfile.read(min(PROXY_BUFFER, remaining))
+        ...
+        conn.send(chunk)
+```
+
+`Transfer-Encoding` is in `HOP_BY_HOP_HEADERS` and is stripped from the forwarded headers. So a `Transfer-Encoding: chunked` request reaches `_proxy()` with no `Content-Length`; `content_length` stays `None`; the body loop is skipped entirely; and the backend receives a bodiless `PUT`. The client's body is left unread in `self.rfile`, and on the keep-alive connection that surfaces to the client as `curl error 56: Connection reset by peer`.
+
+Empirically verified against the real `run.py` proxy: a `Content-Length` PUT delivered 200000 body bytes to a capture backend; an identical `Transfer-Encoding: chunked` PUT delivered **0** body bytes. `nix copy` uses chunked encoding for NAR uploads because the on-the-fly-compressed `.nar.zst` size is unknown ahead of time, so large closures (e.g. `nixos-system`) fail while small `Content-Length` NARs succeed.
+
+This is a dev-harness fault only. ncps server code is correct and out of scope.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The proxy forwards request bodies for both `Content-Length` and `Transfer-Encoding: chunked` framings, delivering the complete body to the backend.
+- Backend failures yield a clean `502` to the client, never a TCP reset from an unconsumed request body.
+- Backend connect/forward failures are logged proxy-side so dev upload failures are diagnosable.
+- A regression test drives the actual `run.py` proxy with both framings and asserts full-body delivery.
+
+**Non-Goals:**
+- No change to ncps server (`pkg/...`) code or behavior.
+- No production runtime change; the proxy is a dev convenience only.
+- No new external dependency — implementation stays within the Python standard library.
+- Not introducing whole-payload buffering; body forwarding remains streamed with the existing bounded buffer.
+
+## Decisions
+
+### Decision 1: Detect chunked framing and stream-decode the client body
+
+When `Content-Length` is absent, inspect the client's `Transfer-Encoding` header (before it is dropped as hop-by-hop). If it contains `chunked`, read the body by decoding the chunk framing from `self.rfile` (read each `<hex-size>\r\n`, then that many bytes, then the trailing `\r\n`, until the `0\r\n\r\n` terminator), streaming each decoded chunk to the backend with the existing `PROXY_BUFFER` bound.
+
+Forward to the backend re-encoded as chunked: send `Transfer-Encoding: chunked` to the backend and re-frame each decoded piece, ending with the zero-length terminator. This preserves streaming (no need to know the total size, no whole-body buffering).
+
+**Why re-encode chunked rather than buffer-and-set-Content-Length:** buffering the whole body to compute a `Content-Length` would make proxy memory scale with payload size — exactly the property the streaming design exists to avoid, and these are multi-hundred-MB NAR closures. Re-encoding chunked keeps memory bounded. Go's `net/http` backend accepts a chunked request body transparently.
+
+**Alternative considered — pass the client body through verbatim by not stripping `Transfer-Encoding`:** rejected. `http.client.HTTPConnection` does not transparently relay an already-chunked stream; the proxy must own the framing. Explicit decode/re-encode is unambiguous and directly testable.
+
+### Decision 2: Unify the body-forwarding into a single helper
+
+Refactor the `Content-Length` loop and the new chunked loop behind one `_forward_request_body(conn)` that picks the strategy from the client headers. Keeps `_proxy()` readable and gives the regression test a single seam if needed.
+
+### Decision 3: Error path drains/aborts before responding 502
+
+On an `OSError` raised while connecting or forwarding, before/around `send_error(502, ...)`, ensure the client connection does not reset due to an unconsumed body. Set `self.close_connection = True` and best-effort drain remaining readable client body (bounded) so the `502` is what the client sees. Where a clean `502` is impossible (body already partially consumed and backend gone), prefer a deterministic close over a silent reset, and log it.
+
+**Why:** `BaseHTTPRequestHandler` resets the socket when the handler returns with unread request data on a keep-alive connection. Draining (or forcing close after writing the response) converts the reset into an observable `502`.
+
+### Decision 4: Make proxy errors visible
+
+`log_message` is currently overridden to a no-op. Keep request access logging quiet (instances log their own), but add explicit `log(...)`/stderr lines for backend connect failures and body-forward failures, including the backend address and the exception. This is the only signal the proxy emits today, so it must not be swallowed.
+
+### Decision 5: TDD regression test driving the real proxy
+
+Add a test that imports `make_proxy_handler`/`start_proxy` from `run.py`, points the proxy at an in-test capture backend that records received body length, and asserts:
+- `Content-Length` PUT → backend receives the full N bytes.
+- `Transfer-Encoding: chunked` PUT → backend receives the full N bytes (currently 0 — the failing test).
+- Backend-unreachable PUT → client gets `502`, not a reset.
+
+This mirrors the manual reproduction already performed. Test placement and runner follow the existing dev-harness test conventions (the same approach used for other `run.py` / e2e-harness unit tests).
+
+## Risks / Trade-offs
+
+- **[Chunked decode edge cases — chunk extensions, trailers]** → Decode defensively: parse the size token up to the first `;` (ignore chunk extensions), and consume trailer lines until the blank line after the `0` chunk. nix/curl do not emit trailers, but the parser must not hang on them.
+- **[Malformed chunk framing from a client could hang or loop]** → Bound reads with timeouts/expected terminators and treat a framing error as a `400`/`502` with a logged reason, consistent with the existing defensive `Content-Length` parse that returns `400`.
+- **[Re-encoding chunked changes the exact bytes on the wire (framing), though not the payload]** → Acceptable: HTTP semantics are preserved and the backend reassembles the identical payload; the test asserts payload-byte equality, not wire-byte equality.
+- **[Draining a large unconsumed body on the error path could be slow]** → Bound the drain; if the body is huge and the backend is already gone, force-close rather than drain unboundedly. The common error case (backend unreachable) happens before much body is read.
+- **[Scope creep into ncps server code]** → Explicitly out of scope; the change touches `dev-scripts/run.py` and its test only.
+
+## Migration Plan
+
+No deployment or data migration. Dev-only change: edit `dev-scripts/run.py`, add the regression test, verify `task fmt` / `task lint` / `task test` plus the new test. Rollback is reverting the commit. No state or schema impact.
+
+## Open Questions
+
+- Exact home for the regression test (alongside existing `run.py`/e2e-harness unit tests) and whether it should be wired into `nix flake check` like the existing `e2e-harness-unit` net — confirm during apply against current harness-test conventions.

--- a/openspec/changes/archive/2026-06-10-fix-dev-proxy-chunked-body/proposal.md
+++ b/openspec/changes/archive/2026-06-10-fix-dev-proxy-chunked-body/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The dev HA round-robin proxy in `dev-scripts/run.py` silently drops the body of any request sent with `Transfer-Encoding: chunked`, forwarding a bodiless request to the backend and leaving the client's body unconsumed — which the client sees as `curl error 56: Connection reset by peer`. `nix copy` uploads large NARs (e.g. a `nixos-system` closure) with chunked encoding because the on-the-fly-compressed `.nar.zst` size is unknown in advance, so large uploads through the HA proxy fail while small `Content-Length` ones succeed. This was reproduced against the actual `run.py` proxy: a `Content-Length` PUT delivered 200000 bytes to the backend; an identical chunked PUT delivered 0 bytes.
+
+## What Changes
+
+- Forward chunked request bodies: when `Content-Length` is absent but the client used `Transfer-Encoding: chunked`, the proxy decodes the chunked framing from the client and delivers the full body to the backend (re-encoded chunked, or with an explicit `Content-Length`). The proxy never forwards a bodiless request when the client supplied a body.
+- Harden the error path: on a backend `OSError` mid-forward, the proxy drains or hard-aborts the client request body around `send_error` so a partially-read body does not turn an intended `502` into a TCP reset. The client receives a real `502`, not a connection reset.
+- Add proxy-side observability: surface backend connect/forward failures (currently `log_message` is silenced) so future proxy failures are diagnosable instead of invisible.
+- Add a regression test driving the real `run.py` proxy with both a `Content-Length` and a `Transfer-Encoding: chunked` PUT, asserting the backend receives the full body in both cases.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `dev-ha-proxy`: the "Proxy streams request and response bodies" requirement is extended so that upload bodies are forwarded regardless of framing (`Content-Length` or `Transfer-Encoding: chunked`); new requirements cover error-path reset avoidance and proxy-side error visibility.
+
+## Impact
+
+- **Code**: `dev-scripts/run.py` only — the `_proxy()` handler's request-body forwarding and error path, plus its `log_message`. ncps server code is **not** changed; it is not at fault.
+- **Tests**: a new dev-harness regression test exercising the proxy's body forwarding for both framings.
+- **I/O / network / memory**: bodies remain streamed with the existing bounded buffer; no whole-payload buffering is introduced, so proxy memory still does not scale with payload size. Chunked uploads gain correct end-to-end delivery; latency is unchanged.
+- **Scope**: dev-harness only; no production or runtime-server behavior is affected.

--- a/openspec/changes/archive/2026-06-10-fix-dev-proxy-chunked-body/specs/dev-ha-proxy/spec.md
+++ b/openspec/changes/archive/2026-06-10-fix-dev-proxy-chunked-body/specs/dev-ha-proxy/spec.md
@@ -1,36 +1,4 @@
-# dev-ha-proxy Specification
-
-## Purpose
-
-Front the multiple `serve` instances spawned by `dev-scripts/run.py` in HA mode with a single round-robin reverse proxy, so a Nix client (or test driver) can target one stable endpoint instead of juggling per-instance ports. The proxy is a dev-harness convenience implemented with the Python standard library only.
-
-## Requirements
-
-### Requirement: Round-robin proxy fronts active instances in HA mode
-
-When `dev-scripts/run.py` starts more than one ncps instance (`--replicas > 1`), it SHALL start an HTTP reverse proxy bound to port `8500` that forwards each incoming request to one of the active ncps instances, selecting backends in round-robin order across requests.
-
-#### Scenario: Proxy starts in HA mode
-
-- **WHEN** `run.py` is invoked with `--replicas 2` (or more) and the instances start successfully
-- **THEN** an HTTP proxy is listening on `127.0.0.1:8500`
-- **AND** the set of backends equals the started instance ports (e.g. `8501`, `8502`)
-
-#### Scenario: Requests rotate across backends
-
-- **WHEN** multiple HTTP requests arrive at the proxy on port `8500`
-- **THEN** the proxy forwards consecutive requests to different instances in round-robin order
-- **AND** each request reaches exactly one backend instance
-
-### Requirement: Proxy is not started for single-instance runs
-
-When `run.py` starts exactly one ncps instance (`--replicas 1`, the default), it SHALL NOT start the port-`8500` proxy.
-
-#### Scenario: Single instance skips the proxy
-
-- **WHEN** `run.py` is invoked with the default `--replicas 1`
-- **THEN** no proxy is bound to port `8500`
-- **AND** the single instance is reachable directly on its own port
+## MODIFIED Requirements
 
 ### Requirement: Proxy streams request and response bodies
 
@@ -57,6 +25,8 @@ The proxy SHALL stream request and response bodies between client and backend ra
 - **AND** the backend does not receive an empty body
 - **AND** the proxy returns the backend's response to the client
 
+## ADDED Requirements
+
 ### Requirement: Proxy reports a clean error instead of resetting the client on backend failure
 
 When the proxy fails to forward a request to a backend (the backend is unreachable, or the connection breaks mid-forward), it SHALL return an HTTP `502` response to the client rather than abruptly resetting the client connection. To do so, the proxy SHALL ensure any unconsumed client request body is drained or the response is delivered such that the client observes the `502` status, not a `Connection reset by peer`.
@@ -82,27 +52,3 @@ The proxy SHALL log backend connection and body-forwarding failures so that dev-
 - **WHEN** the proxy encounters a backend connect failure or a body-forwarding error
 - **THEN** the proxy emits a log line identifying the failed backend and the error
 - **AND** the failure is not silently swallowed
-
-### Requirement: Proxy lifecycle is tied to run.py
-
-The proxy SHALL start and stop together with `run.py`. On `run.py` shutdown (SIGINT/SIGTERM or cleanup), the proxy SHALL be stopped and its listening port released.
-
-#### Scenario: Proxy shuts down with run.py
-
-- **WHEN** `run.py` receives a termination signal and runs its cleanup path
-- **THEN** the proxy stops accepting connections
-- **AND** port `8500` is released
-
-### Requirement: Proxy endpoint is discoverable in state.json
-
-When the proxy is started, `run.py` SHALL record its endpoint in `var/ncps/state.json` so test drivers and clients can discover the single HA entry point.
-
-#### Scenario: State file advertises the proxy
-
-- **WHEN** the proxy is started in HA mode
-- **THEN** `var/ncps/state.json` contains the proxy endpoint (host and port `8500`)
-
-#### Scenario: State file omits proxy when absent
-
-- **WHEN** `run.py` runs a single instance and starts no proxy
-- **THEN** `var/ncps/state.json` does not advertise a proxy endpoint

--- a/openspec/changes/archive/2026-06-10-fix-dev-proxy-chunked-body/tasks.md
+++ b/openspec/changes/archive/2026-06-10-fix-dev-proxy-chunked-body/tasks.md
@@ -1,0 +1,32 @@
+## 1. Regression test (TDD — write failing first)
+
+- [x] 1.1 Add a dev-harness test that imports the real `make_proxy_handler`/`start_proxy` from `dev-scripts/run.py`, starts the proxy in front of an in-test capture backend that records received request-body byte length, following existing `run.py`/e2e-harness test conventions.
+- [x] 1.2 Assert a `Content-Length` PUT delivers the full N body bytes to the backend (passes today — guards against regression).
+- [x] 1.3 Assert a `Transfer-Encoding: chunked` PUT delivers the full N body bytes to the backend (fails today — backend currently receives 0 bytes).
+- [x] 1.4 Assert a request to an unreachable backend returns HTTP `502` to the client and does not reset the connection.
+- [x] 1.5 Run the test and confirm 1.3 (and 1.4 if not yet handled) fail for the expected reasons before implementing.
+
+## 2. Forward chunked request bodies
+
+- [x] 2.1 In `_proxy()`, detect chunked framing from the client `Transfer-Encoding` header before it is dropped as hop-by-hop.
+- [x] 2.2 Extract body forwarding into a single `_forward_request_body(conn)` helper that handles both `Content-Length` (existing loop) and `Transfer-Encoding: chunked`.
+- [x] 2.3 Implement chunked decode from `self.rfile` (parse `<hex-size>[;ext]\r\n`, read that many bytes + trailing `\r\n`, stop at `0\r\n` + trailers + blank line), streaming each piece with the existing `PROXY_BUFFER` bound — no whole-body buffering.
+- [x] 2.4 Re-encode to the backend as `Transfer-Encoding: chunked` (send the header, re-frame each piece, end with the zero-length terminator) so memory stays bounded.
+- [x] 2.5 Treat malformed chunk framing defensively (logged `400`/`502`, no hang), consistent with the existing defensive `Content-Length` parse.
+- [x] 2.6 Run the test suite; confirm tasks 1.2 and 1.3 now pass.
+
+## 3. Harden the error path against client resets
+
+- [x] 3.1 On backend `OSError` (connect or mid-forward), set `self.close_connection = True` and best-effort bounded-drain any unconsumed client body around `send_error(502, ...)` so the client observes the `502` instead of a `Connection reset by peer`.
+- [x] 3.2 Run the test; confirm task 1.4 passes (502, no reset).
+
+## 4. Surface proxy-side errors
+
+- [x] 4.1 Keep per-request access logging quiet, but emit an explicit log line (backend address + exception) on backend connect failures and body-forwarding failures, so dev upload failures are diagnosable.
+
+## 5. Verify and finalize
+
+- [x] 5.1 Run `task fmt` and confirm it exits clean.
+- [x] 5.2 Run `task lint` and confirm it exits clean.
+- [x] 5.3 Run `task test` (plus the new proxy regression test) and confirm all pass.
+- [x] 5.4 Confirm no changes were made outside `dev-scripts/run.py` and its test (ncps server code untouched).


### PR DESCRIPTION
## Summary

The dev HA round-robin reverse proxy in `dev-scripts/run.py` (PR #1389) silently dropped the body of any request sent with `Transfer-Encoding: chunked`. It only streamed the request body when a `Content-Length` header was present; chunked uploads (no `Content-Length`, and `Transfer-Encoding` stripped as hop-by-hop) skipped the body loop entirely, so the backend received a **bodiless PUT** and the unconsumed client body reset the connection — surfacing as `curl error 56: Connection reset by peer` and aborting the whole `nix copy` closure upload.

`nix copy` uploads NARs with chunked encoding because the on-the-fly-compressed `.nar.zst` size is unknown ahead of time, so large closures (e.g. a `nixos-system`) failed while small `Content-Length` NARs succeeded.

### Diagnosis (proven)
Driving the real `run.py` proxy against a capture backend:

| Framing | Client sent | Backend received |
|---|---|---|
| `Content-Length` | 200000 | **200000** ✅ |
| `Transfer-Encoding: chunked` | 200000 | **0** ❌ |

### Fix (`dev-scripts/run.py` only — ncps server untouched)
- Detect chunked framing before the header is dropped; decode the client's chunked body and re-encode it chunked to the backend in bounded `PROXY_BUFFER` units (no whole-body buffering — proxy memory still does not scale with payload size).
- Harden the error path: on backend failure, drain the unconsumed body and force the connection closed so the client gets a real `502` instead of a TCP reset.
- Surface backend connect/forward failures via the log (previously `log_message` was a no-op), so dev upload failures are diagnosable.
- Sync the `dev-ha-proxy` spec (chunked + Content-Length forwarding, 502-not-reset, error visibility) and archive the OpenSpec change.

## Test plan

- [x] New regression test drives the real `run.py` proxy with both `Content-Length` and `Transfer-Encoding: chunked` PUTs; asserts full body reaches the backend in both, and unreachable backend → `502` (not reset).
- [x] Wired `dev-scripts/run.py` into the `e2e-harness-unit` flake check so the test runs in CI (`nix build .#checks.x86_64-linux.e2e-harness-unit` → 43 passed).
- [x] `task fmt` clean · `task lint` 0 issues · `task test` all Go packages pass.