### PR TITLE
fix(fsck): register cache-temp-path flag so --repair honors config

### DIFF
--- a/docs/docs/User Guide/Operations/Integrity Check (fsck).md
+++ b/docs/docs/User Guide/Operations/Integrity Check (fsck).md
@@ -180,6 +180,7 @@ ncps fsck \
 | `--dry-run` | Show what would be fixed without making any changes |
 | `--verified-since` | Skip checking NARs verified within this duration (e.g., `24h`, `168h`) |
 | `--verify-content` | _(CDC only)_ Read and hash every chunk's decompressed bytes to detect corruption. Expensive — reads all chunk data from storage. Combine with `--verified-since` to limit scope. |
+| `--cache-temp-path` | Directory the cache uses for temporary files when `--repair` builds a cache (env `CACHE_TEMP_PATH`, config `cache.temp-path`; default: system temp). On hardened deployments with a read-only root filesystem, point this at a writable directory (e.g. a mounted `emptyDir`) — otherwise `--repair` fails its temp-directory writability check before performing any repair. |
 
 ### Storage Flags
 

--- a/openspec/changes/archive/2026-06-12-fsck-cache-temp-path/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-12-fsck-cache-temp-path/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-12

--- a/openspec/changes/archive/2026-06-12-fsck-cache-temp-path/design.md
+++ b/openspec/changes/archive/2026-06-12-fsck-cache-temp-path/design.md
@@ -1,0 +1,95 @@
+## Context
+
+`createCache` (`pkg/ncps/serve.go:~1154`) is the shared cache constructor used by
+`serve`, the migrate commands, and — under `--repair` — by `fsck`'s
+chunked-residue janitor (`fsckCommand` → `repairChunkedResidue` →
+`createCache`). It calls:
+
+```go
+c.SetTempDir(cmd.String("cache-temp-path"))
+  → helper.EnsureDirWritable(d)        // os.CreateTemp(d, "boot_test")
+```
+
+`SetTempDir`/`EnsureDirWritable` probe writability of `d`. When `d == ""`,
+`os.CreateTemp("", …)` resolves to `os.TempDir()` (`/tmp`).
+
+`serve.go:317`, `migrate_chunks_to_nar.go:57`, and `migrate_nar_to_chunks.go:48`
+all register a `cache-temp-path` flag with
+`Sources: flagSources("cache.temp-path", "CACHE_TEMP_PATH")`. `fsckCommand`
+(`pkg/ncps/fsck.go:230-397`) does not. Consequently, on the fsck subcommand
+`cmd.String("cache-temp-path")` returns `""` even though the mounted config sets
+`cache.temp-path: /tmp/ncps`, and `createCache` probes the read-only `/tmp`,
+failing the whole run before any repair.
+
+The Helm chart is already correct: the fsck CronJob mounts the writable temp
+volume at `.Values.config.cache.tempPath` and the ConfigMap emits `temp-path`.
+The only missing link is the code that lets fsck read that value.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `fsck --repair` honor `cache.temp-path` / `CACHE_TEMP_PATH` /
+  `--cache-temp-path` by registering the flag on `fsckCommand`.
+- Document the flag for fsck.
+- Confirm (and record) that the chart needs no change.
+
+**Non-Goals:**
+
+- Wiring fsck's other cache flags (CDC tuning, staging, secret-key-path,
+  sign-narinfo). Out of scope; the residue janitor disables lazy chunking and the
+  secret key falls back to the DB.
+- Any change to `createCache`, detection, repair, summary, or exit codes.
+- Chart or deployment security-posture changes.
+
+## Decisions
+
+### Decision 1: Register the flag on fsck, mirroring serve — don't special-case the temp dir
+
+Add a single `cli.StringFlag{Name: "cache-temp-path", Usage: …, Sources: flagSources("cache.temp-path", "CACHE_TEMP_PATH")}`
+to `fsckCommand`'s flag list. `createCache` already reads
+`cmd.String("cache-temp-path")`, so no other code changes are needed — once the
+flag exists with its config/env sources, the value flows through.
+
+- **Why over alternatives:** keeps fsck consistent with every other subcommand
+  that builds a cache; the fix is the *absence* being corrected, not new
+  behavior.
+- **Alternative — default the temp dir to the cache data-path inside `createCache`
+  (rejected):** changes shared behavior for all commands and masks the real
+  inconsistency; larger blast radius for a one-flag omission.
+- **Alternative — deployment-only workaround (emptyDir at `/tmp`) (rejected as
+  the fix):** valid as an immediate unblock but leaves the code bug; future
+  hardened deployments would hit it again.
+
+### Decision 2: Docs get one flag row; chart verified-no-change
+
+Add `--cache-temp-path` to the fsck flags table in
+`Integrity Check (fsck).md`, matching how `serve`/migrate already document it.
+Add a tasks step to render/inspect the chart's fsck CronJob and confirm no change
+is required, so the "no chart change" conclusion is explicit and verified rather
+than assumed.
+
+## Risks / Trade-offs
+
+- **[Registering the flag changes fsck's resolved temp dir from `/tmp` to the
+  configured path]** → That is precisely the intended fix; the configured path is
+  already writable and mounted. Where no config/env/flag is set, behavior is
+  unchanged (still `os.TempDir()`).
+- **[A test that asserts fsck flag set / temp-dir behavior could be brittle]** →
+  Test at the seam: assert `fsckCommand()` exposes a `cache-temp-path` flag (flag
+  presence + sources), which is stable and directly encodes the requirement.
+- **[Chart truly needs a change and we miss it]** → Mitigated by an explicit
+  verify-the-rendered-cronjob task before concluding.
+
+## Migration Plan
+
+Single PR off `main`, independent of the messaging PR. No DB migration, no config
+schema change (config key already exists and is already set in prod). Rollback =
+revert the commit. Operators on hardened deployments get working `fsck --repair`
+on the next image; no redeploy of config needed. TDD: write a failing test
+asserting fsck registers `cache-temp-path` (with the right sources), then add the
+flag.
+
+## Open Questions
+
+- None. The fix is mechanical and matches three existing precedents.

--- a/openspec/changes/archive/2026-06-12-fsck-cache-temp-path/proposal.md
+++ b/openspec/changes/archive/2026-06-12-fsck-cache-temp-path/proposal.md
@@ -1,0 +1,66 @@
+## Why
+
+`ncps fsck --repair` aborts before performing any repair on a hardened
+(read-only-root-filesystem) deployment. The `fsck` subcommand never registers
+the `cache-temp-path` flag, so when `--repair` builds a `Cache` for the
+chunked-residue janitor, `createCache` calls `SetTempDir(cmd.String("cache-temp-path"))`
+with an empty string. That falls back to `os.TempDir()` (`/tmp`), whose
+writability probe fails on a read-only `/tmp`:
+
+```
+error creating cache for chunked-residue repair: error setting cache temp dir:
+error verifying tmp directory is writable: open /tmp/boot_test...: read-only file system
+```
+
+The mounted config already sets `cache.temp-path: /tmp/ncps` (a writable
+emptyDir), and `serve`, `migrate-chunks-to-nar`, and `migrate-nar-to-chunks` all
+register this flag — only `fsck` is missing it, so it ignores the config and
+dies. This blocks production residue cleanup entirely (observed: a `--repair`
+run completed phases 1–2 then failed entering phase 3, repairing nothing).
+
+## What Changes
+
+- Register the `cache-temp-path` flag on `fsckCommand`, with
+  `Sources: flagSources("cache.temp-path", "CACHE_TEMP_PATH")`, matching
+  `serve.go` and the migrate commands. `createCache` already reads this flag, so
+  fsck will honor `cache.temp-path` from config / `CACHE_TEMP_PATH` from env.
+- Document `--cache-temp-path` in the fsck flags reference doc
+  (`Integrity Check (fsck).md`), alongside the existing flags.
+- Helm chart: no change required — the fsck CronJob already mounts the writable
+  temp volume at `.Values.config.cache.tempPath` and the ConfigMap already emits
+  `temp-path`. The tasks include verifying this so the conclusion is explicit.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `fsck`: add a requirement that the `fsck` subcommand honors the configured
+  cache temp path (config `cache.temp-path` / env `CACHE_TEMP_PATH` / flag
+  `--cache-temp-path`) when building a cache for `--repair`, instead of always
+  falling back to the system temp dir.
+
+## Impact
+
+- Code: `pkg/ncps/fsck.go` (one flag registration). No change to `createCache`,
+  detection, or repair logic.
+- Docs: `docs/docs/User Guide/Operations/Integrity Check (fsck).md` (one flag
+  row).
+- Charts: none (verified already-correct).
+- No database, migration, API, or dependency changes.
+- I/O / latency / memory: negligible. The flag only redirects where the
+  `--repair` cache writes its temp files — to the already-mounted
+  `cache.temp-path` instead of `/tmp`. No new scans, allocations, or network
+  calls.
+
+## Non-goals
+
+- Not changing fsck's detection, summary, repair logic, or exit codes.
+- Not wiring fsck's other cache flags (CDC tuning, in-flight staging,
+  sign-narinfo, secret-key-path); the residue janitor explicitly disables lazy
+  chunking and the secret key already falls back to the database. Only the
+  temp-path blocker is in scope.
+- Not changing the chart or the deployment's read-only-root-filesystem posture.
+- Not addressing fsck's memory/throughput at very large chunk-residue counts
+  (separate concern).

--- a/openspec/changes/archive/2026-06-12-fsck-cache-temp-path/specs/fsck/spec.md
+++ b/openspec/changes/archive/2026-06-12-fsck-cache-temp-path/specs/fsck/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Fsck MUST honor the configured cache temp path when building a cache for --repair
+
+The `fsck` subcommand SHALL register the `cache-temp-path` flag with the same
+configuration and environment sources as the `serve` and migrate subcommands
+(config key `cache.temp-path`, environment variable `CACHE_TEMP_PATH`). When
+`fsck --repair` builds a cache (for the chunked-residue reconcile janitor), it
+SHALL use the resolved cache temp path for its temporary directory instead of
+unconditionally falling back to the operating system's default temp directory.
+On a deployment whose default temp directory is not writable, fsck SHALL still
+proceed with repair as long as the configured cache temp path is writable.
+
+#### Scenario: Configured temp path is used under --repair
+
+- **WHEN** `cache.temp-path` (or `CACHE_TEMP_PATH`, or `--cache-temp-path`) is set
+  to a writable directory and `ncps fsck --repair` runs in CDC mode
+- **THEN** the cache created for chunked-residue reconciliation uses that
+  configured directory for its temp files
+- **AND** fsck does not fail its temp-directory writability check
+
+#### Scenario: Read-only system temp dir no longer blocks repair
+
+- **WHEN** the OS default temp directory (`/tmp`) is read-only but the configured
+  cache temp path points at a writable directory
+- **THEN** `ncps fsck --repair` proceeds to the repair phase instead of aborting
+  with a "tmp directory is writable" / read-only filesystem error
+
+#### Scenario: Flag parity with serve and migrate
+
+- **WHEN** the `fsck` subcommand's flags are enumerated
+- **THEN** a `cache-temp-path` flag is present, sourced from `cache.temp-path`
+  and `CACHE_TEMP_PATH`, matching the `serve`, `migrate-chunks-to-nar`, and
+  `migrate-nar-to-chunks` subcommands

--- a/openspec/changes/archive/2026-06-12-fsck-cache-temp-path/tasks.md
+++ b/openspec/changes/archive/2026-06-12-fsck-cache-temp-path/tasks.md
@@ -1,0 +1,18 @@
+## 1. Code fix (TDD)
+
+- [x] 1.1 Write a failing test asserting `fsckCommand()` registers a `cache-temp-path` string flag whose sources include config `cache.temp-path` and env `CACHE_TEMP_PATH` (assert flag presence + name; mirror how serve/migrate are wired).
+- [x] 1.2 Add the `cache-temp-path` `cli.StringFlag` to `fsckCommand`'s flag list with `Sources: flagSources("cache.temp-path", "CACHE_TEMP_PATH")` and a usage string matching serve. Confirm `createCache` already consumes `cmd.String("cache-temp-path")` (no further code change expected).
+- [x] 1.3 Run the new test green; confirm no existing fsck tests regress.
+
+## 2. Docs
+
+- [x] 2.1 Add a `--cache-temp-path` row (with `CACHE_TEMP_PATH` env, default = system temp) to the fsck flags reference in `docs/docs/User Guide/Operations/Integrity Check (fsck).md`, and note that hardened (read-only-root) deployments must point it at a writable directory.
+
+## 3. Charts (verify, change only if required)
+
+- [x] 3.1 Render/inspect the fsck CronJob (`charts/ncps/templates/fsck-cronjob.yaml`) and ConfigMap; confirm the writable temp volume is mounted at `.Values.config.cache.tempPath` and the ConfigMap emits `temp-path`. Conclude explicitly whether a chart change is needed; make the change only if the verification shows a gap.
+
+## 4. Verification
+
+- [x] 4.1 Run `task fmt`, `task lint`, and `task test`; confirm each exits zero.
+- [x] 4.2 If `helm unittest charts/ncps` is part of the chart test surface and the chart was touched, run it; otherwise note it was not required.

--- a/openspec/specs/fsck/spec.md
+++ b/openspec/specs/fsck/spec.md
@@ -305,3 +305,36 @@ When `cdcMode` is enabled **solely** by signal 3 (signals 1 and 2 both false), `
 - **WHEN** `cdc_enabled` equals `"true"` and chunk rows also exist
 - **THEN** `cdcMode` is enabled via signal 1 and the residue-detection log is NOT emitted
 
+### Requirement: Fsck MUST honor the configured cache temp path when building a cache for --repair
+
+The `fsck` subcommand SHALL register the `cache-temp-path` flag with the same
+configuration and environment sources as the `serve` and migrate subcommands
+(config key `cache.temp-path`, environment variable `CACHE_TEMP_PATH`). When
+`fsck --repair` builds a cache (for the chunked-residue reconcile janitor), it
+SHALL use the resolved cache temp path for its temporary directory instead of
+unconditionally falling back to the operating system's default temp directory.
+On a deployment whose default temp directory is not writable, fsck SHALL still
+proceed with repair as long as the configured cache temp path is writable.
+
+#### Scenario: Configured temp path is used under --repair
+
+- **WHEN** `cache.temp-path` (or `CACHE_TEMP_PATH`, or `--cache-temp-path`) is set
+  to a writable directory and `ncps fsck --repair` runs in CDC mode
+- **THEN** the cache created for chunked-residue reconciliation uses that
+  configured directory for its temp files
+- **AND** fsck does not fail its temp-directory writability check
+
+#### Scenario: Read-only system temp dir no longer blocks repair
+
+- **WHEN** the OS default temp directory (`/tmp`) is read-only but the configured
+  cache temp path points at a writable directory
+- **THEN** `ncps fsck --repair` proceeds to the repair phase instead of aborting
+  with a "tmp directory is writable" / read-only filesystem error
+
+#### Scenario: Flag parity with serve and migrate
+
+- **WHEN** the `fsck` subcommand's flags are enumerated
+- **THEN** a `cache-temp-path` flag is present, sourced from `cache.temp-path`
+  and `CACHE_TEMP_PATH`, matching the `serve`, `migrate-chunks-to-nar`, and
+  `migrate-nar-to-chunks` subcommands
+

--- a/pkg/ncps/fsck.go
+++ b/pkg/ncps/fsck.go
@@ -253,6 +253,12 @@ Use --repair to automatically fix detected issues, or --dry-run to preview what 
 				Sources: flagSources("cache.fsck.dechunk-residue-grace", "CACHE_FSCK_DECHUNK_RESIDUE_GRACE"),
 				Value:   defaultDechunkResidueGrace,
 			},
+			&cli.StringFlag{
+				Name:    flagNameCacheTempPath,
+				Usage:   flagUsageCacheTempPath,
+				Sources: flagSources("cache.temp-path", "CACHE_TEMP_PATH"),
+				Value:   os.TempDir(),
+			},
 
 			// Storage Flags
 			&cli.StringFlag{

--- a/pkg/ncps/fsck_cache_temp_path_internal_test.go
+++ b/pkg/ncps/fsck_cache_temp_path_internal_test.go
@@ -1,0 +1,43 @@
+package ncps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v3"
+)
+
+// TestFsckRegistersCacheTempPathFlag proves the fsck subcommand registers the
+// cache-temp-path flag wired to the same config key and env var as serve and the
+// migrate commands. Without it, fsck --repair builds a cache with an empty temp
+// dir that falls back to a read-only /tmp on hardened deployments and aborts
+// before any repair.
+func TestFsckRegistersCacheTempPathFlag(t *testing.T) {
+	t.Parallel()
+
+	var sourceCalls [][2]string
+
+	flagSources := func(configFileKey, envVar string) cli.ValueSourceChain {
+		sourceCalls = append(sourceCalls, [2]string{configFileKey, envVar})
+
+		return cli.ValueSourceChain{}
+	}
+
+	cmd := fsckCommand(flagSources, func(string, shutdownFn) {})
+
+	names := make(map[string]bool)
+
+	for _, f := range cmd.Flags {
+		for _, n := range f.Names() {
+			names[n] = true
+		}
+	}
+
+	assert.True(t, names["cache-temp-path"], "fsck must register the --cache-temp-path flag")
+	assert.Contains(
+		t,
+		sourceCalls,
+		[2]string{"cache.temp-path", "CACHE_TEMP_PATH"},
+		"cache-temp-path must be sourced from config cache.temp-path and env CACHE_TEMP_PATH",
+	)
+}

--- a/pkg/ncps/root.go
+++ b/pkg/ncps/root.go
@@ -77,6 +77,7 @@ const (
 
 	// Flag usage strings.
 	flagUsageStorageLocal       = "The local data path used for configuration and cache storage (use this OR S3 storage)"
+	flagUsageCacheTempPath      = "The path to the temporary directory that is used by the cache to download NAR files"
 	flagUsageS3Bucket           = "S3 bucket name for storage (use this OR --cache-storage-local for local storage)"
 	flagUsageS3AccessKeyID      = "S3 access key ID"
 	flagUsageS3Endpoint         = "S3-compatible endpoint URL with scheme"


### PR DESCRIPTION
## Summary

`ncps fsck --repair` aborts after the scan — before performing any repair — on a hardened deployment with a read-only root filesystem:

```
error creating cache for chunked-residue repair: error setting cache temp dir:
error verifying tmp directory is writable: open /tmp/boot_test...: read-only file system
```

**Root cause:** the `fsck` subcommand never registered the `cache-temp-path` flag. `serve`, `migrate-chunks-to-nar`, and `migrate-nar-to-chunks` all do. So when `--repair` builds a cache for the chunked-residue janitor, `createCache` calls `SetTempDir(cmd.String("cache-temp-path"))` with an empty string, which falls back to `os.TempDir()` (`/tmp`). In the prod cronjob `/tmp` is read-only (the writable `emptyDir` is mounted at `/tmp/ncps`, and config sets `cache.temp-path: /tmp/ncps`), so the writability probe fails and the run errors out.

**Fix:** register `cache-temp-path` on `fsckCommand` with the same sources (`cache.temp-path` / `CACHE_TEMP_PATH`). `createCache` already consumes the value, so fsck now honors the configured path. The shared usage string is factored into a `flagUsageCacheTempPath` constant (and the existing `flagNameCacheTempPath` constant is used) to keep the literal under the goconst threshold.

This was found while running the (separate) fsck messaging change in production; it is independent of PR #1402.

## Docs & chart
- Added a `--cache-temp-path` row to the fsck flags reference, with the read-only-root guidance.
- **No chart change needed** — verified via `helm template` that the fsck CronJob mounts the temp volume at `cache.tempPath` (`/tmp/ncps`) and the ConfigMap emits `temp-path`.

## Test plan
- [x] `TestFsckRegistersCacheTempPathFlag` — asserts the flag is present and sourced from `cache.temp-path` / `CACHE_TEMP_PATH` (red before the fix, green after)
- [x] `task fmt` — clean
- [x] `task lint` — 0 issues
- [x] `task test` — all packages pass
- [x] `helm template` — fsck CronJob temp mount + ConfigMap `temp-path` confirmed