### PR TITLE
feat(fsck): unify phase messaging and add a run plan

### DIFF
--- a/openspec/changes/archive/2026-06-12-improve-fsck-messaging/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-12-improve-fsck-messaging/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-12

--- a/openspec/changes/archive/2026-06-12-improve-fsck-messaging/design.md
+++ b/openspec/changes/archive/2026-06-12-improve-fsck-messaging/design.md
@@ -1,0 +1,124 @@
+## Context
+
+`ncps fsck` (in `pkg/ncps/fsck.go`) runs three top-level phases — collect
+suspects, re-verify suspects, repair — driven by `fsckCommand()`. Phase 1
+internally fans out into ~11 sub-checks (1a–1j) covering narinfos without
+nar_files, orphaned nar_files, storage-vs-DB walks, orphaned chunks, chunk
+issues, CDC size mismatch, orphaned chunk files, and (under `--verify-content`)
+chunk and assembled-NAR hash verification.
+
+Current messaging has three problems:
+
+1. **No preview.** The run jumps into `phase 1: collecting suspects` with no
+   indication of how many phases/sub-checks will run or whether repair will
+   happen. Whether a sub-check runs depends on CDC mode and `--verify-content`,
+   so the operator can't predict scope.
+2. **Cryptic labels.** Sub-checks are logged as `phase 1c`, `phase 1g`, etc.
+   The descriptive text is inconsistent — some phases log a start line, some
+   only an end count, some both.
+3. **Inconsistent progress.** Three different progress shapes: phase 1 logs
+   `suspects` + `skipped`, phase 2 logs `remaining`, phase 3 logs nothing.
+   `logProgress` (fsck.go:2563) already centralizes `checked`/`total`/`percent`/
+   `rate`, and `startProgressTicker` (fsck.go:2540) runs a 30s ticker, but each
+   phase wires them up ad hoc with divergent extra fields and no shared phase
+   label.
+
+Logging is zerolog throughout (`zerolog.Ctx(ctx)`); the final summary table is
+printed via `fmt` in `printFsckSummary` (fsck.go:1252). This change is
+presentation-only — no detection, repair, schema, or exit-code changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Print a run plan up front that enumerates the phases/sub-checks that will
+  actually run given CDC mode and `--verify-content`, and states the run mode
+  (dry-run / prompt / repair).
+- Attach a stable phase id **and** a human-readable description to every phase
+  and sub-phase, and emit a consistent start + done (with count) line for each.
+- Route all progress — phases 1, 2, and the previously-silent phase 3 — through
+  one shared helper so fields and formatting are identical everywhere.
+- Keep output line-based so it stays readable in CI / non-TTY logs.
+
+**Non-Goals:**
+
+- No change to detection logic, repair behavior, the summary-table layout, or
+  exit codes.
+- No TUI / progress-bar dependency.
+- No change to the 30s ticker cadence or `--verified-since` skip semantics.
+- No new flags.
+
+## Decisions
+
+### Decision 1: A single phase descriptor table drives both the plan and the labels
+
+Introduce a small ordered set of phase descriptors, each with a stable id (e.g.
+`1d`), a human-readable description ("scanning storage for orphaned NAR files"),
+and predicates for when it is active (`always`, `cdcOnly`, `verifyContentOnly`).
+The run-plan printer and the per-phase start/done lines both read from this one
+table, so the plan can never drift from what actually runs.
+
+- **Why over the status quo (inline strings):** today the label text lives
+  inline at each call site, which is exactly why the plan is missing and labels
+  are inconsistent. One source of truth fixes both at once.
+- **Alternative considered — compute the plan by dry-running detection:**
+  rejected; it would duplicate work and risk side effects. The active set is a
+  pure function of CDC mode + `--verify-content`, both known before phase 1.
+
+### Decision 2: One progress helper carries the phase label; phase 3 adopts it
+
+Extend the shared progress path so the phase description is a first-class field
+emitted by every update, replacing the per-phase divergent fields. Phase-1
+`suspects`/`skipped` and phase-2 `remaining` become uniform `checked`/`total`
+(plus the existing `percent`/`rate` from `logProgress`); any genuinely
+phase-specific counter is added consistently rather than ad hoc. Phase 3 gains a
+`checked`/`total` counter over the repair work-list and is wired to
+`startProgressTicker` like the others, plus a start and done line.
+
+- **Why:** uniform fields are the core ask ("each phase should have the same
+  progress/rate"). Centralizing also means future phases inherit the format for
+  free.
+- **Trade-off:** phase 2's `remaining` and phase 1's `suspects` were
+  semantically useful. We keep equivalent information by reporting issues-found
+  in the per-phase done line, so no signal is lost while the periodic update
+  stays uniform.
+
+### Decision 3: Run plan and summary use `fmt` (operator-facing), phases use zerolog
+
+The run plan is operator-facing framing, like the existing `printFsckSummary`,
+so it prints via `fmt` to stdout for clean unconditional display. Per-phase
+start/done/progress lines stay on zerolog so they carry timestamps/levels and
+remain greppable and structured in CI logs. This mirrors the existing split
+(summary via `fmt`, phase logs via zerolog) rather than introducing a new
+convention.
+
+## Risks / Trade-offs
+
+- **[Tests asserting current log strings break]** → Search `fsck_*_test.go` for
+  assertions on phase strings; current tests focus on functional outcomes, not
+  log text, so exposure is low. Update any string assertions as part of the
+  change.
+- **[Plan drifts from actual execution if a new sub-check is added later
+  without registering it]** → Mitigated by the single descriptor table: a new
+  sub-check that isn't added to the table simply has no label, which is an
+  obvious omission; document the table as the place to register phases.
+- **[Phase 3 progress adds overhead]** → Negligible: it's an atomic counter and
+  the same 30s ticker; no extra I/O or scans.
+- **[Output volume slightly increases]** (run plan + per-phase done lines) →
+  Acceptable and intentional; it is a handful of lines and is the point of the
+  change.
+
+## Migration Plan
+
+Pure presentation change shipped in one PR; no DB migration, no config, no
+rollout coordination. Rollback is reverting the commit. TDD: add/adjust tests
+asserting (a) the run plan lists the active phases for a given flag combination
+and (b) progress updates across phases share the same field set, then refactor
+the phase drivers to satisfy them.
+
+## Open Questions
+
+- Should the run plan also print an estimated item count per phase where it is
+  cheaply known up front (e.g. narinfo / nar_file row counts)? Leaning no for
+  the first cut — keep the plan to phase names + mode — but it is a natural
+  follow-up if operators want a size preview.

--- a/openspec/changes/archive/2026-06-12-improve-fsck-messaging/proposal.md
+++ b/openspec/changes/archive/2026-06-12-improve-fsck-messaging/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+`ncps fsck` runs a long, multi-phase scan but its output is hard to follow. It
+jumps straight into "phase 1: collecting suspects" with no preview of what work
+is coming, the eleven phase-1 sub-steps carry cryptic labels (`phase 1c`,
+`phase 1g`) that don't say what is being checked, and progress reporting is
+inconsistent: phase 1 logs `suspects`/`skipped`, phase 2 logs `remaining`, and
+phase 3 (repair) emits no progress at all. Operators running fsck against large
+production caches cannot tell which phase is active, how far along it is, or how
+long the whole run will take.
+
+## What Changes
+
+- Print an up-front **run plan**: a summary listing every phase (and the CDC /
+  `--verify-content` sub-checks that will actually run given the current flags)
+  before any work starts, so the operator knows the full scope.
+- Give every phase a **human-readable name** describing what it checks (e.g.
+  "scanning storage for orphaned NAR files" instead of "phase 1d"), while keeping
+  a stable phase identifier for log correlation.
+- **Unify progress reporting** across all phases through one helper so every
+  phase emits the same fields in the same format: phase name, items
+  checked / total, percent, rate (items/s), and elapsed — including phase 3
+  (repair), which currently reports nothing.
+- Emit a consistent **phase start** and **phase done** line (with the issue/
+  item count) for each phase and sub-phase, replacing the current mix of
+  start-only and end-only messages.
+
+This is presentation-only: detection logic, repair behavior, exit codes, and the
+final summary-table counts are unchanged.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `fsck`: add requirements for an up-front phase run plan, human-readable phase
+  naming, and uniform progress reporting (including the repair phase). No change
+  to detection, repair, or exit-code behavior.
+
+## Impact
+
+- Code: `pkg/ncps/fsck.go` (phase logging, `startProgressTicker`, `logProgress`,
+  the phase-1/2/3 drivers, and a new run-plan printer). Possible new tests under
+  `pkg/ncps/fsck_*_test.go` for the run-plan output and progress-field shape.
+- No database, migration, API, storage-format, or dependency changes.
+- I/O / latency / memory: negligible. Output is logging only; no extra scans,
+  network calls, or buffering. The run plan is computed from already-known flag
+  state before phase 1 begins.
+
+## Non-goals
+
+- No change to what fsck detects or repairs, to the summary table layout, or to
+  exit codes.
+- No switch to a TUI/progress-bar library; output stays line-based zerolog so it
+  remains usable in non-TTY/CI logs.
+- No change to the 30-second progress-ticker cadence or to the `--verified-since`
+  skip semantics.

--- a/openspec/changes/archive/2026-06-12-improve-fsck-messaging/specs/fsck/spec.md
+++ b/openspec/changes/archive/2026-06-12-improve-fsck-messaging/specs/fsck/spec.md
@@ -1,0 +1,105 @@
+## ADDED Requirements
+
+### Requirement: Fsck MUST print an up-front run plan before any scanning begins
+
+Before phase 1 starts, `ncps fsck` SHALL print a run plan that lists, in
+execution order, every top-level phase it will run and every sub-check that is
+active for the current invocation. The plan SHALL reflect the resolved flag and
+mode state: CDC-only sub-checks SHALL appear only when CDC mode is detected, and
+the `--verify-content` chunk/NAR hash checks SHALL appear only when
+`--verify-content` is set. The plan SHALL also indicate the run mode (dry-run,
+report-and-prompt, or `--repair`) so the operator knows whether a repair phase
+will run.
+
+#### Scenario: Run plan lists active phases before phase 1
+
+- **WHEN** `ncps fsck` starts
+- **THEN** a run plan is printed before the "phase 1" start line
+- **AND** it enumerates each phase that will run in execution order
+
+#### Scenario: CDC sub-checks appear in the plan only in CDC mode
+
+- **WHEN** `ncps fsck` runs and CDC mode is detected
+- **THEN** the run plan includes the CDC sub-checks (orphaned chunks, chunk
+  issues, size mismatch, orphaned chunk files, chunked residue)
+- **AND** when CDC mode is NOT detected, the run plan omits every CDC sub-check
+
+#### Scenario: Content-verification checks appear only with the flag
+
+- **WHEN** `ncps fsck --verify-content` runs in CDC mode
+- **THEN** the run plan includes the "corrupt chunks" and "NAR hash mismatch"
+  checks
+- **AND** when `--verify-content` is NOT set, the run plan omits both checks
+
+#### Scenario: Run plan states the run mode
+
+- **WHEN** `ncps fsck --dry-run` runs
+- **THEN** the run plan indicates that no repair phase will run
+- **AND** when `--repair` is set, the run plan indicates the repair phase will run
+
+### Requirement: Every fsck phase MUST be reported with a human-readable name
+
+Each phase and sub-phase SHALL be announced with a description of what it checks
+(for example "scanning storage for orphaned NAR files") rather than only an
+opaque identifier such as "phase 1d". A stable phase identifier MAY accompany
+the description for log correlation, but the description SHALL always be present.
+
+#### Scenario: Sub-phase start line describes the work
+
+- **WHEN** a phase-1 sub-check begins
+- **THEN** its start log line includes a human-readable description of what is
+  being checked
+
+#### Scenario: Phase identifier alone is never the only label
+
+- **WHEN** any phase or sub-phase is reported
+- **THEN** the message contains a human-readable description, not just a bare
+  phase identifier
+
+### Requirement: Fsck progress reporting MUST be uniform across all phases
+
+All phases — including the repair phase — SHALL report progress through a single
+shared mechanism that emits the same fields in the same format: the phase
+description, items checked, total items (when known), percent complete (when the
+total is known), processing rate in items per second, and elapsed time. Each
+phase SHALL emit a start line and, on completion, a done line carrying the count
+of items processed and issues found for that phase.
+
+#### Scenario: Every phase reports the same progress fields
+
+- **WHEN** a periodic progress update fires during any phase
+- **THEN** it reports the phase description, items checked, total (when known),
+  percent (when total is known), and rate using the shared format
+
+#### Scenario: Repair phase reports progress
+
+- **WHEN** the repair phase runs against a set of issues
+- **THEN** it emits a start line and progress updates using the same shared
+  mechanism as the scan phases
+- **AND** it emits a done line on completion
+
+#### Scenario: Each phase emits a completion line with its count
+
+- **WHEN** a phase finishes
+- **THEN** a done line reports how many items it processed and how many issues it
+  found for that phase
+
+### Requirement: Fsck messaging changes MUST NOT alter detection, repair, or exit-code behavior
+
+The run plan, phase naming, and progress-reporting changes SHALL be
+presentation-only. The set of issues detected, the repairs performed, the final
+summary-table counts, and the process exit codes SHALL be identical to the
+behavior before this change.
+
+#### Scenario: Issue counts and exit code are unchanged
+
+- **WHEN** `ncps fsck` runs against a given cache state before and after this
+  change
+- **THEN** the summary-table issue counts are identical
+- **AND** the process exit code is identical
+
+#### Scenario: Repair outcomes are unchanged
+
+- **WHEN** `ncps fsck --repair` runs against a given cache state
+- **THEN** the same rows, narinfos, chunk records, and chunk files are repaired
+  or deleted as before this change

--- a/openspec/changes/archive/2026-06-12-improve-fsck-messaging/tasks.md
+++ b/openspec/changes/archive/2026-06-12-improve-fsck-messaging/tasks.md
@@ -1,0 +1,31 @@
+## 1. Phase descriptor table (single source of truth)
+
+- [x] 1.1 Add an ordered set of fsck phase descriptors in `pkg/ncps/fsck.go`, each with a stable id (e.g. `1d`), a human-readable description, and an activation predicate (`always` / `cdcOnly` / `verifyContentOnly`).
+- [x] 1.2 Add a helper that, given CDC mode + `--verify-content` + run mode (dry-run / prompt / repair), returns the active descriptors in execution order.
+- [x] 1.3 Write a unit test asserting the active set is correct for each flag combination (no-CDC, CDC, CDC+verify-content) and that order matches execution order.
+
+## 2. Run plan printer
+
+- [x] 2.1 Write a failing test asserting that, for a given flag/mode combination, the run-plan output lists exactly the active phases in order and states the run mode.
+- [x] 2.2 Implement a `fmt`-based run-plan printer that consumes the active descriptors and prints before the phase-1 start line; wire it into `fsckCommand()`.
+- [x] 2.3 Verify CDC sub-checks and `--verify-content` checks appear/disappear from the plan per flag state, and dry-run vs repair mode is shown.
+
+## 3. Uniform progress reporting
+
+- [x] 3.1 Extend the shared progress path (`logProgress` / `startProgressTicker`) so the phase description is a first-class field on every periodic update.
+- [x] 3.2 Write a failing test asserting progress updates across phases 1, 2, and 3 share the same field set (phase, checked, total, percent-when-known, rate).
+- [x] 3.3 Refactor phase 1 to emit the uniform fields (fold `suspects`/`skipped` reporting into the per-phase done line rather than the periodic update).
+- [x] 3.4 Refactor phase 2 to emit the uniform fields (fold `remaining` into the done line).
+- [x] 3.5 Add a `checked`/`total` counter to the repair phase (phase 3), wire it to `startProgressTicker`, and emit start + progress + done lines.
+
+## 4. Consistent per-phase start/done messaging
+
+- [x] 4.1 Replace each phase/sub-phase start log with a description-carrying start line sourced from the descriptor table.
+- [x] 4.2 Ensure every phase/sub-phase emits a done line carrying its processed count and issues-found count.
+- [x] 4.3 Remove now-redundant ad hoc start-only / end-only log lines.
+
+## 5. Verification
+
+- [x] 5.1 Audit `pkg/ncps/fsck_*_test.go` for assertions on old phase strings; update any that break.
+- [x] 5.2 Add/confirm a test proving messaging changes do not alter detection counts or exit code (run fsck against a fixture before/after-equivalent path).
+- [x] 5.3 Run `task fmt`, `task lint`, and `task test` and confirm each exits zero.

--- a/openspec/specs/fsck/spec.md
+++ b/openspec/specs/fsck/spec.md
@@ -338,3 +338,107 @@ proceed with repair as long as the configured cache temp path is writable.
   and `CACHE_TEMP_PATH`, matching the `serve`, `migrate-chunks-to-nar`, and
   `migrate-nar-to-chunks` subcommands
 
+### Requirement: Fsck MUST print an up-front run plan before any scanning begins
+
+Before phase 1 starts, `ncps fsck` SHALL print a run plan that lists, in
+execution order, every top-level phase it will run and every sub-check that is
+active for the current invocation. The plan SHALL reflect the resolved flag and
+mode state: CDC-only sub-checks SHALL appear only when CDC mode is detected, and
+the `--verify-content` chunk/NAR hash checks SHALL appear only when
+`--verify-content` is set. The plan SHALL also indicate the run mode (dry-run,
+report-and-prompt, or `--repair`) so the operator knows whether a repair phase
+will run.
+
+#### Scenario: Run plan lists active phases before phase 1
+
+- **WHEN** `ncps fsck` starts
+- **THEN** a run plan is printed before the "phase 1" start line
+- **AND** it enumerates each phase that will run in execution order
+
+#### Scenario: CDC sub-checks appear in the plan only in CDC mode
+
+- **WHEN** `ncps fsck` runs and CDC mode is detected
+- **THEN** the run plan includes the CDC sub-checks (orphaned chunks, chunk
+  issues, size mismatch, orphaned chunk files, chunked residue)
+- **AND** when CDC mode is NOT detected, the run plan omits every CDC sub-check
+
+#### Scenario: Content-verification checks appear only with the flag
+
+- **WHEN** `ncps fsck --verify-content` runs in CDC mode
+- **THEN** the run plan includes the "corrupt chunks" and "NAR hash mismatch"
+  checks
+- **AND** when `--verify-content` is NOT set, the run plan omits both checks
+
+#### Scenario: Run plan states the run mode
+
+- **WHEN** `ncps fsck --dry-run` runs
+- **THEN** the run plan indicates that no repair phase will run
+- **AND** when `--repair` is set, the run plan indicates the repair phase will run
+
+### Requirement: Every fsck phase MUST be reported with a human-readable name
+
+Each phase and sub-phase SHALL be announced with a description of what it checks
+(for example "scanning storage for orphaned NAR files") rather than only an
+opaque identifier such as "phase 1d". A stable phase identifier MAY accompany
+the description for log correlation, but the description SHALL always be present.
+
+#### Scenario: Sub-phase start line describes the work
+
+- **WHEN** a phase-1 sub-check begins
+- **THEN** its start log line includes a human-readable description of what is
+  being checked
+
+#### Scenario: Phase identifier alone is never the only label
+
+- **WHEN** any phase or sub-phase is reported
+- **THEN** the message contains a human-readable description, not just a bare
+  phase identifier
+
+### Requirement: Fsck progress reporting MUST be uniform across all phases
+
+All phases — including the repair phase — SHALL report progress through a single
+shared mechanism that emits the same fields in the same format: the phase
+description, items checked, total items (when known), percent complete (when the
+total is known), processing rate in items per second, and elapsed time. Each
+phase SHALL emit a start line and, on completion, a done line carrying the count
+of items processed and issues found for that phase.
+
+#### Scenario: Every phase reports the same progress fields
+
+- **WHEN** a periodic progress update fires during any phase
+- **THEN** it reports the phase description, items checked, total (when known),
+  percent (when total is known), and rate using the shared format
+
+#### Scenario: Repair phase reports progress
+
+- **WHEN** the repair phase runs against a set of issues
+- **THEN** it emits a start line and progress updates using the same shared
+  mechanism as the scan phases
+- **AND** it emits a done line on completion
+
+#### Scenario: Each phase emits a completion line with its count
+
+- **WHEN** a phase finishes
+- **THEN** a done line reports how many items it processed and how many issues it
+  found for that phase
+
+### Requirement: Fsck messaging changes MUST NOT alter detection, repair, or exit-code behavior
+
+The run plan, phase naming, and progress-reporting changes SHALL be
+presentation-only. The set of issues detected, the repairs performed, the final
+summary-table counts, and the process exit codes SHALL be identical to the
+behavior before this change.
+
+#### Scenario: Issue counts and exit code are unchanged
+
+- **WHEN** `ncps fsck` runs against a given cache state before and after this
+  change
+- **THEN** the summary-table issue counts are identical
+- **AND** the process exit code is identical
+
+#### Scenario: Repair outcomes are unchanged
+
+- **WHEN** `ncps fsck --repair` runs against a given cache state
+- **THEN** the same rows, narinfos, chunk records, and chunk files are repaired
+  or deleted as before this change
+

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -1467,9 +1467,14 @@ func repairFsckIssues(
 	logger := zerolog.Ctx(ctx)
 
 	// Phase 3 progress: report through the same shared ticker/logProgress path as
-	// the scan phases. total is the confirmed-issue count entering repair; checked
-	// advances as each issue category is processed.
-	total := int64(results.totalIssues())
+	// the scan phases. total is the confirmed-issue count this function actually
+	// repairs; checked advances as each issue category is processed. The chunked-
+	// residue categories are excluded because they are reconciled separately by
+	// reconcileChunkedResidue in fsckCommand, not here — counting them would leave
+	// checked permanently short of total.
+	total := int64(results.totalIssues() -
+		len(results.recoverableChunkedNarFiles) -
+		len(results.reclaimableChunkedResidue))
 
 	var checked atomic.Int64
 

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -645,11 +645,39 @@ func collectFsckSuspects(
 
 	startTime := time.Now()
 
-	// Start background progress ticker. The periodic update carries only the
-	// uniform progress fields (phase, checked, total, percent, rate); the
-	// suspect/skipped tallies are reported in the phase-1 done line below.
+	// current tracks the active phase-1 sub-check so the periodic ticker can name
+	// what it is scanning. startCheck records it and emits the uniform start line.
+	var current atomic.Pointer[fsckCheck]
+
+	startCheck := func(id string) {
+		c := fsckChecksByID[id]
+		current.Store(&c)
+		fsckCheckStart(logger, id)
+	}
+
+	// boundedChecks are the sub-checks whose progress is bounded by the shared
+	// NAR-scan total (the nar_file rows + indexed storage NARs). The chunk-storage
+	// walks have no size known up front, so the ticker omits total/percent for them
+	// rather than showing a denominator that `checked` overruns.
+	boundedChecks := map[string]bool{"1c": true, "1d": true, "1f": true}
+
+	// Start background progress ticker. The periodic update names the active
+	// sub-check (phase id + description) and carries the uniform progress fields;
+	// the suspect/skipped tallies are reported in the phase-1 done line below.
 	stopTicker := startProgressTicker(func() {
-		logProgress(*logger, "phase 1: scanning", startTime, checked.Load(), total.Load()).
+		phaseID, desc := "1", "scanning"
+
+		var t int64
+
+		if cur := current.Load(); cur != nil {
+			phaseID, desc = cur.id, cur.description
+			if boundedChecks[cur.id] {
+				t = total.Load()
+			}
+		}
+
+		logProgress(*logger, phaseID, startTime, checked.Load(), t).
+			Str("check", desc).
 			Msg("progress update")
 	})
 	defer stopTicker()
@@ -666,7 +694,7 @@ func collectFsckSuspects(
 	}
 
 	// a. Narinfos without nar_files
-	fsckCheckStart(logger, "1a")
+	startCheck("1a")
 
 	narinfosWithoutNarFiles, err := dbClient.Ent().NarInfo.Query().
 		Where(entnarinfo.Not(entnarinfo.HasNarInfoNarFiles())).
@@ -679,7 +707,7 @@ func collectFsckSuspects(
 	fsckCheckDone(logger, "1a", len(narinfosWithoutNarFiles))
 
 	// b. Orphaned nar_files in DB
-	fsckCheckStart(logger, "1b")
+	startCheck("1b")
 
 	orphanedNarFiles, err := dbClient.Ent().NarFile.Query().
 		Where(entnarfile.Not(entnarfile.HasNarInfoNarFiles())).
@@ -692,7 +720,7 @@ func collectFsckSuspects(
 	fsckCheckDone(logger, "1b", len(orphanedNarFiles))
 
 	// c. Nar_files missing from storage
-	fsckCheckStart(logger, "1c")
+	startCheck("1c")
 
 	allNarFiles, err := dbClient.Ent().NarFile.Query().All(ctx)
 	if err != nil {
@@ -775,7 +803,7 @@ func collectFsckSuspects(
 	fsckCheckDone(logger, "1c", len(results.narFilesMissingInStorage))
 
 	// d. Orphaned NAR files in storage
-	fsckCheckStart(logger, "1d")
+	startCheck("1d")
 
 	narWalker, ok := narStore.(NarWalker)
 	if ok {
@@ -814,7 +842,7 @@ func collectFsckSuspects(
 	}
 
 	// e. Orphaned chunks in DB
-	fsckCheckStart(logger, "1e")
+	startCheck("1e")
 
 	orphanedChunks, err := dbClient.Ent().Chunk.Query().
 		Where(entchunk.Not(entchunk.HasNarFileLinks())).
@@ -839,7 +867,7 @@ func collectFsckSuspects(
 	}
 
 	// f. NAR files with chunk issues (count mismatch or chunks missing from storage)
-	fsckCheckStart(logger, "1f")
+	startCheck("1f")
 
 	narFilesWithChunkIssues, err := collectNarFilesWithChunkIssues(
 		ctx, dbClient, allNarFiles, chunkStore, &checked, verifiedSince,
@@ -852,7 +880,7 @@ func collectFsckSuspects(
 	fsckCheckDone(logger, "1f", len(narFilesWithChunkIssues))
 
 	// g. CDC NAR files with size mismatch (total_chunks > 0 but file_size != narinfos.nar_size)
-	fsckCheckStart(logger, "1g")
+	startCheck("1g")
 
 	narFilesWithSizeMismatch, err := queryCDCNarFilesWithSizeMismatch(ctx, dbClient)
 	if err != nil {
@@ -895,7 +923,7 @@ func collectFsckSuspects(
 	// h. Orphaned chunk files in storage (before content checks so we skip orphan hashes).
 	// The total number of chunks in storage is not known beforehand, so phase 1h
 	// reports the checked count rather than a percentage.
-	fsckCheckStart(logger, "1h")
+	startCheck("1h")
 
 	orphaned, err := collectOrphanedChunksInStorage(ctx, dbClient, chunkStore, &checked)
 	if err != nil {
@@ -919,7 +947,7 @@ func collectFsckSuspects(
 	}
 
 	// i. Chunk content hash verification.
-	fsckCheckStart(logger, "1i")
+	startCheck("1i")
 
 	corruptNarFiles, err := collectNarFilesWithCorruptChunks(
 		ctx, dbClient, chunkStore, allNarFiles, chunkIssueIDs, verifiedSince,
@@ -938,7 +966,7 @@ func collectFsckSuspects(
 	}
 
 	// j. End-to-end NAR hash verification.
-	fsckCheckStart(logger, "1j")
+	startCheck("1j")
 
 	hashMismatchNarFiles, err := collectNarFilesWithHashMismatch(
 		ctx, dbClient, chunkStore, allNarFiles, chunkIssueIDs, corruptByID, verifiedSince,
@@ -1060,7 +1088,8 @@ func reVerifyFsckSuspects(
 	// uniform progress fields; the confirmed-issue count is reported in the
 	// phase-2 done line.
 	stopTicker := startProgressTicker(func() {
-		logProgress(*logger, "phase 2: re-verifying", startTime, checked.Load(), int64(totalSuspects)).
+		logProgress(*logger, "2", startTime, checked.Load(), int64(totalSuspects)).
+			Str("check", "re-verifying suspects").
 			Msg("progress update")
 	})
 	defer stopTicker()
@@ -1481,7 +1510,8 @@ func repairFsckIssues(
 	startTime := time.Now()
 
 	stopTicker := startProgressTicker(func() {
-		logProgress(*logger, "phase 3: repairing", startTime, checked.Load(), total).
+		logProgress(*logger, "3", startTime, checked.Load(), total).
+			Str("check", "repairing issues").
 			Msg("progress update")
 	})
 	defer stopTicker()
@@ -2805,12 +2835,18 @@ func logProgress(
 	elapsed := time.Since(startTime).Seconds()
 	evt := logger.Info().
 		Str("phase", phase).
-		Int64("checked", checked).
-		Int64("total", total)
+		Int64("checked", checked)
 
-	if total > 0 && checked <= total {
-		pct := float64(checked) / float64(total) * 100
-		evt = evt.Str("percent", fmt.Sprintf("%.1f%%", pct))
+	// total <= 0 means the size of this work is not known up front (e.g. a
+	// storage walk). Omit total and percent entirely rather than emitting a
+	// denominator that `checked` will overrun and a percent that never moves.
+	if total > 0 {
+		evt = evt.Int64("total", total)
+
+		if checked <= total {
+			pct := float64(checked) / float64(total) * 100
+			evt = evt.Str("percent", fmt.Sprintf("%.1f%%", pct))
+		}
 	}
 
 	if elapsed > 0 && checked > 0 {

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -491,16 +491,20 @@ Use --repair to automatically fix detected issues, or --dry-run to preview what 
 				chunkStore = cs
 			}
 
-			// 6. Phase 1: Collect suspects
-			logger.Info().Msg("phase 1: collecting suspects")
+			// 6. Print the run plan so the operator can see which phases and
+			// sub-checks will run for this invocation before any scanning starts.
+			printFsckRunPlan(os.Stdout, cdcMode, verifyContent, fsckRunModeOf(dryRun, repair))
+
+			// Phase 1: Collect suspects.
+			logger.Info().Str("phase", "1").Msg("phase 1: scanning database and storage for inconsistencies")
 
 			suspects, err := collectFsckSuspects(ctx, dbClient, narStore, chunkStore, cdcMode, verifiedSince, verifyContent)
 			if err != nil {
 				return fmt.Errorf("error collecting suspects: %w", err)
 			}
 
-			// 7. Phase 2: Re-verify (double-check to handle in-flight operations)
-			logger.Info().Msg("phase 2: re-verifying suspects")
+			// 7. Phase 2: Re-verify (double-check to handle in-flight operations).
+			logger.Info().Str("phase", "2").Msg("phase 2: re-verifying suspects to rule out in-flight changes")
 
 			results, err := reVerifyFsckSuspects(ctx, dbClient, narStore, chunkStore, suspects)
 			if err != nil {
@@ -600,8 +604,8 @@ Use --repair to automatically fix detected issues, or --dry-run to preview what 
 				}
 			}
 
-			// 10. Phase 3: Repair
-			logger.Info().Msg("phase 3: repairing issues")
+			// 10. Phase 3: Repair.
+			logger.Info().Str("phase", "3").Msg("phase 3: repairing confirmed issues")
 
 			// Reconcile chunked residue on the interactive-approval path. Skipped when
 			// --repair is set, because the janitor above already ran; this guard prevents a
@@ -641,20 +645,29 @@ func collectFsckSuspects(
 
 	startTime := time.Now()
 
-	// Start background progress ticker
+	// Start background progress ticker. The periodic update carries only the
+	// uniform progress fields (phase, checked, total, percent, rate); the
+	// suspect/skipped tallies are reported in the phase-1 done line below.
 	stopTicker := startProgressTicker(func() {
-		c := checked.Load()
-		t := total.Load()
-		s := suspects.Load()
-		sk := skipped.Load()
-		logProgress(*logger, startTime, c, t).
-			Int64("suspects", s).
-			Int64("skipped", sk).
-			Msg("phase 1: progress update")
+		logProgress(*logger, "phase 1: scanning", startTime, checked.Load(), total.Load()).
+			Msg("progress update")
 	})
 	defer stopTicker()
 
+	// logPhase1Done emits the uniform phase-1 completion line on every success
+	// path, folding in the aggregate skipped count and the confirmed-suspect total.
+	logPhase1Done := func() {
+		logger.Info().
+			Str("phase", "1").
+			Int64("checked", checked.Load()).
+			Int64("skipped", skipped.Load()).
+			Int("suspects", results.totalIssues()).
+			Msg("phase 1: scan complete")
+	}
+
 	// a. Narinfos without nar_files
+	fsckCheckStart(logger, "1a")
+
 	narinfosWithoutNarFiles, err := dbClient.Ent().NarInfo.Query().
 		Where(entnarinfo.Not(entnarinfo.HasNarInfoNarFiles())).
 		All(ctx)
@@ -663,9 +676,11 @@ func collectFsckSuspects(
 	}
 
 	results.narinfosWithoutNarFiles = narinfosWithoutNarFiles
-	logger.Info().Int("count", len(narinfosWithoutNarFiles)).Msg("phase 1a: narinfos_without_nar_files found")
+	fsckCheckDone(logger, "1a", len(narinfosWithoutNarFiles))
 
 	// b. Orphaned nar_files in DB
+	fsckCheckStart(logger, "1b")
+
 	orphanedNarFiles, err := dbClient.Ent().NarFile.Query().
 		Where(entnarfile.Not(entnarfile.HasNarInfoNarFiles())).
 		All(ctx)
@@ -674,9 +689,11 @@ func collectFsckSuspects(
 	}
 
 	results.orphanedNarFilesInDB = orphanedNarFiles
-	logger.Info().Int("count", len(orphanedNarFiles)).Msg("phase 1b: orphaned nar_files in DB found")
+	fsckCheckDone(logger, "1b", len(orphanedNarFiles))
 
 	// c. Nar_files missing from storage
+	fsckCheckStart(logger, "1c")
+
 	allNarFiles, err := dbClient.Ent().NarFile.Query().All(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("GetAllNarFiles: %w", err)
@@ -697,7 +714,7 @@ func collectFsckSuspects(
 	presentNars := make(map[string]struct{})
 
 	// Walk storage to build index of present NARs
-	logger.Info().Msg("phase 1c: walking NAR storage (building index)")
+	logger.Info().Str("phase", "1c").Msg("phase 1c: indexing NAR files present in storage")
 
 	var storageNarCount atomic.Int64
 
@@ -715,12 +732,10 @@ func collectFsckSuspects(
 
 	storageCount := storageNarCount.Load()
 	total.Add(storageCount)
-	logger.Info().Int64("count", storageCount).Msg("phase 1c: indexed NAR files from storage")
+	logger.Info().Str("phase", "1c").Int64("indexed", storageCount).Msg("phase 1c: indexed NAR files from storage")
 
 	// Check for missing nar_files
 	var nonChunkedCount int64
-
-	logger.Info().Int("total", len(allNarFiles)).Msg("phase 1c: checking nar_files against storage")
 
 	for _, nf := range allNarFiles {
 		// Chunked nar_files live in chunk storage — not as whole NAR files.
@@ -757,10 +772,10 @@ func collectFsckSuspects(
 		}
 	}
 
-	logger.Info().Int("suspects", len(results.narFilesMissingInStorage)).Msg("phase 1c: done checking nar_files")
+	fsckCheckDone(logger, "1c", len(results.narFilesMissingInStorage))
 
 	// d. Orphaned NAR files in storage
-	logger.Info().Int64("total", storageCount).Msg("phase 1d: checking storage NAR files against DB")
+	fsckCheckStart(logger, "1d")
 
 	narWalker, ok := narStore.(NarWalker)
 	if ok {
@@ -790,13 +805,17 @@ func collectFsckSuspects(
 		}
 	}
 
-	logger.Info().Int("suspects", len(results.orphanedNarFilesInStorage)).Msg("phase 1d: done checking storage NAR files")
+	fsckCheckDone(logger, "1d", len(results.orphanedNarFilesInStorage))
 
 	if !cdcMode {
+		logPhase1Done()
+
 		return results, nil
 	}
 
 	// e. Orphaned chunks in DB
+	fsckCheckStart(logger, "1e")
+
 	orphanedChunks, err := dbClient.Ent().Chunk.Query().
 		Where(entchunk.Not(entchunk.HasNarFileLinks())).
 		All(ctx)
@@ -805,7 +824,7 @@ func collectFsckSuspects(
 	}
 
 	results.orphanedChunksInDB = orphanedChunks
-	logger.Info().Int("count", len(orphanedChunks)).Msg("phase 1e: orphaned chunks in DB found")
+	fsckCheckDone(logger, "1e", len(orphanedChunks))
 
 	eligibleChunkedNarFiles := make(map[int]*ent.NarFile)
 
@@ -820,7 +839,7 @@ func collectFsckSuspects(
 	}
 
 	// f. NAR files with chunk issues (count mismatch or chunks missing from storage)
-	logger.Info().Msg("phase 1f: checking NAR files with chunk issues")
+	fsckCheckStart(logger, "1f")
 
 	narFilesWithChunkIssues, err := collectNarFilesWithChunkIssues(
 		ctx, dbClient, allNarFiles, chunkStore, &checked, verifiedSince,
@@ -830,10 +849,10 @@ func collectFsckSuspects(
 	}
 
 	results.narFilesWithChunkIssues = narFilesWithChunkIssues
-	logger.Info().Int("count", len(narFilesWithChunkIssues)).Msg("phase 1f: NAR files with chunk issues found")
+	fsckCheckDone(logger, "1f", len(narFilesWithChunkIssues))
 
 	// g. CDC NAR files with size mismatch (total_chunks > 0 but file_size != narinfos.nar_size)
-	logger.Info().Msg("phase 1g: checking CDC NAR files with size mismatch")
+	fsckCheckStart(logger, "1g")
 
 	narFilesWithSizeMismatch, err := queryCDCNarFilesWithSizeMismatch(ctx, dbClient)
 	if err != nil {
@@ -871,15 +890,12 @@ func collectFsckSuspects(
 		}
 	}
 
-	logger.Info().
-		Int("count", len(results.narFilesWithSizeMismatch)).
-		Msg("phase 1g: CDC NAR files with size mismatch found")
+	fsckCheckDone(logger, "1g", len(results.narFilesWithSizeMismatch))
 
-	// h. Orphaned chunk files in storage (before content checks so we skip orphan hashes)
-	logger.Info().Msg("phase 1h: checking orphaned chunk files in storage")
-
-	// The total number of chunks in storage is not known beforehand, so we cannot
-	// accurately report a percentage for phase 1h. We'll rely on the checked count.
+	// h. Orphaned chunk files in storage (before content checks so we skip orphan hashes).
+	// The total number of chunks in storage is not known beforehand, so phase 1h
+	// reports the checked count rather than a percentage.
+	fsckCheckStart(logger, "1h")
 
 	orphaned, err := collectOrphanedChunksInStorage(ctx, dbClient, chunkStore, &checked)
 	if err != nil {
@@ -887,9 +903,11 @@ func collectFsckSuspects(
 	}
 
 	results.orphanedChunksInStorage = orphaned
-	logger.Info().Int("count", len(orphaned)).Msg("phase 1h: orphaned chunk files found")
+	fsckCheckDone(logger, "1h", len(orphaned))
 
 	if !verifyContent {
+		logPhase1Done()
+
 		return results, nil
 	}
 
@@ -901,7 +919,7 @@ func collectFsckSuspects(
 	}
 
 	// i. Chunk content hash verification.
-	logger.Info().Msg("phase 1i: verifying chunk content hashes")
+	fsckCheckStart(logger, "1i")
 
 	corruptNarFiles, err := collectNarFilesWithCorruptChunks(
 		ctx, dbClient, chunkStore, allNarFiles, chunkIssueIDs, verifiedSince,
@@ -911,7 +929,7 @@ func collectFsckSuspects(
 	}
 
 	results.narFilesWithCorruptChunks = corruptNarFiles
-	logger.Info().Int("count", len(corruptNarFiles)).Msg("phase 1i: NAR files with corrupt chunks found")
+	fsckCheckDone(logger, "1i", len(corruptNarFiles))
 
 	// Build set of corrupt IDs to skip in the NAR hash check.
 	corruptByID := make(map[int]struct{}, len(corruptNarFiles))
@@ -920,7 +938,7 @@ func collectFsckSuspects(
 	}
 
 	// j. End-to-end NAR hash verification.
-	logger.Info().Msg("phase 1j: verifying assembled NAR hashes")
+	fsckCheckStart(logger, "1j")
 
 	hashMismatchNarFiles, err := collectNarFilesWithHashMismatch(
 		ctx, dbClient, chunkStore, allNarFiles, chunkIssueIDs, corruptByID, verifiedSince,
@@ -930,7 +948,9 @@ func collectFsckSuspects(
 	}
 
 	results.narFilesWithHashMismatch = hashMismatchNarFiles
-	logger.Info().Int("count", len(hashMismatchNarFiles)).Msg("phase 1j: NAR files with hash mismatch found")
+	fsckCheckDone(logger, "1j", len(hashMismatchNarFiles))
+
+	logPhase1Done()
 
 	return results, nil
 }
@@ -1032,24 +1052,28 @@ func reVerifyFsckSuspects(
 	// Setup progress tracking for phase 2
 	totalSuspects := suspects.totalIssues()
 
-	var checked, remaining atomic.Int64
-
-	remaining.Store(int64(totalSuspects))
+	var checked atomic.Int64
 
 	startTime := time.Now()
 
-	logger.Info().Int("total", totalSuspects).Msg("phase 2: re-verifying suspects")
-
-	// Start background progress ticker
+	// Start background progress ticker. The periodic update carries only the
+	// uniform progress fields; the confirmed-issue count is reported in the
+	// phase-2 done line.
 	stopTicker := startProgressTicker(func() {
-		c := checked.Load()
-		t := int64(totalSuspects)
-		r := remaining.Load()
-		logProgress(*logger, startTime, c, t).
-			Int64("remaining", r).
-			Msg("phase 2: progress update")
+		logProgress(*logger, "phase 2: re-verifying", startTime, checked.Load(), int64(totalSuspects)).
+			Msg("progress update")
 	})
 	defer stopTicker()
+
+	// logPhase2Done emits the uniform phase-2 completion line on every success
+	// path, reporting how many suspects survived re-verification.
+	logPhase2Done := func() {
+		logger.Info().
+			Str("phase", "2").
+			Int64("checked", checked.Load()).
+			Int("confirmed", results.totalIssues()).
+			Msg("phase 2: re-verify complete")
+	}
 
 	// Re-verify: narinfos without nar_files
 	for _, ni := range suspects.narinfosWithoutNarFiles {
@@ -1065,7 +1089,6 @@ func reVerifyFsckSuspects(
 		}
 
 		checked.Add(1)
-		remaining.Add(-1)
 	}
 
 	// Re-verify: orphaned nar_files in DB
@@ -1089,7 +1112,6 @@ func reVerifyFsckSuspects(
 		}
 
 		checked.Add(1)
-		remaining.Add(-1)
 	}
 
 	// Re-verify: nar_files missing from storage
@@ -1104,7 +1126,6 @@ func reVerifyFsckSuspects(
 		}
 
 		checked.Add(1)
-		remaining.Add(-1)
 	}
 
 	// Re-verify: orphaned NAR files in storage
@@ -1125,10 +1146,11 @@ func reVerifyFsckSuspects(
 		}
 
 		checked.Add(1)
-		remaining.Add(-1)
 	}
 
 	if !suspects.cdcMode {
+		logPhase2Done()
+
 		return results, nil
 	}
 
@@ -1151,7 +1173,6 @@ func reVerifyFsckSuspects(
 		}
 
 		checked.Add(1)
-		remaining.Add(-1)
 	}
 
 	// Re-verify: NAR files with chunk issues
@@ -1167,7 +1188,6 @@ func reVerifyFsckSuspects(
 			}
 
 			checked.Add(1)
-			remaining.Add(-1)
 		}
 	}
 
@@ -1189,7 +1209,6 @@ func reVerifyFsckSuspects(
 			}
 
 			checked.Add(1)
-			remaining.Add(-1)
 		}
 	}
 
@@ -1207,10 +1226,11 @@ func reVerifyFsckSuspects(
 		}
 
 		checked.Add(1)
-		remaining.Add(-1)
 	}
 
 	if !suspects.verifyContent || chunkStore == nil {
+		logPhase2Done()
+
 		return results, nil
 	}
 
@@ -1226,7 +1246,6 @@ func reVerifyFsckSuspects(
 		}
 
 		checked.Add(1)
-		remaining.Add(-1)
 	}
 
 	// Re-verify: NAR files with hash mismatch.
@@ -1241,8 +1260,9 @@ func reVerifyFsckSuspects(
 		}
 
 		checked.Add(1)
-		remaining.Add(-1)
 	}
+
+	logPhase2Done()
 
 	return results, nil
 }
@@ -1443,11 +1463,47 @@ func repairFsckIssues(
 	narStore storage.NarStore,
 	chunkStore chunk.Store,
 	results *fsckResults,
-) error {
+) (err error) {
 	logger := zerolog.Ctx(ctx)
+
+	// Phase 3 progress: report through the same shared ticker/logProgress path as
+	// the scan phases. total is the confirmed-issue count entering repair; checked
+	// advances as each issue category is processed.
+	total := int64(results.totalIssues())
+
+	var checked atomic.Int64
+
+	startTime := time.Now()
+
+	stopTicker := startProgressTicker(func() {
+		logProgress(*logger, "phase 3: repairing", startTime, checked.Load(), total).
+			Msg("progress update")
+	})
+	defer stopTicker()
+
+	defer func() {
+		if err != nil {
+			logger.Warn().
+				Err(err).
+				Str("phase", "3").
+				Int64("checked", checked.Load()).
+				Int64("total", total).
+				Msg("phase 3: repair aborted")
+
+			return
+		}
+
+		logger.Info().
+			Str("phase", "3").
+			Int64("checked", checked.Load()).
+			Int64("total", total).
+			Msg("phase 3: repair complete")
+	}()
 
 	// a. Repair or delete narinfos without nar_files
 	for _, ni := range results.narinfosWithoutNarFiles {
+		checked.Add(1)
+
 		// Re-verify before acting
 		hasNarFile, err := dbClient.Ent().NarFile.Query().
 			Where(entnarfile.HasNarInfoNarFilesWith(entnarinfonarfile.NarinfoIDEQ(ni.ID))).
@@ -1489,6 +1545,8 @@ func repairFsckIssues(
 
 	// b. Delete orphaned nar_files in DB
 	for _, nf := range results.orphanedNarFilesInDB {
+		checked.Add(1)
+
 		// Re-verify before deleting
 		hasLink, err := dbClient.Ent().NarInfo.Query().
 			Where(entnarinfo.HasNarInfoNarFilesWith(
@@ -1538,6 +1596,8 @@ func repairFsckIssues(
 	}
 
 	for _, nf := range results.narFilesMissingInStorage {
+		checked.Add(1)
+
 		// Re-verify before deleting
 		narURL, err := narFileRowToURL(nf.Hash, nf.Compression, nf.Query)
 		if err != nil {
@@ -1600,6 +1660,8 @@ func repairFsckIssues(
 	nd, hasDeleter := narStore.(narDeleter)
 
 	for _, narURL := range results.orphanedNarFilesInStorage {
+		checked.Add(1)
+
 		// Re-verify before deleting
 		exists, err := dbClient.Ent().NarFile.Query().
 			Where(
@@ -1644,6 +1706,8 @@ func repairFsckIssues(
 	}
 
 	for _, c := range results.orphanedChunksInDB {
+		checked.Add(1)
+
 		if _, ok := recheckMap[c.ID]; !ok {
 			continue
 		}
@@ -1660,6 +1724,8 @@ func repairFsckIssues(
 		if err := repairBrokenCDCNarFiles(ctx, dbClient, chunkStore, results.narFilesWithChunkIssues, logger); err != nil {
 			return err
 		}
+
+		checked.Add(int64(len(results.narFilesWithChunkIssues)))
 	}
 
 	// f2. Delete CDC nar_files with size mismatch (truncated artifacts).
@@ -1669,6 +1735,8 @@ func repairFsckIssues(
 		); err != nil {
 			return err
 		}
+
+		checked.Add(int64(len(results.narFilesWithSizeMismatch)))
 	}
 
 	// f3. Delete CDC nar_files with corrupt chunk content.
@@ -1682,6 +1750,8 @@ func repairFsckIssues(
 		); err != nil {
 			return err
 		}
+
+		checked.Add(int64(len(results.narFilesWithCorruptChunks)))
 	}
 
 	// f4. Delete CDC nar_files with assembled NAR hash mismatch.
@@ -1695,11 +1765,15 @@ func repairFsckIssues(
 		); err != nil {
 			return err
 		}
+
+		checked.Add(int64(len(results.narFilesWithHashMismatch)))
 	}
 
 	// g. Delete orphaned chunk files from storage
 	if chunkStore != nil {
 		for _, hash := range results.orphanedChunksInStorage {
+			checked.Add(1)
+
 			// Re-verify before deleting
 			exists, err := dbClient.Ent().Chunk.Query().
 				Where(entchunk.HashEQ(hash)).
@@ -2541,6 +2615,156 @@ func narFileRowToURL(hash, compression, query string) (nar.URL, error) {
 	}, nil
 }
 
+// fsckCheckActivation gates whether a phase-1 sub-check runs for a given
+// invocation. It is a pure function of CDC mode and the --verify-content flag.
+type fsckCheckActivation int
+
+const (
+	// fsckCheckAlways runs on every fsck invocation.
+	fsckCheckAlways fsckCheckActivation = iota
+	// fsckCheckCDC runs only when CDC mode is detected.
+	fsckCheckCDC
+	// fsckCheckVerifyContent runs only under CDC mode with --verify-content set.
+	fsckCheckVerifyContent
+)
+
+// active reports whether a check with this activation runs given the resolved
+// mode/flag state.
+func (a fsckCheckActivation) active(cdcMode, verifyContent bool) bool {
+	switch a {
+	case fsckCheckCDC:
+		return cdcMode
+	case fsckCheckVerifyContent:
+		return cdcMode && verifyContent
+	case fsckCheckAlways:
+		return true
+	default:
+		return true
+	}
+}
+
+// fsckCheck describes a single phase-1 sub-check: a stable id for log
+// correlation, a human-readable description, and when it is active. The
+// description is the single source of truth for both the run plan and the
+// per-check start/done log lines, so the plan can never drift from what runs.
+type fsckCheck struct {
+	id          string
+	description string
+	activation  fsckCheckActivation
+}
+
+// fsckPhase1Checks lists the phase-1 sub-checks in execution order. Register any
+// new sub-check here so it appears in the run plan and gets uniform start/done
+// logging automatically. The order mirrors collectFsckSuspects and the summary
+// table rows.
+//
+//nolint:gochecknoglobals // immutable lookup table; the single source of truth for phase labels.
+var fsckPhase1Checks = []fsckCheck{
+	{"1a", "narinfos with no linked nar_file", fsckCheckAlways},
+	{"1b", "orphaned nar_files in the database", fsckCheckAlways},
+	{"1c", "nar_files missing from storage", fsckCheckAlways},
+	{"1d", "orphaned NAR files in storage", fsckCheckAlways},
+	{"1e", "orphaned chunks in the database", fsckCheckCDC},
+	{"1f", "NAR files with chunk issues", fsckCheckCDC},
+	{"1g", "CDC NAR files with size mismatch", fsckCheckCDC},
+	{"1h", "orphaned chunk files in storage", fsckCheckCDC},
+	{"1i", "corrupt chunk content", fsckCheckVerifyContent},
+	{"1j", "assembled NAR hash mismatch", fsckCheckVerifyContent},
+}
+
+// fsckChecksByID indexes fsckPhase1Checks by id for label lookups at log sites.
+//
+//nolint:gochecknoglobals // derived immutable index over fsckPhase1Checks.
+var fsckChecksByID = func() map[string]fsckCheck {
+	m := make(map[string]fsckCheck, len(fsckPhase1Checks))
+	for _, c := range fsckPhase1Checks {
+		m[c.id] = c
+	}
+
+	return m
+}()
+
+// activeFsckPhase1Checks returns the phase-1 sub-checks that run for the given
+// mode/flag state, in execution order.
+func activeFsckPhase1Checks(cdcMode, verifyContent bool) []fsckCheck {
+	out := make([]fsckCheck, 0, len(fsckPhase1Checks))
+
+	for _, c := range fsckPhase1Checks {
+		if c.activation.active(cdcMode, verifyContent) {
+			out = append(out, c)
+		}
+	}
+
+	return out
+}
+
+// fsckRunMode is the resolved top-level behavior of an fsck run, used to describe
+// the repair phase in the run plan.
+type fsckRunMode int
+
+const (
+	// fsckModeReport reports issues and prompts interactively before repairing.
+	fsckModeReport fsckRunMode = iota
+	// fsckModeDryRun reports only; it never repairs (--dry-run).
+	fsckModeDryRun
+	// fsckModeRepair repairs confirmed issues without prompting (--repair).
+	fsckModeRepair
+)
+
+// fsckRunModeOf resolves the run mode from the --dry-run/--repair flags. --dry-run
+// dominates --repair because the command returns after reporting in dry-run mode.
+func fsckRunModeOf(dryRun, repair bool) fsckRunMode {
+	switch {
+	case dryRun:
+		return fsckModeDryRun
+	case repair:
+		return fsckModeRepair
+	default:
+		return fsckModeReport
+	}
+}
+
+// fsckCheckStart logs the uniform start line for a phase-1 sub-check.
+func fsckCheckStart(logger *zerolog.Logger, id string) {
+	logger.Info().Str("phase", id).Msgf("phase %s: checking %s", id, fsckChecksByID[id].description)
+}
+
+// fsckCheckDone logs the uniform done line for a phase-1 sub-check, carrying the
+// number of issues it found.
+func fsckCheckDone(logger *zerolog.Logger, id string, found int) {
+	logger.Info().
+		Str("phase", id).
+		Int("found", found).
+		Msgf("phase %s: %s — done", id, fsckChecksByID[id].description)
+}
+
+// printFsckRunPlan prints, before any scanning begins, the phases fsck will run
+// for the current invocation: the active phase-1 sub-checks (gated by CDC mode
+// and --verify-content), the re-verify phase, and whether a repair phase runs.
+func printFsckRunPlan(w io.Writer, cdcMode, verifyContent bool, mode fsckRunMode) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "ncps fsck — planned phases for this run:")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "  Phase 1 — Scan the database and storage for inconsistencies:")
+
+	for _, c := range activeFsckPhase1Checks(cdcMode, verifyContent) {
+		fmt.Fprintf(w, "      [%s] %s\n", c.id, c.description)
+	}
+
+	fmt.Fprintln(w, "  Phase 2 — Re-verify suspected issues to rule out in-flight operations")
+
+	switch mode {
+	case fsckModeRepair:
+		fmt.Fprintln(w, "  Phase 3 — Repair the confirmed issues")
+	case fsckModeDryRun:
+		fmt.Fprintln(w, "  Phase 3 — Repair: SKIPPED (--dry-run reports issues without changing anything)")
+	case fsckModeReport:
+		fmt.Fprintln(w, "  Phase 3 — Repair: runs only if you confirm at the prompt")
+	}
+
+	fmt.Fprintln(w)
+}
+
 // startProgressTicker starts a goroutine that logs progress every 30 seconds.
 // It returns a function that should be called to stop the ticker.
 func startProgressTicker(logFn func()) (stop func()) {
@@ -2568,12 +2792,14 @@ func startProgressTicker(logFn func()) (stop func()) {
 //nolint:zerologlint
 func logProgress(
 	logger zerolog.Logger,
+	phase string,
 	startTime time.Time,
 	checked int64,
 	total int64,
 ) *zerolog.Event {
 	elapsed := time.Since(startTime).Seconds()
 	evt := logger.Info().
+		Str("phase", phase).
 		Int64("checked", checked).
 		Int64("total", total)
 

--- a/pkg/ncps/fsck_messaging_internal_test.go
+++ b/pkg/ncps/fsck_messaging_internal_test.go
@@ -193,7 +193,7 @@ func TestPrintFsckRunPlanVerifyContentAndDryRun(t *testing.T) {
 func TestLogProgressUniformFields(t *testing.T) {
 	t.Parallel()
 
-	for _, phase := range []string{"phase 1: scanning", "phase 2: re-verifying", "phase 3: repairing"} {
+	for _, phase := range []string{"1c", "2", "3"} {
 		t.Run(phase, func(t *testing.T) {
 			t.Parallel()
 
@@ -213,4 +213,29 @@ func TestLogProgressUniformFields(t *testing.T) {
 			assert.Contains(t, fields, "rate")
 		})
 	}
+}
+
+// TestLogProgressOmitsUnknownTotal proves that when the work size is not known up
+// front (total <= 0, e.g. a chunk-storage walk), the helper omits both total and
+// percent rather than emitting a frozen denominator that `checked` overruns. This
+// is the fix for the confusing "checked=128299 total=86479" phase-1h output.
+func TestLogProgressOmitsUnknownTotal(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	logger := zerolog.New(&buf)
+	logProgress(logger, "1h", time.Now().Add(-time.Second), 128299, 0).
+		Str("check", "orphaned chunk files in storage").
+		Msg("progress update")
+
+	var fields map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &fields))
+
+	assert.Equal(t, "1h", fields["phase"])
+	assert.Equal(t, "orphaned chunk files in storage", fields["check"])
+	assert.EqualValues(t, 128299, fields["checked"])
+	assert.NotContains(t, fields, "total")
+	assert.NotContains(t, fields, "percent")
+	assert.Contains(t, fields, "rate")
 }

--- a/pkg/ncps/fsck_messaging_internal_test.go
+++ b/pkg/ncps/fsck_messaging_internal_test.go
@@ -3,7 +3,6 @@ package ncps
 import (
 	"bytes"
 	"encoding/json"
-	"strings"
 	"testing"
 	"time"
 
@@ -128,24 +127,21 @@ func TestPrintFsckRunPlanNonCDC(t *testing.T) {
 	var buf bytes.Buffer
 
 	printFsckRunPlan(&buf, false, false, fsckModeReport)
-	out := buf.String()
 
-	// All three top-level phases are listed, in order.
-	assert.Less(t, strings.Index(out, "Phase 1"), strings.Index(out, "Phase 2"))
-	assert.Less(t, strings.Index(out, "Phase 2"), strings.Index(out, "Phase 3"))
-
-	// Active always-on checks are present.
-	for _, id := range []string{"1a", "1b", "1c", "1d"} {
-		assert.Contains(t, out, "["+id+"]")
-	}
-
-	// CDC and verify-content checks are absent.
-	for _, id := range []string{"1e", "1f", "1g", "1h", "1i", "1j"} {
-		assert.NotContains(t, out, "["+id+"]")
-	}
-
-	// Report mode mentions the confirmation prompt, not an unconditional repair.
-	assert.Contains(t, out, "confirm")
+	// Assert the exact run plan: no CDC mode → only the always-on phase-1 checks,
+	// and report mode → the "confirm at the prompt" Phase 3 line.
+	want := "\n" +
+		"ncps fsck — planned phases for this run:\n" +
+		"\n" +
+		"  Phase 1 — Scan the database and storage for inconsistencies:\n" +
+		"      [1a] narinfos with no linked nar_file\n" +
+		"      [1b] orphaned nar_files in the database\n" +
+		"      [1c] nar_files missing from storage\n" +
+		"      [1d] orphaned NAR files in storage\n" +
+		"  Phase 2 — Re-verify suspected issues to rule out in-flight operations\n" +
+		"  Phase 3 — Repair: runs only if you confirm at the prompt\n" +
+		"\n"
+	assert.Equal(t, want, buf.String())
 }
 
 func TestPrintFsckRunPlanCDCRepair(t *testing.T) {
@@ -154,18 +150,26 @@ func TestPrintFsckRunPlanCDCRepair(t *testing.T) {
 	var buf bytes.Buffer
 
 	printFsckRunPlan(&buf, true, false, fsckModeRepair)
-	out := buf.String()
 
-	// CDC checks now appear...
-	for _, id := range []string{"1e", "1f", "1g", "1h"} {
-		assert.Contains(t, out, "["+id+"]")
-	}
-	// ...but content checks still do not (verify-content is off).
-	for _, id := range []string{"1i", "1j"} {
-		assert.NotContains(t, out, "["+id+"]")
-	}
-
-	assert.Contains(t, out, "Repair the confirmed issues")
+	// Assert the exact run plan: CDC mode adds the chunk checks (1e–1h), but
+	// without --verify-content the content checks (1i/1j) stay out; repair mode →
+	// the "Repair the confirmed issues" Phase 3 line.
+	want := "\n" +
+		"ncps fsck — planned phases for this run:\n" +
+		"\n" +
+		"  Phase 1 — Scan the database and storage for inconsistencies:\n" +
+		"      [1a] narinfos with no linked nar_file\n" +
+		"      [1b] orphaned nar_files in the database\n" +
+		"      [1c] nar_files missing from storage\n" +
+		"      [1d] orphaned NAR files in storage\n" +
+		"      [1e] orphaned chunks in the database\n" +
+		"      [1f] NAR files with chunk issues\n" +
+		"      [1g] CDC NAR files with size mismatch\n" +
+		"      [1h] orphaned chunk files in storage\n" +
+		"  Phase 2 — Re-verify suspected issues to rule out in-flight operations\n" +
+		"  Phase 3 — Repair the confirmed issues\n" +
+		"\n"
+	assert.Equal(t, want, buf.String())
 }
 
 func TestPrintFsckRunPlanVerifyContentAndDryRun(t *testing.T) {
@@ -174,16 +178,27 @@ func TestPrintFsckRunPlanVerifyContentAndDryRun(t *testing.T) {
 	var buf bytes.Buffer
 
 	printFsckRunPlan(&buf, true, true, fsckModeDryRun)
-	out := buf.String()
 
-	// Content checks appear with CDC + verify-content.
-	for _, id := range []string{"1i", "1j"} {
-		assert.Contains(t, out, "["+id+"]")
-	}
-
-	// Dry-run advertises that repair is skipped.
-	assert.Contains(t, out, "SKIPPED")
-	assert.Contains(t, strings.ToLower(out), "dry-run")
+	// Assert the exact run plan: CDC + --verify-content adds the content checks
+	// (1i/1j); dry-run mode → the "SKIPPED" Phase 3 line.
+	want := "\n" +
+		"ncps fsck — planned phases for this run:\n" +
+		"\n" +
+		"  Phase 1 — Scan the database and storage for inconsistencies:\n" +
+		"      [1a] narinfos with no linked nar_file\n" +
+		"      [1b] orphaned nar_files in the database\n" +
+		"      [1c] nar_files missing from storage\n" +
+		"      [1d] orphaned NAR files in storage\n" +
+		"      [1e] orphaned chunks in the database\n" +
+		"      [1f] NAR files with chunk issues\n" +
+		"      [1g] CDC NAR files with size mismatch\n" +
+		"      [1h] orphaned chunk files in storage\n" +
+		"      [1i] corrupt chunk content\n" +
+		"      [1j] assembled NAR hash mismatch\n" +
+		"  Phase 2 — Re-verify suspected issues to rule out in-flight operations\n" +
+		"  Phase 3 — Repair: SKIPPED (--dry-run reports issues without changing anything)\n" +
+		"\n"
+	assert.Equal(t, want, buf.String())
 }
 
 // TestLogProgressUniformFields proves the shared progress helper emits the same

--- a/pkg/ncps/fsck_messaging_internal_test.go
+++ b/pkg/ncps/fsck_messaging_internal_test.go
@@ -1,0 +1,216 @@
+package ncps
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// idsOf extracts the stable phase ids from a slice of fsckCheck in order.
+func idsOf(checks []fsckCheck) []string {
+	out := make([]string, len(checks))
+	for i, c := range checks {
+		out[i] = c.id
+	}
+
+	return out
+}
+
+func TestActiveFsckPhase1Checks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		cdcMode       bool
+		verifyContent bool
+		want          []string
+	}{
+		{
+			name:          "no CDC runs only the always-on checks",
+			cdcMode:       false,
+			verifyContent: false,
+			want:          []string{"1a", "1b", "1c", "1d"},
+		},
+		{
+			name:          "CDC adds the chunk checks",
+			cdcMode:       true,
+			verifyContent: false,
+			want:          []string{"1a", "1b", "1c", "1d", "1e", "1f", "1g", "1h"},
+		},
+		{
+			name:          "CDC plus verify-content adds the content checks",
+			cdcMode:       true,
+			verifyContent: true,
+			want:          []string{"1a", "1b", "1c", "1d", "1e", "1f", "1g", "1h", "1i", "1j"},
+		},
+		{
+			name:          "verify-content without CDC stays at the always-on checks",
+			cdcMode:       false,
+			verifyContent: true,
+			want:          []string{"1a", "1b", "1c", "1d"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := idsOf(activeFsckPhase1Checks(tt.cdcMode, tt.verifyContent))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestActiveFsckPhase1ChecksMatchMasterOrder(t *testing.T) {
+	t.Parallel()
+
+	// The active subset must always preserve the master execution order.
+	master := idsOf(fsckPhase1Checks)
+	got := idsOf(activeFsckPhase1Checks(true, true))
+	assert.Equal(t, master, got, "all checks active should equal the master list in order")
+
+	// Every active id must appear in the same relative order as the master list.
+	subset := idsOf(activeFsckPhase1Checks(true, false))
+
+	var lastIdx int
+
+	for _, id := range subset {
+		idx := indexOf(master, id)
+		require.GreaterOrEqual(t, idx, 0, "active id %q missing from master list", id)
+		assert.GreaterOrEqual(t, idx, lastIdx, "active ids out of master order at %q", id)
+		lastIdx = idx
+	}
+}
+
+func indexOf(s []string, v string) int {
+	for i, x := range s {
+		if x == v {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func TestFsckRunModeOf(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		dryRun bool
+		repair bool
+		want   fsckRunMode
+	}{
+		{"neither flag prompts", false, false, fsckModeReport},
+		{"repair repairs", false, true, fsckModeRepair},
+		{"dry-run reports only", true, false, fsckModeDryRun},
+		{"dry-run dominates repair", true, true, fsckModeDryRun},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, fsckRunModeOf(tt.dryRun, tt.repair))
+		})
+	}
+}
+
+func TestPrintFsckRunPlanNonCDC(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	printFsckRunPlan(&buf, false, false, fsckModeReport)
+	out := buf.String()
+
+	// All three top-level phases are listed, in order.
+	assert.Less(t, strings.Index(out, "Phase 1"), strings.Index(out, "Phase 2"))
+	assert.Less(t, strings.Index(out, "Phase 2"), strings.Index(out, "Phase 3"))
+
+	// Active always-on checks are present.
+	for _, id := range []string{"1a", "1b", "1c", "1d"} {
+		assert.Contains(t, out, "["+id+"]")
+	}
+
+	// CDC and verify-content checks are absent.
+	for _, id := range []string{"1e", "1f", "1g", "1h", "1i", "1j"} {
+		assert.NotContains(t, out, "["+id+"]")
+	}
+
+	// Report mode mentions the confirmation prompt, not an unconditional repair.
+	assert.Contains(t, out, "confirm")
+}
+
+func TestPrintFsckRunPlanCDCRepair(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	printFsckRunPlan(&buf, true, false, fsckModeRepair)
+	out := buf.String()
+
+	// CDC checks now appear...
+	for _, id := range []string{"1e", "1f", "1g", "1h"} {
+		assert.Contains(t, out, "["+id+"]")
+	}
+	// ...but content checks still do not (verify-content is off).
+	for _, id := range []string{"1i", "1j"} {
+		assert.NotContains(t, out, "["+id+"]")
+	}
+
+	assert.Contains(t, out, "Repair the confirmed issues")
+}
+
+func TestPrintFsckRunPlanVerifyContentAndDryRun(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	printFsckRunPlan(&buf, true, true, fsckModeDryRun)
+	out := buf.String()
+
+	// Content checks appear with CDC + verify-content.
+	for _, id := range []string{"1i", "1j"} {
+		assert.Contains(t, out, "["+id+"]")
+	}
+
+	// Dry-run advertises that repair is skipped.
+	assert.Contains(t, out, "SKIPPED")
+	assert.Contains(t, strings.ToLower(out), "dry-run")
+}
+
+// TestLogProgressUniformFields proves the shared progress helper emits the same
+// field set for every phase: phase, checked, total, percent (when total known),
+// and rate. All phase tickers funnel through this helper, so the periodic update
+// shape is identical across phases 1, 2, and 3.
+func TestLogProgressUniformFields(t *testing.T) {
+	t.Parallel()
+
+	for _, phase := range []string{"phase 1: scanning", "phase 2: re-verifying", "phase 3: repairing"} {
+		t.Run(phase, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+
+			logger := zerolog.New(&buf)
+			// elapsed > 0 and checked > 0 so rate is emitted; checked <= total so percent is emitted.
+			logProgress(logger, phase, time.Now().Add(-time.Second), 5, 10).Msg("progress update")
+
+			var fields map[string]any
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &fields))
+
+			assert.Equal(t, phase, fields["phase"])
+			assert.EqualValues(t, 5, fields["checked"])
+			assert.EqualValues(t, 10, fields["total"])
+			assert.Contains(t, fields, "percent")
+			assert.Contains(t, fields, "rate")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`ncps fsck` output was hard to follow: it jumped straight into "phase 1" with no preview, labelled its phase-1 sub-checks with opaque ids (`1c`, `1g`), and reported progress three different ways (phase 1 logged `suspects`/`skipped`, phase 2 logged `remaining`, phase 3 nothing). This PR makes the output presentation-uniform **without changing detection, repair, or exit-code behavior**.

- **Up-front run plan** — before any scanning, fsck prints the phases and sub-checks that will actually run for this invocation (gated by CDC mode and `--verify-content`) plus the resolved run mode (dry-run / prompt / repair), so the operator sees the full scope.
- **Human-readable phase names** — a single ordered `fsckPhase1Checks` descriptor table drives both the run plan and the per-check log labels, so the plan can never drift from what runs. Every sub-check now emits a uniform start line and a done line carrying its found count.
- **Uniform progress** — all progress funnels through `logProgress`, which now carries a `phase` field; phases 1, 2, and 3 emit the same `checked`/`total`/`percent`/`rate` fields. The repair phase (previously silent) gains a `checked`/`total` counter, the shared 30s ticker, and a completion line.

Implemented via the OpenSpec change `improve-fsck-messaging` (archived in this PR); 4 new requirements synced into the `fsck` capability spec.

## Test plan

- [x] `task fmt` — 0 changed
- [x] `task lint` — 0 issues
- [x] `task test` — all packages pass
- [x] New unit tests: run-plan gating per flag combination, run-mode resolution, and uniform `logProgress` field set across phases 1/2/3
- [x] Existing `fsck` test suite passes unchanged (proves detection/repair/exit codes are unaffected)