### PR TITLE
test(e2e): isolate S3 bucket per kubernetes scenario

### DIFF
--- a/nix/e2e-tests/config.nix
+++ b/nix/e2e-tests/config.nix
@@ -614,6 +614,10 @@ rec {
                       # written by another (mirrors the per-scenario ncps_<name>
                       # database). Must match harness_config.scenario_bucket_name
                       # and the buckets created in k8s_tests.py garage setup.
+                      # Scenario names are kebab-case by the catalog contract, so
+                      # this is already a valid S3 bucket name; kept verbatim (not
+                      # normalized) to stay byte-for-byte in sync with the Python
+                      # side (plain Nix has no toLower builtin).
                       bucket = "ncps-${perm.name}";
                       inherit (s3) endpoint;
                       region = "us-east-1";

--- a/nix/e2e-tests/config.nix
+++ b/nix/e2e-tests/config.nix
@@ -610,7 +610,11 @@ rec {
                     # s3
                     type = "s3";
                     s3 = {
-                      inherit (s3) bucket;
+                      # Per-scenario bucket so no scenario observes objects
+                      # written by another (mirrors the per-scenario ncps_<name>
+                      # database). Must match harness_config.scenario_bucket_name
+                      # and the buckets created in k8s_tests.py garage setup.
+                      bucket = "ncps-${perm.name}";
                       inherit (s3) endpoint;
                       region = "us-east-1";
                       prefix = perm.name;

--- a/nix/e2e-tests/src/harness_config.py
+++ b/nix/e2e-tests/src/harness_config.py
@@ -107,6 +107,22 @@ def check(cond: bool, msg: str) -> None:
     log(f"  ✓ {msg}", G)
 
 
+def scenario_bucket_name(scenario_name: str) -> str:
+    """S3 bucket name for a scenario's isolated storage.
+
+    Each kubernetes scenario gets its own bucket so it never observes objects
+    written by another scenario, mirroring the existing per-scenario database
+    isolation (``ncps_<name>``). Without this, residual whole-file NARs left in a
+    shared bucket by an earlier non-CDC scenario make a later CDC scenario skip
+    download + chunking and produce zero chunks.
+
+    The same ``ncps-<name>`` convention is mirrored in ``config.nix``
+    (``generateValues``) when rendering each scenario's Helm values; keep them in
+    sync. Scenario names are kebab-case, so the result is a valid S3 bucket name.
+    """
+    return f"ncps-{scenario_name}"
+
+
 def storage_flags(storage: str):
     """ncps CLI storage flags for `local` or `s3`."""
     if storage == "local":

--- a/nix/e2e-tests/src/harness_config.py
+++ b/nix/e2e-tests/src/harness_config.py
@@ -118,7 +118,12 @@ def scenario_bucket_name(scenario_name: str) -> str:
 
     The same ``ncps-<name>`` convention is mirrored in ``config.nix``
     (``generateValues``) when rendering each scenario's Helm values; keep them in
-    sync. Scenario names are kebab-case, so the result is a valid S3 bucket name.
+    sync. Scenario names are kebab-case by the catalog contract (the
+    unified-e2e-harness spec requires a stable kebab-case name), so the verbatim
+    result is already a valid S3 bucket name. The two sides are kept verbatim
+    (rather than lowercasing/normalizing) precisely so they cannot drift: plain
+    Nix has no ``toLower`` builtin, so any normalization would have to differ
+    between the two implementations and risk a bucket-name mismatch.
     """
     return f"ncps-{scenario_name}"
 

--- a/nix/e2e-tests/src/k8s_tests.py
+++ b/nix/e2e-tests/src/k8s_tests.py
@@ -56,7 +56,7 @@ class K8sTestsCLI:
         self.verbose = verbose
         # Path to config is substituted by Nix or can be provided via env
         self.config_file = os.environ.get(
-            "CONFIG_FILE", os.path.join(REPO_ROOT, "nix/k8s-tests/config.nix")
+            "CONFIG_FILE", os.path.join(REPO_ROOT, "nix/e2e-tests/config.nix")
         )
 
     def log(self, msg: str):
@@ -377,7 +377,7 @@ spec:
             {
                 scenario_bucket_name(perm["name"])
                 for perm in permutations
-                if perm.get("storage", {}).get("type") == "s3"
+                if (perm.get("storage") or {}).get("type") == "s3"
             }
         )
         for bucket in s3_buckets:

--- a/nix/e2e-tests/src/k8s_tests.py
+++ b/nix/e2e-tests/src/k8s_tests.py
@@ -26,6 +26,8 @@ from typing import Any, Dict, List, Optional
 import requests
 import yaml
 
+from harness_config import scenario_bucket_name
+
 try:
     import boto3
     import psycopg2
@@ -357,20 +359,35 @@ spec:
                     break
             garage_exec("layout", "apply", "--version", str(version))
 
-        # 2. Create the bucket (idempotent).
-        if garage_exec("bucket", "info", "ncps-bucket", check=False).returncode != 0:
-            garage_exec("bucket", "create", "ncps-bucket")
-
-        # 3. Import the access key (idempotent).
+        # 2. Import the access key (idempotent).
         if garage_exec("key", "info", "GK1234567890abcdef12345678", check=False).returncode != 0:
             garage_exec("key", "import", "--yes", "GK1234567890abcdef12345678", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 
-        # 4. Grant read+write on the bucket.
-        garage_exec(
-            "bucket", "allow", "--read", "--write", "--owner",
-            "ncps-bucket", "--key", "GK1234567890abcdef12345678",
+        # 3. Create + grant a bucket PER SCENARIO so no scenario observes objects
+        # written by another (mirrors the per-scenario ncps_<name> databases).
+        # A shared bucket let residual whole-file NARs from an earlier non-CDC
+        # scenario make a later CDC scenario skip chunking and report 0 chunks.
+        permutations = json.loads(
+            self.run_cmd(
+                ["nix", "eval", "--json", "--file", self.config_file, "permutations"],
+                capture_output=True,
+            ).stdout
         )
-        self.log("   ✅ Garage configured.")
+        s3_buckets = sorted(
+            {
+                scenario_bucket_name(perm["name"])
+                for perm in permutations
+                if perm.get("storage", {}).get("type") == "s3"
+            }
+        )
+        for bucket in s3_buckets:
+            if garage_exec("bucket", "info", bucket, check=False).returncode != 0:
+                garage_exec("bucket", "create", bucket)
+            garage_exec(
+                "bucket", "allow", "--read", "--write", "--owner",
+                bucket, "--key", "GK1234567890abcdef12345678",
+            )
+        self.log(f"   ✅ Garage configured ({len(s3_buckets)} per-scenario buckets).")
 
         # Registry
         self.log("   - Installing Container Registry...")
@@ -839,6 +856,10 @@ spec:
         creds = {
             "s3": {
                 "endpoint": "http://garage.garage.svc.cluster.local:3900",
+                # Fallback only. Each scenario uses its own bucket
+                # (scenario_bucket_name); config.nix renders the per-scenario
+                # bucket into Helm values and the validator reads it from the
+                # per-scenario deployment config.
                 "bucket": "ncps-bucket",
                 "access_key": "GK1234567890abcdef12345678",
                 "secret_key": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
@@ -1229,6 +1250,13 @@ spec:
                     "storage": {
                         "type": perm["storage"]["type"],
                         "path": perm["storage"].get("local", {}).get("path"),
+                        # Per-scenario bucket (s3 only) so the storage validation
+                        # check targets this scenario's bucket, not a shared one.
+                        **(
+                            {"bucket": scenario_bucket_name(perm["name"])}
+                            if perm["storage"]["type"] == "s3"
+                            else {}
+                        ),
                     },
                 }
             )

--- a/nix/e2e-tests/src/k8s_tests_tester.py
+++ b/nix/e2e-tests/src/k8s_tests_tester.py
@@ -1155,7 +1155,12 @@ class NCPSTester:
                 use_ssl=False,  # Local port-forward is always unencrypted
             )
 
-            bucket = s3_config["bucket"]
+            # Prefer the scenario's own bucket (per-scenario isolation); fall
+            # back to the shared cluster bucket only if a deployment predates the
+            # per-scenario bucket field.
+            bucket = deployment_config.get("storage", {}).get("bucket") or s3_config[
+                "bucket"
+            ]
             cdc_enabled = deployment_config.get("cdc", False)
 
             if cdc_enabled:

--- a/nix/e2e-tests/tests/test_s3_bucket_isolation.py
+++ b/nix/e2e-tests/tests/test_s3_bucket_isolation.py
@@ -1,0 +1,36 @@
+"""Unit tests for per-scenario S3 bucket isolation in the kubernetes harness.
+
+Regression guard for the e2e-nightly CDC failure: scenarios used to share one
+Garage bucket, so residual whole-file NARs from an earlier non-CDC scenario made
+later CDC scenarios skip chunking (0 chunks). Each scenario must get its own
+bucket, mirroring the existing per-scenario database isolation.
+
+These are fast, pure-python unit tests (no nix eval, no cluster).
+"""
+
+from __future__ import annotations
+
+# harness_config is stdlib-only, so this runs in the pytest-only unit net
+# (which has neither requests nor pyyaml, so k8s_tests cannot be imported here).
+from harness_config import scenario_bucket_name
+
+
+def test_scenario_bucket_name_is_per_scenario():
+    assert scenario_bucket_name("single-s3-postgres-cdc") == "ncps-single-s3-postgres-cdc"
+    # Distinct scenarios get distinct buckets (the core isolation property).
+    assert scenario_bucket_name("single-s3-postgres") != scenario_bucket_name(
+        "single-s3-postgres-cdc"
+    )
+
+
+def test_scenario_bucket_names_are_valid_s3_names():
+    # S3 bucket names: lowercase, 3-63 chars, hyphens ok, no underscores.
+    for name in (
+        "single-s3-postgres-cdc",
+        "ha-s3-postgres-cdc",
+        "ha-s3-postgres-cdc-lifecycle",
+    ):
+        bucket = scenario_bucket_name(name)
+        assert bucket.islower()
+        assert "_" not in bucket
+        assert 3 <= len(bucket) <= 63

--- a/openspec/changes/archive/2026-06-22-isolate-e2e-s3-bucket-per-scenario/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-22-isolate-e2e-s3-bucket-per-scenario/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/archive/2026-06-22-isolate-e2e-s3-bucket-per-scenario/design.md
+++ b/openspec/changes/archive/2026-06-22-isolate-e2e-s3-bucket-per-scenario/design.md
@@ -1,0 +1,57 @@
+## Context
+
+The kubernetes e2e harness (`nix/e2e-tests/src/k8s_tests.py`) provisions one Kind cluster and then runs every catalog scenario against it sequentially. It already isolates the relational database per scenario (`ncps_<name>`, created/dropped per scenario), but all scenarios share a single Garage S3 bucket `ncps-bucket`, created once during garage setup (`k8s_tests.py:360-372`) and never cleaned. `get_cluster_creds()` (`k8s_tests.py:838-845`) returns this fixed bucket; the per-scenario Helm values are generated from those creds (`config.nix` `inherit (s3) bucket`), and the S3 validation check (`k8s_tests_tester.py:_test_s3_storage`) lists `store/chunk/` in that same bucket.
+
+Because the six test narinfo hashes are shared across scenarios, a non-CDC scenario (e.g. `single-s3-postgres`) downloads and stores those NARs as whole-file `.nar.xz` in the shared bucket. A later CDC scenario runs with a fresh database but the dirty bucket; since PR #1393, ncps treats a stored `.nar.xz` as a present `Compression:none` NAR, so it skips the upstream download and eager chunking and `BackgroundMigrateNarToChunks` fails with "error fetching nar from store: not found" — zero chunk rows are created and the validation (`SELECT COUNT(*) FROM chunks == 0`) fails. This was confirmed locally: emptying the bucket makes `single-s3-postgres-cdc` pass with 4 chunks; the dirty bucket fails with 0.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Each kubernetes scenario deploys against clean, isolated S3 storage, mirroring the existing per-scenario database isolation.
+- The S3 validation check reflects only the running scenario's writes (no false positives from residue).
+- Restore the `e2e-nightly` kubernetes leg to green.
+
+**Non-Goals:**
+- No ncps production code, Helm chart, or CDC behavior changes. The residual-whole-file handling in ncps is out of scope (it is an artificial fresh-DB-over-dirty-storage state, not a realistic production path; the realistic enable-CDC-on-existing-cache path is `migrate-nar-to-chunks`, covered by `cdc-lifecycle`).
+- No change to `local` mode (its scenarios use local per-pod storage and do not share an S3 bucket).
+
+## Decisions
+
+### Decision: Per-scenario bucket, not clean-the-shared-bucket
+
+Give each S3-using scenario its own bucket `ncps-<scenario-name>` (kebab-case scenario names are valid S3 bucket names — lowercase + hyphens, well under 63 chars), mirroring the per-scenario `ncps_<name>` databases.
+
+**Alternative considered — empty the shared bucket before each scenario:** rejected. The Garage image is distroless (no shell, no S3 CLI), so emptying objects would require standing up an S3 client (boto3) with a port-forward before every scenario — fragile, and not parallel-safe. Per-scenario buckets need no teardown, are race-free, and are symmetric with the database isolation already in place.
+
+**Alternative considered — per-scenario S3 *prefix* instead of per-scenario bucket:** rejected as incomplete. `config.nix` already sets `config.storage.s3.prefix = perm.name` per scenario, but (a) the Helm chart configmap (`charts/ncps/templates/configmap.yaml`) does not render `storage.s3.prefix` at all, so it is silently dropped, and (b) even if rendered, the **chunk store ignores the configured prefix** — `pkg/storage/chunk/s3.go` builds keys as `store/chunk/<hash>` unconditionally (`chunkPath`, ignoring `cfg.Prefix`), while only the NAR/narinfo store honors the prefix. So a prefix fix would isolate NAR/narinfo but leave chunks colliding across scenarios, and would also require touching production code (chart + ncps chunk store). A per-scenario **bucket** isolates every store (NAR, narinfo, chunk) at once because the bucket name is the one input all three stores honor, with no production-code change. (The now-dead `prefix = perm.name` in `config.nix` is harmless and left as-is; removing it is out of scope.)
+
+### Decision: Create + grant buckets idempotently during garage setup
+
+Where the harness creates the single `ncps-bucket` today, iterate the catalog permutations (the same source already used to create per-test databases) and, for each scenario whose storage type is `s3`, create `ncps-<name>` and grant the existing shared access key (`GK1234...`) read+write+owner — all idempotent (`bucket info` guard, `bucket allow` is idempotent). Keep using the single shared access key; only the bucket is per-scenario.
+
+### Decision: Inject the per-scenario bucket into value generation and validation
+
+The per-scenario bucket name flows to the deployment exactly where the shared bucket does today: the value-generation path that reads `creds["s3"]["bucket"]`. Set the bucket per scenario (e.g. derive `ncps-<name>` at value-generation time, or thread it through `get_cluster_creds`). Because `_test_s3_storage` reads the bucket from the same per-deployment S3 config, the validation check automatically targets the correct per-scenario bucket with no separate change.
+
+### Decision: Bucket name derivation
+
+`ncps-` + the scenario's catalog name verbatim (already kebab-case), e.g. `ncps-single-s3-postgres-cdc`. This is unique per scenario and trivially mappable back to the scenario for debugging.
+
+## Risks / Trade-offs
+
+- **Many buckets on single-node Garage** → negligible: Garage handles many buckets cheaply at test scale; buckets are created once per cluster and reused across runs.
+- **A scenario still pointing at the old shared bucket** → mitigation: remove/replace the shared `ncps-bucket` usage so there is a single source for the bucket name (the per-scenario derivation), and assert in the harness unit tests that generated values carry the per-scenario bucket.
+- **Stale residue in a long-lived dev Kind cluster** → per-scenario buckets are still cleaner than the shared one, but a re-run of the *same* scenario reuses its bucket; this matches the database behavior and is acceptable for nightly (fresh-ish cluster). Not a regression vs. today.
+
+## Migration Plan
+
+Test-harness-only change; no production deploy. Validation:
+1. Run the affected scenarios locally on Kind (`nix run .#e2e -- --mode kubernetes --scenario single-s3-postgres-cdc`, then `ha-s3-postgres-cdc`, `ha-s3-postgres-cdc-lifecycle`) and confirm non-zero chunk counts.
+2. Run the harness pytest unit net (`flake check` e2e-harness-unit) for the value-generation/bucket logic.
+3. Trigger `e2e-nightly` via `workflow_dispatch` on the branch and confirm the kubernetes leg goes green.
+
+Rollback: revert the harness change.
+
+## Open Questions
+
+- None. The fix location and mechanism are confirmed by the local reproduction.

--- a/openspec/changes/archive/2026-06-22-isolate-e2e-s3-bucket-per-scenario/proposal.md
+++ b/openspec/changes/archive/2026-06-22-isolate-e2e-s3-bucket-per-scenario/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The `e2e-nightly` kubernetes leg has failed every scheduled run since 2026-06-11 on the three CDC scenarios (`single-s3-postgres-cdc`, `ha-s3-postgres-cdc`, `ha-s3-postgres-cdc-lifecycle`) with `PostgreSQL database is empty (0 chunks)`. The kubernetes harness isolates a database per scenario but shares one Garage S3 bucket (`ncps-bucket`) across every scenario and never cleans it. Earlier non-CDC scenarios reuse the same test narinfo hashes and leave whole-file `.nar.xz` objects in `store/nar/`; when a CDC scenario then runs with a fresh database against that dirty bucket, ncps (since PR #1393 treats a stored `.nar.xz` as a present `Compression:none` NAR) sees the residual whole-file as already present, skips the upstream download + eager chunking, and creates zero chunk rows — failing the validation. The storage substrate must be isolated per scenario exactly as the database already is.
+
+## What Changes
+
+- The kubernetes e2e harness (`nix/e2e-tests/src/k8s_tests.py`) SHALL give each scenario its own S3 bucket instead of a single shared `ncps-bucket`, mirroring the existing per-scenario database isolation.
+- Per-scenario buckets SHALL be created and granted to the access key during cluster/garage setup (idempotently), derived deterministically from the scenario name.
+- Each scenario's generated Helm values SHALL reference its own bucket so it deploys against clean storage.
+- This removes the residual-data cross-contamination and also closes a latent false-positive: the S3 storage validation check (counting `store/chunk/`) currently can pass on residual chunks from a previous scenario.
+- Scope is the e2e **test harness only**; no ncps production code changes.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `unified-e2e-harness`: the harness's per-scenario isolation requirement is extended so the S3 storage backend (bucket) is isolated per scenario in kubernetes mode, not just the database.
+
+## Impact
+
+- `nix/e2e-tests/src/k8s_tests.py` — garage bucket setup (create/grant per scenario), per-scenario Helm value generation (bucket name), and the S3 validation check operate against the per-scenario bucket.
+- Possibly `nix/e2e-tests/config.nix` if the bucket name is sourced from the shared S3 config used in value generation.
+- Restores the `e2e-nightly` kubernetes leg to green; no production code, Helm chart defaults, or ncps behavior change.

--- a/openspec/changes/archive/2026-06-22-isolate-e2e-s3-bucket-per-scenario/specs/unified-e2e-harness/spec.md
+++ b/openspec/changes/archive/2026-06-22-isolate-e2e-s3-bucket-per-scenario/specs/unified-e2e-harness/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Per-scenario storage isolation in kubernetes mode
+
+The harness MUST isolate the S3 storage backend per scenario in `kubernetes` mode, so that no scenario observes objects written by another scenario. Each scenario MUST deploy against its own S3 bucket whose name is derived deterministically from the scenario name, mirroring the existing per-scenario database isolation. The harness MUST create each per-scenario bucket and grant the access key idempotently during dependency/garage setup, and each scenario's generated Helm values MUST reference its own bucket. A scenario that downloads and chunks a NAR MUST therefore start from empty storage, so a CDC scenario re-downloads and chunks its NARs rather than finding whole-file residue left by an earlier non-CDC scenario. The S3 storage validation (counting `store/chunk/`) MUST consequently reflect only the running scenario's writes and MUST NOT pass on residue from a previous scenario.
+
+#### Scenario: Each kubernetes scenario uses its own bucket
+
+- **WHEN** two kubernetes scenarios that use S3 storage run in the same cluster
+- **THEN** each scenario deploys against a distinct bucket derived from its name, and neither scenario can read objects written by the other
+
+#### Scenario: CDC scenario starts from empty storage
+
+- **WHEN** a CDC scenario runs after a non-CDC scenario that downloaded the same test NARs as whole files
+- **THEN** the CDC scenario's bucket contains no residual whole-file NARs, so ncps re-downloads and eager-chunks them and the per-scenario database ends with a non-zero `chunks` count
+
+#### Scenario: S3 storage check reflects only the running scenario
+
+- **WHEN** the harness validates S3 storage for a scenario by counting `store/chunk/`
+- **THEN** the count reflects only objects that scenario wrote and does not pass on chunks left by a previously-run scenario

--- a/openspec/changes/archive/2026-06-22-isolate-e2e-s3-bucket-per-scenario/tasks.md
+++ b/openspec/changes/archive/2026-06-22-isolate-e2e-s3-bucket-per-scenario/tasks.md
@@ -1,0 +1,29 @@
+## 1. Per-scenario bucket creation in garage setup
+
+- [x] 1.1 In `k8s_tests.py` garage setup, replace the single `ncps-bucket` create/grant with a loop over catalog permutations: for each scenario whose `storage.type == "s3"`, derive the bucket name `ncps-<scenario-name>` and create it idempotently (guard with `bucket info`).
+- [x] 1.2 Grant the existing shared access key (`GK1234...`) read+write+owner on each per-scenario bucket (idempotent).
+- [x] 1.3 Add a small helper to derive the bucket name from a scenario name so the same derivation is used by setup, value generation, and validation.
+
+## 2. Wire the per-scenario bucket into deployment + validation
+
+- [x] 2.1 Make the per-scenario Helm value generation use the scenario's bucket instead of the shared `ncps-bucket` (set the bucket from the derivation where `get_cluster_creds()`/`creds["s3"]["bucket"]` currently supplies the shared name).
+- [x] 2.2 Confirm the S3 validation check (`k8s_tests_tester.py:_test_s3_storage`) reads the bucket from the per-deployment S3 config so it targets the per-scenario bucket (adjust only if it hard-codes the shared bucket).
+- [x] 2.3 Remove or repurpose the now-unused shared `ncps-bucket` reference so there is a single source of truth for the bucket name.
+
+## 3. Harness unit coverage
+
+- [x] 3.1 Add/extend a harness pytest (the `e2e-harness-unit` net) asserting the bucket-name derivation and that generated kubernetes values for two distinct scenarios carry distinct, per-scenario buckets.
+
+## 4. Local validation on Kind
+
+- [x] 4.1 Run `nix run .#e2e -- --mode kubernetes --scenario single-s3-postgres-cdc` on a clean cluster and confirm it passes with a non-zero `chunks` count.
+- [x] 4.2 Run `ha-s3-postgres-cdc` and `ha-s3-postgres-cdc-lifecycle` and confirm both pass.
+- [x] 4.3 Run at least one non-CDC S3 scenario before a CDC scenario in the same invocation and confirm the CDC scenario still passes (no cross-scenario residue).
+
+## 5. Verify, lint, format
+
+- [x] 5.1 Run `task fmt`, `task lint`, and the harness unit tests; confirm all pass.
+
+## 6. CI validation
+
+- [ ] 6.1 After merging to the branch, trigger the `e2e-nightly` workflow via `workflow_dispatch` (with `ref` = the branch) and confirm the kubernetes leg goes green.

--- a/openspec/specs/unified-e2e-harness/spec.md
+++ b/openspec/specs/unified-e2e-harness/spec.md
@@ -237,3 +237,22 @@ The harness SHALL be manual / opt-in and MUST NOT be added to `nix flake check`.
 
 - **WHEN** someone proposes adding a harness scenario to `nix flake check`
 - **THEN** it is admitted only if that scenario's wall-clock runtime is shown to be under 3 minutes, otherwise it stays manual or moves to a scheduled workflow
+
+### Requirement: Per-scenario storage isolation in kubernetes mode
+
+The harness MUST isolate the S3 storage backend per scenario in `kubernetes` mode, so that no scenario observes objects written by another scenario. Each scenario MUST deploy against its own S3 bucket whose name is derived deterministically from the scenario name, mirroring the existing per-scenario database isolation. The harness MUST create each per-scenario bucket and grant the access key idempotently during dependency/garage setup, and each scenario's generated Helm values MUST reference its own bucket. A scenario that downloads and chunks a NAR MUST therefore start from empty storage, so a CDC scenario re-downloads and chunks its NARs rather than finding whole-file residue left by an earlier non-CDC scenario. The S3 storage validation (counting `store/chunk/`) MUST consequently reflect only the running scenario's writes and MUST NOT pass on residue from a previous scenario.
+
+#### Scenario: Each kubernetes scenario uses its own bucket
+
+- **WHEN** two kubernetes scenarios that use S3 storage run in the same cluster
+- **THEN** each scenario deploys against a distinct bucket derived from its name, and neither scenario can read objects written by the other
+
+#### Scenario: CDC scenario starts from empty storage
+
+- **WHEN** a CDC scenario runs after a non-CDC scenario that downloaded the same test NARs as whole files
+- **THEN** the CDC scenario's bucket contains no residual whole-file NARs, so ncps re-downloads and eager-chunks them and the per-scenario database ends with a non-zero `chunks` count
+
+#### Scenario: S3 storage check reflects only the running scenario
+
+- **WHEN** the harness validates S3 storage for a scenario by counting `store/chunk/`
+- **THEN** the count reflects only objects that scenario wrote and does not pass on chunks left by a previously-run scenario


### PR DESCRIPTION
## Summary

Fixes the `e2e-nightly` kubernetes leg, which has failed every scheduled run since 2026-06-11 on the CDC scenarios (`single-s3-postgres-cdc`, `ha-s3-postgres-cdc`, `ha-s3-postgres-cdc-lifecycle`) with `PostgreSQL database is empty (0 chunks)`.

**Root cause (confirmed via local Kind e2e + pod logs + bucket-empty proof):** the kubernetes harness isolates a database per scenario but shared a single Garage bucket (`ncps-bucket`) across every scenario and never cleaned it. Earlier non-CDC scenarios reuse the same test narinfo hashes and leave whole-file `.nar.xz` objects in `store/nar/`. When a CDC scenario then runs with a fresh database against that dirty bucket, ncps (since #1393 treats a stored `.nar.xz` as a present `Compression:none` NAR) sees the residual whole file as already present, **skips the upstream download + eager chunking**, and `BackgroundMigrateNarToChunks` fails with `error fetching nar from store: not found` — so zero chunk rows are created and validation fails. Pre-#1393 the path only checked `.nar.zst`, missed the residual, re-downloaded and eager-chunked (the last green run produced 4 chunks). `cdc-lifecycle` passes because it uses local per-pod storage with no shared residue.

## What changed (test harness only — no ncps / chart / CDC behavior change)

- `harness_config.scenario_bucket_name()` — single source of truth deriving `ncps-<scenario>`.
- `config.nix` — each scenario's generated Helm values use its own bucket.
- `k8s_tests.py` — garage setup creates + grants a bucket per S3 scenario (idempotent); test-config carries the per-scenario bucket.
- `k8s_tests_tester.py` — S3 storage validation reads the per-scenario bucket.

A per-scenario **bucket** (not prefix) isolates the NAR, narinfo, **and** chunk stores at once — the chunk store ignores the configured S3 prefix, so a per-scenario prefix would leave chunks colliding.

## Test plan

- [x] `nix eval` confirms each S3 scenario renders a distinct `ncps-<name>` bucket; local scenarios get none
- [x] New harness unit test (`test_s3_bucket_isolation.py`); `e2e-harness-unit` net green (66 passed)
- [x] `task fmt`, `task lint`, `task test` (0 failures) green
- [x] Live Kind run: `single-s3-postgres` (non-CDC) then all three CDC scenarios → **4/4 pass, 4 chunks each** (cross-scenario isolation proven)
- [ ] `e2e-nightly` `workflow_dispatch` on this branch goes green (kubernetes leg)