### PR TITLE
feat(fsck): repair narinfos advertising a non-producible compression

### DIFF
--- a/openspec/changes/archive/2026-06-10-repair-narinfo-compression-desync/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-10-repair-narinfo-compression-desync/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-10

--- a/openspec/changes/archive/2026-06-10-repair-narinfo-compression-desync/design.md
+++ b/openspec/changes/archive/2026-06-10-repair-narinfo-compression-desync/design.md
@@ -1,0 +1,35 @@
+## Context
+
+`narinfos` advertises `url`/`compression`/`file_hash`/`file_size`; `nar_files` stores the physical NAR keyed by `(hash, compression, query)`. CDC normalizes a narinfo to `Compression: none` (`maybeCDCNormalizeNarInfoURL`), but drift leaves some narinfos advertising `xz` while the NAR is stored as none/zstd/chunks. The serve path can now produce `none` (decompress any) and `zstd` (recompress), but not `xz` (no compressor), so an `xz`-advertised/non-xz-stored narinfo still fails. fsck (`pkg/ncps/fsck.go`) already has narinfo repair helpers (e.g. `relinkNarInfoToBackingNarFile`) invoked from `repairFsckIssues` under `--repair`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One-shot, idempotent repair of pre-existing `xz`-advertised/non-xz-stored narinfos: rewrite to the servable `none` form so they serve via transparent decompression.
+- Leave healthy narinfos untouched; safe to run repeatedly.
+
+**Non-Goals:**
+- Serve-time changes (covered by #1393 / serve-zstd-from-chunks).
+- Preventing new drift (the write-path-invariant change).
+- Repairing narinfos with no backing NAR at all (the existing orphan-narinfo fsck path handles those).
+- Adding an xz compressor.
+
+## Decisions
+
+- **Rewrite to `none`, not to the stored compression.** `none` is universally servable (the serve path decompresses any stored whole-file/chunk representation), so rewriting to `nar/<nar_hash>.nar` + `Compression: none` + cleared `FileHash`/`FileSize` is correct regardless of whether the backing is none, zstd, or chunks. This reuses the exact shape `maybeCDCNormalizeNarInfoURL` produces, so the serve path already handles it. *Alternative:* rewrite to match the stored compression — rejected: more cases, and zstd/none both serve fine as `none`.
+- **Target only non-producible advertised compressions with a differing backing.** A narinfo is repaired iff its advertised compression is not producible (not `none`/`zstd`) and no `nar_file` exists in that advertised compression. This precisely captures `xz`-advertised/non-xz-stored and avoids touching healthy or already-servable rows. *Alternative:* repair every drift — rejected: serve-side already handles none/zstd drift; rewriting them is churn.
+- **Live in fsck `--repair`, operate on `dbClient`.** Mirrors `relinkNarInfoToBackingNarFile`; bulk-queries the affected narinfos rather than threading a pre-collected suspect list, keeping the change self-contained.
+
+## Risks / Trade-offs
+
+- **Rewriting a narinfo to `none` when the backing bytes are absent would still 404** → guarded: only rewrite when a backing `nar_file` exists under the NAR hash; rows with no backing are left to the existing orphan path.
+- **Signature/`FileHash` semantics** → `none` narinfos carry no `FileHash`/`FileSize` by convention (enforced elsewhere); clearing them matches that and the NAR-hash-based signature remains valid.
+- **Idempotency** → after rewrite the narinfo advertises `none`, which no longer matches the repair predicate, so re-running is a no-op.
+
+## Migration Plan
+
+Ships as fsck repair logic; operators run `ncps fsck --repair` once to reconcile existing rows. No DB migration. Rollback: revert the binary; rewritten narinfos remain valid (they serve correctly).
+
+## Open Questions
+
+- None blocking.

--- a/openspec/changes/archive/2026-06-10-repair-narinfo-compression-desync/proposal.md
+++ b/openspec/changes/archive/2026-06-10-repair-narinfo-compression-desync/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+After the serve-side fixes (#1393 and serve-zstd-from-chunks), ncps tolerates most narinfo↔nar_file compression drift at serve time by transcoding. The one case it still cannot serve is a narinfo advertising a compression ncps has no compressor for — in practice `xz` — while the NAR is stored under a different compression (none/zstd/chunks). DB inspection of the live cache found ~59 such pairs (`xz|none` 53, `xz|zstd` 6); each 404s or yields `Lzma: No progress is possible`. These are pre-existing drifted rows that the serve fixes cannot heal at request time, so they need a one-shot data repair.
+
+## What Changes
+
+- `ncps fsck --repair` SHALL repair narinfos that advertise a non-producible compression (`xz`) whose backing NAR is stored under a different compression, by rewriting the narinfo to the servable uncompressed form: `URL: nar/<nar_hash>.nar`, `Compression: none`, and clearing `FileHash`/`FileSize` (matching the CDC narinfo normalization the serve path already expects). The uncompressed NAR is then served by transparent decompression of the stored bytes (#1393).
+- A healthy narinfo (advertised compression matches a stored representation, or is directly producible) MUST NOT be modified.
+- The repair is idempotent and reports how many narinfos were rewritten.
+
+## Capabilities
+
+### New Capabilities
+- `narinfo-compression-repair`: A one-shot fsck repair that rewrites narinfos advertising a non-producible compression (no matching stored NAR) to the servable `none` form, reconciling pre-existing compression drift.
+
+### Modified Capabilities
+<!-- none -->
+
+## Impact
+
+- `pkg/ncps/fsck.go`: new `repairNarInfoCompressionDesync` bulk repair, invoked from `repairFsckIssues`; a count in the fsck summary.
+- New unit test in `pkg/ncps`.
+- Repair runs only under `--repair`; read-only fsck is unchanged. No schema/migration/API change.

--- a/openspec/changes/archive/2026-06-10-repair-narinfo-compression-desync/specs/narinfo-compression-repair/spec.md
+++ b/openspec/changes/archive/2026-06-10-repair-narinfo-compression-desync/specs/narinfo-compression-repair/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Repair narinfos advertising a non-producible compression
+
+The system SHALL, during `fsck --repair`, rewrite any narinfo that advertises a non-producible compression (one ncps has no compressor for, e.g. `xz`) whose backing NAR is stored under a different compression, to the servable uncompressed form: `URL: nar/<nar_hash>.nar`, `Compression: none`, with `FileHash` and `FileSize` cleared. It MUST NOT modify a narinfo whose advertised compression matches a stored representation or is directly producible, and the repair MUST be idempotent.
+
+#### Scenario: xz-advertised narinfo backed by a non-xz NAR is rewritten to none
+
+- **WHEN** a narinfo advertises `Compression: xz` (`URL: nar/<file_hash>.nar.xz`) but the backing NAR is stored as `none`/`zstd`/chunks (no `xz` nar_file) and `fsck --repair` runs
+- **THEN** the narinfo is rewritten to `URL: nar/<nar_hash>.nar`, `Compression: none`, with `FileHash`/`FileSize` cleared, so it is served by transparent decompression
+
+#### Scenario: healthy narinfo is left untouched
+
+- **WHEN** a narinfo advertises a compression that matches a stored representation (e.g. `xz` with an `xz` nar_file, or `none`/`zstd`) and `fsck --repair` runs
+- **THEN** the narinfo is not modified
+
+#### Scenario: repair is idempotent
+
+- **WHEN** `fsck --repair` runs a second time after a prior repair
+- **THEN** no further narinfos are rewritten

--- a/openspec/changes/archive/2026-06-10-repair-narinfo-compression-desync/tasks.md
+++ b/openspec/changes/archive/2026-06-10-repair-narinfo-compression-desync/tasks.md
@@ -1,0 +1,14 @@
+## 1. Reproduce (TDD red)
+
+- [x] 1.1 Add a `pkg/ncps` test that seeds a desynced narinfo (advertises `xz`, `url=nar/<file_hash>.nar.xz`, `file_hash`/`file_size` set) linked to a non-xz `nar_file`, plus a healthy `xz`/`xz` pair, then calls the repair and asserts only the desynced one is rewritten to `none` form. Confirm it fails before the repair exists (RED).
+
+## 2. Implement the repair (TDD green)
+
+- [x] 2.1 Add `repairNarInfoCompressionDesync(ctx, dbClient) (int, error)` in `pkg/ncps/fsck.go`: find narinfos advertising a non-producible compression (`xz`) with no matching `xz` nar_file but a backing non-xz nar_file; rewrite each to `URL: nar/<nar_hash>.nar`, `Compression: none`, clearing `FileHash`/`FileSize`. Return the count.
+- [x] 2.2 Invoke it from `repairFsckIssues` (under `--repair`) and log the repaired count.
+- [x] 2.3 Confirm the test passes (GREEN) and a second run repairs zero (idempotent).
+
+## 3. Verify (no regressions)
+
+- [x] 3.1 Existing fsck tests pass; healthy narinfos untouched.
+- [x] 3.2 `task fmt`, `task lint`, `task test` all green.

--- a/openspec/specs/narinfo-compression-repair/spec.md
+++ b/openspec/specs/narinfo-compression-repair/spec.md
@@ -1,0 +1,42 @@
+# NarInfo Compression Repair
+
+## Purpose
+
+Defines the one-shot fsck data-repair that reconciles pre-existing narinfo↔nar_file
+compression drift the serve path cannot heal at request time: narinfos advertising
+a compression ncps has no compressor for (i.e. `xz`) whose backing NAR is stored
+under a different compression. Such narinfos are rewritten to the servable `none`
+form so they are served by transparent decompression (see
+`nar-serving-compression-fallback`).
+
+## Requirements
+
+### Requirement: Repair narinfos advertising a non-producible compression
+
+The system SHALL, during `fsck --repair`, rewrite any narinfo that advertises a
+non-producible compression (one ncps has no compressor for, e.g. `xz`) whose
+backing NAR is stored under a different compression, to the servable uncompressed
+form: `URL: nar/<hash>.nar`, `Compression: none`, with `FileHash` and `FileSize`
+cleared. It MUST NOT modify a narinfo whose advertised compression matches a
+stored representation or is directly producible, and the repair MUST be
+idempotent.
+
+#### Scenario: xz-advertised narinfo backed by a non-xz NAR is rewritten to none
+
+- **WHEN** a narinfo advertises `Compression: xz` but the backing NAR is stored as `none`/`zstd`/chunks (no `xz` nar_file) and `fsck --repair` runs
+- **THEN** the narinfo is rewritten to `Compression: none` with the `.nar` URL and `FileHash`/`FileSize` cleared, so it is served by transparent decompression
+
+#### Scenario: healthy narinfo is left untouched
+
+- **WHEN** a narinfo advertises a compression that matches a stored representation (e.g. `xz` with an `xz` nar_file, or `none`/`zstd`) and `fsck --repair` runs
+- **THEN** the narinfo is not modified
+
+#### Scenario: narinfo with no backing NAR is left for the orphan path
+
+- **WHEN** a narinfo advertises `xz` but has no backing nar_file at all
+- **THEN** the compression repair does not rewrite it (the existing orphan-narinfo repair path handles it)
+
+#### Scenario: repair is idempotent
+
+- **WHEN** `fsck --repair` runs a second time after a prior repair
+- **THEN** no further narinfos are rewritten

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -1715,7 +1715,118 @@ func repairFsckIssues(
 		}
 	}
 
+	// f. Repair narinfos advertising a non-producible compression (xz) whose backing
+	// NAR is stored otherwise: rewrite to the servable none form so they serve via
+	// transparent decompression (#1392).
+	repairedCompression, err := repairNarInfoCompressionDesync(ctx, dbClient)
+	if err != nil {
+		return fmt.Errorf("repair narinfo compression desync: %w", err)
+	}
+
+	if repairedCompression > 0 {
+		logger.Info().
+			Int("count", repairedCompression).
+			Msg("repaired narinfos advertising a non-producible compression")
+	}
+
 	return nil
+}
+
+// repairNarInfoCompressionDesync rewrites narinfos that advertise a
+// non-producible compression (one ncps has no compressor for, i.e. xz) whose
+// backing NAR is stored under a different compression, to the servable
+// uncompressed form (URL nar/<nar_hash>.nar, Compression: none, FileHash/
+// FileSize cleared). The uncompressed NAR is then served by transparent
+// decompression of the stored bytes (#1392). Healthy narinfos (advertised
+// compression matches a stored representation, or is directly producible: none /
+// zstd) are left untouched, and the repair is idempotent. Returns the count
+// rewritten.
+func repairNarInfoCompressionDesync(ctx context.Context, dbClient *database.Client) (int, error) {
+	// Only xz lacks a serve-time compressor; none and zstd are producible from any
+	// stored representation, so a narinfo advertising them is already servable.
+	nis, err := dbClient.Ent().NarInfo.Query().
+		Where(entnarinfo.CompressionEQ(nar.CompressionTypeXz.String())).
+		All(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("query xz-advertised narinfos: %w", err)
+	}
+
+	repaired := 0
+
+	for _, ni := range nis {
+		ok, err := repairOneNarInfoCompressionDesync(ctx, dbClient, ni)
+		if err != nil {
+			return repaired, err
+		}
+
+		if ok {
+			repaired++
+		}
+	}
+
+	return repaired, nil
+}
+
+func repairOneNarInfoCompressionDesync(ctx context.Context, dbClient *database.Client, ni *ent.NarInfo) (bool, error) {
+	// Without an advertised URL we cannot reconcile the compression.
+	if ni.URL == nil || *ni.URL == "" {
+		return false, nil
+	}
+
+	advertised, err := nar.ParseURL(*ni.URL)
+	if err != nil {
+		return false, nil //nolint:nilerr // unparseable URL: nothing to reconcile here
+	}
+
+	// If the NAR is actually stored in the advertised (xz) compression, the narinfo
+	// is correct — leave it.
+	xzExists, err := dbClient.Ent().NarFile.Query().
+		Where(
+			entnarfile.HashEQ(advertised.Hash),
+			entnarfile.CompressionEQ(nar.CompressionTypeXz.String()),
+			entnarfile.QueryEQ(advertised.Query.Encode()),
+		).
+		Exist(ctx)
+	if err != nil {
+		return false, fmt.Errorf("check xz nar_file for narinfo(%d): %w", ni.ID, err)
+	}
+
+	if xzExists {
+		return false, nil
+	}
+
+	// Confirm a backing NAR exists before rewriting, so we never advertise none for
+	// bytes that are absent. A linked (non-xz) nar_file is enough; the serve path
+	// produces none from any stored representation. Rows with no backing are left to
+	// the orphan-narinfo repair path above.
+	hasBacking, err := dbClient.Ent().NarFile.Query().
+		Where(entnarfile.HasNarInfoNarFilesWith(entnarinfonarfile.NarinfoIDEQ(ni.ID))).
+		Exist(ctx)
+	if err != nil {
+		return false, fmt.Errorf("check backing nar_file for narinfo(%d): %w", ni.ID, err)
+	}
+
+	if !hasBacking {
+		return false, nil
+	}
+
+	// Reuse the advertised URL's hash (the same hash the backing nar_file is keyed
+	// by); only the compression/extension changes. This matches the CDC narinfo
+	// normalization (maybeCDCNormalizeNarInfoURL) and lets the resolve-by-hash serve
+	// path (#1393) decompress the stored bytes for the none request.
+	noneURL := nar.URL{Hash: advertised.Hash, Compression: nar.CompressionTypeNone, Query: advertised.Query}
+
+	if _, err := dbClient.Ent().NarInfo.Update().
+		Where(entnarinfo.IDEQ(ni.ID)).
+		SetURL(noneURL.String()).
+		SetCompression(nar.CompressionTypeNone.String()).
+		ClearFileHash().
+		ClearFileSize().
+		Save(ctx); err != nil {
+		return false, fmt.Errorf("rewrite narinfo(%d) to none: %w", ni.ID, err)
+	}
+
+	return true, nil
 }
 
 // repairBrokenCDCNarFiles deletes broken CDC nar_files, their orphaned narinfos, and orphaned chunks.

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -1809,12 +1809,20 @@ func repairOneNarInfoCompressionDesync(ctx context.Context, dbClient *database.C
 		return false, nil
 	}
 
-	// Confirm a backing NAR exists before rewriting, so we never advertise none for
-	// bytes that are absent. A linked (non-xz) nar_file is enough; the serve path
-	// produces none from any stored representation. Rows with no backing are left to
-	// the orphan-narinfo repair path above.
+	// Confirm a backing NAR exists AT THE ADVERTISED ADDRESS before rewriting, so we
+	// never advertise none for bytes that are absent. The backing must match the
+	// advertised hash+query, not merely be any link on the narinfo: a stale or
+	// mismatched link to a different nar_file would otherwise pass and rewrite the URL
+	// to none for a hash that has no servable bytes. The advertised xz row was already
+	// excluded above, so a match here is a non-xz row the serve path can produce none
+	// from. Rows with no matching backing are left to the relink/orphan-narinfo repair
+	// paths above.
 	hasBacking, err := dbClient.Ent().NarFile.Query().
-		Where(entnarfile.HasNarInfoNarFilesWith(entnarinfonarfile.NarinfoIDEQ(ni.ID))).
+		Where(
+			entnarfile.HashEQ(advertised.Hash),
+			entnarfile.QueryEQ(advertised.Query.Encode()),
+			entnarfile.HasNarInfoNarFilesWith(entnarinfonarfile.NarinfoIDEQ(ni.ID)),
+		).
 		Exist(ctx)
 	if err != nil {
 		return false, fmt.Errorf("check backing nar_file for narinfo(%d): %w", ni.ID, err)

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -1744,11 +1744,25 @@ func repairFsckIssues(
 func repairNarInfoCompressionDesync(ctx context.Context, dbClient *database.Client) (int, error) {
 	// Only xz lacks a serve-time compressor; none and zstd are producible from any
 	// stored representation, so a narinfo advertising them is already servable.
+	//
+	// Narrow the candidate set in SQL to just the desynced rows — advertised xz,
+	// backed by at least one nar_file, but NOT backed by an xz nar_file — so a cache
+	// with many healthy xz entries loads only the few desynced narinfos (~tens) and
+	// does no per-row work for the healthy ones. repairOneNarInfoCompressionDesync
+	// re-verifies precisely (by the advertised hash) before rewriting.
 	nis, err := dbClient.Ent().NarInfo.Query().
-		Where(entnarinfo.CompressionEQ(nar.CompressionTypeXz.String())).
+		Where(
+			entnarinfo.CompressionEQ(nar.CompressionTypeXz.String()),
+			entnarinfo.HasNarInfoNarFiles(),
+			entnarinfo.Not(entnarinfo.HasNarInfoNarFilesWith(
+				entnarinfonarfile.HasNarFileWith(
+					entnarfile.CompressionEQ(nar.CompressionTypeXz.String()),
+				),
+			)),
+		).
 		All(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("query xz-advertised narinfos: %w", err)
+		return 0, fmt.Errorf("query desynced xz-advertised narinfos: %w", err)
 	}
 
 	repaired := 0

--- a/pkg/ncps/fsck_narinfo_compression_repair_internal_test.go
+++ b/pkg/ncps/fsck_narinfo_compression_repair_internal_test.go
@@ -1,0 +1,105 @@
+package ncps
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/testdata"
+)
+
+// TestRepairNarInfoCompressionDesync verifies the bulk data-repair for the still
+// un-servable inverse of the compression desync (issue #1392): a narinfo
+// advertising a non-producible compression (xz) whose backing NAR is stored
+// otherwise. It MUST be rewritten to the servable none form, healthy narinfos
+// MUST be left alone, and the repair MUST be idempotent.
+func TestRepairNarInfoCompressionDesync(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	dbClient := newCDCModeTestDB(t)
+
+	// Desynced: narinfo advertises xz, but the only backing nar_file is none.
+	driftedHash := testdata.Nar1.NarHash
+	driftedNF, err := dbClient.Ent().NarFile.Create().
+		SetHash(driftedHash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(100).
+		Save(ctx)
+	require.NoError(t, err)
+
+	driftedNI, err := dbClient.Ent().NarInfo.Create().
+		SetHash(testdata.Nar1.NarInfoHash).
+		SetStorePath("/nix/store/" + testdata.Nar1.NarInfoHash + "-pkg").
+		SetURL("nar/" + driftedHash + ".nar.xz").
+		SetCompression(nar.CompressionTypeXz.String()).
+		SetFileHash("sha256:" + driftedHash).
+		SetFileSize(50).
+		SetNarSize(100).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = dbClient.Ent().NarInfoNarFile.Create().
+		SetNarinfoID(driftedNI.ID).
+		SetNarFileID(driftedNF.ID).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Healthy: narinfo advertises xz and an xz nar_file actually exists.
+	healthyHash := testdata.Nar2.NarHash
+	healthyNF, err := dbClient.Ent().NarFile.Create().
+		SetHash(healthyHash).
+		SetCompression(nar.CompressionTypeXz.String()).
+		SetQuery("").
+		SetFileSize(80).
+		Save(ctx)
+	require.NoError(t, err)
+
+	healthyNI, err := dbClient.Ent().NarInfo.Create().
+		SetHash(testdata.Nar2.NarInfoHash).
+		SetStorePath("/nix/store/" + testdata.Nar2.NarInfoHash + "-pkg").
+		SetURL("nar/" + healthyHash + ".nar.xz").
+		SetCompression(nar.CompressionTypeXz.String()).
+		SetFileHash("sha256:" + healthyHash).
+		SetFileSize(80).
+		SetNarSize(160).
+		Save(ctx)
+	require.NoError(t, err)
+
+	_, err = dbClient.Ent().NarInfoNarFile.Create().
+		SetNarinfoID(healthyNI.ID).
+		SetNarFileID(healthyNF.ID).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Repair.
+	repaired, err := repairNarInfoCompressionDesync(ctx, dbClient)
+	require.NoError(t, err)
+	assert.Equal(t, 1, repaired, "exactly the one desynced narinfo must be repaired")
+
+	// The desynced narinfo is rewritten to the servable none form.
+	got, err := dbClient.Ent().NarInfo.Get(ctx, driftedNI.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.URL)
+	assert.Equal(t, "nar/"+driftedHash+".nar", *got.URL, "URL must drop the .xz extension")
+	require.NotNil(t, got.Compression)
+	assert.Equal(t, nar.CompressionTypeNone.String(), *got.Compression, "compression must become none")
+	assert.Nil(t, got.FileHash, "FileHash must be cleared for a none narinfo")
+	assert.Nil(t, got.FileSize, "FileSize must be cleared for a none narinfo")
+
+	// The healthy narinfo is untouched.
+	stillHealthy, err := dbClient.Ent().NarInfo.Get(ctx, healthyNI.ID)
+	require.NoError(t, err)
+	require.NotNil(t, stillHealthy.Compression)
+	assert.Equal(t, nar.CompressionTypeXz.String(), *stillHealthy.Compression, "healthy xz narinfo must be untouched")
+
+	// Idempotent: a second run repairs nothing.
+	again, err := repairNarInfoCompressionDesync(ctx, dbClient)
+	require.NoError(t, err)
+	assert.Equal(t, 0, again, "a second repair run must be a no-op")
+}


### PR DESCRIPTION
## Summary

Stacked on #1394. After the serve-side fixes (#1393, #1394) ncps tolerates most narinfo↔nar_file compression drift at serve time by transcoding. The one case it still cannot serve is a narinfo advertising a compression ncps has no compressor for (`xz`) whose backing NAR is stored otherwise (none/zstd/chunks) — ~59 such pairs on the live cache. These pre-existing drifted rows cannot be healed at request time, so they need a one-shot data repair.

Add `repairNarInfoCompressionDesync`, invoked from `repairFsckIssues` under `--repair`: find narinfos advertising `xz` with no matching `xz` nar_file but a backing non-xz nar_file, and rewrite each to the servable `none` form (`URL: nar/<hash>.nar`, `Compression: none`, `FileHash`/`FileSize` cleared), reusing the advertised hash so the resolve-by-hash serve path (#1393) decompresses the stored bytes. Healthy narinfos are untouched; the repair is idempotent.

## Test plan

- [x] New `TestRepairNarInfoCompressionDesync`: a desynced xz-advertised/none-stored narinfo is rewritten to none; a healthy xz/xz pair is untouched; a second run is a no-op.
- [x] `task fmt`/`lint` green; targeted fsck tests pass.

Refs #1392