### PR TITLE
fix(cache): serve a zstd request by recompressing CDC chunks

### DIFF
--- a/openspec/changes/archive/2026-06-10-serve-compressed-nar-via-zstd-recompression/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-10-serve-compressed-nar-via-zstd-recompression/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/archive/2026-06-10-serve-compressed-nar-via-zstd-recompression/design.md
+++ b/openspec/changes/archive/2026-06-10-serve-compressed-nar-via-zstd-recompression/design.md
@@ -1,0 +1,43 @@
+## Context
+
+CDC stores NARs as uncompressed chunks; the canonical narinfo is normalized to `Compression: none`. But an upstream (e.g. cachix, gepbird's cache) serves `Compression: zstd`, and that narinfo can be served/retained advertising `zstd` while the local representation is uncompressed chunks. In `serveNarFromStorageViaPipe` (`pkg/cache/cache.go`), `serveFromChunks` is true (no whole file in store, chunk store available); the guard at ~3579 then returns `ErrNotFound` for any non-`none` compression:
+
+```go
+if serveFromChunks && narURL.Compression != nar.CompressionTypeNone {
+    return 0, nil, fmt.Errorf("NAR %s is only available as chunks, cannot serve as %s: %w", ...)
+}
+```
+
+`getNarFromChunks` reassembles the uncompressed NAR. `pkg/zstd` provides a pooled streaming writer (`NewPooledWriter`), already used to store `none` NARs as `.nar.zst` (cache.go:2186). There is **no** xz compressor in ncps (`pkg/xz` only decompresses).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Serve a `Compression: zstd` request from uncompressed CDC chunks by recompressing on the fly, labeled `zstd`, instead of 404.
+- Stream (no full-NAR buffering); reuse the existing pooled zstd writer and the `io.Pipe` + `analytics.SafeGo` pattern already used in `serveNarFromStorageViaPipe`.
+- Preserve all existing paths: `none` from chunks (progressive/decompressed), zstd from a stored `.nar.zst` whole file (as-is), and the 404 for compressions we cannot produce.
+
+**Non-Goals:**
+- xz recompression (no compressor; expensive). An `xz`-advertised request with only an uncompressed/chunk representation keeps returning `ErrNotFound`; the write-path invariant and data-repair follow-ups ensure ncps does not advertise xz it cannot serve.
+- Changing what compression is advertised (that is the write-path-invariant change).
+- The in-flight staging reader's compressed-from-uncompressed fallback (`compressedRequestNeedsUpstreamFallback`) — separate path, unchanged here.
+
+## Decisions
+
+- **Recompress only for zstd; keep the 404 for other codecs.** Gate the new path on `narURL.Compression == zstd`. This solves the dominant inverse case (gepbird/cachix) with a fast compressor and leaves the un-producible codecs to the higher-level invariant/repair work. *Alternative:* add an xz compressor — rejected: no streaming xz writer wrapper, high CPU per serve, and the better fix for xz is to not advertise it.
+- **Reassemble via the uncompressed chunk path, then wrap in a zstd pipe.** Call `getNarFromChunks` with the `none` URL to get the raw stream, then `io.Copy` it through a `zstd.NewPooledWriter` into an `io.Pipe`, returning the pipe reader labeled `zstd` with size `-1` (compressed size unknown up front). *Alternative:* compress to a temp file to get a Content-Length — rejected: adds disk IO and latency; chunked transfer is already used elsewhere for `size == -1`.
+- **Report the served compression as `zstd`.** The returned `narURL.Compression` stays `zstd` so the response is labeled correctly (mirrors the lesson from `TestCDCWholeFileServeReportsServedCompression`: never mislabel the served stream).
+
+## Risks / Trade-offs
+
+- **Serve-time CPU for recompression** → bounded to the compressed-request-from-chunks path; zstd is fast and pooled. Net win vs a 404 that aborts the build. Mitigation: only zstd (cheap), streaming (no buffering).
+- **Unknown Content-Length (`size = -1`)** → chunked transfer; already supported by the HTTP layer and used by the decompress paths. No client-visible regression.
+- **Double work if both a stored `.nar.zst` whole file and chunks exist** → not triggered: `serveFromChunks` is only true when no whole file is in store; a stored `.nar.zst` is served as-is by the existing path.
+
+## Migration Plan
+
+Behavior-only change in `pkg/cache`. No schema/migration/config/API change. Roll the image; revert to roll back.
+
+## Open Questions
+
+- None blocking. xz-advertised-from-uncompressed is intentionally deferred to the write-path-invariant + data-repair changes in this stack.

--- a/openspec/changes/archive/2026-06-10-serve-compressed-nar-via-zstd-recompression/proposal.md
+++ b/openspec/changes/archive/2026-06-10-serve-compressed-nar-via-zstd-recompression/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+A client whose narinfo advertises `Compression: zstd` requests `/nar/<hash>.nar.zst`, but the NAR is stored only as uncompressed CDC chunks. The serve path cannot produce a compressed stream from chunks, so it returns 404 ("NAR is only available as chunks, cannot serve as zstd") and the build aborts with `does not exist in binary cache`. This is the steady-state-CDC manifestation of the narinfo↔nar_file compression desync independently reported on a CDC-on deployment (issue #1392), and the inverse direction of the already-merged uncompressed-serve fix (#1393). zstd is the common upstream compression (cachix, gepbird's cache), so this blocks CDC-on caches.
+
+## What Changes
+
+- When a `Compression: zstd` request can only be served from uncompressed CDC chunks (or an uncompressed whole file), the serve path SHALL reassemble the uncompressed bytes and recompress them to zstd on the fly, serving a correctly-labeled `zstd` stream instead of returning 404.
+- Recompression is scoped to **zstd** (a fast streaming compressor already vendored, `pkg/zstd`). Other compressed requests we cannot cheaply produce (notably `xz`, which has no compressor in ncps) keep the existing 404/fallback behavior — those are addressed by the write-path invariant and data-repair follow-ups so ncps never advertises a compression it cannot serve.
+- A regression test reproduces the failure: chunk a NAR under CDC, request it as `zstd`, and assert the served stream decompresses (zstd) to the original NAR (was 404).
+
+## Capabilities
+
+### New Capabilities
+- `nar-serving-recompression`: Serving a `Compression: zstd` NAR request by recompressing the reassembled uncompressed bytes (from CDC chunks or an uncompressed whole file) on the fly, so a NAR present only in an uncompressed representation is served in the advertised compression instead of 404'd.
+
+### Modified Capabilities
+<!-- none -->
+
+## Impact
+
+- `pkg/cache/cache.go`: `serveNarFromStorageViaPipe` (the `serveFromChunks && compression != none` branch at ~3579) gains a zstd recompression path; a small zstd-compress pipe helper.
+- New test in `pkg/cache`.
+- Behavior-only; no schema/migration/config/API change. Adds serve-time CPU for zstd recompression of chunk-served NARs (bounded; only on the compressed-request-from-chunks path).

--- a/openspec/changes/archive/2026-06-10-serve-compressed-nar-via-zstd-recompression/specs/nar-serving-recompression/spec.md
+++ b/openspec/changes/archive/2026-06-10-serve-compressed-nar-via-zstd-recompression/specs/nar-serving-recompression/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Serve a zstd request by recompressing uncompressed bytes
+
+The system SHALL serve a `Compression: zstd` NAR request whose NAR is present only in an uncompressed representation (CDC chunks or an uncompressed whole file) by reassembling the uncompressed bytes and recompressing them to zstd on the fly. It MUST NOT return 404 for such a request when the uncompressed bytes are available locally, and the served stream MUST be labeled `zstd`.
+
+#### Scenario: zstd request served from uncompressed CDC chunks
+
+- **WHEN** a NAR is stored as uncompressed CDC chunks (no whole file in the store) and a client requests `/nar/<hash>.nar.zst`
+- **THEN** the system reassembles the chunks, recompresses them to zstd, and streams a `zstd`-labeled response whose bytes decompress to the original NAR — without returning 404 or contacting an upstream
+
+#### Scenario: uncompressed (none) request from chunks is unchanged
+
+- **WHEN** a client requests `/nar/<hash>.nar` (Compression: none) for a chunked NAR
+- **THEN** the system serves the reassembled uncompressed bytes as before (no recompression)
+
+#### Scenario: a request for a non-producible compression still falls back
+
+- **WHEN** a client requests a compression the system has no compressor for (e.g. `xz`) and the NAR is available only as uncompressed chunks
+- **THEN** the system does not fabricate the stream; it returns not-found so the request can fall back (upstream / repair), rather than serving mislabeled bytes

--- a/openspec/changes/archive/2026-06-10-serve-compressed-nar-via-zstd-recompression/tasks.md
+++ b/openspec/changes/archive/2026-06-10-serve-compressed-nar-via-zstd-recompression/tasks.md
@@ -1,0 +1,13 @@
+## 1. Reproduce (TDD red)
+
+- [x] 1.1 Add a test in `pkg/cache` that enables CDC, stores+chunks a NAR (uncompressed chunks, no whole file), requests it as `Compression: zstd`, and asserts the served stream decompresses (zstd) to the original NAR. Confirm it fails today with a 404 / "cannot serve as zstd" (RED).
+
+## 2. Implement zstd recompression on serve (TDD green)
+
+- [x] 2.1 In `serveNarFromStorageViaPipe` (`pkg/cache/cache.go`), replace the unconditional `serveFromChunks && compression != none` 404 with: for `Compression: zstd`, reassemble the uncompressed bytes via `getNarFromChunks` (none URL) and recompress to zstd through an `io.Pipe` + `zstd.NewPooledWriter` (mirroring the existing pipe/SafeGo pattern); return the reader labeled `zstd`, size `-1`. Keep the 404 for all other non-`none` compressions.
+- [x] 2.2 Confirm the new test passes (GREEN) and the served compression is reported as `zstd`.
+
+## 3. Verify (no regressions)
+
+- [x] 3.1 `none`-from-chunks, zstd-from-stored-`.nar.zst`, and the xz-not-producible fallback paths still behave as before (existing `TestGetNar*` / CDC serve tests pass).
+- [x] 3.2 `task fmt`, `task lint`, `task test` all green.

--- a/openspec/specs/nar-serving-recompression/spec.md
+++ b/openspec/specs/nar-serving-recompression/spec.md
@@ -1,0 +1,35 @@
+# NAR Serving Recompression
+
+## Purpose
+
+Defines requirements for serving a compressed NAR request whose NAR is present
+only in an uncompressed representation (CDC chunks or an uncompressed whole file)
+by recompressing the reassembled bytes on the fly. This is the inverse of the
+uncompressed-serve fallback (see `nar-serving-compression-fallback`): it lets a
+NAR whose narinfo advertises `Compression: zstd` be served from uncompressed
+chunks instead of returning `does not exist in binary cache`.
+
+## Requirements
+
+### Requirement: Serve a zstd request by recompressing uncompressed bytes
+
+The system SHALL serve a `Compression: zstd` NAR request whose NAR is present
+only in an uncompressed representation (CDC chunks or an uncompressed whole file)
+by reassembling the uncompressed bytes and recompressing them to zstd on the fly.
+It MUST NOT return 404 for such a request when the uncompressed bytes are
+available locally, and the served stream MUST be labeled `zstd`.
+
+#### Scenario: zstd request served from uncompressed CDC chunks
+
+- **WHEN** a NAR is stored as uncompressed CDC chunks (no whole file in the store) and a client requests `/nar/<hash>.nar.zst`
+- **THEN** the system reassembles the chunks, recompresses them to zstd, and streams a `zstd`-labeled response whose bytes decompress to the original NAR — without returning 404 or contacting an upstream
+
+#### Scenario: uncompressed (none) request from chunks is unchanged
+
+- **WHEN** a client requests `/nar/<hash>.nar` (Compression: none) for a chunked NAR
+- **THEN** the system serves the reassembled uncompressed bytes as before (no recompression)
+
+#### Scenario: a request for a non-producible compression still falls back
+
+- **WHEN** a client requests a compression the system has no compressor for (e.g. `xz`) and the NAR is available only as uncompressed chunks
+- **THEN** the system does not fabricate the stream; it returns not-found so the request can fall back (upstream / repair), rather than serving mislabeled bytes

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -3571,12 +3571,20 @@ func (c *Cache) serveNarFromStorageViaPipe(
 	}
 
 	// Chunks are always uncompressed. If the client requested a compressed NAR
-	// (e.g. .nar.xz) but the whole-file is no longer in storage (only chunks
-	// remain), we cannot reconstruct the compressed stream. Return not-found so
-	// the client falls back to an upstream cache that still has the original
-	// compressed file. This prevents "input compression not recognized" errors
-	// caused by serving raw chunk bytes to a client expecting xz data.
+	// but only chunks remain, we must produce the compressed stream on the fly
+	// (the inverse of the uncompressed-serve fallback; issue #1392):
+	//   - zstd: reassemble the chunks and recompress to zstd while streaming, so a
+	//     zstd-advertised request (e.g. a cachix-origin narinfo under steady-state
+	//     CDC) is served instead of 404'd.
+	//   - any other codec (e.g. xz): ncps has no compressor, so return not-found
+	//     and let the client fall back to an upstream that still has the original
+	//     compressed file. Serving raw chunk bytes for it would cause
+	//     "input compression not recognized" at the client.
 	if serveFromChunks && narURL.Compression != nar.CompressionTypeNone {
+		if narURL.Compression == nar.CompressionTypeZstd {
+			return c.serveZstdFromChunks(ctx, narURL)
+		}
+
 		return 0, nil, fmt.Errorf("NAR %s is only available as chunks, cannot serve as %s: %w",
 			narURL.Hash, narURL.Compression, storage.ErrNotFound)
 	}
@@ -3660,6 +3668,42 @@ func (c *Cache) serveNarFromStorageViaPipe(
 
 	// Return pipe reader (safe from request context cancellation) with known size
 	return storageSize, pipeReader, nil
+}
+
+// serveZstdFromChunks serves a Compression:zstd request whose NAR is present
+// only as uncompressed CDC chunks. It reassembles the uncompressed bytes via
+// getNarFromChunks and recompresses them to zstd while streaming, so a
+// zstd-advertised request is served instead of 404'd (the inverse of the
+// uncompressed-serve fallback; issue #1392). The compressed length is not known
+// up front, so it returns size -1; the reader yields the zstd-compressed NAR.
+func (c *Cache) serveZstdFromChunks(ctx context.Context, narURL *nar.URL) (int64, io.ReadCloser, error) {
+	noneURL := *narURL
+	noneURL.Compression = nar.CompressionTypeNone
+
+	_, rawReader, err := c.getNarFromChunks(ctx, &noneURL)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	pipeReader, pipeWriter := io.Pipe()
+
+	analytics.SafeGo(ctx, func() {
+		zw := zstd.NewPooledWriter(pipeWriter)
+
+		_, copyErr := io.Copy(zw, rawReader)
+
+		closeErr := zw.Close()
+
+		_ = rawReader.Close()
+
+		if copyErr != nil {
+			pipeWriter.CloseWithError(copyErr)
+		} else {
+			pipeWriter.CloseWithError(closeErr)
+		}
+	})
+
+	return -1, pipeReader, nil
 }
 
 // wholeFileServeCompressions lists the stored whole-file compressions that can

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -3690,17 +3690,24 @@ func (c *Cache) serveZstdFromChunks(ctx context.Context, narURL *nar.URL) (int64
 	analytics.SafeGo(ctx, func() {
 		zw := zstd.NewPooledWriter(pipeWriter)
 
-		_, copyErr := io.Copy(zw, rawReader)
+		var copyErr error
 
-		closeErr := zw.Close()
+		// Run all teardown in a single defer so an unexpected early exit or panic in
+		// io.Copy still returns the pooled encoder, closes the chunk reader, and —
+		// critically — closes the pipe, so the consumer never hangs.
+		// PooledWriter.Close is idempotent.
+		defer func() {
+			closeErr := zw.Close()
+			_ = rawReader.Close()
 
-		_ = rawReader.Close()
+			if copyErr != nil {
+				pipeWriter.CloseWithError(copyErr)
+			} else {
+				pipeWriter.CloseWithError(closeErr)
+			}
+		}()
 
-		if copyErr != nil {
-			pipeWriter.CloseWithError(copyErr)
-		} else {
-			pipeWriter.CloseWithError(closeErr)
-		}
+		_, copyErr = io.Copy(zw, rawReader)
 	})
 
 	return -1, pipeReader, nil

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -3676,6 +3676,16 @@ func (c *Cache) serveNarFromStorageViaPipe(
 // zstd-advertised request is served instead of 404'd (the inverse of the
 // uncompressed-serve fallback; issue #1392). The compressed length is not known
 // up front, so it returns size -1; the reader yields the zstd-compressed NAR.
+//
+// The freshly-recompressed bytes will not byte-match the origin's zstd, so their
+// FileHash/FileSize differ from what the client's narinfo advertises. This is
+// safe for Nix by protocol design: the narinfo signature fingerprint covers only
+// StorePath/NarHash/NarSize/References (not FileHash/FileSize/Compression/URL),
+// and BinaryCacheStore::narFromPath decompresses by the narinfo's Compression
+// without ever verifying FileHash — FileHash is producer-only and FileSize only
+// drives the download progress counter. Integrity is the signed NarHash, checked
+// after decompression; our stream decompresses to the identical NAR, so it passes.
+// This is the same mechanism that lets any pull-through cache transcode.
 func (c *Cache) serveZstdFromChunks(ctx context.Context, narURL *nar.URL) (int64, io.ReadCloser, error) {
 	noneURL := *narURL
 	noneURL.Compression = nar.CompressionTypeNone

--- a/pkg/cache/serve_zstd_from_chunks_internal_test.go
+++ b/pkg/cache/serve_zstd_from_chunks_internal_test.go
@@ -1,0 +1,73 @@
+package cache
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage/chunk"
+)
+
+// TestServeZstdRequestFromChunks reproduces the inverse compression desync
+// (issue #1392) observed on a steady-state CDC deployment: the NAR is stored
+// only as uncompressed CDC chunks, but the client's narinfo advertises
+// `Compression: zstd`, so it requests `/nar/<hash>.nar.zst`. The serve path
+// cannot produce a compressed stream from chunks and returns
+// `does not exist in binary cache`.
+//
+// Correct behavior: reassemble the chunks and recompress to zstd on the fly,
+// serving a zstd-labeled stream that decompresses to the original NAR.
+func TestServeZstdRequestFromChunks(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	c, _, _, dir, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	chunkStore, err := chunk.NewLocalStore(filepath.Join(dir, "chunks-store"))
+	require.NoError(t, err)
+	c.SetChunkStore(chunkStore)
+	require.NoError(t, c.SetCDCConfiguration(true, 1024, 4096, 8192)) // small sizes for testing
+
+	content := "this is a test nar content that should be chunked by fastcdc and served as zstd"
+	noneURL := nar.URL{Hash: "testnarzstd", Compression: nar.CompressionTypeNone}
+
+	require.NoError(t, c.PutNar(ctx, noneURL, io.NopCloser(strings.NewReader(content))))
+
+	// Precondition: the NAR exists only as chunks, no whole file in the store.
+	require.False(t, c.HasNarInStore(ctx, noneURL),
+		"precondition: the chunked NAR must not have a whole file in the store")
+
+	// A client whose narinfo advertises zstd requests the compressed NAR.
+	zstdURL := nar.URL{Hash: "testnarzstd", Compression: nar.CompressionTypeZstd}
+
+	nu, _, rc, err := c.GetNar(ctx, zstdURL)
+	require.NoError(t, err,
+		"a zstd request for a chunked NAR must be served by recompression, not 404'd")
+
+	t.Cleanup(func() { _ = rc.Close() })
+
+	assert.Equal(t, nar.CompressionTypeZstd, nu.Compression,
+		"the served stream must be labeled zstd")
+
+	served, err := io.ReadAll(rc)
+	require.NoError(t, err)
+
+	dr, err := nar.DecompressReader(ctx, bytes.NewReader(served), nar.CompressionTypeZstd)
+	require.NoError(t, err)
+
+	defer dr.Close()
+
+	got, err := io.ReadAll(dr)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(got),
+		"served zstd bytes must decompress to the original NAR")
+}


### PR DESCRIPTION
## Summary

Inverse direction of the merged uncompressed-serve fix (#1393) and the steady-state-CDC manifestation of the narinfo↔nar_file compression desync (#1392). A client whose narinfo advertises `Compression: zstd` requests `/nar/<hash>.nar.zst`, but under CDC the NAR is stored only as uncompressed chunks. `serveNarFromStorageViaPipe` returned `404` ("only available as chunks, cannot serve as zstd"), aborting the build with `does not exist in binary cache`. zstd is the common upstream compression (cachix), so this blocks CDC-on caches.

Recompress on the fly: reassemble the uncompressed chunks via `getNarFromChunks` and stream them through `zstd.NewPooledWriter` into an `io.Pipe` (mirroring the existing none→zstd store path), serving a `zstd`-labeled response. Scoped to zstd, the one streaming compressor ncps vendors; `xz` (no compressor) keeps the 404/fallback and is handled by the data-repair PR stacked on top.

## Test plan

- [x] New `TestServeZstdRequestFromChunks` (RED→GREEN): chunk a NAR under CDC, request it as `zstd`, assert the served stream decompresses to the original (was 404).
- [x] Existing `TestGetNar*` / CDC serve tests pass; `task fmt`/`lint`/`test` green.

Refs #1392