### PR TITLE
fix(dev): HTTP/1.1 keep-alive in HA proxy (run.py)

### DIFF
--- a/dev-scripts/run.py
+++ b/dev-scripts/run.py
@@ -527,7 +527,13 @@ def make_proxy_handler(backends):
                     or self.command == "HEAD"
                     or 100 <= resp.status < 200
                 )
-                if not has_length and not bodiless:
+                # Advertise the close when we will close for any reason — an
+                # unframed body (above), or the connection was already marked to
+                # close (e.g. the client sent `Connection: close`, or it is an
+                # HTTP/1.0 client). RFC 7230 §6.3 requires the server to send
+                # `Connection: close` in that case so a keep-alive client does
+                # not assume the connection persists and reuse it.
+                if self.close_connection or (not has_length and not bodiless):
                     self.send_header("Connection", "close")
                     self.close_connection = True
                 self.end_headers()

--- a/dev-scripts/run.py
+++ b/dev-scripts/run.py
@@ -319,6 +319,18 @@ def make_proxy_handler(backends):
     lock = threading.Lock()
 
     class ProxyHandler(http.server.BaseHTTPRequestHandler):
+        # Speak HTTP/1.1 so client connections are persistent and reused across
+        # requests. `nix copy` (libcurl) pushes a large closure over a small
+        # pool of keep-alive connections; an HTTP/1.0 proxy force-closes after
+        # every request, forcing a brand-new TCP connection per object
+        # (thousands for a big closure). That churn intermittently resets an
+        # upload before the proxy ever handles it (`curl error 56`), aborting
+        # the copy. HTTP/1.1 also makes BaseHTTPRequestHandler auto-answer
+        # `Expect: 100-continue` (it gates that on protocol_version >= 1.1),
+        # removing the ~1s-per-PUT stall. Response framing is handled in
+        # `_proxy` so a reused connection never desyncs.
+        protocol_version = "HTTP/1.1"
+
         # Quiet: the instances do their own logging.
         def log_message(self, *_args):
             pass
@@ -493,12 +505,31 @@ def make_proxy_handler(backends):
                 # body). Drop any header carrying embedded CRLF to prevent
                 # response splitting.
                 self.send_response_only(resp.status, resp.reason)
+                has_length = False
                 for key, value in resp.getheaders():
-                    if key.lower() in HOP_BY_HOP_HEADERS:
+                    lowered = key.lower()
+                    if lowered in HOP_BY_HOP_HEADERS:
                         continue
                     if not _is_safe_header(key, value):
                         continue
+                    if lowered == "content-length":
+                        has_length = True
                     self.send_header(key, value)
+                # Keep a persistent connection only if the response is framed so
+                # the next request stays in sync. 204/304, responses to HEAD,
+                # and 1xx carry no body; anything else needs a Content-Length.
+                # When the body length is unknown (e.g. the backend used
+                # Transfer-Encoding: chunked, stripped above as hop-by-hop),
+                # signal close so the client reads to EOF instead of mis-framing
+                # the following response.
+                bodiless = (
+                    resp.status in (204, 304)
+                    or self.command == "HEAD"
+                    or 100 <= resp.status < 200
+                )
+                if not has_length and not bodiless:
+                    self.send_header("Connection", "close")
+                    self.close_connection = True
                 self.end_headers()
                 try:
                     shutil.copyfileobj(resp, self.wfile, PROXY_BUFFER)
@@ -519,13 +550,21 @@ def make_proxy_handler(backends):
     return ProxyHandler
 
 
+class _ProxyServer(http.server.ThreadingHTTPServer):
+    # Absorb connection-establishment bursts: `nix copy` opens many connections
+    # in parallel, and the stdlib default backlog of 5 is too small. Must be a
+    # class attribute so it takes effect during server_activate() (listen()),
+    # which runs inside __init__ — setting it on the instance afterwards is too
+    # late. Defense-in-depth alongside HTTP/1.1 keep-alive, which already
+    # collapses the per-object connection churn.
+    request_queue_size = 256
+
+
 def start_proxy(host, port, backends):
     """Start a threaded round-robin reverse proxy and return the server.
 
     Raises OSError if the address cannot be bound (e.g. the port is in use)."""
-    server = http.server.ThreadingHTTPServer(
-        (host, port), make_proxy_handler(backends)
-    )
+    server = _ProxyServer((host, port), make_proxy_handler(backends))
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     return server

--- a/nix/e2e-tests/tests/test_dev_proxy.py
+++ b/nix/e2e-tests/tests/test_dev_proxy.py
@@ -329,6 +329,38 @@ def test_expect_100_continue_is_answered():
         backend.shutdown()
 
 
+def test_client_connection_close_is_echoed():
+    # RFC 7230 §6.3: when the proxy will close the connection — e.g. the client
+    # asked with `Connection: close` — it MUST advertise `Connection: close` in
+    # the response, even for an otherwise-reusable (delimitable) response, so a
+    # keep-alive client does not assume the connection persists and reuse it.
+    backend, backend_port = _start_capture_backend()
+    proxy = run.start_proxy("127.0.0.1", _free_port(), [f"127.0.0.1:{backend_port}"])
+    proxy_port = proxy.server_address[1]
+    try:
+        time.sleep(0.2)
+        sock = socket.create_connection(("127.0.0.1", proxy_port), timeout=10)
+        sock.settimeout(10)
+        try:
+            body = b"X" * 100
+            sock.sendall(
+                b"PUT /upload/nar/close_case.nar.zst HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"X-Test-Case: close_case\r\n"
+                + f"Content-Length: {len(body)}\r\n".encode()
+                + b"Connection: close\r\n\r\n"
+                + body
+            )
+            status, headers, _leftover = _read_response_head(sock)
+            assert status is not None and b"204" in status, status
+            assert headers.get(b"connection", b"").lower() == b"close", headers
+        finally:
+            sock.close()
+    finally:
+        proxy.shutdown()
+        backend.shutdown()
+
+
 def test_unframed_response_forces_connection_close():
     # If the backend response has no Content-Length and is not bodiless, the
     # proxy cannot keep the connection in sync for a following request, so it

--- a/nix/e2e-tests/tests/test_dev_proxy.py
+++ b/nix/e2e-tests/tests/test_dev_proxy.py
@@ -93,6 +93,27 @@ class _CaptureHandler(http.server.BaseHTTPRequestHandler):
         self.send_response(204)
         self.end_headers()
 
+    def do_GET(self):
+        # Two response shapes for keep-alive framing tests:
+        #   /upload/framed   -> 200 with an explicit Content-Length (delimitable)
+        #   /upload/unframed -> 200 with NO Content-Length; this HTTP/1.0 backend
+        #                       signals end-of-body by closing the connection.
+        if self.path == "/upload/framed":
+            body = b"framed-body"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/upload/unframed":
+            body = b"unframed-body-no-length"
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
 
 def _start_capture_backend():
     port = _free_port()
@@ -201,6 +222,179 @@ def test_truncated_content_length_body_returns_502_not_hang():
             status_line = sock.recv(64)
             assert status_line.startswith(b"HTTP/"), status_line
             assert b" 502 " in status_line, status_line
+        finally:
+            sock.close()
+    finally:
+        proxy.shutdown()
+        backend.shutdown()
+
+
+def _read_response_head(sock):
+    """Read one HTTP response's status line + headers from ``sock``.
+
+    Returns ``(status_line, headers, leftover)`` where ``headers`` is a
+    lower-cased dict and ``leftover`` is any bytes already read past the header
+    block (the start of the body), or ``(None, data, b"")`` if the connection
+    closed before a full header block arrived. Returning ``leftover`` keeps
+    body reads deterministic even when the kernel coalesces the headers and
+    body into a single ``recv``."""
+    data = b""
+    while b"\r\n\r\n" not in data:
+        chunk = sock.recv(4096)
+        if not chunk:
+            return None, data, b""
+        data += chunk
+    head, leftover = data.split(b"\r\n\r\n", 1)
+    lines = head.split(b"\r\n")
+    headers = {}
+    for line in lines[1:]:
+        if b":" in line:
+            key, value = line.split(b":", 1)
+            headers[key.strip().lower()] = value.strip()
+    return lines[0], headers, leftover
+
+
+def _send_put(sock, case, body):
+    sock.sendall(
+        f"PUT /upload/nar/{case}.nar.zst HTTP/1.1\r\n".encode()
+        + b"Host: 127.0.0.1\r\n"
+        + f"X-Test-Case: {case}\r\n".encode()
+        + f"Content-Length: {len(body)}\r\n".encode()
+        + b"Connection: keep-alive\r\n\r\n"
+        + body
+    )
+
+
+def test_http11_connection_is_reused_across_requests():
+    # The bug: the proxy spoke HTTP/1.0 and closed every connection after one
+    # request, so a keep-alive client (nix/libcurl) was forced to open a new
+    # TCP connection per object — thousands for a large closure — which under
+    # load intermittently reset uploads (curl error 56). The proxy must keep a
+    # persistent HTTP/1.1 connection so the client can reuse it.
+    backend, backend_port = _start_capture_backend()
+    proxy = run.start_proxy("127.0.0.1", _free_port(), [f"127.0.0.1:{backend_port}"])
+    proxy_port = proxy.server_address[1]
+    try:
+        time.sleep(0.2)
+        sock = socket.create_connection(("127.0.0.1", proxy_port), timeout=10)
+        sock.settimeout(10)
+        try:
+            for i in range(3):
+                _send_put(sock, f"reuse_{i}", b"X" * 1000)
+                status, _headers, _leftover = _read_response_head(sock)
+                assert status is not None, (
+                    f"proxy closed the connection before request {i}; "
+                    "it is not honoring keep-alive"
+                )
+                assert status.startswith(b"HTTP/1.1"), status
+                assert b"204" in status, status
+            # All three requests were served on a single reused connection.
+            assert _CaptureHandler.received.get("reuse_2") == 1000
+        finally:
+            sock.close()
+    finally:
+        proxy.shutdown()
+        backend.shutdown()
+
+
+def test_expect_100_continue_is_answered():
+    # A large PUT carries `Expect: 100-continue`; the proxy must answer the
+    # interim `100 Continue` before the client streams the body, otherwise the
+    # client stalls ~1s per upload waiting for it.
+    backend, backend_port = _start_capture_backend()
+    proxy = run.start_proxy("127.0.0.1", _free_port(), [f"127.0.0.1:{backend_port}"])
+    proxy_port = proxy.server_address[1]
+    try:
+        time.sleep(0.2)
+        sock = socket.create_connection(("127.0.0.1", proxy_port), timeout=5)
+        sock.settimeout(5)
+        try:
+            body = b"X" * 5000
+            sock.sendall(
+                b"PUT /upload/nar/expect_case.nar.zst HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"X-Test-Case: expect_case\r\n"
+                b"Content-Length: 5000\r\n"
+                b"Expect: 100-continue\r\n\r\n"
+            )
+            interim, _headers, _leftover = _read_response_head(sock)
+            assert interim is not None and interim.startswith(b"HTTP/1.1 100"), interim
+            sock.sendall(body)
+            status, _headers2, _leftover2 = _read_response_head(sock)
+            assert status is not None and b"204" in status, status
+        finally:
+            sock.close()
+    finally:
+        proxy.shutdown()
+        backend.shutdown()
+
+
+def test_unframed_response_forces_connection_close():
+    # If the backend response has no Content-Length and is not bodiless, the
+    # proxy cannot keep the connection in sync for a following request, so it
+    # must signal `Connection: close` and let the client read to EOF rather
+    # than mis-framing the next response.
+    backend, backend_port = _start_capture_backend()
+    proxy = run.start_proxy("127.0.0.1", _free_port(), [f"127.0.0.1:{backend_port}"])
+    proxy_port = proxy.server_address[1]
+    try:
+        time.sleep(0.2)
+        sock = socket.create_connection(("127.0.0.1", proxy_port), timeout=10)
+        sock.settimeout(10)
+        try:
+            sock.sendall(
+                b"GET /upload/unframed HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Connection: keep-alive\r\n\r\n"
+            )
+            status, headers, leftover = _read_response_head(sock)
+            assert status is not None and b"200" in status, status
+            assert headers.get(b"connection", b"").lower() == b"close", headers
+            # The rest of the socket is the body, terminated by EOF (close).
+            rest = bytearray(leftover)
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                rest += chunk
+            assert b"unframed-body-no-length" in bytes(rest), bytes(rest)
+        finally:
+            sock.close()
+    finally:
+        proxy.shutdown()
+        backend.shutdown()
+
+
+def test_framed_get_keeps_connection_alive():
+    # A delimitable response (explicit Content-Length) must keep the connection
+    # open AND be framed exactly so a second request on the same raw socket is
+    # served correctly. (A buffered client like http.client would silently
+    # reconnect on an HTTP/1.0 close and mask the bug, so we use a raw socket.)
+    backend, backend_port = _start_capture_backend()
+    proxy = run.start_proxy("127.0.0.1", _free_port(), [f"127.0.0.1:{backend_port}"])
+    proxy_port = proxy.server_address[1]
+    try:
+        time.sleep(0.2)
+        sock = socket.create_connection(("127.0.0.1", proxy_port), timeout=10)
+        sock.settimeout(10)
+        try:
+            for _ in range(2):
+                sock.sendall(
+                    b"GET /upload/framed HTTP/1.1\r\n"
+                    b"Host: 127.0.0.1\r\n"
+                    b"Connection: keep-alive\r\n\r\n"
+                )
+                status, headers, leftover = _read_response_head(sock)
+                assert status is not None, "proxy did not keep the connection alive"
+                assert status.startswith(b"HTTP/1.1") and b"200" in status, status
+                length = int(headers.get(b"content-length", b"0"))
+                body = bytearray(leftover)
+                while len(body) < length:
+                    chunk = sock.recv(length - len(body))
+                    if not chunk:
+                        break
+                    body += chunk
+                assert bytes(body) == b"framed-body", bytes(body)
         finally:
             sock.close()
     finally:

--- a/openspec/changes/archive/2026-06-10-fix-dev-proxy-http10-keepalive/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-10-fix-dev-proxy-http10-keepalive/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/archive/2026-06-10-fix-dev-proxy-http10-keepalive/design.md
+++ b/openspec/changes/archive/2026-06-10-fix-dev-proxy-http10-keepalive/design.md
@@ -1,0 +1,38 @@
+## Context
+
+`dev-scripts/run.py` runs an HA round-robin reverse proxy on `:8500` (added in #1389) in front of N ncps `serve` instances. #1390 fixed it dropping `Transfer-Encoding: chunked` request bodies. The proxy is a stdlib-only `http.server.ThreadingHTTPServer` whose handler (`make_proxy_handler`) subclasses `BaseHTTPRequestHandler`.
+
+`BaseHTTPRequestHandler.protocol_version` defaults to `"HTTP/1.0"`. With that default, after each response the handler sets `close_connection = True` and the connection is closed. A keep-alive client (libcurl, which `nix copy` uses) therefore cannot reuse connections through the proxy and opens a fresh TCP connection per request. For a large closure that is thousands of connections; the resulting churn — together with the stdlib default listen backlog of 5 and a ~1 s stall per PUT (the HTTP/1.0 handler never answers `Expect: 100-continue`) — starves the single-threaded accept loop and intermittently leaves nix's upload connection reset before the proxy processes it (`curl error 56`), aborting the copy.
+
+Reproduced deterministically: isolated clean ncps (sqlite, `--cache-lock-backend=local`) behind the real proxy → exact `curl error 56`. Patched proxy (`protocol_version="HTTP/1.1"` + response framing + larger backlog) → 3488 PUTs, 0 resets; `curl -v` shows `HTTP/1.1 200` + "Connection left intact".
+
+## Goals / Non-Goals
+
+**Goals:**
+- The dev proxy supports HTTP/1.1 persistent connections so a keep-alive client reuses connections, eliminating the connection-churn that triggers `curl error 56` on large `nix copy` uploads.
+- Forwarded responses remain correctly framed so a reused connection never desyncs.
+- Remove the per-PUT `Expect: 100-continue` stall (a free consequence of HTTP/1.1).
+- A regression test that drives the real proxy and fails on the current HTTP/1.0 behavior.
+
+**Non-Goals:**
+- No ncps server changes — ncps is not at fault.
+- No change to the round-robin backend selection, request-body forwarding (#1390), or the `_fail`/502 error path.
+- Not implementing response re-chunking; unknown-length responses fall back to `Connection: close` (correct, just not reused).
+- No production (non-dev) impact.
+
+## Decisions
+
+1. **`ProxyHandler.protocol_version = "HTTP/1.1"`.** This is the core fix. It makes connections persistent (client reuse) and makes `BaseHTTPRequestHandler` auto-answer `Expect: 100-continue` (it gates that on `protocol_version >= "HTTP/1.1"`), removing the ~1 s-per-PUT stall. Default keep-alive behavior then depends on correct response framing (next decision).
+
+2. **Frame every forwarded response.** When relaying the backend response: keep `Content-Length` if present; treat `204`/`304`, `HEAD` requests, and `1xx` as bodiless (no body, connection reusable). If the body length is otherwise unknown — e.g. the backend used `Transfer-Encoding: chunked`, which the proxy already strips as a hop-by-hop header — send `Connection: close` and set `self.close_connection = True` so the client reads the body to EOF and does not attempt to reuse the connection. Upload responses (`204`, `404` with `Content-Length`, narinfo `GET` with `Content-Length`) are all delimitable, so keep-alive engages for the hot path; only genuinely unframed responses fall back to close. This keeps correctness absolute while capturing the reuse benefit.
+
+3. **Raise the listener backlog.** Set `request_queue_size` (e.g. 128) on the server **before** `server_activate()` listens — i.e. via a `ThreadingHTTPServer` subclass class attribute or by setting it prior to bind/activate — so bursts of connection establishment are absorbed. With keep-alive in place this is defense-in-depth, but it is cheap and removes the backlog-5 cliff.
+
+4. **Preserve all #1390 hardening.** Chunked request-body forwarding, RFC 7230 §3.3.3 (chunked wins over Content-Length; don't forward CL to backend when chunked), the bounded `_fail` drain, and `log(..., RED)` error surfacing are unchanged.
+
+## Risks / Trade-offs
+
+- **Response mis-framing on a persistent connection** would corrupt the next response. Mitigated by decision 2: anything not provably delimitable forces `Connection: close`. The conservative default is "close", never "reuse with a guessed length".
+- **`HEAD` semantics**: a `HEAD` response may carry a `Content-Length` describing the entity but no body; the handler must not try to read a body for `HEAD`. Treated as bodiless regardless of headers.
+- **Idle persistent connections** hold a worker thread in `ThreadingHTTPServer` until the client closes or times out. For a dev harness under a finite `nix copy` this is bounded and far cheaper than the thousands-of-threads churn it replaces; `BaseHTTPRequestHandler.timeout` still applies.
+- **Backlog set too late** (on the instance after activation) would silently no-op; the implementation must set it before `server_activate()`.

--- a/openspec/changes/archive/2026-06-10-fix-dev-proxy-http10-keepalive/proposal.md
+++ b/openspec/changes/archive/2026-06-10-fix-dev-proxy-http10-keepalive/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+After PR #1390 fixed `Transfer-Encoding: chunked` request-body forwarding, `nix copy` of a large closure (e.g. a ~9.35 GB `nixos-system`) to the dev HA proxy on `:8500` **still** fails intermittently with `error: ... Recv failure: Connection reset by peer (curl error code=56)`, aborting the entire copy on the first reset. Small/single uploads succeed; the failure only appears under the real parallel large-closure workload.
+
+Root cause (empirically reproduced on a clean isolated ncps behind the real proxy, then fix-validated): the proxy's `ProxyHandler` leaves `protocol_version` at the stdlib `BaseHTTPRequestHandler` default of **HTTP/1.0**, so it **force-closes every client connection after one request**. `nix copy` drives hundreds of objects over ~25 parallel HTTP/1.1 keep-alive connections, but because the proxy refuses to keep any connection alive, nix must open a brand-new TCP connection for every narinfo/NAR/HEAD — thousands of short-lived connections. Under that churn (amplified by the stdlib default listen backlog of 5 and a ~1 s-per-PUT stall because the proxy never answers `Expect: 100-continue`), the single-threaded accept loop stalls (a ~19 s stall was measured) and intermittently nix's upload connection is reset **before the proxy ever processes it** — surfacing as `curl error 56`. The failed NAR shows only a `HEAD→404` with no PUT on any backend and no proxy-side error log; a lone secondary PUT-500 (`error writing the nar to the temporary file: read ... connection reset by peer`) is nix tearing down in-flight uploads after the abort, not the primary cause.
+
+This is a **second, distinct** dev-harness bug from the #1390 chunked-body fix (which is necessary and stays). The fix is confined to `dev-scripts/run.py`; ncps server code is not at fault.
+
+## What Changes
+
+- The dev HA proxy (`dev-scripts/run.py` `make_proxy_handler`) speaks **HTTP/1.1 with persistent connections**, so a keep-alive client (nix/libcurl) reuses a small pool of connections across the whole copy instead of being forced into thousands of short-lived ones. As a direct consequence, `BaseHTTPRequestHandler` now auto-answers `Expect: 100-continue` (it only does so for `protocol_version >= HTTP/1.1`), removing the ~1 s-per-PUT stall.
+- The proxy frames every forwarded response so a persistent connection stays in sync: preserve `Content-Length`; treat `204`/`304`/`HEAD`/`1xx` as bodiless; and when the response body length is unknown (e.g. the backend used `Transfer-Encoding: chunked`, which is stripped as hop-by-hop), send `Connection: close` and stop reusing that connection so the client reads to EOF instead of mis-framing the next response.
+- The proxy listener backlog is raised well above the stdlib default of 5 (set before the socket is activated) to absorb connection bursts.
+- All existing #1390 hardening is preserved: chunked request-body forwarding, RFC 7230 §3.3.3 handling, the bounded `_fail` drain, and proxy error logging.
+- A regression test drives the real `run.py` proxy (imported via `NCPS_RUN_PY`, like the existing `test_dev_proxy.py`) asserting the proxy answers HTTP/1.1, a single client connection is reused for multiple sequential requests without a reset, and responses stay correctly framed. It is wired into the `e2e-harness-unit` check.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `dev-ha-proxy`: the proxy MUST support HTTP/1.1 persistent client connections (connection reuse) and frame forwarded responses so persistent connections stay synchronized, rather than closing every connection after a single request.
+
+## Impact
+
+- **Code**: `dev-scripts/run.py` (proxy handler `protocol_version`, response-framing in `_proxy`, listener backlog in `start_proxy`). No ncps server changes.
+- **Tests**: new regression test in `nix/e2e-tests/tests/` (sibling to `test_dev_proxy.py`); wired into `checks.e2e-harness-unit` in `nix/e2e-tests/flake-module.nix`.
+- **Spec**: `openspec/specs/dev-ha-proxy/spec.md` (modified requirement on streaming/connection handling).
+- **Runtime behavior**: dev-only. Eliminates `curl error 56` aborts when pushing large closures through `:8500`; reduces connection churn and removes per-PUT `Expect` stalls.

--- a/openspec/changes/archive/2026-06-10-fix-dev-proxy-http10-keepalive/specs/dev-ha-proxy/spec.md
+++ b/openspec/changes/archive/2026-06-10-fix-dev-proxy-http10-keepalive/specs/dev-ha-proxy/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Proxy supports HTTP/1.1 persistent client connections
+
+The proxy SHALL serve HTTP/1.1 and keep client connections alive so that a keep-alive client (e.g. `nix copy`/libcurl) can reuse a single connection for multiple sequential requests, instead of closing every connection after one request. This prevents the connection-churn that resets uploads (`curl error 56: Connection reset by peer`) when pushing a large closure through the proxy.
+
+#### Scenario: A reused client connection serves multiple requests
+
+- **WHEN** a client sends two or more sequential requests on the same TCP connection through the proxy
+- **THEN** the proxy answers `HTTP/1.1` and keeps the connection open after each delimitable response
+- **AND** every request on the reused connection receives its response without the connection being reset
+
+#### Scenario: A large parallel upload completes without a reset
+
+- **WHEN** a client uploads many objects (narinfo and NAR files) through the proxy using keep-alive connections, as `nix copy` does for a large closure
+- **THEN** the proxy reuses connections rather than forcing a new TCP connection per object
+- **AND** the client does not observe a connection reset (`curl error 56`) that aborts the upload
+
+#### Scenario: Expect: 100-continue is answered
+
+- **WHEN** a client sends a request with an `Expect: 100-continue` header through the proxy
+- **THEN** the proxy responds with an interim `100 Continue` before the client streams the request body
+- **AND** the upload proceeds without a per-request stall
+
+### Requirement: Proxy frames forwarded responses for safe connection reuse
+
+The proxy SHALL frame every forwarded backend response so that a persistent connection stays synchronized for the next request. It MUST preserve a backend `Content-Length`, treat `204`/`304` responses, responses to `HEAD` requests, and `1xx` responses as bodiless, and — when the response body length is otherwise unknown (for example the backend used `Transfer-Encoding: chunked`, which the proxy strips as a hop-by-hop header) — signal `Connection: close` and stop reusing that connection so the client reads the body to end-of-stream rather than mis-framing the following response.
+
+#### Scenario: Delimitable response keeps the connection alive
+
+- **WHEN** the backend response is bodiless (`204`/`304`/`HEAD`) or carries a `Content-Length`
+- **THEN** the proxy forwards it with intact framing and keeps the client connection open for reuse
+
+#### Scenario: Unframed response falls back to connection close
+
+- **WHEN** the backend response has no `Content-Length` and is not bodiless (its body length is unknown to the proxy)
+- **THEN** the proxy adds `Connection: close` to the forwarded response and closes the connection after the body
+- **AND** the client reads the body to end-of-stream and does not reuse the connection

--- a/openspec/changes/archive/2026-06-10-fix-dev-proxy-http10-keepalive/tasks.md
+++ b/openspec/changes/archive/2026-06-10-fix-dev-proxy-http10-keepalive/tasks.md
@@ -1,0 +1,19 @@
+## 1. Regression test (TDD red)
+
+- [x] 1.1 Add a test (sibling of `nix/e2e-tests/tests/test_dev_proxy.py`, importing the real proxy via `NCPS_RUN_PY`) asserting the proxy answers `HTTP/1.1` and a single client connection can serve multiple sequential requests (PUT/HEAD) without a reset. Confirm it FAILS against the current HTTP/1.0 proxy (the second request on a reused connection resets).
+- [x] 1.2 Add a test asserting forwarded responses stay correctly framed on a reused connection: a `Content-Length`/`204` response keeps the connection alive; a response with unknown body length is delimited via `Connection: close`.
+- [x] 1.3 Add a test asserting an `Expect: 100-continue` request through the proxy receives an interim `100 Continue` before the body.
+
+## 2. Fix the proxy (TDD green) — `dev-scripts/run.py` only
+
+- [x] 2.1 Set `ProxyHandler.protocol_version = "HTTP/1.1"` in `make_proxy_handler` so client connections are persistent and `Expect: 100-continue` is auto-answered.
+- [x] 2.2 In `_proxy`'s response-forwarding, frame the response for safe reuse: track whether a `Content-Length` was forwarded; treat `204`/`304`/`HEAD`/`1xx` as bodiless; when the body length is unknown (e.g. backend `Transfer-Encoding: chunked` stripped as hop-by-hop), send `Connection: close` and set `self.close_connection = True`.
+- [x] 2.3 Raise the proxy listener backlog in `start_proxy` (set `request_queue_size` well above the stdlib default of 5, **before** the socket is activated, e.g. via a `ThreadingHTTPServer` subclass class attribute).
+- [x] 2.4 Confirm all existing #1390 hardening is preserved (chunked request-body forwarding, RFC 7230 §3.3.3, bounded `_fail` drain, `log(..., RED)` error surfacing) and the new tests from Section 1 now pass.
+
+## 3. CI wiring & verification
+
+- [x] 3.1 Ensure the new test runs in the `e2e-harness-unit` check (it already copies `run.py` and sets `NCPS_RUN_PY` per #1390; confirm the new test file is picked up and add wiring if needed in `nix/e2e-tests/flake-module.nix`).
+- [x] 3.2 Run the existing `test_dev_proxy.py` to confirm no regression in chunked-body forwarding / `_fail` behavior.
+- [x] 3.3 Run `task fmt`, `task lint`, and `task test` and confirm each exits 0.
+- [x] 3.4 Sync the `dev-ha-proxy` delta spec into `openspec/specs/` and archive the change.

--- a/openspec/specs/dev-ha-proxy/spec.md
+++ b/openspec/specs/dev-ha-proxy/spec.md
@@ -83,6 +83,43 @@ The proxy SHALL log backend connection and body-forwarding failures so that dev-
 - **THEN** the proxy emits a log line identifying the failed backend and the error
 - **AND** the failure is not silently swallowed
 
+### Requirement: Proxy supports HTTP/1.1 persistent client connections
+
+The proxy SHALL serve HTTP/1.1 and keep client connections alive so that a keep-alive client (e.g. `nix copy`/libcurl) can reuse a single connection for multiple sequential requests, instead of closing every connection after one request. This prevents the connection-churn that resets uploads (`curl error 56: Connection reset by peer`) when pushing a large closure through the proxy.
+
+#### Scenario: A reused client connection serves multiple requests
+
+- **WHEN** a client sends two or more sequential requests on the same TCP connection through the proxy
+- **THEN** the proxy answers `HTTP/1.1` and keeps the connection open after each delimitable response
+- **AND** every request on the reused connection receives its response without the connection being reset
+
+#### Scenario: A large parallel upload completes without a reset
+
+- **WHEN** a client uploads many objects (narinfo and NAR files) through the proxy using keep-alive connections, as `nix copy` does for a large closure
+- **THEN** the proxy reuses connections rather than forcing a new TCP connection per object
+- **AND** the client does not observe a connection reset (`curl error 56`) that aborts the upload
+
+#### Scenario: Expect: 100-continue is answered
+
+- **WHEN** a client sends a request with an `Expect: 100-continue` header through the proxy
+- **THEN** the proxy responds with an interim `100 Continue` before the client streams the request body
+- **AND** the upload proceeds without a per-request stall
+
+### Requirement: Proxy frames forwarded responses for safe connection reuse
+
+The proxy SHALL frame every forwarded backend response so that a persistent connection stays synchronized for the next request. It MUST preserve a backend `Content-Length`, treat `204`/`304` responses, responses to `HEAD` requests, and `1xx` responses as bodiless, and — when the response body length is otherwise unknown (for example the backend used `Transfer-Encoding: chunked`, which the proxy strips as a hop-by-hop header) — signal `Connection: close` and stop reusing that connection so the client reads the body to end-of-stream rather than mis-framing the following response.
+
+#### Scenario: Delimitable response keeps the connection alive
+
+- **WHEN** the backend response is bodiless (`204`/`304`/`HEAD`) or carries a `Content-Length`
+- **THEN** the proxy forwards it with intact framing and keeps the client connection open for reuse
+
+#### Scenario: Unframed response falls back to connection close
+
+- **WHEN** the backend response has no `Content-Length` and is not bodiless (its body length is unknown to the proxy)
+- **THEN** the proxy adds `Connection: close` to the forwarded response and closes the connection after the body
+- **AND** the client reads the body to end-of-stream and does not reuse the connection
+
 ### Requirement: Proxy lifecycle is tied to run.py
 
 The proxy SHALL start and stop together with `run.py`. On `run.py` shutdown (SIGINT/SIGTERM or cleanup), the proxy SHALL be stopped and its listening port released.


### PR DESCRIPTION
## Summary

A **second, distinct** dev-harness bug from the chunked-body fix in #1390 (which is necessary and stays). After #1390, `nix copy` of a large closure (e.g. a ~9.35 GB `nixos-system`) to the `:8500` HA proxy **still** intermittently fails with `curl error 56: Connection reset by peer`, aborting the whole copy on the first reset.

**Root cause:** the proxy's `ProxyHandler` left `protocol_version` at the stdlib `BaseHTTPRequestHandler` default of **HTTP/1.0**, so it force-closed every client connection after one request. `nix copy` pushes hundreds of objects over a small pool of HTTP/1.1 keep-alive connections; because the proxy refused keep-alive, nix was forced to open a brand-new TCP connection per object — thousands for a multi-GB closure. Under that churn (amplified by the default listen backlog of 5 and a ~1 s-per-PUT stall from unanswered `Expect: 100-continue`), the accept loop stalls and intermittently nix's upload connection is reset **before the proxy ever handles it** (`curl error 56`).

**Reproduced & fix-validated** on a clean isolated ncps behind the real proxy: the unpatched proxy dies at PUT #2; the patched proxy completes **3,488 PUTs with 0 resets**. `curl -v` confirms `HTTP/1.1 200` + "Connection left intact" (reuse).

## What changed (`dev-scripts/run.py` proxy only; ncps unchanged)

- `ProxyHandler.protocol_version = "HTTP/1.1"` — persistent, reused client connections; also makes `BaseHTTPRequestHandler` auto-answer `Expect: 100-continue`, removing the per-PUT stall.
- Response framing for safe reuse: preserve `Content-Length`; treat `204`/`304`/`HEAD`/`1xx` as bodiless; send `Connection: close` when the body length is unknown (e.g. backend chunked, stripped as hop-by-hop) so the client reads to EOF instead of mis-framing the next response.
- Raise the listener backlog (`request_queue_size`) above the stdlib default of 5, set before the socket is activated.
- All #1390 hardening preserved (chunked request-body forwarding, RFC 7230 §3.3.3, bounded `_fail` drain, error logging).

## Test plan

- [x] `task fmt` (0 changed), `task lint` (0 issues), `task test` (all Go packages ok)
- [x] New keep-alive / framing / `Expect: 100-continue` regression tests drive the real `run.py` proxy via `NCPS_RUN_PY`; confirmed RED on HTTP/1.0, GREEN after the fix
- [x] `e2e-harness-unit` nix check green (52 passed; +4 new tests)
- [x] End-to-end: full `nix copy` of the 9.35 GB closure through the patched proxy — 3,488 PUTs, 0 resets