### PR TITLE
feat(server): add Bearer token auth for GET/HEAD routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **Optional Bearer-token authentication for read paths.** A new
+  `--cache-get-token` flag (env `CACHE_GET_TOKEN`) protects `GET` and `HEAD`
+  requests: when set, requests without a matching `Authorization: Bearer <token>`
+  header are rejected with `401 Unauthorized` (carrying a `WWW-Authenticate: Bearer`
+  challenge), with a constant-time token comparison to avoid timing side-channels.
+  The `/healthz` and `/metrics` infrastructure routes are always exempt, and
+  `PUT`/`DELETE` are unaffected (they keep their `--cache-allow-put-verb` /
+  `--cache-allow-delete-verb` guards). Empty (the default) leaves reads
+  unauthenticated, so this is opt-in and non-breaking. In the Helm chart the
+  token is delivered as the `CACHE_GET_TOKEN` env var sourced from a Kubernetes
+  Secret via `config.permissions.getToken` (chart-managed Secret) or
+  `config.permissions.getTokenExistingSecret`, never the plaintext ConfigMap.
+  (#1136)
+
 - **In-flight NAR staging for cross-pod serving during download.** A replica
   holding a download can now serve the in-flight NAR to other replicas while it
   is still downloading, by staging it to shared storage as ordered, immutable,

--- a/charts/ncps/templates/deployment.yaml
+++ b/charts/ncps/templates/deployment.yaml
@@ -149,6 +149,13 @@ spec:
                   key: {{ if .Values.config.redis.existingSecret }}"password"{{ else }}"redis-password"{{ end }}
             {{- end }}
             {{- end }}
+            {{- if or .Values.config.permissions.getToken .Values.config.permissions.getTokenExistingSecret }}
+            - name: CACHE_GET_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.permissions.getTokenExistingSecret | default (include "ncps.fullname" .) }}
+                  key: get-token
+            {{- end }}
             {{- $scratch := dict "gomemlimitDefined" false }}
             {{- range .Values.extraEnvVars }}
               {{- if eq .name "GOMEMLIMIT" }}

--- a/charts/ncps/templates/secret.yaml
+++ b/charts/ncps/templates/secret.yaml
@@ -4,6 +4,7 @@
   (and (eq .Values.config.database.type "mysql") (not .Values.config.database.mysql.existingSecret))
   (and .Values.config.redis.enabled (not .Values.config.redis.existingSecret) (or .Values.config.redis.password .Values.config.redis.username))
   (and .Values.config.upstream.netrcFile (not .Values.config.upstream.existingNetrcSecret))
+  (and .Values.config.permissions.getToken (not .Values.config.permissions.getTokenExistingSecret))
 -}}
 apiVersion: v1
 kind: Secret
@@ -55,5 +56,8 @@ data:
   {{- end }}
   {{- if and .Values.config.upstream.netrcFile (not .Values.config.upstream.existingNetrcSecret) }}
   netrc: {{ .Values.config.upstream.netrcFile | b64enc | quote }}
+  {{- end }}
+  {{- if and .Values.config.permissions.getToken (not .Values.config.permissions.getTokenExistingSecret) }}
+  get-token: {{ .Values.config.permissions.getToken | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/ncps/templates/statefulset.yaml
+++ b/charts/ncps/templates/statefulset.yaml
@@ -140,6 +140,13 @@ spec:
                   key: {{ if .Values.config.redis.existingSecret }}"password"{{ else }}"redis-password"{{ end }}
             {{- end }}
             {{- end }}
+            {{- if or .Values.config.permissions.getToken .Values.config.permissions.getTokenExistingSecret }}
+            - name: CACHE_GET_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.config.permissions.getTokenExistingSecret | default (include "ncps.fullname" .) }}
+                  key: get-token
+            {{- end }}
             {{- $scratch := dict "gomemlimitDefined" false }}
             {{- range .Values.extraEnvVars }}
               {{- if eq .name "GOMEMLIMIT" }}

--- a/charts/ncps/tests/configmap_test.yaml
+++ b/charts/ncps/tests/configmap_test.yaml
@@ -260,6 +260,18 @@ tests:
           path: data["config.yaml"]
           pattern: "allow-delete-verb: true"
 
+  - it: should never place the get-token in the plaintext ConfigMap
+    set:
+      config.hostname: test.example.com
+      config.permissions.getToken: test-bearer-token
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "get-token"
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "test-bearer-token"
+
   - it: should configure narinfo signing
     set:
       config.hostname: test.example.com

--- a/charts/ncps/tests/deployment_test.yaml
+++ b/charts/ncps/tests/deployment_test.yaml
@@ -617,3 +617,78 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: GOMEMLIMIT
+
+  # CACHE_GET_TOKEN (read-path auth) env injection
+  - it: should inject CACHE_GET_TOKEN from managed secret when getToken set in Deployment
+    template: deployment.yaml
+    set:
+      mode: deployment
+      config.hostname: test.example.com
+      config.storage.type: s3
+      config.storage.s3.bucket: my-bucket
+      config.storage.s3.endpoint: https://s3.amazonaws.com
+      config.storage.s3.accessKeyId: test-key
+      config.storage.s3.secretAccessKey: test-secret
+      config.permissions.getToken: test-bearer-token
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CACHE_GET_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-ncps
+                key: get-token
+
+  - it: should inject CACHE_GET_TOKEN from existing secret when getTokenExistingSecret set in Deployment
+    template: deployment.yaml
+    set:
+      mode: deployment
+      config.hostname: test.example.com
+      config.storage.type: s3
+      config.storage.s3.bucket: my-bucket
+      config.storage.s3.endpoint: https://s3.amazonaws.com
+      config.storage.s3.accessKeyId: test-key
+      config.storage.s3.secretAccessKey: test-secret
+      config.permissions.getTokenExistingSecret: my-get-token-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CACHE_GET_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-get-token-secret
+                key: get-token
+
+  - it: should not inject CACHE_GET_TOKEN when no token configured in Deployment
+    template: deployment.yaml
+    set:
+      mode: deployment
+      config.hostname: test.example.com
+      config.storage.type: s3
+      config.storage.s3.bucket: my-bucket
+      config.storage.s3.endpoint: https://s3.amazonaws.com
+      config.storage.s3.accessKeyId: test-key
+      config.storage.s3.secretAccessKey: test-secret
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CACHE_GET_TOKEN
+
+  - it: should inject CACHE_GET_TOKEN from managed secret when getToken set in StatefulSet
+    template: statefulset.yaml
+    set:
+      mode: statefulset
+      config.hostname: test.example.com
+      config.permissions.getToken: test-bearer-token
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CACHE_GET_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-ncps
+                key: get-token

--- a/charts/ncps/tests/deployment_test.yaml
+++ b/charts/ncps/tests/deployment_test.yaml
@@ -692,3 +692,30 @@ tests:
               secretKeyRef:
                 name: RELEASE-NAME-ncps
                 key: get-token
+
+  - it: should inject CACHE_GET_TOKEN from existing secret when getTokenExistingSecret set in StatefulSet
+    template: statefulset.yaml
+    set:
+      mode: statefulset
+      config.hostname: test.example.com
+      config.permissions.getTokenExistingSecret: my-get-token-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CACHE_GET_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-get-token-secret
+                key: get-token
+
+  - it: should not inject CACHE_GET_TOKEN when no token configured in StatefulSet
+    template: statefulset.yaml
+    set:
+      mode: statefulset
+      config.hostname: test.example.com
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CACHE_GET_TOKEN

--- a/charts/ncps/tests/secret_test.yaml
+++ b/charts/ncps/tests/secret_test.yaml
@@ -298,6 +298,34 @@ tests:
       - hasDocuments:
           count: 0
 
+  # GET token (read-path auth) tests
+  - it: should create get-token in secret when set inline
+    set:
+      config.hostname: test.example.com
+      config.permissions.getToken: test-bearer-token
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: data["get-token"]
+          value: dGVzdC1iZWFyZXItdG9rZW4=
+          # Decodes to: test-bearer-token
+
+  - it: should not create get-token when using existing secret
+    set:
+      config.hostname: test.example.com
+      config.permissions.getTokenExistingSecret: my-get-token-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create get-token when not configured
+    set:
+      config.hostname: test.example.com
+    asserts:
+      - hasDocuments:
+          count: 0
+
   # Combined scenarios
   - it: should create secret with multiple credential types
     set:

--- a/charts/ncps/values.schema.json
+++ b/charts/ncps/values.schema.json
@@ -104,6 +104,12 @@
             },
             "allowDelete": {
               "type": "boolean"
+            },
+            "getToken": {
+              "type": "string"
+            },
+            "getTokenExistingSecret": {
+              "type": "string"
             }
           }
         },

--- a/charts/ncps/values.yaml
+++ b/charts/ncps/values.yaml
@@ -107,6 +107,16 @@ config:
     allowPut: false
     # Allow DELETE verb to delete narInfo and nar files
     allowDelete: false
+    # Optional Bearer token required on GET/HEAD requests. When set, the token is
+    # delivered to the container as the CACHE_GET_TOKEN env var sourced from a
+    # Kubernetes Secret (never the plaintext ConfigMap). /healthz and /metrics
+    # are always exempt; PUT/DELETE are unaffected. Leave empty to serve reads
+    # without authentication.
+    # Provide the token inline (a chart-managed Secret is created)...
+    getToken: ""
+    # ...or reference an existing Secret containing the token under key "get-token".
+    # When set, getToken is ignored.
+    getTokenExistingSecret: ""
 
   # NAR info signing
   signing:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -32,6 +32,12 @@ cache:
   allow-delete-verb: true
   # Whether to allow the PUT verb to push narInfo and nar files directly
   allow-put-verb: true
+  # Optional Bearer token required to access GET and HEAD routes. When set,
+  # requests without a matching "Authorization: Bearer <token>" header are
+  # rejected with 401 Unauthorized. /healthz and /metrics are always exempt;
+  # PUT and DELETE are unaffected. Leave empty (the default) to serve reads
+  # without authentication. Env: CACHE_GET_TOKEN.
+  get-token: ""
   # The hostname of the cache server
   hostname: "ncps.mycompany.tld"
   # Download configuration

--- a/docs/docs/User Guide/Configuration/Reference.md
+++ b/docs/docs/User Guide/Configuration/Reference.md
@@ -210,6 +210,7 @@ In-flight staging resolves the cross-pod serve-during-download gap for **all** m
 | `--cache-secret-key-path` | Path to signing private key | `CACHE_SECRET_KEY_PATH` | auto-generated |
 | `--cache-allow-put-verb` | Allow PUT uploads to cache (requires `/upload` prefix) | `CACHE_ALLOW_PUT_VERB` | `false` |
 | `--cache-allow-delete-verb` | Allow DELETE operations on cache | `CACHE_ALLOW_DELETE_VERB` | `false` |
+| `--cache-get-token` | Bearer token required on GET/HEAD requests when set (`/healthz` and `/metrics` always exempt; PUT/DELETE unaffected) | `CACHE_GET_TOKEN` | _(empty: reads are unauthenticated)_ |
 | `--netrc-file` | Path to netrc file for upstream auth | `NETRC_FILE` | `~/.netrc` |
 
 **Example:**

--- a/docs/docs/User Guide/Usage/Cache Management.md
+++ b/docs/docs/User Guide/Usage/Cache Management.md
@@ -255,7 +255,7 @@ are unaffected (they are governed by `--cache-allow-put-verb` /
 Consuming clients can supply the token via a `netrc` file referenced from
 `nix.conf` (`netrc-file`), for example:
 
-```
+```netrc
 machine your-ncps-hostname password <token>
 ```
 

--- a/docs/docs/User Guide/Usage/Cache Management.md
+++ b/docs/docs/User Guide/Usage/Cache Management.md
@@ -235,6 +235,36 @@ nix copy --to http://your-ncps-hostname:8501/upload ./your-package
 > [!NOTE]
 > The `/upload` prefix is required for all PUT operations. This ensures that the upload is handled correctly and skips any upstream checks.
 
+## Authenticating Read Access
+
+By default, read paths (`GET`/`HEAD` for `.narinfo` and `.nar` files) are served
+without authentication. On shared or public-facing deployments you can require a
+Bearer token by setting `--cache-get-token` (env `CACHE_GET_TOKEN`):
+
+```sh
+ncps serve --cache-get-token="$(cat /etc/ncps/get-token)"
+```
+
+When set, every `GET` and `HEAD` request must include a matching
+`Authorization: Bearer <token>` header; requests without it receive
+`401 Unauthorized`. The `/healthz` and `/metrics` infrastructure routes are
+always exempt so health probes and metrics scraping keep working, and `PUT`/`DELETE`
+are unaffected (they are governed by `--cache-allow-put-verb` /
+`--cache-allow-delete-verb`).
+
+Consuming clients can supply the token via a `netrc` file referenced from
+`nix.conf` (`netrc-file`), for example:
+
+```
+machine your-ncps-hostname password <token>
+```
+
+> [!NOTE]
+> The token is a shared secret. Distribute it over a secure channel and prefer
+> sourcing it from a file or secret store rather than embedding it in shell
+> history. In Kubernetes, the Helm chart sources it from a `Secret` (see
+> `config.permissions.getToken` / `getTokenExistingSecret`).
+
 ## Best Practices
 
 1. **Set reasonable max-size** - Based on available disk space

--- a/openspec/changes/archive/2026-06-20-proxy-get-token-auth/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-20-proxy-get-token-auth/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/archive/2026-06-20-proxy-get-token-auth/design.md
+++ b/openspec/changes/archive/2026-06-20-proxy-get-token-auth/design.md
@@ -33,12 +33,16 @@ discoverable.
   exemption in the gate is belt-and-suspenders; the `/metrics` exemption is
   load-bearing because `/metrics` is a real route handler that runs after the
   middleware. We keep both path checks for clarity and defense-in-depth.
-- **Constant-time compare.** Use `subtle.ConstantTimeCompare([]byte(got), []byte(s.getToken)) == 1`
-  guarded by a `strings.HasPrefix(authHeader, "Bearer ")` check first.
-  Rationale: ordinary `!=` short-circuits on the first differing byte and leaks
-  token bytes via response timing; `ConstantTimeCompare` does not. Alternative
-  (hashing both sides and comparing) was rejected as unnecessary complexity for
-  a single static secret.
+- **Constant-time compare over SHA-256 digests.** SHA-256-hash both the
+  presented and configured tokens to a fixed 32 bytes, then compare with
+  `subtle.ConstantTimeCompare(presentedHash[:], expectedHash[:]) == 1`, guarded
+  by a `strings.HasPrefix(authHeader, "Bearer ")` check first. Rationale:
+  ordinary `!=` short-circuits on the first differing byte and leaks token bytes
+  via response timing. `ConstantTimeCompare` fixes that, but called on the raw
+  variable-length tokens it still returns early when the slice lengths differ —
+  leaking the secret's *length* (Gemini review on PR #1406). Hashing both sides
+  first makes the compared inputs always 32 bytes, so the comparison time is
+  independent of both content and length.
 - **401 header.** Emit `WWW-Authenticate: Bearer` before writing the status, as
   RFC 7235 §4.1 requires a challenge on `401`.
 - **Helm secret handling.** The token is sensitive, so it is delivered as the

--- a/openspec/changes/archive/2026-06-20-proxy-get-token-auth/design.md
+++ b/openspec/changes/archive/2026-06-20-proxy-get-token-auth/design.md
@@ -1,0 +1,80 @@
+## Context
+
+ncps serves cache reads (`.narinfo`, `.nar`, build-trace, pins) over plain
+unauthenticated HTTP. On shared or public deployments this allows anonymous
+bandwidth scraping. The codebase already has an opt-in verb-permission pattern
+(`SetPutPermitted` / `SetDeletePermitted` + chi middleware) that read-path auth
+can follow for consistency. PR #1406 introduced the core flag, field, setter and
+`requireGetToken` middleware; this change adopts that work, hardens it, and
+completes the surrounding docs/chart/changelog so the feature is usable and
+discoverable.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Opt-in, non-breaking Bearer-token gate on GET/HEAD read paths.
+- Constant-time secret comparison (no timing side-channel).
+- RFC 7235-compliant `401` (`WWW-Authenticate: Bearer`).
+- Infra routes (`/healthz`, `/metrics`) always reachable for probes/scrape.
+- First-class Helm support that treats the token as a secret, not config.
+- Documentation parity with the existing verb flags.
+
+**Non-Goals:**
+- Multi-token, scopes, JWT/OAuth, or per-route policies (single shared token).
+- Authenticating PUT/DELETE (own guards) or changing signing behavior.
+- Touching the upstream nixpkgs NixOS module (`NixOS.md`).
+
+## Decisions
+
+- **Middleware placement.** `requireGetToken` is registered via `s.router.Use`
+  after `skipTelemetryForInfraRoutes` and before route registration, matching
+  the existing middleware chain. `middleware.Heartbeat("/healthz")` already
+  short-circuits `/healthz` earlier in the chain, so the explicit `/healthz`
+  exemption in the gate is belt-and-suspenders; the `/metrics` exemption is
+  load-bearing because `/metrics` is a real route handler that runs after the
+  middleware. We keep both path checks for clarity and defense-in-depth.
+- **Constant-time compare.** Use `subtle.ConstantTimeCompare([]byte(got), []byte(s.getToken)) == 1`
+  guarded by a `strings.HasPrefix(authHeader, "Bearer ")` check first.
+  Rationale: ordinary `!=` short-circuits on the first differing byte and leaks
+  token bytes via response timing; `ConstantTimeCompare` does not. Alternative
+  (hashing both sides and comparing) was rejected as unnecessary complexity for
+  a single static secret.
+- **401 header.** Emit `WWW-Authenticate: Bearer` before writing the status, as
+  RFC 7235 §4.1 requires a challenge on `401`.
+- **Helm secret handling.** The token is sensitive, so it is delivered as the
+  `CACHE_GET_TOKEN` env var via `secretKeyRef`, mirroring `redis-password`:
+  `config.permissions.getToken` (inline → chart-managed Secret key
+  `get-token`) and `config.permissions.getTokenExistingSecret` (operator Secret;
+  key `get-token`). It is deliberately NOT written into the ConfigMap, which is
+  plaintext. Alternative (ConfigMap value, like the verb booleans) was rejected
+  because the verb flags are non-secret booleans whereas this is a credential.
+- **Env precedence.** The flag reads from `cache.get-token` (file) and
+  `CACHE_GET_TOKEN` (env). The chart sets only the env var; the ConfigMap omits
+  `get-token`, so there is no plaintext-vs-secret conflict.
+
+## Risks / Trade-offs
+
+- **Operator misconfig leaving reads open** → Default empty preserves current
+  behavior; documented prominently in Reference + Cache Management so operators
+  know it is opt-in.
+- **Token in ConfigMap by accident** → Chart sources it only from a Secret; a
+  chart unit test asserts the ConfigMap has no plaintext token and the env var
+  uses `secretKeyRef`.
+- **Probes/scrape breaking under auth** → Infra-route exemption + an explicit
+  `/healthz` test guard against regressions.
+- **Clients that cannot send Authorization** → Out of scope; this is opt-in and
+  intended for deployments whose clients can set the header (e.g. via netrc /
+  `nix.conf` `netrc-file` on the consuming side).
+
+## Migration Plan
+
+Additive and opt-in; no data migration. Operators enable by setting
+`--cache-get-token` / `CACHE_GET_TOKEN` (or the chart `getToken` /
+`getTokenExistingSecret` values) and distributing the token to clients. Rollback
+is unsetting the flag/value (reverts to open reads). No schema or storage
+changes.
+
+## Open Questions
+
+- None blocking. A future enhancement could support multiple/rotating tokens,
+  but that is explicitly out of scope here.

--- a/openspec/changes/archive/2026-06-20-proxy-get-token-auth/proposal.md
+++ b/openspec/changes/archive/2026-06-20-proxy-get-token-auth/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+On shared or public-facing ncps deployments, the read paths (GET/HEAD for
+`.narinfo` and `.nar`) are unauthenticated, exposing the cache to anonymous
+abuse and bandwidth scraping. Issue #1136 requested an opt-in way to require a
+token on read paths; the maintainer agreed. PR #1406 began this work; this
+change captures it and rounds it out to full project scope (security hardening,
+docs, Helm, changelog).
+
+## What Changes
+
+- Add a `--cache-get-token` flag (env `CACHE_GET_TOKEN`) that, when set,
+  requires `Authorization: Bearer <token>` on every GET and HEAD request.
+  Unauthenticated/incorrect requests get `401 Unauthorized`. Empty (default)
+  preserves today's open behavior, so this is non-breaking.
+- A `requireGetToken` chi middleware enforces this. Infra routes (`/healthz`,
+  `/metrics`) are always exempt; PUT/DELETE are unaffected (they keep their
+  existing `putPermitted`/`deletePermitted` guards).
+- **Security:** compare the presented token with `crypto/subtle.ConstantTimeCompare`
+  to avoid leaking the secret via a timing side-channel.
+- The 401 response carries a `WWW-Authenticate: Bearer` header per RFC 7235.
+- **Docs:** document the flag in the Configuration Reference (Security & Signing)
+  and Cache Management usage guide; add `cache.get-token` to `config.example.yaml`.
+- **Helm:** because the token is a secret, expose it as the `CACHE_GET_TOKEN`
+  env var sourced from a managed/existing Kubernetes Secret (mirroring the
+  `redis-password` pattern) rather than placing it in the plaintext ConfigMap.
+  Add `values.yaml` keys, a `values.schema.json` entry, and a chart unit test.
+- **Changelog:** add an `Added` entry under `[Unreleased]`.
+
+## Capabilities
+
+### New Capabilities
+- `read-path-auth`: optional Bearer-token authentication gate for GET/HEAD
+  cache read paths, configured via flag/env and (in Kubernetes) a Secret-backed
+  env var, with infra routes always exempt and write verbs unaffected.
+
+### Modified Capabilities
+<!-- None: write-verb guards, signing, and the API surface keep their existing requirements. -->
+
+## Impact
+
+- Code: `pkg/server/server.go` (field, setter, middleware), `pkg/ncps/serve.go`
+  (flag wiring), `pkg/server/server_test.go` (tests).
+- Config/docs: `config.example.yaml`, `docs/.../Reference.md`,
+  `docs/.../Cache Management.md`, `CHANGELOG.md`.
+- Helm: `charts/ncps/values.yaml`, `templates/secret.yaml`,
+  `templates/deployment.yaml`, `templates/statefulset.yaml`,
+  `values.schema.json`, and chart tests.
+- Out of scope: NixOS module docs (`NixOS.md`) — that module lives in upstream
+  nixpkgs, not this repo.
+
+## Non-goals
+
+- No per-user/multi-token, scopes, JWT, or OAuth — a single shared static token.
+- No authentication for PUT/DELETE (already governed by their own verb guards).
+- No change to signing, trusted-signature, or upstream-auth behavior.
+
+## I/O, latency, memory
+
+Negligible: when the token is empty the middleware short-circuits with a single
+string check; when set it adds one header read and a constant-time byte compare
+per GET/HEAD request. No additional I/O, network calls, or allocations on the
+hot path.

--- a/openspec/changes/archive/2026-06-20-proxy-get-token-auth/specs/read-path-auth/spec.md
+++ b/openspec/changes/archive/2026-06-20-proxy-get-token-auth/specs/read-path-auth/spec.md
@@ -1,0 +1,114 @@
+## ADDED Requirements
+
+### Requirement: Optional Bearer token for read paths
+
+The server SHALL support an optional read-path authentication token, configured
+via the `--cache-get-token` flag (env `CACHE_GET_TOKEN`). When the token is
+non-empty, the server SHALL require an `Authorization: Bearer <token>` header
+that matches the configured token on every `GET` and `HEAD` request, and SHALL
+reject non-matching requests with `401 Unauthorized`. When the token is empty
+(the default), the server SHALL serve read paths without authentication,
+preserving existing behavior.
+
+#### Scenario: No token configured allows anonymous reads
+
+- **WHEN** no token is configured and a `GET` request arrives without an `Authorization` header
+- **THEN** the server processes the request normally (no `401` is returned by the auth gate)
+
+#### Scenario: Correct token allows GET
+
+- **WHEN** a token is configured and a `GET` request carries `Authorization: Bearer <token>` matching the configured token
+- **THEN** the server processes the request normally
+
+#### Scenario: Correct token allows HEAD
+
+- **WHEN** a token is configured and a `HEAD` request carries `Authorization: Bearer <token>` matching the configured token
+- **THEN** the server processes the request normally
+
+#### Scenario: Missing Authorization header is rejected
+
+- **WHEN** a token is configured and a `GET` or `HEAD` request arrives without an `Authorization` header
+- **THEN** the server responds with `401 Unauthorized`
+
+#### Scenario: Wrong token is rejected
+
+- **WHEN** a token is configured and a request carries `Authorization: Bearer <wrong>` that does not match the configured token
+- **THEN** the server responds with `401 Unauthorized`
+
+#### Scenario: Malformed Authorization scheme is rejected
+
+- **WHEN** a token is configured and a request carries an `Authorization` header that does not use the `Bearer ` scheme (e.g. `Basic ...`)
+- **THEN** the server responds with `401 Unauthorized`
+
+### Requirement: Token comparison resists timing attacks
+
+The server SHALL compare the presented Bearer token against the configured token
+using a constant-time comparison so that the per-request processing time does
+not reveal how many leading bytes of the secret are correct.
+
+#### Scenario: Comparison is constant-time
+
+- **WHEN** the presented token is compared against the configured token
+- **THEN** the comparison uses a constant-time primitive (`crypto/subtle.ConstantTimeCompare`) rather than ordinary string equality
+
+### Requirement: 401 responses advertise the Bearer scheme
+
+The server SHALL include a `WWW-Authenticate: Bearer` header on `401 Unauthorized`
+responses produced by the read-path auth gate, per RFC 7235.
+
+#### Scenario: Unauthorized response carries WWW-Authenticate
+
+- **WHEN** the read-path auth gate rejects a request with `401 Unauthorized`
+- **THEN** the response includes a `WWW-Authenticate: Bearer` header
+
+### Requirement: Infrastructure routes are always exempt
+
+The server SHALL always serve the `/healthz` and `/metrics` infrastructure
+routes without requiring the read-path token, regardless of whether a token is
+configured.
+
+#### Scenario: healthz is exempt
+
+- **WHEN** a token is configured and a `GET /healthz` request arrives without an `Authorization` header
+- **THEN** the server responds with `200 OK`
+
+#### Scenario: metrics is exempt
+
+- **WHEN** a token is configured and a `GET /metrics` request arrives without an `Authorization` header
+- **THEN** the read-path auth gate does not return `401` for that route
+
+### Requirement: Write verbs are unaffected by the read-path token
+
+The read-path token SHALL apply only to `GET` and `HEAD` requests. `PUT` and
+`DELETE` requests SHALL continue to be governed solely by their existing
+`putPermitted` / `deletePermitted` guards and SHALL NOT be additionally gated by
+the read-path token.
+
+#### Scenario: PUT is not gated by the read-path token
+
+- **WHEN** a token is configured and a `PUT` request arrives without a matching `Authorization` header
+- **THEN** the read-path auth gate does not return `401`, and the request is handled by the existing PUT guard
+
+### Requirement: Kubernetes deployments source the token from a Secret
+
+The Helm chart SHALL deliver the read-path token to the container as the
+`CACHE_GET_TOKEN` environment variable sourced from a Kubernetes Secret (a
+chart-managed Secret when an inline value is provided, or an operator-supplied
+existing Secret), and SHALL NOT place the token in the plaintext ConfigMap. When
+no token is configured, the chart SHALL NOT inject the env var or create a Secret
+key for it.
+
+#### Scenario: Inline token value creates a managed Secret key and env var
+
+- **WHEN** an inline read-path token value is set in chart values
+- **THEN** the rendered manifests include a Secret holding the token and a `CACHE_GET_TOKEN` env var with a `secretKeyRef` to it, and the ConfigMap contains no plaintext token
+
+#### Scenario: Existing Secret is referenced
+
+- **WHEN** the chart values reference an existing Secret for the read-path token
+- **THEN** the rendered `CACHE_GET_TOKEN` env var uses a `secretKeyRef` pointing at that existing Secret
+
+#### Scenario: No token leaves deployments unchanged
+
+- **WHEN** no read-path token is configured in chart values
+- **THEN** the rendered manifests contain no `CACHE_GET_TOKEN` env var and no token Secret key

--- a/openspec/changes/archive/2026-06-20-proxy-get-token-auth/tasks.md
+++ b/openspec/changes/archive/2026-06-20-proxy-get-token-auth/tasks.md
@@ -1,0 +1,27 @@
+## 1. Server hardening (TDD)
+
+- [x] 1.1 Extend `TestSetGetToken` (or add cases) asserting `401` responses carry a `WWW-Authenticate: Bearer` header — RED.
+- [x] 1.2 Add `WWW-Authenticate: Bearer` header before writing `401` in `requireGetToken` (`pkg/server/server.go`) — GREEN.
+- [x] 1.3 Replace the `!= s.getToken` string comparison in `requireGetToken` with `crypto/subtle.ConstantTimeCompare` (guarded by the existing `Bearer ` prefix check); add the `crypto/subtle` import.
+- [x] 1.4 Run `task test` for `pkg/server` and confirm all `TestSetGetToken` subtests pass (including no-token, GET/HEAD, missing/wrong/malformed, `/healthz` exempt, PUT unaffected, and the new WWW-Authenticate case).
+
+## 2. Configuration & docs
+
+- [x] 2.1 Add `get-token` under `cache:` in `config.example.yaml` with an explanatory comment (sibling to `allow-put-verb`).
+- [x] 2.2 Add `--cache-get-token` row to the Security & Signing table in `docs/docs/User Guide/Configuration/Reference.md` (env `CACHE_GET_TOKEN`, default empty).
+- [x] 2.3 Add a short "Authenticating read access" subsection in `docs/docs/User Guide/Usage/Cache Management.md` explaining the flag, the `Authorization: Bearer` requirement, and the `/healthz` + `/metrics` exemption.
+
+## 3. Helm chart (token as a Secret)
+
+- [x] 3.1 Add `config.permissions.getToken` (inline value, default `""`) and `config.permissions.getTokenExistingSecret` (default `""`) to `charts/ncps/values.yaml` with comments.
+- [x] 3.2 Add a `values.schema.json` entry for the two new `permissions` keys (string types).
+- [x] 3.3 In `templates/secret.yaml`, render a `get-token` key (b64-encoded) when `getToken` is set and no `getTokenExistingSecret` is provided; update the top-level `{{- if or ... }}` guard so the Secret is emitted in that case.
+- [x] 3.4 In `templates/deployment.yaml` and `templates/statefulset.yaml`, inject `CACHE_GET_TOKEN` via `secretKeyRef` (existing secret name + key `get-token`, falling back to the chart-managed secret) when `getToken` or `getTokenExistingSecret` is set — mirroring the `CACHE_REDIS_PASSWORD` pattern.
+- [x] 3.5 Ensure the ConfigMap does NOT contain the token (no change needed beyond confirming `get-token` is absent from `templates/configmap.yaml`).
+- [x] 3.6 Add a chart unit test under `charts/ncps/tests/` asserting: env var present with `secretKeyRef` when `getToken` set; existing-secret reference when `getTokenExistingSecret` set; no env var / no Secret key when unset; and ConfigMap has no plaintext token.
+
+## 4. Changelog & verification
+
+- [x] 4.1 Add an `Added` entry under `## [Unreleased]` in `CHANGELOG.md` describing `--cache-get-token` / `CACHE_GET_TOKEN`, the infra-route exemption, PUT/DELETE being unaffected, and the Helm `config.permissions.getToken` / `getTokenExistingSecret` keys (reference #1136).
+- [x] 4.2 Run `task fmt`, `task lint`, `task test` and confirm all exit zero.
+- [x] 4.3 Run `helm unittest charts/ncps` and confirm the new and existing chart tests pass.

--- a/openspec/specs/read-path-auth/spec.md
+++ b/openspec/specs/read-path-auth/spec.md
@@ -1,0 +1,127 @@
+# read-path-auth Specification
+
+## Purpose
+
+Defines an optional Bearer-token authentication gate on the cache read paths
+(`GET`/`HEAD`). On shared or public-facing ncps deployments the read paths are
+otherwise unauthenticated, exposing the cache to anonymous bandwidth scraping
+(issue #1136). When an operator configures a token, ncps requires
+`Authorization: Bearer <token>` on every `GET`/`HEAD` request and rejects
+non-matching requests with `401 Unauthorized`. Infrastructure routes
+(`/healthz`, `/metrics`) are always exempt, and write verbs (`PUT`/`DELETE`)
+keep their own guards. The gate defaults off, preserving today's open reads.
+
+## Requirements
+
+### Requirement: Optional Bearer token for read paths
+
+The server SHALL support an optional read-path authentication token, configured
+via the `--cache-get-token` flag (env `CACHE_GET_TOKEN`). When the token is
+non-empty, the server SHALL require an `Authorization: Bearer <token>` header
+that matches the configured token on every `GET` and `HEAD` request, and SHALL
+reject non-matching requests with `401 Unauthorized`. When the token is empty
+(the default), the server SHALL serve read paths without authentication,
+preserving existing behavior.
+
+#### Scenario: No token configured allows anonymous reads
+
+- **WHEN** no token is configured and a `GET` request arrives without an `Authorization` header
+- **THEN** the server processes the request normally (no `401` is returned by the auth gate)
+
+#### Scenario: Correct token allows GET
+
+- **WHEN** a token is configured and a `GET` request carries `Authorization: Bearer <token>` matching the configured token
+- **THEN** the server processes the request normally
+
+#### Scenario: Correct token allows HEAD
+
+- **WHEN** a token is configured and a `HEAD` request carries `Authorization: Bearer <token>` matching the configured token
+- **THEN** the server processes the request normally
+
+#### Scenario: Missing Authorization header is rejected
+
+- **WHEN** a token is configured and a `GET` or `HEAD` request arrives without an `Authorization` header
+- **THEN** the server responds with `401 Unauthorized`
+
+#### Scenario: Wrong token is rejected
+
+- **WHEN** a token is configured and a request carries `Authorization: Bearer <wrong>` that does not match the configured token
+- **THEN** the server responds with `401 Unauthorized`
+
+#### Scenario: Malformed Authorization scheme is rejected
+
+- **WHEN** a token is configured and a request carries an `Authorization` header that does not use the `Bearer ` scheme (e.g. `Basic ...`)
+- **THEN** the server responds with `401 Unauthorized`
+
+### Requirement: Token comparison resists timing attacks
+
+The server SHALL compare the presented Bearer token against the configured token
+using a constant-time comparison so that the per-request processing time does
+not reveal how many leading bytes of the secret are correct.
+
+#### Scenario: Comparison is constant-time
+
+- **WHEN** the presented token is compared against the configured token
+- **THEN** the comparison uses a constant-time primitive (`crypto/subtle.ConstantTimeCompare`) rather than ordinary string equality
+
+### Requirement: 401 responses advertise the Bearer scheme
+
+The server SHALL include a `WWW-Authenticate: Bearer` header on `401 Unauthorized`
+responses produced by the read-path auth gate, per RFC 7235.
+
+#### Scenario: Unauthorized response carries WWW-Authenticate
+
+- **WHEN** the read-path auth gate rejects a request with `401 Unauthorized`
+- **THEN** the response includes a `WWW-Authenticate: Bearer` header
+
+### Requirement: Infrastructure routes are always exempt
+
+The server SHALL always serve the `/healthz` and `/metrics` infrastructure
+routes without requiring the read-path token, regardless of whether a token is
+configured.
+
+#### Scenario: healthz is exempt
+
+- **WHEN** a token is configured and a `GET /healthz` request arrives without an `Authorization` header
+- **THEN** the server responds with `200 OK`
+
+#### Scenario: metrics is exempt
+
+- **WHEN** a token is configured and a `GET /metrics` request arrives without an `Authorization` header
+- **THEN** the read-path auth gate does not return `401` for that route
+
+### Requirement: Write verbs are unaffected by the read-path token
+
+The read-path token SHALL apply only to `GET` and `HEAD` requests. `PUT` and
+`DELETE` requests SHALL continue to be governed solely by their existing
+`putPermitted` / `deletePermitted` guards and SHALL NOT be additionally gated by
+the read-path token.
+
+#### Scenario: PUT is not gated by the read-path token
+
+- **WHEN** a token is configured and a `PUT` request arrives without a matching `Authorization` header
+- **THEN** the read-path auth gate does not return `401`, and the request is handled by the existing PUT guard
+
+### Requirement: Kubernetes deployments source the token from a Secret
+
+The Helm chart SHALL deliver the read-path token to the container as the
+`CACHE_GET_TOKEN` environment variable sourced from a Kubernetes Secret (a
+chart-managed Secret when an inline value is provided, or an operator-supplied
+existing Secret), and SHALL NOT place the token in the plaintext ConfigMap. When
+no token is configured, the chart SHALL NOT inject the env var or create a Secret
+key for it.
+
+#### Scenario: Inline token value creates a managed Secret key and env var
+
+- **WHEN** an inline read-path token value is set in chart values
+- **THEN** the rendered manifests include a Secret holding the token and a `CACHE_GET_TOKEN` env var with a `secretKeyRef` to it, and the ConfigMap contains no plaintext token
+
+#### Scenario: Existing Secret is referenced
+
+- **WHEN** the chart values reference an existing Secret for the read-path token
+- **THEN** the rendered `CACHE_GET_TOKEN` env var uses a `secretKeyRef` pointing at that existing Secret
+
+#### Scenario: No token leaves deployments unchanged
+
+- **WHEN** no read-path token is configured in chart values
+- **THEN** the rendered manifests contain no `CACHE_GET_TOKEN` env var and no token Secret key

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -139,6 +139,11 @@ func serveCommand(
 				Sources: flagSources("cache.allow-put-verb", "CACHE_ALLOW_PUT_VERB"),
 			},
 			&cli.StringFlag{
+				Name:    "cache-get-token",
+				Usage:   "Bearer token required to access GET and HEAD routes. When set, requests without a matching Authorization: Bearer <token> header are rejected with 401 Unauthorized. /healthz and /metrics are always exempt.",
+				Sources: flagSources("cache.get-token", "CACHE_GET_TOKEN"),
+			},
+			&cli.StringFlag{
 				Name:     "cache-hostname",
 				Usage:    "The hostname of the cache server",
 				Sources:  flagSources("cache.hostname", "CACHE_HOSTNAME"),
@@ -732,6 +737,7 @@ func serveAction(registerShutdown registerShutdownFn) cli.ActionFunc {
 
 		srv := server.New(cache)
 		srv.SetDeletePermitted(cmd.Bool("cache-allow-delete-verb"))
+		srv.SetGetToken(cmd.String("cache-get-token"))
 		srv.SetPutPermitted(cmd.Bool("cache-allow-put-verb"))
 
 		server := &http.Server{

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -139,8 +139,10 @@ func serveCommand(
 				Sources: flagSources("cache.allow-put-verb", "CACHE_ALLOW_PUT_VERB"),
 			},
 			&cli.StringFlag{
-				Name:    "cache-get-token",
-				Usage:   "Bearer token required to access GET and HEAD routes. When set, requests without a matching Authorization: Bearer <token> header are rejected with 401 Unauthorized. /healthz and /metrics are always exempt.",
+				Name: "cache-get-token",
+				Usage: "Bearer token required to access GET and HEAD routes. When set, requests without a " +
+					"matching Authorization: Bearer <token> header are rejected with 401 Unauthorized. " +
+					"/healthz and /metrics are always exempt.",
 				Sources: flagSources("cache.get-token", "CACHE_GET_TOKEN"),
 			},
 			&cli.StringFlag{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"compress/gzip"
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"io"
@@ -231,7 +232,14 @@ func (s *Server) requireGetToken(next http.Handler) http.Handler {
 
 		const bearerPrefix = "Bearer "
 
-		if !strings.HasPrefix(authHeader, bearerPrefix) || strings.TrimPrefix(authHeader, bearerPrefix) != s.getToken {
+		// Use a constant-time comparison so the per-request processing time does
+		// not reveal how many leading bytes of the token are correct (timing
+		// side-channel on the secret).
+		presented := strings.TrimPrefix(authHeader, bearerPrefix)
+		if !strings.HasPrefix(authHeader, bearerPrefix) ||
+			subtle.ConstantTimeCompare([]byte(presented), []byte(s.getToken)) != 1 {
+			// RFC 7235 §4.1: a 401 response must carry a challenge.
+			w.Header().Set("WWW-Authenticate", "Bearer")
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 
 			return

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
@@ -232,12 +233,18 @@ func (s *Server) requireGetToken(next http.Handler) http.Handler {
 
 		const bearerPrefix = "Bearer "
 
-		// Use a constant-time comparison so the per-request processing time does
-		// not reveal how many leading bytes of the token are correct (timing
-		// side-channel on the secret).
+		// Hash both tokens to a fixed length before the constant-time compare.
+		// subtle.ConstantTimeCompare returns early when the slice lengths differ,
+		// so comparing the raw variable-length tokens directly would leak the
+		// secret's length via a timing side-channel. SHA-256 digests are always
+		// 32 bytes, so the comparison time is independent of both token contents
+		// and length.
 		presented := strings.TrimPrefix(authHeader, bearerPrefix)
+		presentedHash := sha256.Sum256([]byte(presented))
+		expectedHash := sha256.Sum256([]byte(s.getToken))
+
 		if !strings.HasPrefix(authHeader, bearerPrefix) ||
-			subtle.ConstantTimeCompare([]byte(presented), []byte(s.getToken)) != 1 {
+			subtle.ConstantTimeCompare(presentedHash[:], expectedHash[:]) != 1 {
 			// RFC 7235 §4.1: a 401 response must carry a challenge.
 			w.Header().Set("WWW-Authenticate", "Bearer")
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -76,6 +76,7 @@ type Server struct {
 	router *chi.Mux
 
 	deletePermitted bool
+	getToken        string
 	putPermitted    bool
 }
 
@@ -94,6 +95,12 @@ func New(cache *cache.Cache) *Server {
 // SetDeletePermitted configures the server to either allow or deny access to DELETE.
 func (s *Server) SetDeletePermitted(dp bool) { s.deletePermitted = dp }
 
+// SetGetToken configures a Bearer token required to access GET and HEAD routes.
+// When non-empty, requests without a matching Authorization: Bearer <token> header
+// are rejected with 401 Unauthorized. The /healthz and /metrics routes are always
+// exempt.
+func (s *Server) SetGetToken(token string) { s.getToken = token }
+
 // SetPutPermitted configures the server to either allow or deny access to PUT.
 func (s *Server) SetPutPermitted(pp bool) { s.putPermitted = pp }
 
@@ -108,6 +115,7 @@ func (s *Server) createRouter() {
 	s.router.Use(recoverer)
 
 	s.router.Use(s.skipTelemetryForInfraRoutes)
+	s.router.Use(s.requireGetToken)
 
 	// 1. Register standard routes at the root
 	s.registerRoutes(s.router)
@@ -192,6 +200,45 @@ func (s *Server) registerRoutes(r chi.Router) {
 
 	r.Head(routeBuildTrace, s.getBuildTrace(false))
 	r.Get(routeBuildTrace, s.getBuildTrace(true))
+}
+
+// requireGetToken is a middleware that enforces Bearer token authentication for
+// GET and HEAD requests when s.getToken is non-empty. Infrastructure endpoints
+// (/healthz and /metrics) are always exempt regardless of configuration.
+func (s *Server) requireGetToken(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.getToken == "" {
+			next.ServeHTTP(w, r)
+
+			return
+		}
+
+		// Only apply to GET and HEAD; other methods have their own guards.
+		if r.Method != http.MethodGet && r.Method != http.MethodHead {
+			next.ServeHTTP(w, r)
+
+			return
+		}
+
+		// Infrastructure routes are always exempt.
+		if r.URL.Path == "/healthz" || r.URL.Path == "/metrics" {
+			next.ServeHTTP(w, r)
+
+			return
+		}
+
+		authHeader := r.Header.Get("Authorization")
+
+		const bearerPrefix = "Bearer "
+
+		if !strings.HasPrefix(authHeader, bearerPrefix) || strings.TrimPrefix(authHeader, bearerPrefix) != s.getToken {
+			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }
 
 func recoverer(next http.Handler) http.Handler {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -827,6 +827,12 @@ func TestSetGetToken(t *testing.T) {
 			s.ServeHTTP(w, req)
 
 			assert.Equal(t, tc.wantStatus, w.Code)
+
+			// RFC 7235: a 401 from the read-path auth gate must advertise the
+			// Bearer challenge so clients know how to authenticate.
+			if tc.wantStatus == http.StatusUnauthorized {
+				assert.Equal(t, "Bearer", w.Header().Get("WWW-Authenticate"))
+			}
 		})
 	}
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -705,6 +705,132 @@ func newContext() context.Context {
 		WithContext(context.Background())
 }
 
+func TestSetGetToken(t *testing.T) {
+	t.Parallel()
+
+	dir, err := os.MkdirTemp("", "cache-path-get-token-")
+	require.NoError(t, err)
+
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	dbFile := filepath.Join(dir, "var", "ncps", "db", "db.sqlite")
+	testhelper.CreateMigrateDatabase(t, dbFile)
+
+	dbClient, err := database.Open("sqlite:"+dbFile, nil)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = dbClient.Close() })
+
+	localStore, err := local.New(newContext(), dir)
+	require.NoError(t, err)
+
+	c, err := newTestCache(newContext(), dbClient, localStore, localStore, localStore)
+	require.NoError(t, err)
+
+	t.Cleanup(c.Close)
+
+	const secretToken = "test-bearer-token"
+
+	narInfoPath := "/" + testdata.Nar1.NarInfoHash + ".narinfo"
+
+	tests := []struct {
+		name           string
+		configureToken bool
+		method         string
+		path           string
+		authHeader     string
+		wantStatus     int
+	}{
+		{
+			name:           "no token configured: GET passes without auth",
+			configureToken: false,
+			method:         http.MethodGet,
+			path:           narInfoPath,
+			authHeader:     "",
+			wantStatus:     http.StatusNotFound, // cache is empty, not a 401
+		},
+		{
+			name:           "token configured: correct Bearer token allows GET",
+			configureToken: true,
+			method:         http.MethodGet,
+			path:           narInfoPath,
+			authHeader:     "Bearer " + secretToken,
+			wantStatus:     http.StatusNotFound, // cache is empty, not a 401
+		},
+		{
+			name:           "token configured: correct Bearer token allows HEAD",
+			configureToken: true,
+			method:         http.MethodHead,
+			path:           narInfoPath,
+			authHeader:     "Bearer " + secretToken,
+			wantStatus:     http.StatusNotFound, // cache is empty, not a 401
+		},
+		{
+			name:           "token configured: missing auth header returns 401",
+			configureToken: true,
+			method:         http.MethodGet,
+			path:           narInfoPath,
+			authHeader:     "",
+			wantStatus:     http.StatusUnauthorized,
+		},
+		{
+			name:           "token configured: wrong token returns 401",
+			configureToken: true,
+			method:         http.MethodGet,
+			path:           narInfoPath,
+			authHeader:     "Bearer wrong-token",
+			wantStatus:     http.StatusUnauthorized,
+		},
+		{
+			name:           "token configured: malformed auth header returns 401",
+			configureToken: true,
+			method:         http.MethodGet,
+			path:           narInfoPath,
+			authHeader:     "Basic " + secretToken,
+			wantStatus:     http.StatusUnauthorized,
+		},
+		{
+			name:           "token configured: /healthz is always exempt",
+			configureToken: true,
+			method:         http.MethodGet,
+			path:           "/healthz",
+			authHeader:     "",
+			wantStatus:     http.StatusOK,
+		},
+		{
+			name:           "token configured: PUT routes are unaffected",
+			configureToken: true,
+			method:         http.MethodPut,
+			path:           "/upload/" + testdata.Nar1.NarInfoHash + ".narinfo",
+			authHeader:     "",
+			wantStatus:     http.StatusMethodNotAllowed, // putPermitted=false
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := server.New(c)
+
+			if tc.configureToken {
+				s.SetGetToken(secretToken)
+			}
+
+			req := httptest.NewRequestWithContext(t.Context(), tc.method, tc.path, nil)
+
+			if tc.authHeader != "" {
+				req.Header.Set("Authorization", tc.authHeader)
+			}
+
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, req)
+
+			assert.Equal(t, tc.wantStatus, w.Code)
+		})
+	}
+}
+
 func TestGetNar_HeadBytelessNarIs404(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

GET paths can now be auth-protected: a new `--cache-get-token` flag (env: `CACHE_GET_TOKEN`) accepts a Bearer token that, when configured, is required on all GET and HEAD requests. Unauthenticated requests receive `401 Unauthorized`. Infrastructure routes (`/healthz`, `/metrics`) are always exempt. PUT and DELETE paths are unaffected.

## Why this matters

Issue #1136 requested the ability to protect read paths from unauthenticated abuse on shared or public-facing ncps deployments. The maintainer agreed ("Agree...") with the request. This PR implements the feature by extending the existing `putPermitted`/`deletePermitted` pattern already present in the server, adding a minimal chi middleware and a corresponding CLI flag/env var.

## Changes

- `pkg/server/server.go`: add `getToken string` field, `SetGetToken(token string)` setter, and `requireGetToken` chi middleware wired into the router before route registration
- `pkg/ncps/serve.go`: add `--cache-get-token` / `CACHE_GET_TOKEN` flag, call `srv.SetGetToken(...)` alongside existing `SetDeletePermitted`/`SetPutPermitted`
- `pkg/server/server_test.go`: `TestSetGetToken` covering no-token passthrough, correct token (GET + HEAD), missing header, wrong token, malformed header, `/healthz` exempt, and PUT unaffected

Fixes #1136
