### PR TITLE
feat(fsck): reclaim chunks behind stale links to dechunked nar_files

### DIFF
--- a/openspec/changes/archive/2026-06-10-cleanup-stale-cdc-chunk-links/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-10-cleanup-stale-cdc-chunk-links/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-11

--- a/openspec/changes/archive/2026-06-10-cleanup-stale-cdc-chunk-links/design.md
+++ b/openspec/changes/archive/2026-06-10-cleanup-stale-cdc-chunk-links/design.md
@@ -1,0 +1,33 @@
+## Context
+
+CDC stores a NAR's data as `chunks` rows linked to a `nar_file` via `nar_file_chunks`, with the parent `nar_file.total_chunks > 0`. When a NAR is dechunked (migrate-chunks-to-nar) or chunking is abandoned, `total_chunks` is reset to 0 but the `nar_file_chunks` links were not always removed — leaving stale links. fsck (`pkg/ncps/fsck.go`) reclaims orphaned chunks via `entchunk.Not(entchunk.HasNarFileLinks())`, so a chunk still referenced by a stale link is not orphaned and survives forever. `detectFsckCDCMode` already re-enables CDC mode on chunk residue (#1364), so the read/repair phases run; the gap is purely the stale-link case.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reclaim chunks stranded behind `nar_file_chunks` links to dechunked (`total_chunks = 0`) nar_files: delete the stale links, then delete the now-orphaned chunk DB rows and storage blobs.
+- Safe and idempotent; never touch a chunked (`total_chunks > 0`) NAR.
+
+**Non-Goals:**
+- Changing how chunking/dechunking writes links (prevention is out of scope; this reclaims existing residue).
+- The already-handled unlinked-orphan reclamation and chunk-count-mismatch repairs.
+
+## Decisions
+
+- **Define stale links by the parent's `total_chunks <= 0`.** A dechunked nar_file must own no chunk links, so `nar_file_chunks` whose `nar_file.total_chunks <= 0` are unambiguously stale. Delete them, then reclaim chunks via the existing `Not(HasNarFileLinks())` predicate. *Alternative:* delete chunks directly by walking links — rejected: a chunk may be shared (dedup) by a still-chunked nar_file; deleting only after it has no remaining links is the safe order.
+- **Reclaim within the same repair function.** The orphaned-chunk suspect list is collected in the read phase, before this deletion, so newly-orphaned chunks must be re-queried and deleted here (mirrors `repairSizeMismatchCDCNarFiles`, which re-queries orphaned chunks after its nar_file deletions). *Alternative:* rely on a second fsck pass — rejected: one `--repair` run should converge.
+- **Gate on CDC mode + repair, like the other chunk repairs.** Reuses the existing `repair && cdcMode && chunkStore != nil` guard around `repairFsckIssues`.
+
+## Risks / Trade-offs
+
+- **Deleting a chunk shared with a still-chunked NAR** → prevented: chunks are deleted only when they have NO remaining `nar_file_chunks` links after stale-link removal, so a chunk still referenced by a `total_chunks > 0` nar_file is retained.
+- **Large delete volume (millions of rows)** → bounded by batched deletes; runs under `--repair` which operators invoke deliberately. Storage-blob deletion tolerates already-absent blobs (ErrNotFound non-fatal), matching existing reclamation.
+- **Mis-classifying an in-progress chunking NAR** → excluded: in-progress chunking has `chunking_started_at` set with `total_chunks = 0`, but a freshly-chunking NAR's links are being written, not stale. To be safe the cleanup only removes links whose parent is dechunked AND not actively chunking (chunking_started_at NULL), leaving mid-chunking NARs alone.
+
+## Migration Plan
+
+Ships as fsck repair logic; operators run `ncps fsck --repair` once to reclaim the residue. No DB migration. Rollback: revert the binary; reclaimed rows/blobs were unreferenced.
+
+## Open Questions
+
+- None blocking.

--- a/openspec/changes/archive/2026-06-10-cleanup-stale-cdc-chunk-links/proposal.md
+++ b/openspec/changes/archive/2026-06-10-cleanup-stale-cdc-chunk-links/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+A live cache accumulated millions of orphaned CDC chunk rows: `chunks` ≈ 5.5M and `nar_file_chunks` ≈ 8164, yet **zero** `nar_files` have `total_chunks > 0`. fsck's orphaned-chunk reclamation only deletes chunks with NO `nar_file_chunks` link (`Not(HasNarFileLinks())`); the ~8164 stale links point to **dechunked** (`total_chunks = 0`) nar_files, so those chunks are never considered orphaned and are never reclaimed. `collectNarFilesWithChunkIssues` only inspects `total_chunks > 0` rows, so the stale links also escape there. The result is unbounded Postgres bloat that drain/fsck cannot clear.
+
+## What Changes
+
+- `ncps fsck --repair` SHALL delete `nar_file_chunks` links whose parent `nar_file` is dechunked (`total_chunks <= 0`) — a dechunked NAR must own no chunk links — and then reclaim the chunks left orphaned by that deletion (DB rows and chunk-store blobs), mirroring the existing orphaned-chunk reclamation.
+- A chunked NAR (`total_chunks > 0`) and its links/chunks MUST NOT be touched.
+- The cleanup runs whenever fsck is in CDC mode, including the post-drain chunk-residue mode (#1364), so it reclaims residue even with CDC disabled.
+
+## Capabilities
+
+### New Capabilities
+- `cdc-chunk-residue-cleanup`: fsck reclamation of chunks stranded behind stale `nar_file_chunks` links to dechunked nar_files (`total_chunks = 0`), which the orphaned-chunk (unlinked) reclamation cannot reach.
+
+### Modified Capabilities
+<!-- none -->
+
+## Impact
+
+- `pkg/ncps/fsck.go`: new `reclaimStaleChunkLinks`, invoked from `repairFsckIssues` under `--repair` + CDC mode; counts logged.
+- New unit test in `pkg/ncps`.
+- Repair-only; read-only fsck unchanged. No schema/migration/API change. Reclaims significant DB + storage space.

--- a/openspec/changes/archive/2026-06-10-cleanup-stale-cdc-chunk-links/specs/cdc-chunk-residue-cleanup/spec.md
+++ b/openspec/changes/archive/2026-06-10-cleanup-stale-cdc-chunk-links/specs/cdc-chunk-residue-cleanup/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Reclaim chunks stranded behind stale links to dechunked nar_files
+
+The system SHALL, during `fsck --repair` in CDC mode, delete `nar_file_chunks` links whose parent `nar_file` is dechunked (`total_chunks <= 0` and not actively chunking) and then reclaim the chunks left with no remaining links, deleting both their `chunks` DB rows and their chunk-store blobs. A chunked NAR (`total_chunks > 0`), its links, and its chunks MUST NOT be modified, and a chunk still referenced by any chunked NAR MUST be retained.
+
+#### Scenario: stale link to a dechunked nar_file is removed and its chunk reclaimed
+
+- **WHEN** a `nar_file` has `total_chunks = 0` (not actively chunking) yet still has a `nar_file_chunks` link to a chunk used by no other nar_file, and `fsck --repair` runs
+- **THEN** the stale link is deleted and the chunk's DB row and storage blob are reclaimed
+
+#### Scenario: chunked NAR is left intact
+
+- **WHEN** a `nar_file` has `total_chunks > 0` with its chunk links and chunks, and `fsck --repair` runs
+- **THEN** its links and chunks are not modified
+
+#### Scenario: shared chunk retained while still referenced
+
+- **WHEN** a chunk is linked by both a dechunked nar_file (stale) and a chunked (`total_chunks > 0`) nar_file
+- **THEN** only the stale link is removed and the chunk is retained because it still has a live link
+
+#### Scenario: idempotent
+
+- **WHEN** `fsck --repair` runs again after a prior cleanup
+- **THEN** no further links or chunks are removed

--- a/openspec/changes/archive/2026-06-10-cleanup-stale-cdc-chunk-links/tasks.md
+++ b/openspec/changes/archive/2026-06-10-cleanup-stale-cdc-chunk-links/tasks.md
@@ -1,0 +1,14 @@
+## 1. Reproduce (TDD red)
+
+- [x] 1.1 Add a `pkg/ncps` test seeding: a dechunked nar_file (`total_chunks=0`) with a stale `nar_file_chunks` link to a chunk (blob in chunk store); a healthy chunked nar_file (`total_chunks>0`) with its link+chunk; and a chunk shared by both. Assert the reclaim removes only the stale link + its now-orphaned chunk, keeps the chunked NAR and the shared chunk, and is idempotent. Confirm it fails before the reclaim exists (RED).
+
+## 2. Implement the reclaim (TDD green)
+
+- [x] 2.1 Add `reclaimStaleChunkLinks(ctx, dbClient, chunkStore) (linksDeleted, chunksReclaimed int, err error)` in `pkg/ncps/fsck.go`: delete `nar_file_chunks` whose parent `nar_file` has `total_chunks <= 0` and `chunking_started_at` NULL; then delete chunks with `Not(HasNarFileLinks())` from the chunk store and DB.
+- [x] 2.2 Invoke it from `repairFsckIssues` (under `--repair` + CDC mode) and log the counts.
+- [x] 2.3 Confirm the test passes (GREEN), including idempotency.
+
+## 3. Verify (no regressions)
+
+- [x] 3.1 Existing fsck tests pass; chunked NARs untouched.
+- [x] 3.2 `task fmt`, `task lint`, `task test` all green.

--- a/openspec/specs/cdc-chunk-residue-cleanup/spec.md
+++ b/openspec/specs/cdc-chunk-residue-cleanup/spec.md
@@ -1,0 +1,40 @@
+# CDC Chunk Residue Cleanup
+
+## Purpose
+
+Defines the fsck reclamation of chunks stranded behind stale `nar_file_chunks`
+links to dechunked (`total_chunks = 0`) nar_files. The standard orphaned-chunk
+reclamation only deletes chunks with no link at all, so chunks held by a stale
+link to a dechunked nar_file are never reclaimed; this closes that gap, bounding
+post-drain CDC chunk residue.
+
+## Requirements
+
+### Requirement: Reclaim chunks stranded behind stale links to dechunked nar_files
+
+The system SHALL, during `fsck --repair` in CDC mode, delete `nar_file_chunks`
+links whose parent `nar_file` is dechunked (`total_chunks <= 0` and not actively
+chunking) and then reclaim the chunks left with no remaining links, deleting both
+their `chunks` DB rows and their chunk-store blobs. A chunked NAR
+(`total_chunks > 0`), its links, and its chunks MUST NOT be modified, and a chunk
+still referenced by any chunked NAR MUST be retained.
+
+#### Scenario: stale link to a dechunked nar_file is removed and its chunk reclaimed
+
+- **WHEN** a `nar_file` has `total_chunks = 0` (not actively chunking) yet still has a `nar_file_chunks` link to a chunk used by no other nar_file, and `fsck --repair` runs
+- **THEN** the stale link is deleted and the chunk's DB row and storage blob are reclaimed
+
+#### Scenario: chunked NAR is left intact
+
+- **WHEN** a `nar_file` has `total_chunks > 0` with its chunk links and chunks, and `fsck --repair` runs
+- **THEN** its links and chunks are not modified
+
+#### Scenario: shared chunk retained while still referenced
+
+- **WHEN** a chunk is linked by both a dechunked nar_file (stale) and a chunked (`total_chunks > 0`) nar_file
+- **THEN** only the stale link is removed and the chunk is retained because it still has a live link
+
+#### Scenario: idempotent
+
+- **WHEN** `fsck --repair` runs again after a prior cleanup
+- **THEN** no further links or chunks are removed

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -1762,55 +1762,71 @@ func reclaimStaleChunkLinks(
 	dbClient *database.Client,
 	chunkStore chunk.Store,
 ) (int, int, error) {
-	// A mid-chunking nar_file has chunking_started_at set with total_chunks still 0;
-	// its links are being written, not stale, so exclude it via ChunkingStartedAtIsNil.
-	staleLinks, err := dbClient.Ent().NarFileChunk.Query().
+	if dbClient == nil {
+		return 0, 0, nil
+	}
+
+	// Delete every stale link in one bulk statement with the predicate evaluated at
+	// delete time. This avoids materializing the (potentially huge) link set, avoids
+	// N per-row deletes, and closes the TOCTOU window: a parent that transitions to
+	// active chunking between scan and delete no longer matches the predicate and is
+	// not affected. A mid-chunking nar_file has chunking_started_at set with
+	// total_chunks still 0; its links are being written, not stale, so it is excluded
+	// via ChunkingStartedAtIsNil.
+	linksDeleted, err := dbClient.Ent().NarFileChunk.Delete().
 		Where(entnarfilechunk.HasNarFileWith(
 			entnarfile.TotalChunksLTE(0),
 			entnarfile.ChunkingStartedAtIsNil(),
 		)).
-		All(ctx)
+		Exec(ctx)
 	if err != nil {
-		return 0, 0, fmt.Errorf("query stale chunk links: %w", err)
-	}
-
-	linksDeleted := 0
-
-	for _, link := range staleLinks {
-		if err := dbClient.Ent().NarFileChunk.DeleteOneID(link.ID).Exec(ctx); err != nil {
-			return linksDeleted, 0, fmt.Errorf("delete stale chunk link %d: %w", link.ID, err)
-		}
-
-		linksDeleted++
+		return 0, 0, fmt.Errorf("delete stale chunk links: %w", err)
 	}
 
 	if linksDeleted == 0 {
 		return 0, 0, nil
 	}
 
-	// Reclaim chunks left with no remaining links after stale-link removal. A chunk
-	// shared with a still-chunked nar_file keeps a live link and is skipped here.
-	orphaned, err := dbClient.Ent().Chunk.Query().
-		Where(entchunk.Not(entchunk.HasNarFileLinks())).
-		All(ctx)
-	if err != nil {
-		return linksDeleted, 0, fmt.Errorf("query orphaned chunks after stale-link cleanup: %w", err)
-	}
-
+	// Reclaim chunks left with no remaining links after stale-link removal, paged to
+	// bound memory on large residue (millions of chunks). A chunk shared with a
+	// still-chunked nar_file keeps a live link and is skipped. Each page is deleted
+	// by a bounded IDIn bulk delete; the next page query re-evaluates the predicate,
+	// so the loop converges as rows are removed.
 	chunksReclaimed := 0
 
-	for _, ch := range orphaned {
-		if chunkStore != nil {
-			if err := chunkStore.DeleteChunk(ctx, ch.Hash); err != nil && !errors.Is(err, storage.ErrNotFound) {
-				return linksDeleted, chunksReclaimed, fmt.Errorf("delete orphaned chunk blob %s: %w", ch.Hash, err)
+	for {
+		orphaned, err := dbClient.Ent().Chunk.Query().
+			Where(entchunk.Not(entchunk.HasNarFileLinks())).
+			Limit(fsckEagerLoadBatchSize).
+			All(ctx)
+		if err != nil {
+			return linksDeleted, chunksReclaimed, fmt.Errorf("query orphaned chunks after stale-link cleanup: %w", err)
+		}
+
+		if len(orphaned) == 0 {
+			break
+		}
+
+		ids := make([]int, 0, len(orphaned))
+
+		for _, ch := range orphaned {
+			if chunkStore != nil {
+				if err := chunkStore.DeleteChunk(ctx, ch.Hash); err != nil && !errors.Is(err, storage.ErrNotFound) {
+					return linksDeleted, chunksReclaimed, fmt.Errorf("delete orphaned chunk blob %s: %w", ch.Hash, err)
+				}
 			}
+
+			ids = append(ids, ch.ID)
 		}
 
-		if err := dbClient.Ent().Chunk.DeleteOneID(ch.ID).Exec(ctx); err != nil {
-			return linksDeleted, chunksReclaimed, fmt.Errorf("delete orphaned chunk row %d: %w", ch.ID, err)
+		deleted, err := dbClient.Ent().Chunk.Delete().
+			Where(entchunk.IDIn(ids...)).
+			Exec(ctx)
+		if err != nil {
+			return linksDeleted, chunksReclaimed, fmt.Errorf("delete orphaned chunk rows: %w", err)
 		}
 
-		chunksReclaimed++
+		chunksReclaimed += deleted
 	}
 
 	return linksDeleted, chunksReclaimed, nil

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -1715,6 +1715,23 @@ func repairFsckIssues(
 		}
 	}
 
+	// e2. Reclaim chunks stranded behind stale nar_file_chunks links to dechunked
+	// nar_files (total_chunks = 0). The orphaned-chunk (unlinked) reclamation above
+	// cannot reach them because they still carry a stale link.
+	if chunkStore != nil {
+		staleLinks, staleChunks, err := reclaimStaleChunkLinks(ctx, dbClient, chunkStore)
+		if err != nil {
+			return fmt.Errorf("reclaim stale chunk links: %w", err)
+		}
+
+		if staleLinks > 0 || staleChunks > 0 {
+			logger.Info().
+				Int("links", staleLinks).
+				Int("chunks", staleChunks).
+				Msg("reclaimed chunks stranded behind stale links to dechunked nar_files")
+		}
+	}
+
 	// f. Repair narinfos advertising a non-producible compression (xz) whose backing
 	// NAR is stored otherwise: rewrite to the servable none form so they serve via
 	// transparent decompression (#1392).
@@ -1730,6 +1747,73 @@ func repairFsckIssues(
 	}
 
 	return nil
+}
+
+// reclaimStaleChunkLinks deletes nar_file_chunks links whose parent nar_file is
+// dechunked (total_chunks <= 0 and not actively chunking) — a dechunked NAR must
+// own no chunk links — and then reclaims the chunks left with no remaining links
+// (their chunk-store blobs and DB rows). A chunk still referenced by a chunked
+// (total_chunks > 0) nar_file keeps a live link and is retained. The orphaned-
+// chunk reclamation elsewhere only deletes chunks that are already unlinked, so it
+// cannot reach chunks held by these stale links. Returns (linksDeleted,
+// chunksReclaimed). Idempotent: once the stale links are gone, a re-run finds none.
+func reclaimStaleChunkLinks(
+	ctx context.Context,
+	dbClient *database.Client,
+	chunkStore chunk.Store,
+) (int, int, error) {
+	// A mid-chunking nar_file has chunking_started_at set with total_chunks still 0;
+	// its links are being written, not stale, so exclude it via ChunkingStartedAtIsNil.
+	staleLinks, err := dbClient.Ent().NarFileChunk.Query().
+		Where(entnarfilechunk.HasNarFileWith(
+			entnarfile.TotalChunksLTE(0),
+			entnarfile.ChunkingStartedAtIsNil(),
+		)).
+		All(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("query stale chunk links: %w", err)
+	}
+
+	linksDeleted := 0
+
+	for _, link := range staleLinks {
+		if err := dbClient.Ent().NarFileChunk.DeleteOneID(link.ID).Exec(ctx); err != nil {
+			return linksDeleted, 0, fmt.Errorf("delete stale chunk link %d: %w", link.ID, err)
+		}
+
+		linksDeleted++
+	}
+
+	if linksDeleted == 0 {
+		return 0, 0, nil
+	}
+
+	// Reclaim chunks left with no remaining links after stale-link removal. A chunk
+	// shared with a still-chunked nar_file keeps a live link and is skipped here.
+	orphaned, err := dbClient.Ent().Chunk.Query().
+		Where(entchunk.Not(entchunk.HasNarFileLinks())).
+		All(ctx)
+	if err != nil {
+		return linksDeleted, 0, fmt.Errorf("query orphaned chunks after stale-link cleanup: %w", err)
+	}
+
+	chunksReclaimed := 0
+
+	for _, ch := range orphaned {
+		if chunkStore != nil {
+			if err := chunkStore.DeleteChunk(ctx, ch.Hash); err != nil && !errors.Is(err, storage.ErrNotFound) {
+				return linksDeleted, chunksReclaimed, fmt.Errorf("delete orphaned chunk blob %s: %w", ch.Hash, err)
+			}
+		}
+
+		if err := dbClient.Ent().Chunk.DeleteOneID(ch.ID).Exec(ctx); err != nil {
+			return linksDeleted, chunksReclaimed, fmt.Errorf("delete orphaned chunk row %d: %w", ch.ID, err)
+		}
+
+		chunksReclaimed++
+	}
+
+	return linksDeleted, chunksReclaimed, nil
 }
 
 // repairNarInfoCompressionDesync rewrites narinfos that advertise a

--- a/pkg/ncps/fsck_reclaim_stale_chunk_links_internal_test.go
+++ b/pkg/ncps/fsck_reclaim_stale_chunk_links_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,6 +47,16 @@ func TestReclaimStaleChunkLinks(t *testing.T) {
 		Save(ctx)
 	require.NoError(t, err)
 
+	// Mid-chunking nar_file (total_chunks=0 but chunking_started_at set): its links
+	// are being written, NOT stale, and must be preserved by the not-actively-chunking
+	// guard.
+	midChunkingNF, err := dbClient.Ent().NarFile.Create().
+		SetHash("midchunkingnarfilehashcccccccccccccccccccccccccccccc").
+		SetCompression(nar.CompressionTypeNone.String()).SetQuery("").
+		SetFileSize(15).SetTotalChunks(0).SetChunkingStartedAt(time.Now()).
+		Save(ctx)
+	require.NoError(t, err)
+
 	mkChunk := func() string {
 		h := testhelper.MustRandBase32NarHash()
 		_, _, perr := chunkStore.PutChunk(ctx, h, []byte("chunk-"+h))
@@ -60,6 +71,7 @@ func TestReclaimStaleChunkLinks(t *testing.T) {
 	staleHash := mkChunk()   // linked only to the dechunked nar_file → reclaim
 	sharedHash := mkChunk()  // linked to both → retain (chunked keeps a live link)
 	healthyHash := mkChunk() // linked only to the chunked nar_file → retain
+	midHash := mkChunk()     // linked only to the mid-chunking nar_file → retain
 
 	link := func(nfID int, chunkHash string, idx int) {
 		ch, qerr := dbClient.Ent().Chunk.Query().Where(entchunk.HashEQ(chunkHash)).Only(ctx)
@@ -74,6 +86,7 @@ func TestReclaimStaleChunkLinks(t *testing.T) {
 	link(dechunkedNF.ID, sharedHash, 1) // stale
 	link(chunkedNF.ID, sharedHash, 0)   // live
 	link(chunkedNF.ID, healthyHash, 1)  // live
+	link(midChunkingNF.ID, midHash, 0)  // mid-chunking, not stale
 
 	linksDeleted, chunksReclaimed, err := reclaimStaleChunkLinks(ctx, dbClient, chunkStore)
 	require.NoError(t, err)
@@ -89,12 +102,19 @@ func TestReclaimStaleChunkLinks(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, staleBlob, "stale-only chunk blob must be reclaimed")
 
-	// sharedHash + healthyHash: retained (still linked to the chunked nar_file).
-	for _, h := range []string{sharedHash, healthyHash} {
+	// sharedHash + healthyHash retained (still linked to the chunked nar_file);
+	// midHash retained because its parent is mid-chunking (not stale).
+	for _, h := range []string{sharedHash, healthyHash, midHash} {
 		exists, err := dbClient.Ent().Chunk.Query().Where(entchunk.HashEQ(h)).Exist(ctx)
 		require.NoError(t, err)
-		assert.True(t, exists, "chunk still referenced by a chunked NAR must be retained: %s", h)
+		assert.True(t, exists, "chunk that must be retained was reclaimed: %s", h)
 	}
+
+	// The mid-chunking nar_file's link must be preserved (the not-actively-chunking guard).
+	midLinks, err := dbClient.Ent().NarFileChunk.Query().
+		Where(entnarfilechunk.NarFileIDEQ(midChunkingNF.ID)).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 1, midLinks, "a mid-chunking nar_file's links must not be treated as stale")
 
 	// The chunked nar_file keeps both its links.
 	chunkedLinks, err := dbClient.Ent().NarFileChunk.Query().

--- a/pkg/ncps/fsck_reclaim_stale_chunk_links_internal_test.go
+++ b/pkg/ncps/fsck_reclaim_stale_chunk_links_internal_test.go
@@ -1,0 +1,110 @@
+package ncps
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	entchunk "github.com/kalbasit/ncps/ent/chunk"
+	entnarfilechunk "github.com/kalbasit/ncps/ent/narfilechunk"
+
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage/chunk"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// TestReclaimStaleChunkLinks verifies the orphaned-chunk-residue cleanup
+// (issue #1392 follow-up): chunks stranded behind stale nar_file_chunks links to
+// dechunked (total_chunks=0) nar_files are reclaimed, while chunked NARs and any
+// chunk still shared with a chunked NAR are retained. Idempotent.
+func TestReclaimStaleChunkLinks(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	dbClient := newCDCModeTestDB(t)
+
+	chunkStore, err := chunk.NewLocalStore(filepath.Join(t.TempDir(), "chunks-store"))
+	require.NoError(t, err)
+
+	// Dechunked nar_file (total_chunks=0): its links are stale.
+	dechunkedNF, err := dbClient.Ent().NarFile.Create().
+		SetHash("dechunkednarfilehashaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").
+		SetCompression(nar.CompressionTypeNone.String()).SetQuery("").
+		SetFileSize(10).SetTotalChunks(0).
+		Save(ctx)
+	require.NoError(t, err)
+
+	// Healthy chunked nar_file (total_chunks>0): keep its links/chunks.
+	chunkedNF, err := dbClient.Ent().NarFile.Create().
+		SetHash("chunkednarfilehashbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").
+		SetCompression(nar.CompressionTypeNone.String()).SetQuery("").
+		SetFileSize(20).SetTotalChunks(2).
+		Save(ctx)
+	require.NoError(t, err)
+
+	mkChunk := func() string {
+		h := testhelper.MustRandBase32NarHash()
+		_, _, perr := chunkStore.PutChunk(ctx, h, []byte("chunk-"+h))
+		require.NoError(t, perr)
+
+		_, cerr := dbClient.Ent().Chunk.Create().SetHash(h).SetSize(10).SetCompressedSize(5).Save(ctx)
+		require.NoError(t, cerr)
+
+		return h
+	}
+
+	staleHash := mkChunk()   // linked only to the dechunked nar_file → reclaim
+	sharedHash := mkChunk()  // linked to both → retain (chunked keeps a live link)
+	healthyHash := mkChunk() // linked only to the chunked nar_file → retain
+
+	link := func(nfID int, chunkHash string, idx int) {
+		ch, qerr := dbClient.Ent().Chunk.Query().Where(entchunk.HashEQ(chunkHash)).Only(ctx)
+		require.NoError(t, qerr)
+
+		_, lerr := dbClient.Ent().NarFileChunk.Create().
+			SetNarFileID(nfID).SetChunkID(ch.ID).SetChunkIndex(idx).Save(ctx)
+		require.NoError(t, lerr)
+	}
+
+	link(dechunkedNF.ID, staleHash, 0)  // stale
+	link(dechunkedNF.ID, sharedHash, 1) // stale
+	link(chunkedNF.ID, sharedHash, 0)   // live
+	link(chunkedNF.ID, healthyHash, 1)  // live
+
+	linksDeleted, chunksReclaimed, err := reclaimStaleChunkLinks(ctx, dbClient, chunkStore)
+	require.NoError(t, err)
+	assert.Equal(t, 2, linksDeleted, "both stale links on the dechunked nar_file must be deleted")
+	assert.Equal(t, 1, chunksReclaimed, "only the stale-only chunk is reclaimed; the shared chunk is retained")
+
+	// staleHash: gone from DB and storage.
+	staleExists, err := dbClient.Ent().Chunk.Query().Where(entchunk.HashEQ(staleHash)).Exist(ctx)
+	require.NoError(t, err)
+	assert.False(t, staleExists, "stale-only chunk DB row must be reclaimed")
+
+	staleBlob, err := chunkStore.HasChunk(ctx, staleHash)
+	require.NoError(t, err)
+	assert.False(t, staleBlob, "stale-only chunk blob must be reclaimed")
+
+	// sharedHash + healthyHash: retained (still linked to the chunked nar_file).
+	for _, h := range []string{sharedHash, healthyHash} {
+		exists, err := dbClient.Ent().Chunk.Query().Where(entchunk.HashEQ(h)).Exist(ctx)
+		require.NoError(t, err)
+		assert.True(t, exists, "chunk still referenced by a chunked NAR must be retained: %s", h)
+	}
+
+	// The chunked nar_file keeps both its links.
+	chunkedLinks, err := dbClient.Ent().NarFileChunk.Query().
+		Where(entnarfilechunk.NarFileIDEQ(chunkedNF.ID)).Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, chunkedLinks, "the chunked nar_file's links must be untouched")
+
+	// Idempotent.
+	l2, c2, err := reclaimStaleChunkLinks(ctx, dbClient, chunkStore)
+	require.NoError(t, err)
+	assert.Zero(t, l2, "a second run deletes no links")
+	assert.Zero(t, c2, "a second run reclaims no chunks")
+}


### PR DESCRIPTION
## Summary

Stacked on #1394 / the data-repair PR. A live cache accumulated ~5.5M orphaned chunk rows and ~8164 `nar_file_chunks` links while **zero** nar_files have `total_chunks > 0`. fsck's orphaned-chunk reclamation only deletes chunks with NO link, so chunks held by a stale link to a dechunked (`total_chunks = 0`) nar_file are never orphaned and never reclaimed; `collectNarFilesWithChunkIssues` only inspects `total_chunks > 0` rows, so the stale links escape there too. The residue grows unbounded.

Add `reclaimStaleChunkLinks`, invoked from `repairFsckIssues` under `--repair` + CDC mode (which #1364's chunk-residue signal already enables post-drain): delete `nar_file_chunks` whose parent nar_file is dechunked and not actively chunking, then reclaim the chunks left with no remaining links (DB rows + chunk-store blobs). Chunks shared with a still-chunked nar_file keep a live link and are retained; chunked NARs are untouched; idempotent.

## Test plan

- [x] New `TestReclaimStaleChunkLinks`: stale link + its chunk reclaimed; shared chunk and chunked NAR retained; idempotent.
- [x] `task fmt`/`lint` green; targeted fsck tests pass.

Refs #1392