### PR TITLE
feat(cache): trust uploads via dedicated upload keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **Trusted-signature gate on PUT uploads.** A new
+  `--cache-require-trusted-signature` flag (env `CACHE_REQUIRE_TRUSTED_SIGNATURE`,
+  **off by default**) makes ncps verify client-uploaded (`PUT`) narinfos before
+  re-signing and persisting them, closing the signature-laundering gap. When
+  enabled, an upload is accepted only if it carries a signature trusted by the
+  operator-configured `--cache-trusted-upload-key`s (repeatable, env
+  `CACHE_TRUSTED_UPLOAD_KEYS`; nix-format `name:base64`). Upload-trust is
+  **independent** of the upstream public keys (which govern pull-trust), so
+  operators authorize their own build/signing key to push self-built paths
+  without trusting them for substitution. The gate is fail-closed: enabled with
+  no upload keys configured rejects every upload. Exposed in the Helm chart as
+  `config.signing.requireTrustedSignature` and `config.signing.trustedUploadKeys`.
+  (#1269)
+
 - **Optional Bearer-token authentication for read paths.** A new
   `--cache-get-token` flag (env `CACHE_GET_TOKEN`) protects `GET` and `HEAD`
   requests: when set, requests without a matching `Authorization: Bearer <token>`

--- a/charts/ncps/templates/configmap.yaml
+++ b/charts/ncps/templates/configmap.yaml
@@ -90,6 +90,12 @@ data:
 
       sign-narinfo: {{ ne .Values.config.signing.enabled false }}
       require-trusted-signature: {{ eq .Values.config.signing.requireTrustedSignature true }}
+      {{- with .Values.config.signing.trustedUploadKeys }}
+      trusted-upload-keys:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
 
       upstream:
         urls:

--- a/charts/ncps/tests/configmap_test.yaml
+++ b/charts/ncps/tests/configmap_test.yaml
@@ -440,3 +440,28 @@ tests:
       - matchRegex:
           path: data["config.yaml"]
           pattern: "allow-degraded-mode: true"
+
+  - it: should omit trusted-upload-keys when none are configured
+    set:
+      config.hostname: test.example.com
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: "trusted-upload-keys:"
+
+  - it: should render trusted-upload-keys when configured
+    set:
+      config.hostname: test.example.com
+      config.signing.requireTrustedSignature: true
+      config.signing.trustedUploadKeys:
+        - "my-cache-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "require-trusted-signature: true"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "trusted-upload-keys:"
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'my-cache-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX\+/rkCWyvRCYg3Fs='

--- a/charts/ncps/values.yaml
+++ b/charts/ncps/values.yaml
@@ -123,11 +123,16 @@ config:
     # Whether to sign narInfo files
     enabled: true
     # Reject narInfos uploaded via PUT that do not carry a signature trusted by
-    # the configured upstream public keys (fail-closed). When enabled, uploads
-    # lacking a valid trusted upstream signature are rejected, and uploads are
-    # also rejected when no trusted upstream keys are configured. Default off
+    # the configured trustedUploadKeys (fail-closed). When enabled, uploads
+    # lacking a valid trusted upload signature are rejected, and uploads are
+    # also rejected when no trusted upload keys are configured. Default off
     # preserves backward-compatible passthru of client uploads.
     requireTrustedSignature: false
+    # Public keys (nix-format name:base64) that authorize PUT uploads when
+    # requireTrustedSignature is enabled. Independent of upstream public keys:
+    # to accept your own builds, sign them and list the matching public key here.
+    trustedUploadKeys: []
+    #   - my-cache-1:abcdef0123456789...=
     # Signing key (provided via secret if not auto-generated)
     # Leave empty to auto-generate
     secretKey: ""

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -120,11 +120,18 @@ cache:
   # Whether to sign narInfo files or passthru as-is from upstream
   sign-narinfo: true
   # Reject narInfos uploaded via PUT that do not carry a signature trusted by
-  # the configured upstream public keys (fail-closed). When enabled, uploads
-  # are rejected if no signature validates against the trusted upstream keys,
-  # and also rejected when no trusted upstream keys are configured at all.
-  # Default off preserves backward-compatible passthru of client uploads.
+  # the configured trusted-upload-keys (fail-closed). When enabled, uploads are
+  # rejected if no signature validates against a trusted upload key, and also
+  # rejected when no trusted upload keys are configured at all. Upload-trust is
+  # independent of the upstream public keys below (which govern what ncps pulls):
+  # to accept your own builds, sign them (nix `secret-key-files`) and list the
+  # matching public key in trusted-upload-keys. Default off preserves
+  # backward-compatible passthru of client uploads.
   require-trusted-signature: false
+  # Public keys (nix-format name:base64) that authorize PUT uploads when
+  # require-trusted-signature is enabled. Independent of upstream public keys.
+  trusted-upload-keys: []
+  #   - my-cache-1:abcdef0123456789...=
   storage:
     # The local data path used for configuration and cache storage
     # Use this OR S3 storage (cache.storage.s3.bucket) - not both

--- a/docs/docs/User Guide/Configuration/Reference.md
+++ b/docs/docs/User Guide/Configuration/Reference.md
@@ -235,7 +235,7 @@ The gate is fail-closed — with it enabled and no upload keys configured, every
 upload is rejected. To upload your own builds, sign them and trust the matching
 public key:
 
-```
+```bash
 # 1. Generate a key pair
 nix key generate-secret --key-name my-cache-1 > /etc/ncps-upload.sec
 nix key convert-secret-to-public < /etc/ncps-upload.sec   # → my-cache-1:<base64>

--- a/docs/docs/User Guide/Configuration/Reference.md
+++ b/docs/docs/User Guide/Configuration/Reference.md
@@ -206,7 +206,8 @@ In-flight staging resolves the cross-pod serve-during-download gap for **all** m
 | Option | Description | Environment Variable | Default |
 | --- | --- | --- | --- |
 | `--cache-sign-narinfo` | Sign NarInfo files with private key | `CACHE_SIGN_NARINFO` | `true` |
-| `--cache-require-trusted-signature` | Reject PUT-uploaded narinfos lacking a signature trusted by the configured upstream public keys (fail-closed) | `CACHE_REQUIRE_TRUSTED_SIGNATURE` | `false` |
+| `--cache-require-trusted-signature` | Reject PUT-uploaded narinfos lacking a signature trusted by the configured `--cache-trusted-upload-key`s (fail-closed; rejects all uploads when no upload keys are configured) | `CACHE_REQUIRE_TRUSTED_SIGNATURE` | `false` |
+| `--cache-trusted-upload-key` | Repeatable nix-format `name:base64` public key authorizing PUT uploads when `--cache-require-trusted-signature` is enabled; independent of the upstream public keys | `CACHE_TRUSTED_UPLOAD_KEYS` | _(empty)_ |
 | `--cache-secret-key-path` | Path to signing private key | `CACHE_SECRET_KEY_PATH` | auto-generated |
 | `--cache-allow-put-verb` | Allow PUT uploads to cache (requires `/upload` prefix) | `CACHE_ALLOW_PUT_VERB` | `false` |
 | `--cache-allow-delete-verb` | Allow DELETE operations on cache | `CACHE_ALLOW_DELETE_VERB` | `false` |
@@ -220,6 +221,32 @@ ncps serve \
   --cache-secret-key-path=/etc/ncps/secret-key \
   --cache-allow-put-verb=true \
   --netrc-file=/etc/ncps/netrc
+```
+
+### Trusted upload verification
+
+`--cache-require-trusted-signature` gates the `PUT` (`/upload`) ingestion path.
+When enabled, ncps verifies each uploaded narinfo against the keys listed in
+`--cache-trusted-upload-key` (repeatable) **before** re-signing and persisting
+it. This trust set is deliberately **independent** of the upstream public keys:
+those govern what ncps pulls, not whose uploads it accepts.
+
+The gate is fail-closed — with it enabled and no upload keys configured, every
+upload is rejected. To upload your own builds, sign them and trust the matching
+public key:
+
+```
+# 1. Generate a key pair
+nix key generate-secret --key-name my-cache-1 > /etc/ncps-upload.sec
+nix key convert-secret-to-public < /etc/ncps-upload.sec   # → my-cache-1:<base64>
+
+# 2. Trust the public key on the server
+ncps serve --cache-require-trusted-signature \
+  --cache-trusted-upload-key=my-cache-1:<base64> ...
+
+# 3. Sign locally before copying (nix.conf: secret-key-files = /etc/ncps-upload.sec)
+nix store sign --key-file /etc/ncps-upload.sec <store-path>
+nix copy --to https://cache.example.com/upload <store-path>
 ```
 
 ## Upstream Connection Timeouts

--- a/openspec/changes/archive/2026-06-20-add-trusted-upload-keys/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-20-add-trusted-upload-keys/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-20

--- a/openspec/changes/archive/2026-06-20-add-trusted-upload-keys/design.md
+++ b/openspec/changes/archive/2026-06-20-add-trusted-upload-keys/design.md
@@ -1,0 +1,117 @@
+## Context
+
+`cache.require-trusted-signature` (issue #1269) closes a signature-laundering
+gap: ncps re-signs every ingested narinfo with its own key and serves it as
+trusted, so an unverified `PUT` upload would be laundered into a trusted
+artifact. The gate verifies `PUT` narinfos before signing.
+
+The flaw is the **key set** it verifies against. `verifyNarInfoTrusted`
+(`pkg/cache/cache.go:1102`) calls `trustedPublicKeys()`, which aggregates the
+public keys of the configured upstream caches (cache.go:1084). A locally-built
+store path is unsigned, or signed by the operator's own key — never by an
+upstream key — so the gate rejects every self-built upload with
+`ErrUntrustedNarInfo` → HTTP 500. PUT itself has no per-uploader auth (only the
+`putPermitted` on/off boolean, server.go:107), so this gate is the only
+upload-authenticity control, and it points at the wrong keys.
+
+Upstream public keys are parsed today via `signature.ParsePublicKey` in the
+`upstream` package (upstream/cache.go:192-193) from nix-format `name:base64`
+strings into `[]signature.PublicKey`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Decouple upload-trust from pull-trust: verify `PUT` narinfos against an
+  operator-designated key set, not the upstream pull keys.
+- Let operators accept their own signed self-builds while keeping the
+  anti-laundering guarantee (only operator-trusted signatures get re-signed).
+- Keep `require-trusted-signature` as the single enable switch; preserve
+  default-off and fail-closed semantics.
+- Update all config surfaces: example config, reference docs, Helm chart, Helm
+  unit tests.
+
+**Non-Goals:**
+- Per-token / per-uploader authentication on `PUT`.
+- Auto-trusting ncps's own signing key or upstream keys for uploads.
+- Changing the upstream-fetch verification path or GET/HEAD Bearer auth.
+
+## Decisions
+
+### D1: New `trustedUploadKeys []signature.PublicKey` on `Cache`, replacing the upstream-key source in `verifyNarInfoTrusted`
+
+Add a field plus `SetCacheTrustedUploadKeys([]signature.PublicKey)` setter.
+`verifyNarInfoTrusted` keeps its structure but consults `c.trustedUploadKeys`
+instead of `c.trustedPublicKeys()`:
+
+```go
+func (c *Cache) verifyNarInfoTrusted(narInfo *narinfo.NarInfo) error {
+    if !c.requireTrustedSignature {
+        return nil
+    }
+    keys := c.trustedUploadKeys           // was c.trustedPublicKeys()
+    if len(keys) == 0 {
+        return ErrUntrustedNarInfo         // fail closed, unchanged
+    }
+    if !signature.VerifyFirst(narInfo.Fingerprint(), narInfo.Signatures, keys) {
+        return ErrUntrustedNarInfo
+    }
+    return nil
+}
+```
+
+`trustedPublicKeys()` stays (still used elsewhere if needed) but is no longer
+the PUT-verification source.
+
+**Alternative considered — keep upstream keys and add a bypass flag**
+(`allow-unsigned-uploads`): rejected. Two interacting booleans with unclear
+precedence is a footgun, and it still can't *authorize* a specific uploader key
+— it only weakens the gate to "accept anything".
+
+### D2: No new enable flag — reuse `require-trusted-signature`
+
+`require-trusted-signature` remains the master toggle. Enabling it with an empty
+`trusted-upload-keys` list rejects all uploads (fail-closed), exactly mirroring
+today's "gate on + no trusted keys" behavior. Operators opt in to specific
+uploads by populating `trusted-upload-keys`. This keeps a single, well-understood
+switch and avoids a confusing second flag.
+
+### D3: Parse `--cache-trusted-upload-key` in serve.go with `signature.ParsePublicKey`
+
+A repeatable `StringSliceFlag` `cache-trusted-upload-key`
+(`cache.trusted-upload-keys` / `CACHE_TRUSTED_UPLOAD_KEYS`). In serve.go, parse
+each entry with `signature.ParsePublicKey` (same as upstream keys); a parse
+error fails startup with a clear message. Pass the parsed slice to
+`SetCacheTrustedUploadKeys`. Keys are NOT host-filtered (unlike upstream keys,
+which regex-match a host) — upload keys are a flat global trust set.
+
+### D4: Helm surface — `config.signing.trustedUploadKeys` list
+
+Add `signing.trustedUploadKeys: []` to `values.yaml`, render it under
+`cache.trusted-upload-keys` in `configmap.yaml` (range emit, like
+`upstream.public-keys`). Add Helm unit-test coverage for empty (omitted/empty)
+and populated cases.
+
+## Risks / Trade-offs
+
+- **No existing users.** The PUT signature gate (`require-trusted-signature`) is
+  unreleased — it does not appear in the CHANGELOG `[Unreleased]` section — so
+  there is no deployed behavior to preserve and this is not a breaking change.
+  It ships in its correct form before any release.
+- **Operator must sign uploads** (set `secret-key-files` in nix.conf and add
+  the matching public key) to use the gate → this is the intended, correct
+  trust model; documented in the reference docs.
+- **Empty-list fail-closed could surprise** an operator who flips the gate on
+  without keys → preserved deliberately (matches nix posture); the rejection
+  error and docs make the cause explicit.
+
+## Migration Plan
+
+No operator migration: the feature is unreleased, so no deployed config relies
+on the old behavior. Ship code + config/docs/chart + CHANGELOG together as one
+change. No persisted-data or schema changes, so rollback is a clean release
+revert.
+
+## Open Questions
+
+- None. The empty-list-fail-closed and no-second-flag decisions are settled per
+  the operator's direction.

--- a/openspec/changes/archive/2026-06-20-add-trusted-upload-keys/proposal.md
+++ b/openspec/changes/archive/2026-06-20-add-trusted-upload-keys/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+The `cache.require-trusted-signature` gate verifies client-uploaded (`PUT`)
+narinfos against the configured **upstream** public keys. Upstream keys can
+never match a locally-built store path (it is unsigned, or signed by the
+operator's own key), so enabling the gate makes it impossible to `nix copy`
+your own builds — every upload fails with HTTP 500 `rejecting untrusted
+narinfo`. The gate conflates "content an upstream already signed" with
+"uploader I authorize", which are different trust relationships. Pull-trust
+(which upstreams I mirror) and upload-trust (whose uploads I re-sign and serve)
+must be decoupled.
+
+## What Changes
+
+- Introduce a new operator-configured key set, `cache.trusted-upload-keys`
+  (flag `--cache-trusted-upload-key`, env `CACHE_TRUSTED_UPLOAD_KEYS`), holding
+  nix-format `name:base64` public keys that authorize `PUT` uploads.
+- When `require-trusted-signature` is enabled, verify `PUT` narinfos against
+  `trusted-upload-keys` **instead of** the upstream public keys. The operator
+  adds their own signing key here; signed self-builds are then accepted.
+- Preserve the existing master switch and fail-closed posture: gate stays off
+  by default; when on with an empty `trusted-upload-keys` list, every upload is
+  rejected (no silent no-op verifier). No second enable flag is added —
+  `require-trusted-signature` remains the single toggle, only its key source
+  changes.
+- Not breaking: `require-trusted-signature` and the PUT signature gate are
+  **unreleased** (absent from the CHANGELOG `[Unreleased]` section), so there
+  are no existing users relying on the old upstream-key behavior. This change
+  ships the gate in its correct form before any release.
+- Update `config.example.yaml`, the Configuration Reference docs, the Helm
+  chart (`values.yaml` + `configmap.yaml`), Helm unit tests, and the CHANGELOG
+  `[Unreleased]` section.
+
+## Capabilities
+
+### New Capabilities
+<!-- none; the new config surface belongs to the existing capability below -->
+
+### Modified Capabilities
+- `narinfo-trusted-signature`: the verification key source changes from the
+  union of upstream public keys to the dedicated `trusted-upload-keys` set, and
+  the fail-closed condition keys on that set being empty. The anti-laundering
+  goal (issue #1269) is preserved — only narinfos signed by an operator-trusted
+  uploader key are re-signed and served.
+
+## Non-goals
+
+- No per-token or per-uploader authentication on `PUT` (still governed solely
+  by `putPermitted`); this change only governs which narinfo signatures are
+  trusted.
+- No automatic trust of ncps's own signing key, nor of upstream keys, for
+  uploads — the operator lists exactly what they intend to trust.
+- No change to the upstream-fetch verification path or to GET/HEAD Bearer auth.
+- No change to the default behavior (gate remains off).
+
+## Impact
+
+- Code: `pkg/cache/cache.go` (`verifyNarInfoTrusted`, new `trustedUploadKeys`
+  field/setter), `pkg/ncps/serve.go` (new flag + wiring).
+- Config/docs/chart: `config.example.yaml`, `docs/.../Configuration/Reference.md`,
+  `charts/ncps/values.yaml`, `charts/ncps/templates/configmap.yaml`, Helm tests.
+- I/O, network latency, memory: negligible — verification is an in-memory
+  signature check over a small fixed key set on the already-buffered narinfo;
+  no added network calls, allocations, or storage.

--- a/openspec/changes/archive/2026-06-20-add-trusted-upload-keys/specs/narinfo-trusted-signature/spec.md
+++ b/openspec/changes/archive/2026-06-20-add-trusted-upload-keys/specs/narinfo-trusted-signature/spec.md
@@ -1,20 +1,4 @@
-# narinfo-trusted-signature Specification
-
-## Purpose
-
-Defines an optional, fail-closed verification gate on the client `PutNarInfo`
-(`PUT`) ingestion path. ncps re-signs every narinfo it ingests with its own key
-and serves it under that key; the upstream-fetch path already verifies incoming
-signatures against the configured trusted public keys, but the `PUT` path did not.
-This capability lets an operator require that client-uploaded narinfos carry a
-signature trusted by a dedicated set of upload keys before ncps signs and serves
-them, closing the signature-laundering gap (issue #1269). Upload-trust is
-decoupled from the upstream pull keys, so an operator can authorize their own
-build/signing key to upload self-built paths without trusting it for
-substitution. The gate defaults off, preserving backward-compatible passthru of
-client uploads.
-
-## Requirements
+## ADDED Requirements
 
 ### Requirement: Operator-configured trusted upload keys
 
@@ -40,6 +24,8 @@ configurable via the `--cache-trusted-upload-key` flag (repeatable), the
 - **THEN** verification of `PUT` uploads consults only the trusted upload keys
   and never the upstream caches' public keys, so pull-trust and upload-trust are
   decoupled
+
+## MODIFIED Requirements
 
 ### Requirement: Operator gate for trusted-signature verification on PUT ingestion
 

--- a/openspec/changes/archive/2026-06-20-add-trusted-upload-keys/tasks.md
+++ b/openspec/changes/archive/2026-06-20-add-trusted-upload-keys/tasks.md
@@ -1,0 +1,31 @@
+## 1. Cache: trusted upload keys (TDD)
+
+- [x] 1.1 Write failing tests in `pkg/cache/cache_test.go` for `verifyNarInfoTrusted` using a dedicated trusted-upload-key set: (a) gate off → accept regardless of signature; (b) gate on + empty upload keys → `ErrUntrustedNarInfo`; (c) gate on + narinfo signed by a trusted upload key → accept; (d) gate on + narinfo signed only by an upstream key (not in upload keys) → reject; (e) gate on + unsigned narinfo → reject.
+- [x] 1.2 Add `trustedUploadKeys []signature.PublicKey` field and `SetCacheTrustedUploadKeys(...)` setter to `Cache` (`pkg/cache/cache.go`).
+- [x] 1.3 Change `verifyNarInfoTrusted` to consult `c.trustedUploadKeys` instead of `c.trustedPublicKeys()`, preserving the default-off and empty-list fail-closed branches; update the doc comment.
+- [x] 1.4 Run `task test` for the cache package and confirm 1.1 tests pass.
+
+## 2. Serve wiring: new flag (TDD)
+
+- [x] 2.1 Write/extend failing tests in `pkg/ncps/serve_test.go` covering: flag/env/config parse of `cache-trusted-upload-key` into the cache's upload key set, and a startup error on a malformed key string.
+- [x] 2.2 Add the repeatable `cache-trusted-upload-key` `StringSliceFlag` (`cache.trusted-upload-keys`, `CACHE_TRUSTED_UPLOAD_KEYS`) in `pkg/ncps/serve.go` near `cache-require-trusted-signature`.
+- [x] 2.3 Parse each entry with `signature.ParsePublicKey` (no host filtering), failing startup with a clear error on a bad key, and call `SetCacheTrustedUploadKeys` with the parsed slice.
+- [x] 2.4 Run `task test` for the ncps package and confirm 2.1 tests pass.
+
+## 3. Config + docs
+
+- [x] 3.1 Update `config.example.yaml`: revise the `require-trusted-signature` comment to reference upload keys and add a documented `trusted-upload-keys: []` example under `cache:`.
+- [x] 3.2 Update `docs/docs/User Guide/Configuration/Reference.md`: document `cache.trusted-upload-keys`, its relationship to `require-trusted-signature`, the empty-list fail-closed behavior, and the self-build signing workflow (`secret-key-files` + matching public key).
+- [x] 3.3 Add a CHANGELOG `[Unreleased]` entry describing the PUT signature gate in its shipped form: `require-trusted-signature` verifies uploads against operator-configured `cache.trusted-upload-keys` (decoupled from upstream pull-keys), default off, fail-closed on empty list.
+
+## 4. Helm chart
+
+- [x] 4.1 Add `config.signing.trustedUploadKeys: []` to `charts/ncps/values.yaml` with an explanatory comment; update the `requireTrustedSignature` comment to reference upload keys.
+- [x] 4.2 Render `cache.trusted-upload-keys` from `signing.trustedUploadKeys` in `charts/ncps/templates/configmap.yaml` (range-emit, mirroring `upstream.public-keys`), omitting the key when the list is empty.
+- [x] 4.3 Add Helm unit tests under `charts/ncps/tests/` asserting the configmap output for empty (key omitted) and populated cases; run `helm unittest charts/ncps`.
+
+## 5. Verify
+
+- [x] 5.1 Run `task fmt`, `task lint`, `task test` and confirm all exit zero.
+- [x] 5.2 Run `openspec validate add-trusted-upload-keys --no-interactive` (with `OPENSPEC_TELEMETRY=0`) and confirm it passes.
+- [x] 5.3 Manual smoke per design Migration Plan: gate on + own key in `trusted-upload-keys` + `nix store sign` → `nix copy` to `/upload` succeeds; gate on + empty list → upload rejected.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -494,9 +494,17 @@ type Cache struct {
 	shouldSignNarinfo bool
 
 	// requireTrustedSignature, when true, makes PutNarInfo reject any narinfo
-	// that does not carry at least one signature validating against the trusted
-	// upstream public keys. Default false preserves prior behavior.
+	// that does not carry at least one signature validating against the
+	// configured trusted upload keys. Default false preserves prior behavior.
 	requireTrustedSignature bool
+
+	// trustedUploadKeys is the operator-configured set of public keys that
+	// authorize client PUT uploads. It is intentionally decoupled from the
+	// upstream caches' public keys (which govern pull-trust): a locally-built
+	// store path is signed by the operator's own key, not by an upstream, so
+	// upload-trust must be configured separately. Consulted by
+	// verifyNarInfoTrusted only when requireTrustedSignature is true.
+	trustedUploadKeys []signature.PublicKey
 
 	// recordAgeIgnoreTouch represents the duration at which a record is
 	// considered up to date and a touch is not invoked. This helps avoid
@@ -1070,41 +1078,35 @@ func (c *Cache) GetConfig() *config.Config {
 func (c *Cache) SetCacheSignNarinfo(shouldSignNarinfo bool) { c.shouldSignNarinfo = shouldSignNarinfo }
 
 // SetCacheRequireTrustedSignature configures whether PutNarInfo rejects
-// narinfos lacking a valid trusted upstream signature.
+// narinfos lacking a valid signature trusted by the configured upload keys.
 func (c *Cache) SetCacheRequireTrustedSignature(requireTrustedSignature bool) {
 	c.requireTrustedSignature = requireTrustedSignature
+}
+
+// SetCacheTrustedUploadKeys configures the set of public keys that authorize
+// client PUT uploads when requireTrustedSignature is enabled. These are
+// independent of the upstream caches' public keys.
+func (c *Cache) SetCacheTrustedUploadKeys(keys []signature.PublicKey) {
+	c.trustedUploadKeys = keys
 }
 
 // SetMaxSize sets the maxsize of the cache. This will be used by the LRU
 // cronjob to automatically clean-up the store.
 func (c *Cache) SetMaxSize(maxSize uint64) { c.maxSize = maxSize }
 
-// trustedPublicKeys aggregates the public keys from all configured upstream
-// caches.
-func (c *Cache) trustedPublicKeys() []signature.PublicKey {
-	c.upstreamCachesMu.RLock()
-	defer c.upstreamCachesMu.RUnlock()
-
-	var keys []signature.PublicKey
-	for _, uc := range c.upstreamCaches {
-		keys = append(keys, uc.PublicKeys()...)
-	}
-
-	return keys
-}
-
 // verifyNarInfoTrusted returns nil when requireTrustedSignature is disabled,
 // or when the narinfo carries at least one signature that validates against
-// the trusted upstream public keys. When the gate is enabled it fails closed:
-// if no trusted keys are configured, or no signature validates, it returns
-// ErrUntrustedNarInfo (matching nix's fail-closed posture so an operator
-// cannot accidentally run a no-op verifier).
+// the configured trusted upload keys. When the gate is enabled it fails closed:
+// if no trusted upload keys are configured, or no signature validates, it
+// returns ErrUntrustedNarInfo (matching nix's fail-closed posture so an
+// operator cannot accidentally run a no-op verifier). Upload-trust is
+// deliberately decoupled from the upstream pull keys.
 func (c *Cache) verifyNarInfoTrusted(narInfo *narinfo.NarInfo) error {
 	if !c.requireTrustedSignature {
 		return nil
 	}
 
-	keys := c.trustedPublicKeys()
+	keys := c.trustedUploadKeys
 	if len(keys) == 0 {
 		return ErrUntrustedNarInfo
 	}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -946,14 +946,29 @@ func testPutNarInfoRequireTrustedSignature(factory cacheFactory) func(*testing.T
 			return count
 		}
 
-		t.Run("disabled accepts narinfo without trusted upstream signature", func(t *testing.T) {
+		parseKeys := func(t *testing.T, raw []string) []signature.PublicKey {
+			t.Helper()
+
+			keys := make([]signature.PublicKey, 0, len(raw))
+
+			for _, r := range raw {
+				pk, err := signature.ParsePublicKey(r)
+				require.NoError(t, err)
+
+				keys = append(keys, pk)
+			}
+
+			return keys
+		}
+
+		t.Run("disabled accepts narinfo without trusted upload signature", func(t *testing.T) {
 			c, _, _, _, _, cleanup := factory(t)
 			t.Cleanup(cleanup)
 
 			require.NoError(t, putNarInfo(t, c))
 		})
 
-		t.Run("enabled rejects when no trusted keys are configured", func(t *testing.T) {
+		t.Run("enabled rejects when no trusted upload keys are configured", func(t *testing.T) {
 			c, dbClient, _, _, _, cleanup := factory(t)
 			t.Cleanup(cleanup)
 
@@ -965,14 +980,41 @@ func testPutNarInfoRequireTrustedSignature(factory cacheFactory) func(*testing.T
 		})
 
 		t.Run("enabled rejects narinfo with untrusted signature", func(t *testing.T) {
+			c, dbClient, _, _, _, cleanup := factory(t)
+			t.Cleanup(cleanup)
+
+			c.SetCacheTrustedUploadKeys(parseKeys(t,
+				[]string{"untrusted-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="}))
+			c.SetCacheRequireTrustedSignature(true)
+
+			err := putNarInfo(t, c)
+			require.ErrorIs(t, err, cache.ErrUntrustedNarInfo)
+			assert.Equal(t, 0, narInfoCount(t, dbClient))
+		})
+
+		t.Run("enabled accepts narinfo with trusted upload signature", func(t *testing.T) {
+			c, dbClient, _, _, _, cleanup := factory(t)
+			t.Cleanup(cleanup)
+
+			c.SetCacheTrustedUploadKeys(parseKeys(t, testdata.PublicKeys()))
+			c.SetCacheRequireTrustedSignature(true)
+
+			require.NoError(t, putNarInfo(t, c))
+			assert.Equal(t, 1, narInfoCount(t, dbClient))
+		})
+
+		t.Run("enabled rejects when only an upstream key trusts the signature", func(t *testing.T) {
 			ts := testdata.NewTestServer(t, 40)
 			t.Cleanup(ts.Close)
 
 			c, dbClient, _, _, _, cleanup := factory(t)
 			t.Cleanup(cleanup)
 
+			// The upstream trusts the narinfo's signature, but upload-trust is
+			// decoupled from pull-trust: with no trusted upload keys configured,
+			// the upload is still rejected.
 			uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
-				PublicKeys: []string{"untrusted-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="},
+				PublicKeys: testdata.PublicKeys(),
 			})
 			require.NoError(t, err)
 
@@ -982,25 +1024,6 @@ func testPutNarInfoRequireTrustedSignature(factory cacheFactory) func(*testing.T
 			err = putNarInfo(t, c)
 			require.ErrorIs(t, err, cache.ErrUntrustedNarInfo)
 			assert.Equal(t, 0, narInfoCount(t, dbClient))
-		})
-
-		t.Run("enabled accepts narinfo with trusted upstream signature", func(t *testing.T) {
-			ts := testdata.NewTestServer(t, 40)
-			t.Cleanup(ts.Close)
-
-			c, dbClient, _, _, _, cleanup := factory(t)
-			t.Cleanup(cleanup)
-
-			uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{
-				PublicKeys: testdata.PublicKeys(),
-			})
-			require.NoError(t, err)
-
-			c.AddUpstreamCaches(newContext(), uc)
-			c.SetCacheRequireTrustedSignature(true)
-
-			require.NoError(t, putNarInfo(t, c))
-			assert.Equal(t, 1, narInfoCount(t, dbClient))
 		})
 	}
 }

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nix-community/go-nix/pkg/narinfo/signature"
 	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog"
 	"github.com/sysbot/go-netrc"
@@ -316,9 +317,17 @@ func serveCommand(
 			&cli.BoolFlag{
 				Name: "cache-require-trusted-signature",
 				Usage: "Reject narinfos uploaded via PUT that do not carry a signature trusted " +
-					"by the configured upstream public keys (fail-closed). Default off.",
+					"by the configured trusted upload keys (--cache-trusted-upload-key), fail-closed. " +
+					"Default off.",
 				Sources: flagSources("cache.require-trusted-signature", "CACHE_REQUIRE_TRUSTED_SIGNATURE"),
 				Value:   false,
+			},
+			&cli.StringSliceFlag{
+				Name: "cache-trusted-upload-key",
+				Usage: "Set to a nix-format name:base64 public key authorizing PUT uploads when " +
+					"--cache-require-trusted-signature is enabled (repeatable). Independent of the " +
+					"upstream public keys.",
+				Sources: flagSources("cache.trusted-upload-keys", "CACHE_TRUSTED_UPLOAD_KEYS"),
 			},
 			&cli.StringFlag{
 				Name:    "cache-temp-path",
@@ -759,6 +768,25 @@ func serveAction(registerShutdown registerShutdownFn) cli.ActionFunc {
 
 		return nil
 	}
+}
+
+// parseTrustedUploadKeys parses operator-supplied nix-format `name:base64`
+// public keys into the signature.PublicKey form used to verify PUT uploads. It
+// returns an error on the first malformed entry so a typo fails startup rather
+// than silently producing a key set that rejects every upload.
+func parseTrustedUploadKeys(raw []string) ([]signature.PublicKey, error) {
+	keys := make([]signature.PublicKey, 0, len(raw))
+
+	for _, r := range raw {
+		pk, err := signature.ParsePublicKey(r)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing trusted upload key %q: %w", r, err)
+		}
+
+		keys = append(keys, pk)
+	}
+
+	return keys, nil
 }
 
 func getUpstreamCaches(ctx context.Context, cmd *cli.Command, netrcData *netrc.Netrc) ([]*upstream.Cache, error) {
@@ -1284,6 +1312,13 @@ func createCache(
 	}
 
 	c.AddUpstreamCaches(ctx, ucs...)
+
+	uploadKeys, err := parseTrustedUploadKeys(cmd.StringSlice("cache-trusted-upload-key"))
+	if err != nil {
+		return nil, err
+	}
+
+	c.SetCacheTrustedUploadKeys(uploadKeys)
 	c.SetCacheRequireTrustedSignature(cmd.Bool("cache-require-trusted-signature"))
 
 	// Trigger the health-checker to speed-up the boot but do not wait for the check to complete.

--- a/pkg/ncps/serve.go
+++ b/pkg/ncps/serve.go
@@ -778,6 +778,12 @@ func parseTrustedUploadKeys(raw []string) ([]signature.PublicKey, error) {
 	keys := make([]signature.PublicKey, 0, len(raw))
 
 	for _, r := range raw {
+		// An empty CACHE_TRUSTED_UPLOAD_KEYS env var can yield a [""] slice;
+		// skip blanks so a templated/empty deployment does not fail startup.
+		if r == "" {
+			continue
+		}
+
 		pk, err := signature.ParsePublicKey(r)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing trusted upload key %q: %w", r, err)

--- a/pkg/ncps/serve_trusted_upload_keys_internal_test.go
+++ b/pkg/ncps/serve_trusted_upload_keys_internal_test.go
@@ -10,10 +10,15 @@ import (
 func TestParseTrustedUploadKeys(t *testing.T) {
 	t.Parallel()
 
-	t.Run("empty input yields no keys and no error", func(t *testing.T) {
+	t.Run("empty input or empty strings yield no keys and no error", func(t *testing.T) {
 		t.Parallel()
 
 		keys, err := parseTrustedUploadKeys(nil)
+		require.NoError(t, err)
+		assert.Empty(t, keys)
+
+		// An empty env var can surface as a [""] slice; it must be ignored.
+		keys, err = parseTrustedUploadKeys([]string{"", ""})
 		require.NoError(t, err)
 		assert.Empty(t, keys)
 	})

--- a/pkg/ncps/serve_trusted_upload_keys_internal_test.go
+++ b/pkg/ncps/serve_trusted_upload_keys_internal_test.go
@@ -1,0 +1,40 @@
+package ncps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTrustedUploadKeys(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty input yields no keys and no error", func(t *testing.T) {
+		t.Parallel()
+
+		keys, err := parseTrustedUploadKeys(nil)
+		require.NoError(t, err)
+		assert.Empty(t, keys)
+	})
+
+	t.Run("valid nix-format keys parse", func(t *testing.T) {
+		t.Parallel()
+
+		raw := []string{
+			"cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=",
+			"nasreddine-uploads-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=",
+		}
+
+		keys, err := parseTrustedUploadKeys(raw)
+		require.NoError(t, err)
+		require.Len(t, keys, 2)
+	})
+
+	t.Run("malformed key returns an error", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := parseTrustedUploadKeys([]string{"not-a-valid-key"})
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

The `cache.require-trusted-signature` PUT gate verified uploaded narinfos against the configured **upstream** public keys. Upstream keys can never match a locally-built store path (unsigned, or signed by the operator's own key), so enabling the gate made it impossible to `nix copy` your own builds — every upload failed with `rejecting untrusted narinfo` (HTTP 500). The gate conflated **pull-trust** (which upstreams ncps mirrors) with **upload-trust** (whose uploads ncps re-signs and serves).

This decouples the two:

- New operator-configured `cache.trusted-upload-keys` (flag `--cache-trusted-upload-key`, env `CACHE_TRUSTED_UPLOAD_KEYS`; nix-format `name:base64`), independent of the upstream keys.
- `require-trusted-signature` now verifies PUT narinfos against the upload keys. It remains the **single** enable switch — only its key source changes.
- Fail-closed is preserved: gate enabled with an empty upload-key set rejects every upload.
- The anti-laundering goal (#1269) holds — only operator-trusted signatures are re-signed and served.

To push self-built paths: sign them (`nix store sign` / `secret-key-files`) and list the matching public key in `trusted-upload-keys`.

**Not breaking:** the PUT signature gate is unreleased (absent from the CHANGELOG), so there are no existing users relying on the old upstream-key behavior.

## Changes

- `pkg/cache/cache.go`: `trustedUploadKeys` field + `SetCacheTrustedUploadKeys`; `verifyNarInfoTrusted` consults upload keys; removed now-unused `trustedPublicKeys`.
- `pkg/ncps/serve.go`: new repeatable flag + `parseTrustedUploadKeys` (fails startup on a malformed key).
- Config/docs/chart: `config.example.yaml`, Configuration Reference, Helm `values.yaml` + `configmap.yaml` + unit tests, CHANGELOG.
- Spec: `narinfo-trusted-signature` updated; change archived under `openspec/changes/archive/`.

## Test plan

- [x] `task fmt` / `task lint` / `task test` pass
- [x] Cache unit tests cover all 5 gate scenarios (incl. upstream-key-but-no-upload-key → reject)
- [x] Serve helper tests (parse valid/empty/malformed keys)
- [x] `helm template` verified: key omitted when empty, rendered when populated
- [ ] Live smoke: `nix copy` with a trusted upload key succeeds; empty list rejects