### PR TITLE
fix(cache): serve in-flight compressed NAR or 404, never mislabeled

### DIFF
--- a/nix/e2e-tests/config.nix
+++ b/nix/e2e-tests/config.nix
@@ -406,6 +406,39 @@ rec {
       redis.enabled = true;
       features = [ ];
     }
+
+    # 16. Single instance, eager CDC, exercising the #1398 compressed-request
+    #     mislabel. `phase`/`modes` are harness-only keys (ignored by
+    #     generateValues). Single replica + local locker (in-flight staging OFF)
+    #     is the reporter's topology. Local-only: the in-flight chunking window is
+    #     a timing event (same rationale as staging-contention), so a `.nar.xz`
+    #     request must land mid-pull to catch the mislabel; the cross-pod port
+    #     forward jitter on Kind de-synchronizes that race. See GitHub issue #1398.
+    {
+      name = "input-compression";
+      description = "Eager-CDC compressed (.nar.xz) request mislabel during the in-flight chunking window (#1398)";
+      replicas = 1;
+      mode = null;
+      migration.mode = "initContainer";
+      phase = "input-compression";
+      modes = [ "local" ];
+      storage = {
+        type = "local";
+        local = {
+          path = "/storage";
+          persistence = {
+            enabled = true;
+            size = "5Gi";
+          };
+        };
+      };
+      database = {
+        type = "sqlite";
+        sqlite.path = "/storage/db/ncps.db";
+      };
+      redis.enabled = false;
+      features = [ ];
+    }
   ];
 
   # Composable feature definitions

--- a/nix/e2e-tests/src/phases/__init__.py
+++ b/nix/e2e-tests/src/phases/__init__.py
@@ -21,4 +21,8 @@ def get_phase(name: str):
         from phases.staging_contention import run
 
         return run
+    if name == "input-compression":
+        from phases.input_compression import run
+
+        return run
     raise ValueError(f"unknown phase: {name!r}")

--- a/nix/e2e-tests/src/phases/input_compression.py
+++ b/nix/e2e-tests/src/phases/input_compression.py
@@ -1,0 +1,209 @@
+"""The ``input-compression`` phase: eager-CDC compressed-request mislabel (#1398).
+
+Reproduces GitHub issue #1398 ("input compression not recognized on
+0.10.0-rc13"). Under eager CDC, fetching a narinfo starts a background
+pull-through that downloads the upstream ``.nar.xz``, decompresses it into a
+``none`` temp file, and chunks it. While that download/chunk window is open, a
+client whose narinfo still advertises ``Compression: xz`` requests
+``/nar/<hash>.nar.xz``. ncps piggybacks on the in-flight (none-temp) download and
+relabels the request to ``Compression: none`` (cache.go:1459), streaming the
+decompressed bytes — optionally re-wrapped in transport zstd (server.go:897).
+The client, which expects xz per its narinfo, receives bytes it cannot xz-decode
+and fails with ``input compression not recognized``.
+
+Correct behavior for a ``.nar.xz`` request is EITHER a valid xz body OR HTTP 404
+(so the client falls back to an upstream that still has the original file) — but
+NEVER a 200 whose body is not xz. This phase asserts that invariant.
+
+Topology: single replica, in-flight staging OFF (the local/sqlite locker is not
+distributed) — the exact reporter setup, where the staging path that would 404 a
+compressed request never engages. Local-only: the in-flight window is a timing
+event (like ``staging-contention``), so — reusing that phase's machinery — it
+uses a large NAR (so the download/chunk window lasts seconds), DB-gates the race
+to the open window (``total_chunks`` not yet set), and clean-restart-retries a
+bounded number of times if a run misses the window. A ``.nar.xz`` request fired
+while the holder is in-flight is the one that 404s or, on a buggy build, is
+served mislabeled.
+"""
+
+from __future__ import annotations
+
+import lzma
+import threading
+import time
+import urllib.error
+import urllib.request
+
+from client import hash_of_store_path, realise_package
+from harness_config import AssertionFailure, B, R, Y, check, log, section
+
+# A NAR large enough that the eager-CDC download+decompress+chunk window lasts
+# several seconds on a fast host (so concurrent .nar.xz requests reliably overlap
+# it), and substitutable from the configured upstream. gcc-unwrapped (~several
+# hundred MiB, Hydra-built on cache.nixos.org) is the same package the
+# staging-contention phase uses for the identical "open an in-flight window" need.
+PACKAGE = "nixpkgs#gcc-unwrapped"
+
+# Per-attempt: how long to keep firing the .nar.xz variant, and the concurrency.
+HAMMER_SECONDS = 8.0
+HAMMER_THREADS = 8
+
+# Bounded retries: a run can miss the in-flight window (the NAR fully chunked
+# before any .nar.xz request lands). That is a timing loss, not a result — clean
+# restart and retry, failing only if the window is never overlapped.
+ATTEMPTS = 4
+
+
+def _inflight_state(db, nar_hash: str) -> str:
+    """Classify eager-CDC materialization from the ``nar_files`` row.
+
+    ``absent`` (download in progress, no chunk row yet) or ``inflight``
+    (``total_chunks == 0``, actively chunking) both mean the in-flight window is
+    OPEN; ``done`` (``total_chunks > 0``) means it has closed.
+    """
+    rows = db.query("SELECT total_chunks FROM nar_files WHERE hash = ?", (nar_hash,))
+    if not rows:
+        return "absent"
+    tc = rows[0][0] or 0
+    return "done" if tc > 0 else "inflight"
+
+
+def _xz_path_from_none_url(nar_url: str) -> str:
+    """``nar/<h>.nar`` (predictive-none) -> ``/nar/<h>.nar.xz`` (compressed variant).
+
+    The predictive-none narinfo URL is ``nar/<h>.nar``; the compressed variant the
+    reporter's client requests is the SAME hash with a ``.xz`` suffix appended
+    (``nar/<h>.nar.xz``) — not ``.nar`` replaced by ``.xz``.
+    """
+    p = "/" + nar_url.lstrip("/")
+    if p.endswith(".nar.xz"):
+        return p
+    if p.endswith(".nar"):
+        return p + ".xz"
+    # narinfo already advertises some other compression: swap to .nar.xz.
+    return p.split(".nar", 1)[0] + ".nar.xz"
+
+
+def _classify_xz(base_url: str, xz_path: str) -> str:
+    """Fetch ``xz_path`` and classify: 'notfound' | 'valid' | 'mislabeled'.
+
+    'mislabeled' is the #1398 bug: a 200 whose body is not decodable as xz
+    (the client-visible "input compression not recognized").
+    """
+    try:
+        with urllib.request.urlopen(base_url + xz_path, timeout=120) as r:
+            status = r.status
+            body = r.read()
+    except urllib.error.HTTPError as e:
+        return "notfound" if e.code == 404 else "mislabeled" if e.code == 200 else "notfound"
+    except Exception:  # noqa: BLE001 — connection resets etc. are not the invariant under test
+        return "notfound"
+    if status == 404 or status != 200:
+        return "notfound"
+    if not body:
+        return "mislabeled"
+    try:
+        lzma.decompress(body)
+    except lzma.LZMAError:
+        return "mislabeled"
+    return "valid"
+
+
+def _race_xz_during_window(deployment, nar_hash: str, xz_path: str) -> dict:
+    """Hammer ``xz_path`` concurrently while the holder is in-flight.
+
+    Stops as soon as the DB shows the NAR fully chunked (window closed) or the
+    time budget expires. Returns verdict counts plus whether the window was
+    actually overlapped (so a pure-404 'never opened' run is distinguishable from
+    a genuine all-404 pass).
+    """
+    base = deployment.replica_urls()[0]
+    db = deployment.db()
+    counts = {"valid": 0, "notfound": 0, "mislabeled": 0}
+    lock = threading.Lock()
+    overlapped = {"seen": False}
+    deadline = time.time() + HAMMER_SECONDS
+
+    def worker():
+        while time.time() < deadline:
+            if _inflight_state(db, nar_hash) != "done":
+                overlapped["seen"] = True
+            verdict = _classify_xz(base, xz_path)
+            with lock:
+                counts[verdict] += 1
+
+    threads = [threading.Thread(target=worker, daemon=True) for _ in range(HAMMER_THREADS)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    counts["overlapped"] = overlapped["seen"]
+    return counts
+
+
+def run(deployment, scenario) -> None:
+    section("INPUT-COMPRESSION — eager-CDC compressed-request mislabel (#1398)")
+
+    # Eager CDC, single replica, in-flight staging OFF (local locker) — the
+    # reporter's topology.
+    deployment.restart(cdc=True)
+
+    # Canonical store hash from the host; ncps pulls the same path through from
+    # the configured upstream (whose narinfo advertises xz).
+    store_path = realise_package(PACKAGE)
+    store_hash = hash_of_store_path(store_path)
+    log(f"  target {PACKAGE} (store hash {store_hash})", B)
+
+    for attempt in range(1, ATTEMPTS + 1):
+        c = deployment.client(0)
+
+        # Prime the narinfo: under eager CDC this fires the background prefetch
+        # (the holder) that opens the in-flight window, and yields the none URL.
+        ni = None
+        for _ in range(30):
+            ni = c.fetch_narinfo(store_hash)
+            if ni:
+                break
+            time.sleep(1)
+        check(ni is not None, "narinfo served (NAR still uncached)")
+        fields = c.parse_narinfo(ni)
+        nar_url = fields.get("URL", "")
+        check(bool(nar_url), "narinfo has a NAR URL")
+        nar_hash = nar_url.rsplit("/", 1)[-1].split(".", 1)[0]
+        xz_path = _xz_path_from_none_url(nar_url)
+
+        log(f"  attempt {attempt}/{ATTEMPTS}: racing .nar.xz ({xz_path}) during in-flight window", B)
+        counts = _race_xz_during_window(deployment, nar_hash, xz_path)
+        log(
+            f"    .nar.xz responses — valid: {counts['valid']}, "
+            f"404(fallback): {counts['notfound']}, mislabeled: {counts['mislabeled']} "
+            f"(window overlapped: {counts['overlapped']})",
+            B,
+        )
+
+        # Any mislabeled response reproduces #1398 — fail immediately.
+        check(
+            counts["mislabeled"] == 0,
+            f"every .nar.xz response is valid xz or 404 — got {counts['mislabeled']} "
+            f"mislabeled 200 response(s): an uncompressed body served under a .nar.xz "
+            f"URL is the client-visible 'input compression not recognized'",
+        )
+
+        # No mislabel AND we genuinely overlapped the in-flight window → the
+        # invariant held under the conditions that trigger the bug → done.
+        if counts["overlapped"]:
+            log("  in-flight window overlapped; .nar.xz never served mislabeled", B)
+            return
+
+        # Missed the window (NAR chunked before any .nar.xz landed): retry clean.
+        if attempt < ATTEMPTS:
+            log(f"  in-flight window missed; clean restart + retry", Y)
+            deployment.clean_restart(cdc=True)
+
+    raise AssertionFailure(
+        f"never overlapped the eager-CDC in-flight window after {ATTEMPTS} attempts — "
+        f"the compressed-request mislabel could not be exercised (try a larger PACKAGE "
+        f"or longer HAMMER_SECONDS). Not a pass: the invariant was never tested under "
+        f"the conditions that trigger #1398."
+    )

--- a/nix/e2e-tests/src/phases/input_compression.py
+++ b/nix/e2e-tests/src/phases/input_compression.py
@@ -90,15 +90,14 @@ def _classify_xz(base_url: str, xz_path: str) -> str:
     'mislabeled' is the #1398 bug: a 200 whose body is not decodable as xz
     (the client-visible "input compression not recognized").
     """
+    # urlopen raises HTTPError for any non-2xx/3xx status (404, 5xx), so a return
+    # from the with-block means a 2xx (200 for a NAR GET) and `body` is set.
     try:
         with urllib.request.urlopen(base_url + xz_path, timeout=120) as r:
-            status = r.status
             body = r.read()
-    except urllib.error.HTTPError as e:
-        return "notfound" if e.code == 404 else "mislabeled" if e.code == 200 else "notfound"
-    except Exception:  # noqa: BLE001 — connection resets etc. are not the invariant under test
+    except urllib.error.HTTPError:
         return "notfound"
-    if status == 404 or status != 200:
+    except Exception:  # noqa: BLE001 — connection resets etc. are not the invariant under test
         return "notfound"
     if not body:
         return "mislabeled"
@@ -126,7 +125,12 @@ def _race_xz_during_window(deployment, nar_hash: str, xz_path: str) -> dict:
 
     def worker():
         while time.time() < deadline:
-            if _inflight_state(db, nar_hash) != "done":
+            # Serialize the DB gate under the shared lock: db.query opens its own
+            # sqlite connection per call, but the lock avoids 8 threads churning
+            # connections in lockstep and keeps DB access single-threaded.
+            with lock:
+                in_flight = _inflight_state(db, nar_hash) != "done"
+            if in_flight:
                 overlapped["seen"] = True
             verdict = _classify_xz(base, xz_path)
             with lock:
@@ -198,7 +202,7 @@ def run(deployment, scenario) -> None:
 
         # Missed the window (NAR chunked before any .nar.xz landed): retry clean.
         if attempt < ATTEMPTS:
-            log(f"  in-flight window missed; clean restart + retry", Y)
+            log("  in-flight window missed; clean restart + retry", Y)
             deployment.clean_restart(cdc=True)
 
     raise AssertionFailure(

--- a/openspec/changes/archive/2026-06-11-fix-inflight-eager-cdc-compressed-mislabel/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-11-fix-inflight-eager-cdc-compressed-mislabel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-11

--- a/openspec/changes/archive/2026-06-11-fix-inflight-eager-cdc-compressed-mislabel/design.md
+++ b/openspec/changes/archive/2026-06-11-fix-inflight-eager-cdc-compressed-mislabel/design.md
@@ -1,0 +1,112 @@
+## Context
+
+`Cache.GetNar` (`pkg/cache/cache.go`) serves a NAR from several paths. When the
+NAR is not yet local and an upstream download is in flight, it serves via the
+**per-client live-streaming** path: it joins the holder's `downloadState` (`ds`)
+and streams the holder's temp file.
+
+Under eager CDC the holder downloads the upstream `.nar.xz`, decompresses it into
+a temp file holding the raw **uncompressed** NAR (`ds.tempFileCompression =
+none`, `cache.go:3300`), and chunks it in the background. `GetNar` captures the
+client's `requestedCompression` at entry (`cache.go:1294`) but, on the streaming
+branch, does:
+
+```go
+case <-ds.start:
+    narURL.Compression = ds.tempFileCompression   // cache.go:1459 — becomes none
+```
+
+So a `.nar.xz` (or `.nar.zst`) request piggybacking on the in-flight holder is
+relabeled `none` and streamed as the decompressed body. `server.go:897` then
+sees `Compression == none` and may add transport zstd. The client, told `xz` by
+its narinfo, gets `input compression not recognized` (issue #1398). The
+finished-chunk and staging paths already handle this:
+`compressedRequestNeedsUpstreamFallback` (`inflight_staging_reader.go:298`) and
+`serveZstdFromChunks` (`cache.go:3689`). The in-flight streaming branch is the
+one gap. `ds.compressedAssetPath` is declared but never assigned, so the
+original xz is not retained on disk during the window — serving real xz mid-pull
+is not possible.
+
+RED proof exists on this branch: unit
+`pkg/cache/input_compression_not_recognized_test.go`; e2e scenario
+`input-compression` (`nix/e2e-tests`, `mislabeled: 24`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- A compressed request served via the in-flight streaming path is either served
+  in the requested compression (none/zstd) or 404s for upstream fallback — never
+  a mislabeled 200.
+- Reuse the existing fallback predicate and zstd-recompression mechanism; one
+  rule shared with the staging path.
+- Keep the `none` in-flight serve and all other paths byte-for-byte unchanged.
+
+**Non-Goals:**
+- Adding an xz compressor (xz stays a fallback, never recompressed).
+- Retaining the original compressed download on disk (`compressedAssetPath`).
+- Changing predictive-none narinfo behavior or the proxied-narinfo path.
+
+## Decisions
+
+**D1 — Gate the relabel on `requestedCompression`, in `GetNar`'s streaming
+branch.** The fix lives where the bug is: in the `case <-ds.start:` block, before
+`narURL.Compression = ds.tempFileCompression` at `cache.go:1459`, consult the
+captured `requestedCompression`:
+- if `compressedRequestNeedsUpstreamFallback(requestedCompression,
+  ds.tempFileCompression)` is true (the in-flight holder representation cannot
+  satisfy a non-matching compressed request) → `ds.wg.Done()` and return
+  `storage.ErrNotFound`, so `GetNar`'s caller falls back to upstream;
+- otherwise → current behavior (`narURL.Compression = ds.tempFileCompression`,
+  stream; the existing decompress-on-the-fly goroutine handles a `none` request
+  from a compressed temp).
+
+*Alternative considered:* fix it in `server.go` by not adding transport zstd for
+a compressed request. Rejected — that only hides the zstd-transport symptom; the
+body would still be uncompressed bytes mislabeled `none`, and the client still
+fails. The defect is the compression relabel, not the HTTP encoding.
+
+**D2 — Fall back (404) for BOTH xz and zstd from an uncompressed in-flight
+holder, rather than recompressing in-flight.** `compressedRequestNeedsUpstreamFallback`
+already returns true for both (`!isNone(requested) && requested != available`),
+and this is exactly how the in-flight **staging** serve path behaves
+(`inflight_staging_reader.go:252`) — so the two in-flight paths stay identical.
+ncps cannot produce xz at all; for zstd, in-flight recompression would require
+threading a zstd encoder through the complex progressive-streaming loop (real
+risk for a bugfix), and a racing zstd request 404ing simply triggers one upstream
+fallback fetch. Crucially this is **only the brief in-flight window**: once the
+NAR is fully chunked, a `zstd` request is served by `serveZstdFromChunks`
+(`nar-serving-recompression`), so steady-state zstd serving is unchanged.
+*Alternative:* recompress zstd in-flight (mirror `serveZstdFromChunks`).
+Deferred as an optimization — higher risk, negligible benefit (rare race), and
+not needed to fix #1398.
+
+**D3 — Reuse `compressedRequestNeedsUpstreamFallback`** rather than new logic, so
+the in-flight streaming path and the in-flight staging path share one fallback
+rule and cannot diverge.
+
+## Risks / Trade-offs
+
+- [A racing xz request now 404s instead of returning corrupt 200] → This is the
+  intended, already-graceful behavior (client falls back to upstream). It trades
+  a guaranteed client failure for one extra upstream fetch on the racing
+  request. Net strictly better.
+- [zstd recompression cost on the in-flight path] → Same streaming, pooled-encoder
+  mechanism already used by `serveZstdFromChunks`; O(1) memory, no buffering.
+  Only incurred for zstd requests that race the window (rare).
+- [Behavior change could regress the `none` in-flight serve] → Guarded: the
+  `none` branch is unchanged; the unit + e2e tests assert byte-identity and the
+  existing `nar-concurrent-streaming` truncation/termination scenarios still
+  apply.
+
+## Migration Plan
+
+No schema, config, or API change. Pure serve-path logic. Deploy is a binary
+roll; rollback is reverting the binary. Forward/backward compatible with peers
+(no shared-state contract change).
+
+## Open Questions
+
+- Should the proxied-narinfo path have normalized to predictive-none here (so
+  clients never request xz in the first place)? Out of scope for this change;
+  tracked separately. This change makes the serve path correct regardless of how
+  the client obtained an xz-advertising narinfo.

--- a/openspec/changes/archive/2026-06-11-fix-inflight-eager-cdc-compressed-mislabel/proposal.md
+++ b/openspec/changes/archive/2026-06-11-fix-inflight-eager-cdc-compressed-mislabel/proposal.md
@@ -14,14 +14,16 @@ this right (`nar-serving-recompression`); the in-flight path does not.
 
 - Before the in-flight temp-file serve relabels the request to the holder's
   compression, it consults the **originally requested** compression and applies
-  the same discipline the store/staging paths already use:
+  the same discipline the in-flight staging path already uses:
   - `none` request → serve the decompressed temp bytes as today (unchanged).
-  - `zstd` request → recompress the reassembled bytes to zstd on the fly
-    (mirroring `serveZstdFromChunks`), labeled `zstd`.
-  - `xz`/any non-producible compression → return `storage.ErrNotFound` (HTTP
-    404) so the client falls back to an upstream that still has the original
-    file — never a mislabeled body. This folds the fatal mislabel into the
-    already-graceful 404-fallback the post-window path produces.
+  - any non-matching compression the uncompressed in-flight holder cannot
+    satisfy (`zstd` *or* `xz`) → return `storage.ErrNotFound` (HTTP 404) so the
+    client falls back to an upstream that still has the original file — never a
+    mislabeled body. This folds the fatal mislabel into the already-graceful
+    404-fallback the post-window path produces.
+  - This is only the brief in-flight window: once the NAR is fully chunked, a
+    `zstd` request is served by recompression (`serveZstdFromChunks` /
+    `nar-serving-recompression`) and a `none` request by reassembly — unchanged.
 - Reuse the existing `compressedRequestNeedsUpstreamFallback` predicate so the
   in-flight path and the staging path share one fallback rule.
 

--- a/openspec/changes/archive/2026-06-11-fix-inflight-eager-cdc-compressed-mislabel/proposal.md
+++ b/openspec/changes/archive/2026-06-11-fix-inflight-eager-cdc-compressed-mislabel/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+GitHub issue #1398: under eager CDC, a client requesting a compressed NAR
+(`/nar/<h>.nar.xz` or `.nar.zst`) while that NAR is mid pull-through gets an
+HTTP 200 whose body is the **uncompressed** NAR, relabeled `Compression: none`.
+The client — told `xz` by its narinfo — cannot decode it and fails with
+`input compression not recognized`. The in-flight live-streaming path
+(`GetNar` → temp-file serve) overwrites the requested compression with the
+holder temp file's compression (`none`) and streams the decompressed bytes,
+ignoring what the client asked for. The finished-chunk serve paths already get
+this right (`nar-serving-recompression`); the in-flight path does not.
+
+## What Changes
+
+- Before the in-flight temp-file serve relabels the request to the holder's
+  compression, it consults the **originally requested** compression and applies
+  the same discipline the store/staging paths already use:
+  - `none` request → serve the decompressed temp bytes as today (unchanged).
+  - `zstd` request → recompress the reassembled bytes to zstd on the fly
+    (mirroring `serveZstdFromChunks`), labeled `zstd`.
+  - `xz`/any non-producible compression → return `storage.ErrNotFound` (HTTP
+    404) so the client falls back to an upstream that still has the original
+    file — never a mislabeled body. This folds the fatal mislabel into the
+    already-graceful 404-fallback the post-window path produces.
+- Reuse the existing `compressedRequestNeedsUpstreamFallback` predicate so the
+  in-flight path and the staging path share one fallback rule.
+
+## Capabilities
+
+### New Capabilities
+- (none)
+
+### Modified Capabilities
+- `nar-concurrent-streaming`: add a requirement that the per-client in-flight
+  live-streaming path MUST serve the client's requested compression (none
+  as-is, zstd recompressed) or fall back with not-found — it MUST NOT emit a
+  200 whose body is mislabeled as a different compression than the client
+  requested.
+
+## Non-goals
+
+- No change to finished-chunk / whole-file serve paths (`nar-serving-*`), which
+  already behave correctly.
+- No xz compressor: ncps still cannot produce xz; xz requests fall back to
+  upstream rather than being recompressed.
+- Not fixing why the proxied narinfo advertised xz instead of predictive-none
+  here (a possible separate concern, tracked separately).
+- No on-disk retention of the original compressed download (`compressedAssetPath`
+  stays unused).
+
+## Impact
+
+- Code: `pkg/cache/cache.go` (`GetNar` in-flight temp-file serve branch, ~line
+  1455-1499). Tests already RED on this branch: unit
+  `pkg/cache/input_compression_not_recognized_test.go`; e2e scenario
+  `input-compression` (`nix/e2e-tests`).
+- Network: a compressed (xz) request landing in the in-flight window now 404s →
+  one upstream fallback fetch for that request (same as the post-window path
+  already does), instead of a corrupt 200. No new memory; the zstd path streams
+  through a pooled encoder (O(1) memory), no extra buffering. No DB/migration
+  impact.

--- a/openspec/changes/archive/2026-06-11-fix-inflight-eager-cdc-compressed-mislabel/specs/nar-concurrent-streaming/spec.md
+++ b/openspec/changes/archive/2026-06-11-fix-inflight-eager-cdc-compressed-mislabel/specs/nar-concurrent-streaming/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: In-flight live-streaming MUST NOT serve a compressed request as a mislabeled uncompressed body
+
+The system SHALL serve a NAR request that piggybacks on an in-flight upstream
+download (the per-client live-streaming path, where the holder's temp file is
+held only as the uncompressed/decompressed representation under eager CDC) in
+the client's originally requested compression, or fall back with not-found. It
+MUST NOT emit an HTTP 200 whose body is in a different compression than the
+client requested. Specifically, when the holder's in-flight temp bytes are
+uncompressed:
+
+- a `Compression: none` request SHALL stream the uncompressed bytes (unchanged);
+- a request for any non-matching compression the in-flight uncompressed holder
+  cannot directly satisfy (e.g. `xz` or `zstd`) SHALL return
+  `storage.ErrNotFound` so the client falls back to an upstream that has the
+  original file, rather than streaming the uncompressed bytes mislabeled as the
+  requested compression. Steady-state requests for such a NAR are unaffected:
+  once it is fully chunked, a `zstd` request is served by recompression
+  (`nar-serving-recompression`) and a `none` request by reassembly; only the
+  brief in-flight window falls back.
+
+The decision SHALL use the same fallback predicate
+(`compressedRequestNeedsUpstreamFallback`) as the in-flight staging serve path,
+so both paths share one rule. The requested compression captured at request
+entry SHALL gate this branch; the holder temp file's compression MUST NOT
+silently overwrite it on the served stream.
+
+#### Scenario: xz request during the in-flight eager-CDC window falls back, not mislabeled
+
+- **WHEN** eager CDC is enabled and a holder is mid pull-through for hash `H` (its temp file holds the decompressed, uncompressed NAR and chunking is in progress)
+- **AND** a client requests `/nar/<H>.nar.xz`
+- **THEN** the system SHALL return `storage.ErrNotFound` (HTTP 404) so the client falls back to an upstream that still has the `.nar.xz`
+- **AND** the system SHALL NOT return an HTTP 200 whose body is the uncompressed NAR labeled `Compression: none`
+
+#### Scenario: zstd request during the in-flight window falls back, not mislabeled
+
+- **WHEN** a holder is mid pull-through for hash `H` with an uncompressed in-flight temp file
+- **AND** a client requests `/nar/<H>.nar.zst`
+- **THEN** the system SHALL return `storage.ErrNotFound` (HTTP 404) so the client falls back to an upstream that has the original file
+- **AND** the system SHALL NOT serve the uncompressed bytes labeled `Compression: none`
+- **AND** once `H` is fully chunked a later `/nar/<H>.nar.zst` request SHALL be served by recompression (`nar-serving-recompression`), unaffected by this in-flight rule
+
+#### Scenario: none request during the in-flight window is unchanged
+
+- **WHEN** a holder is mid pull-through for hash `H` with an uncompressed in-flight temp file
+- **AND** a client requests `/nar/<H>.nar` (Compression: none)
+- **THEN** the system SHALL stream the uncompressed bytes labeled `Compression: none` as before
+
+#### Scenario: served stream reports the requested compression, not the holder temp compression
+
+- **WHEN** `GetNar` serves a compressed request from an in-flight holder whose temp file is uncompressed
+- **THEN** the returned NAR URL's compression SHALL equal the client's requested compression (for a producible compression) or the call SHALL surface `storage.ErrNotFound`
+- **AND** the returned compression SHALL NOT be silently set to the holder temp file's compression for a compressed request

--- a/openspec/changes/archive/2026-06-11-fix-inflight-eager-cdc-compressed-mislabel/tasks.md
+++ b/openspec/changes/archive/2026-06-11-fix-inflight-eager-cdc-compressed-mislabel/tasks.md
@@ -1,0 +1,23 @@
+## 1. Confirm RED (already on branch)
+
+- [x] 1.1 Run `go test ./pkg/cache/ -run '^TestGetNar_InFlightEagerCDC_CompressedRequestNotMislabeled$' -count=1 -v` and confirm it FAILS with `expected "xz" actual "none"` + `xz: invalid header magic bytes`
+- [x] 1.2 (optional, heavy) Run `nix run .#e2e -- --mode local --scenario input-compression` and confirm it FAILs with `mislabeled > 0`
+
+## 2. Implement the in-flight compression guard
+
+- [x] 2.1 In `pkg/cache/cache.go` `GetNar`, in the `case <-ds.start:` block, before the relabel (`narURL.Compression = ds.tempFileCompression`, ~line 1459), call `compressedRequestNeedsUpstreamFallback(requestedCompression, ds.tempFileCompression)`
+- [x] 2.2 When that predicate is true (a non-matching compressed request — xz or zstd — the uncompressed in-flight holder cannot satisfy), `ds.wg.Done()` and return `storage.ErrNotFound` so `GetNar`'s caller falls back to upstream — do NOT stream the uncompressed temp bytes mislabeled
+- [x] 2.3 When the predicate is false (none request, or a compressed request matching the temp's own compression), keep the current behavior unchanged (relabel to `ds.tempFileCompression` and stream; the existing decompress-on-the-fly goroutine still handles a none request from a compressed temp)
+- [x] 2.4 Verify the new early-return path releases `ds.wg` exactly once (no leak/double-Done) and records an appropriate metric attribute, consistent with the sibling `ctx.Done()` / `getError()` returns
+
+## 3. Verify GREEN + no regressions
+
+- [x] 3.1 Re-run 1.1 — the unit test now PASSES (xz request 404s; none unchanged). Also caught + fixed a regression: `nar_does_not_exist_upstream` must surface `upstream.ErrNotFound`, so the fallback is checked only after `ds.getError()`
+- [x] 3.2 Run `go test ./pkg/cache/...` — full package green (no truncation/termination/recompression regressions)
+- [x] 3.3 Run `nix run .#e2e -- --mode local --scenario input-compression` — now PASSES (`mislabeled: 0`, `404(fallback): 16048`, window overlapped True)
+- [x] 3.4 Run `task fmt`, `task lint`, `task test` and confirm each exits 0 (lint needed a stale cross-worktree golangci cache clean)
+
+## 4. Sync + archive
+
+- [x] 4.1 `/opsx:sync` the `nar-concurrent-streaming` delta into `openspec/specs/`
+- [x] 4.2 `/opsx:archive` the change once implementation + verification are complete

--- a/openspec/specs/nar-concurrent-streaming/spec.md
+++ b/openspec/specs/nar-concurrent-streaming/spec.md
@@ -226,3 +226,56 @@ The streaming path SHALL terminate a post-commit chunk stall in a way the client
 - **THEN** it SHALL accept either the concrete `file_size` or `-1` for the size
 - **AND** it SHALL verify content by comparing the streamed bytes, which are correct on both paths
 
+### Requirement: In-flight live-streaming MUST NOT serve a compressed request as a mislabeled uncompressed body
+
+The system SHALL serve a NAR request that piggybacks on an in-flight upstream
+download (the per-client live-streaming path, where the holder's temp file is
+held only as the uncompressed/decompressed representation under eager CDC) in
+the client's originally requested compression, or fall back with not-found. It
+MUST NOT emit an HTTP 200 whose body is in a different compression than the
+client requested. Specifically, when the holder's in-flight temp bytes are
+uncompressed:
+
+- a `Compression: none` request SHALL stream the uncompressed bytes (unchanged);
+- a request for any non-matching compression the in-flight uncompressed holder
+  cannot directly satisfy (e.g. `xz` or `zstd`) SHALL return
+  `storage.ErrNotFound` so the client falls back to an upstream that has the
+  original file, rather than streaming the uncompressed bytes mislabeled as the
+  requested compression. Steady-state requests for such a NAR are unaffected:
+  once it is fully chunked, a `zstd` request is served by recompression
+  (`nar-serving-recompression`) and a `none` request by reassembly; only the
+  brief in-flight window falls back.
+
+The decision SHALL use the same fallback predicate
+(`compressedRequestNeedsUpstreamFallback`) as the in-flight staging serve path,
+so both paths share one rule. The requested compression captured at request
+entry SHALL gate this branch; the holder temp file's compression MUST NOT
+silently overwrite it on the served stream.
+
+#### Scenario: xz request during the in-flight eager-CDC window falls back, not mislabeled
+
+- **WHEN** eager CDC is enabled and a holder is mid pull-through for hash `H` (its temp file holds the decompressed, uncompressed NAR and chunking is in progress)
+- **AND** a client requests `/nar/<H>.nar.xz`
+- **THEN** the system SHALL return `storage.ErrNotFound` (HTTP 404) so the client falls back to an upstream that still has the `.nar.xz`
+- **AND** the system SHALL NOT return an HTTP 200 whose body is the uncompressed NAR labeled `Compression: none`
+
+#### Scenario: zstd request during the in-flight window falls back, not mislabeled
+
+- **WHEN** a holder is mid pull-through for hash `H` with an uncompressed in-flight temp file
+- **AND** a client requests `/nar/<H>.nar.zst`
+- **THEN** the system SHALL return `storage.ErrNotFound` (HTTP 404) so the client falls back to an upstream that has the original file
+- **AND** the system SHALL NOT serve the uncompressed bytes labeled `Compression: none`
+- **AND** once `H` is fully chunked a later `/nar/<H>.nar.zst` request SHALL be served by recompression (`nar-serving-recompression`), unaffected by this in-flight rule
+
+#### Scenario: none request during the in-flight window is unchanged
+
+- **WHEN** a holder is mid pull-through for hash `H` with an uncompressed in-flight temp file
+- **AND** a client requests `/nar/<H>.nar` (Compression: none)
+- **THEN** the system SHALL stream the uncompressed bytes labeled `Compression: none` as before
+
+#### Scenario: served stream reports the requested compression, not the holder temp compression
+
+- **WHEN** `GetNar` serves a compressed request from an in-flight holder whose temp file is uncompressed
+- **THEN** the returned NAR URL's compression SHALL equal the client's requested compression (for a producible compression) or the call SHALL surface `storage.ErrNotFound`
+- **AND** the returned compression SHALL NOT be silently set to the holder temp file's compression for a compressed request
+

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1481,6 +1481,26 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL) (nar.URL, int64, io.
 			return err
 		}
 
+		// The download is healthy, but the in-flight temp file holds a single
+		// representation (under eager CDC, the decompressed/uncompressed NAR;
+		// ds.tempFileCompression). A client that requested a *different* compression
+		// we cannot produce from it (e.g. .nar.xz, or .nar.zst while the temp is
+		// uncompressed) must NOT be served the temp bytes relabeled as that
+		// compression — the client decodes by its narinfo's Compression and fails
+		// with "input compression not recognized" (#1398). Fall back to not-found so
+		// it re-fetches the real compressed file from an upstream, mirroring the
+		// in-flight staging serve path. This is only the brief in-flight window:
+		// once chunked, a zstd request is served by recompression and a none request
+		// by reassembly. Checked only after ds.getError so a genuine upstream miss
+		// still surfaces upstream.ErrNotFound rather than this fallback's not-found.
+		if compressedRequestNeedsUpstreamFallback(requestedCompression, ds.tempFileCompression) {
+			metricAttrs = append(metricAttrs, attribute.String("status", "error"))
+
+			ds.wg.Done()
+
+			return storage.ErrNotFound
+		}
+
 		// Add upstream hostname to metrics on success
 		if upstreamHostname := ds.getUpstreamHostname(); upstreamHostname != "" {
 			metricAttrs = append(metricAttrs,

--- a/pkg/cache/input_compression_not_recognized_test.go
+++ b/pkg/cache/input_compression_not_recognized_test.go
@@ -1,0 +1,174 @@
+package cache_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/pkg/cache/upstream"
+	"github.com/kalbasit/ncps/pkg/chunker"
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
+	"github.com/kalbasit/ncps/pkg/storage/chunk"
+	"github.com/kalbasit/ncps/testdata"
+	"github.com/kalbasit/ncps/testhelper"
+)
+
+// TestGetNar_InFlightEagerCDC_CompressedRequestNotMislabeled reproduces GitHub
+// issue #1398 ("input compression not recognized on 0.10.0-rc13").
+//
+// Topology (matches the reporter's single-node raspi5 deployment): eager CDC is
+// enabled and in-flight staging is OFF (the local/sqlite locker is not
+// distributed). A narinfo prefetch starts the eager-CDC download, which streams
+// the upstream .nar.xz through a decompressor into a temp file holding the raw
+// UNCOMPRESSED NAR (ds.tempFileCompression == none) and then chunks it.
+//
+// While that download/chunk window is open, a client whose narinfo still
+// advertises Compression: xz requests `/nar/<hash>.nar.xz`. GetNar piggybacks on
+// the in-flight ds and, at cache.go:1459, overwrites the requested compression
+// with ds.tempFileCompression (none), then streams the decompressed temp file.
+// The HTTP layer (server.go:897) sees Compression==none and may further wrap the
+// body in transport zstd. Either way the client — which expects xz per its
+// narinfo — receives bytes it cannot xz-decode and fails with
+// "input compression not recognized".
+//
+// Correct behavior is EITHER:
+//   - serve the request as real xz (nu.Compression == xz, body is valid xz), OR
+//   - return storage.ErrNotFound so the client falls back to an upstream that
+//     still has the original .nar.xz (the same graceful fallback the post-chunk
+//     window already produces — the 404s in the issue log).
+//
+// The bug is that ncps does NEITHER: it answers 200 with the body relabeled to
+// Compression: none. This test asserts the request is never served mislabeled.
+func TestGetNar_InFlightEagerCDC_CompressedRequestNotMislabeled(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	ts := testdata.NewTestServer(t, 40)
+	t.Cleanup(ts.Close)
+
+	c, _, _, dir, _, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	// Eager CDC: chunk store present, CDC enabled, lazy chunking off.
+	chunkStore, err := chunk.NewLocalStore(filepath.Join(dir, "chunks-store"))
+	require.NoError(t, err)
+
+	c.SetChunkStore(chunkStore)
+	require.NoError(t, c.SetCDCConfiguration(true, 1024, 4096, 8192))
+
+	// In-flight staging deliberately left OFF (single-node locker is not
+	// distributed), so the staging path that already 404s a compressed request
+	// from uncompressed staged bytes never engages — exactly the reporter's setup.
+
+	// Keep the eager-CDC chunking window open long enough that the concurrent
+	// .nar.xz request deterministically lands while the NAR is only present as the
+	// decompressed temp file. The assertions are happens-before style, not
+	// wall-clock based, so the generous delay only bounds a regression's wait.
+	const chunkingDelay = 30 * time.Second
+
+	realChunker, err := chunker.NewCDCChunker(1024, 4096, 8192)
+	require.NoError(t, err)
+
+	c.SetChunker(&slowChunker{real: realChunker, delay: chunkingDelay})
+
+	// Serve real xz-compressed bytes for Nar2 so the streamed body can be checked
+	// for genuine xz framing, and signal when the upstream NAR fetch begins so the
+	// test can fire the concurrent request inside the in-flight window.
+	originalContent := testhelper.MustRandString(50160)
+	xzContent := compressXz(t, originalContent)
+
+	narServing := make(chan struct{})
+
+	var narServingOnce sync.Once
+
+	nar2NARPath := "/nar/" + testdata.Nar2.NarHash + ".nar.xz"
+	idx := ts.AddMaybeHandler(func(w http.ResponseWriter, r *http.Request) bool {
+		if r.URL.Path != nar2NARPath {
+			return false
+		}
+
+		narServingOnce.Do(func() { close(narServing) })
+
+		_, _ = io.WriteString(w, xzContent)
+
+		return true
+	})
+
+	t.Cleanup(func() { ts.RemoveMaybeHandler(idx) })
+
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
+		PublicKeys: testdata.PublicKeys(),
+	})
+	require.NoError(t, err)
+
+	c.AddUpstreamCaches(newContext(), uc)
+	<-c.GetHealthChecker().Trigger()
+
+	// Pull the narinfo. Under eager CDC this kicks off the background NAR prefetch
+	// (the holder): it downloads the .nar.xz, decompresses into a none temp file,
+	// and begins the (slow) chunking — the in-flight window the bug lives in.
+	_, err = c.GetNarInfo(ctx, testdata.Nar2.NarInfoHash)
+	require.NoError(t, err)
+
+	// Wait until the holder is actually fetching the NAR upstream, guaranteeing the
+	// concurrent request below piggybacks on the in-flight (none-temp) download
+	// rather than starting its own.
+	select {
+	case <-narServing:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for the eager-CDC holder to begin fetching the NAR")
+	}
+
+	// A client whose narinfo still advertises xz requests the compressed NAR while
+	// the holder is mid-window. THIS is the request that 404s or, when it hits the
+	// bug, is served mislabeled as Compression: none.
+	reqURL := nar.URL{Hash: testdata.Nar2.NarHash, Compression: nar.CompressionTypeXz}
+
+	nu, _, rc, err := c.GetNar(ctx, reqURL)
+
+	// Acceptable correct behavior #1: 404 -> client falls back to an upstream that
+	// still has the real .nar.xz.
+	if errors.Is(err, storage.ErrNotFound) {
+		return
+	}
+
+	require.NoError(t, err, "GetNar(.nar.xz) returned an unexpected error")
+	require.NotNil(t, rc)
+
+	defer rc.Close()
+
+	body, err := io.ReadAll(rc)
+	require.NoError(t, err)
+
+	// ncps answered the .nar.xz request with a body. Acceptable correct behavior
+	// #2: it is served as real xz. The BUG relabels it to Compression: none and
+	// streams the decompressed temp file instead.
+	assert.Equalf(t, nar.CompressionTypeXz, nu.Compression,
+		"BUG #1398: GetNar served a .nar.xz request as Compression:%s — it relabeled the "+
+			"in-flight eager-CDC temp file (uncompressed) to none. A client that requested "+
+			".nar.xz (its narinfo says xz) receives bytes it cannot xz-decode and fails with "+
+			"'input compression not recognized'.", nu.Compression)
+
+	// The served bytes must genuinely be xz that decompresses to the canonical NAR;
+	// under the bug the body is the raw decompressed NAR, so xz-decoding it fails —
+	// the client-visible "input compression not recognized".
+	dr, err := nar.DecompressReader(ctx, bytes.NewReader(body), nar.CompressionTypeXz)
+	require.NoError(t, err, "served .nar.xz body must be valid xz (input compression must be recognized)")
+
+	defer dr.Close()
+
+	got, err := io.ReadAll(dr)
+	require.NoError(t, err, "served .nar.xz body must xz-decompress without 'input compression not recognized'")
+	assert.Equal(t, originalContent, string(got), "decompressed .nar.xz body must equal the canonical NAR")
+}


### PR DESCRIPTION
## Summary

Fixes #1398 ("input compression not recognized on 0.10.0-rc13").

Under eager CDC, a narinfo prefetch becomes the download holder: it streams the
upstream `.nar.xz` through a decompressor into a temp file holding the raw
**uncompressed** NAR (`ds.tempFileCompression = none`) and chunks it. A client
requesting `/nar/<h>.nar.xz` (or `.nar.zst`) while that pull is in flight
piggybacked on the holder's `downloadState`, and `GetNar`'s live-streaming
branch overwrote the requested compression with the holder temp's (`none`) and
streamed the decompressed bytes. The client — told `xz` by its narinfo — could
not decode the body and failed with `input compression not recognized`.

The finished-chunk and in-flight-staging serve paths already handle this
(`serveZstdFromChunks`, `compressedRequestNeedsUpstreamFallback`); the in-flight
live-streaming branch was the gap.

## What changed

- `pkg/cache/cache.go` (`GetNar`): gate the relabel on the originally requested
  compression. When `compressedRequestNeedsUpstreamFallback(requested, ds.tempFileCompression)`
  is true (a non-matching compression the uncompressed in-flight holder cannot
  produce, e.g. `xz` or `zstd`), return `storage.ErrNotFound` so the client falls
  back to an upstream with the real file — never a mislabeled `200`. Checked
  **after** `ds.getError()` so a genuine upstream miss still surfaces
  `upstream.ErrNotFound`. Reuses the same predicate as the in-flight staging path.
- Only the brief in-flight window falls back; once chunked, `zstd` is served by
  recompression and `none` by reassembly (unchanged).
- OpenSpec: new requirement under `nar-concurrent-streaming`; change archived.

## Tests

- **Unit** `TestGetNar_InFlightEagerCDC_CompressedRequestNotMislabeled`
  (deterministic via a slow chunker holding the window open) — RED before, GREEN
  after.
- **E2E** local scenario `input-compression` (`nix/e2e-tests`) races `.nar.xz`
  requests during a DB-gated eager-CDC window against a real upstream — RED
  before (`mislabeled: 24`), GREEN after (`mislabeled: 0`, `404 fallback: 16048`,
  window overlapped).

## Test plan

- [x] `task fmt`, `task lint`, `task test` all pass
- [x] unit + e2e flip RED -> GREEN
- [x] `nar_does_not_exist_upstream` still returns `upstream.ErrNotFound` (regression caught + fixed)