### PR TITLE
fix(cache): proxy snix-castore opaque nar URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,23 @@ project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **snix-castore (and other `.nar`-less opaque) upstream narinfo URLs are now
+  proxied instead of returning `HTTP 500 "invalid nar URL"`.** Upstreams such as
+  `cache.snix.dev` serve narinfos whose `URL:` field is a content-addressed
+  reference like `nar/snix-castore/<blob>?narsize=N` (`Compression: none`, no
+  `.nar` extension). ncps previously rejected these while parsing, so a request
+  for such a `.narinfo` failed with a 500 — intermittently, because upstream
+  selection races and a retry that landed on a conventional cache (e.g.
+  cache.nixos.org) succeeded. Following the Nix HTTP binary-cache protocol (the
+  narinfo `URL:` is an opaque path relative to the cache root), ncps now tolerates
+  `.nar`-less opaque URLs: it fetches the NAR from the original opaque path —
+  preserving the required query string (snix returns `400` without `?narsize=N`) —
+  keys local storage off the narinfo `NarHash`, and re-serves under its own
+  hash-named `nar/<hash>.nar` (`Compression: none`). The opaque path and query are
+  persisted so the NAR is re-fetchable from upstream after local eviction. This
+  generalizes the existing cachix UUID opaque-URL handling; conventional
+  hash-named URLs are unaffected.
+
 - **Eager-CDC narinfos are now advertised as `Compression: none` predictively.**
   Under eager CDC the durable form of a NAR is its uncompressed chunk sequence, and
   ncps has no NAR compressor — so a `.nar.xz` request during the chunking window

--- a/docs/docs/Developer Guide/Architecture/Request Flow.md
+++ b/docs/docs/Developer Guide/Architecture/Request Flow.md
@@ -50,6 +50,28 @@ Client Request: GET /nar/<path>
              [8] Stream NAR to client
 ```
 
+### Upstream NAR URL handling (opaque URLs)
+
+Per the Nix HTTP binary-cache protocol, a narinfo's `URL:` field is an **opaque
+path relative to the cache root** — ncps must not assume it is
+`nar/<hash>.nar[.<compression>]`. ncps handles three shapes:
+
+- **Conventional hash-named** (e.g. cache.nixos.org `nar/<hash>.nar.xz`): parsed
+  directly; storage and serving key off the URL hash.
+- **Opaque with a `.nar` token** (e.g. cachix `nar/<uuid>.nar.zst`): the filename
+  is not a valid Nix hash, so ncps keys local storage off the narinfo `NarHash`
+  and preserves the original path for the upstream `GET`.
+- **Opaque without a `.nar` token** (e.g. snix-castore
+  `nar/snix-castore/<blob>?narsize=N`, `Compression: none`): tolerated the same
+  way, treating compression as `none`. The full opaque path **and its query
+  string** are preserved for the upstream `GET` (snix returns `400` without
+  `?narsize=N`).
+
+For both opaque shapes ncps re-serves the NAR to clients under its own hash-named
+`nar/<NarHash>.nar[.<compression>]` URL, and persists the opaque upstream path
+(with query) so the NAR can be re-fetched from the origin after local eviction.
+The upstream query is never carried onto ncps's own hash-named serve/storage key.
+
 ## High Availability Flow
 
 With Redis distributed locking:

--- a/openspec/changes/archive/2026-06-30-support-snix-castore-opaque-urls/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-30-support-snix-castore-opaque-urls/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-01

--- a/openspec/changes/archive/2026-06-30-support-snix-castore-opaque-urls/design.md
+++ b/openspec/changes/archive/2026-06-30-support-snix-castore-opaque-urls/design.md
@@ -1,0 +1,94 @@
+## Context
+
+ncps proxies several upstream binary caches. The Nix HTTP binary-cache protocol
+treats a narinfo's `URL:` field as an **opaque path relative to the cache root**;
+clients and pull-through proxies must not assume it is `nar/<hash>.nar[.<comp>]`.
+
+ncps already tolerates *some* non-conventional URLs: `nar.ParseUpstreamURL` accepts
+filenames whose stem is not a valid Nix hash (cachix's `nar/<uuid>.nar.zst`),
+preserving the path for the upstream GET and keying local storage off `NarHash`.
+But `parseURLParts` still hard-requires a `.nar` token — it does
+`strings.Cut(filename, ".nar")` and returns `ErrInvalidURL` when absent.
+
+`cache.snix.dev` (a configured upstream) serves snix-castore URLs that have **no**
+`.nar` token:
+
+```
+URL: nar/snix-castore/CiUSIATh-lHQ2Dp92sJJfOGg0-s8mLizwHc0z3OtQ953fwSUGNoC?narsize=7415800
+Compression: none
+NarHash: sha256:0cr6df6...   NarSize == FileSize == 7415800
+```
+
+Fetching that path returns `HTTP 200/206`, `Content-Type: application/x-nix-nar`, a
+plain uncompressed NAR (verified). The `?narsize=N` query is **required** — snix
+returns `400` without it. Because `parseURLParts` rejects the URL, the `.narinfo`
+request 500s ("invalid nar URL"). It is intermittent: upstream selection races all
+healthy upstreams, so a retry landing on cache.nixos.org (conventional URL) succeeds.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Proxy snix-castore (and any `.nar`-less opaque) upstream narinfo URLs instead of
+  500-ing, following the opaque-URL contract already spec'd for cachix.
+- Preserve the full upstream path **and query string** for the upstream GET.
+- Key local storage off `NarHash`; treat compression as `none`.
+
+**Non-Goals:**
+- Decoding the tvix/snix-castore protobuf blob (never needed by a proxy).
+- Native castore storage, new storage formats, or new config flags.
+- Changing upstream selection or adding cross-upstream parse-failure fall-through.
+- Compressed `.nar`-less opaque URLs (unobserved; snix-castore is always `none`).
+
+## Decisions
+
+**D1 — Recover in `ParseUpstreamURL`, not `ParseURL`.** Only the upstream-facing
+parser gains `.nar`-less tolerance; the strict `ParseURL` (used for ncps's own
+serve/storage keys) stays unchanged, so ncps still only ever *emits* hash-named
+URLs. *Alternative rejected:* loosening `parseURLParts` globally would let malformed
+URLs through the serve path.
+
+**D2 — Detect the `.nar`-less case explicitly and build an opaque URL.** When the
+filename has no `.nar` token, `ParseUpstreamURL` treats the whole path (query
+stripped) as the `opaquePath`, parses and retains the query into `URL.Query`, sets
+`Compression = none`, and uses `fallbackHash` (`NarHash`) as the storage key —
+exactly the existing opaque mechanism, minus the `.nar` requirement. A `.nar`-less
+URL with no valid `NarHash` still errors (never fabricate a key). *Alternative
+rejected:* a snix-specific `nar/snix-castore/` prefix match — brittle and narrower
+than the protocol's opaque-path guarantee.
+
+**D3 — Compression comes from the narinfo, defaulted to `none`.** The URL carries no
+compression extension, and snix advertises `Compression: none` with
+`FileSize == NarSize`. The `.nar`-less opaque URL therefore parses as `none`; the
+existing `narInfo.Compression == none` branch in the pull path already re-advertises
+`nar/<narhash>.nar` (`none`) and nulls `FileHash`/`FileSize`, so re-serving needs no
+new logic once parsing succeeds.
+
+**D4 — Reuse opaque-path persistence.** The preserved opaque path (incl. query) is
+persisted via the existing `upstream_url` mechanism so an evicted NAR is re-fetched
+from snix, not from ncps's local-only hash-named URL. No schema/migration change.
+
+## Risks / Trade-offs
+
+- **Dropping the `?narsize=N` query → upstream `400`.** → Test that the query
+  round-trips `ParseUpstreamURL` → `JoinURL` into the reconstructed upstream GET.
+- **Switch-case ordering (`none` before `IsOpaque`) skips opaque-path persistence.**
+  → Test opaque-`none` re-fetch after eviction; ensure `upstreamNarPath` is captured
+  before the compression branch and persisted regardless of branch taken.
+- **Over-broadening: genuinely malformed URLs slip through as opaque.** → Only
+  recover when the path is non-empty *and* `fallbackHash` is valid; empty URL and
+  bad-query cases still return `ErrInvalidURL`.
+- **`none` opaque NAR storage/serve path is less exercised than compressed opaque.**
+  → Integration test the full snix pull → store → serve → re-serve loop.
+
+## Migration Plan
+
+Pure code change; no DB migration, no config, no data backfill. Deploy via normal
+rolling update; rollback = revert the commit. Note: current production runs an old
+unmerged feature-branch image — this fix must ship from a clean `main` build. No
+behavior change for conventional or cachix-style opaque URLs.
+
+## Open Questions
+
+- Should ncps still hard-fail the request when a *selected* upstream's narinfo URL
+  is unparseable, or fall through to the next upstream? Deferred to a separate
+  upstream-resilience change; out of scope here.

--- a/openspec/changes/archive/2026-06-30-support-snix-castore-opaque-urls/proposal.md
+++ b/openspec/changes/archive/2026-06-30-support-snix-castore-opaque-urls/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+`cache.snix.dev` — a configured upstream — serves narinfos whose `URL:` field is a
+snix-castore blob reference, `nar/snix-castore/<base64-protobuf>?narsize=N`, with
+`Compression: none` and **no `.nar` extension**. ncps's opaque-URL tolerance
+(`nar.ParseUpstreamURL`) still requires a `.nar` token, so `parseURLParts` rejects
+these with `ErrInvalidURL`, and the `<hash>.narinfo` request returns **HTTP 500
+"invalid nar URL"**. The failure is intermittent — upstream selection races all
+healthy upstreams and the first responder wins, so a retry that lands on
+cache.nixos.org succeeds — which makes it a confusing, hard-to-diagnose prod error
+(confirmed in production logs).
+
+## What Changes
+
+- Generalize opaque upstream NAR URL handling so a narinfo `URL:` that carries **no
+  `.nar` token** is treated as opaque rather than rejected: preserve the full path
+  **and query string** verbatim for the upstream GET, derive the local storage key
+  from `NarHash`, and treat compression as `none` (taken from the narinfo, not the
+  URL extension).
+- Re-serve such NARs to downstream clients under ncps's own hash-named
+  `nar/<narhash>.nar` (`Compression: none`), reusing the existing opaque-path
+  persistence so the NAR is re-fetchable from the original upstream after eviction.
+- The upstream GET MUST retain the `?narsize=N` query (snix returns `400` without it).
+- Update `CHANGELOG.md` and `docs/` to document snix-castore / opaque-URL support.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `upstream-fetch-resilience`: broaden the "Opaque (non hash-named) upstream NAR
+  URLs MUST be tolerated" requirement to cover URLs with **no `.nar` token** (e.g.
+  snix-castore), including preserving the query string on the upstream GET and
+  sourcing compression from the narinfo `Compression:` field.
+
+## Non-goals
+
+- Decoding or interpreting the tvix/snix-castore protobuf blob. ncps follows the
+  Nix HTTP binary-cache protocol, where the narinfo `URL:` is an **opaque path
+  relative to the cache root**; a pull-through proxy never needs castore internals.
+- Native castore storage, a new storage format, or any new configuration flag.
+- Changing upstream **selection** ordering or adding parse-failure fall-through
+  between upstreams (a separate resilience concern; out of scope here).
+- Supporting compressed opaque URLs that lack a `.nar` token (none observed;
+  snix-castore is always `Compression: none`).
+
+## Impact
+
+- **Code**: `pkg/nar/url.go` (`parseURLParts` / `ParseUpstreamURL`), `pkg/cache/cache.go`
+  (narinfo pull + re-advertise path). No schema/migration change — opaque-path
+  persistence (`upstream_url`) already exists.
+- **Docs**: `CHANGELOG.md`, `docs/` (Request Flow / upstream handling).
+- **I/O / network / memory**: negligible. Same single upstream GET, same
+  uncompressed-NAR handling already used for cachix opaque URLs; no extra
+  round-trips, no added buffering.

--- a/openspec/changes/archive/2026-06-30-support-snix-castore-opaque-urls/specs/upstream-fetch-resilience/spec.md
+++ b/openspec/changes/archive/2026-06-30-support-snix-castore-opaque-urls/specs/upstream-fetch-resilience/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: Opaque (non hash-named) upstream NAR URLs MUST be tolerated
+
+The system MUST proxy an upstream narinfo whose `URL:` field is not a conventional
+hash-named `nar/<hash>.nar[.<compression>]` path rather than rejecting it. This
+covers two opaque shapes:
+
+1. **Non-hash filename that still ends in `.nar[.<compression>]`** — e.g. cachix's
+   `nar/<uuidv4>.nar.zst` (the stem before `.nar` is not a valid Nix hash).
+2. **No `.nar` token at all** — e.g. snix-castore's
+   `nar/snix-castore/<base64-blob>?narsize=N`, served with `Compression: none`.
+
+For any opaque URL the system SHALL derive its local storage key from the narinfo
+`NarHash` (re-encoded as a bare nix32 digest), SHALL preserve the original opaque
+upstream path **including its query string** verbatim for the upstream GET, and
+SHALL re-serve the NAR to downstream clients under its own hash-named URL keyed off
+the `NarHash`. For a `.nar`-less opaque URL the compression SHALL be taken as `none`
+(the URL carries no compression extension and such upstreams advertise
+`Compression: none`). Conventional hash-named upstream URLs SHALL continue to be
+handled exactly as before.
+
+When an opaque upstream URL is encountered but the narinfo carries no usable
+`NarHash`, the system SHALL surface a parse error rather than fabricate a storage
+key. The strict parser used for ncps's own serve/storage keys SHALL remain
+unchanged, so ncps continues to emit only hash-named URLs to clients.
+
+#### Scenario: Opaque upstream URL is proxied successfully
+
+- **WHEN** an upstream narinfo has an opaque `URL:` (e.g. `nar/<uuid>.nar.zst`) and a valid `NarHash`
+- **THEN** the request SHALL succeed rather than failing with an invalid-nar-hash error
+- **AND** the served narinfo `URL:` SHALL be ncps's own hash-named URL derived from the `NarHash`
+- **AND** the NAR bytes SHALL be fetched from the original opaque upstream path
+
+#### Scenario: snix-castore `.nar`-less upstream URL is proxied successfully
+
+- **WHEN** an upstream narinfo has an opaque `URL:` with no `.nar` token and a query string (e.g. `nar/snix-castore/<blob>?narsize=7415800`), `Compression: none`, and a valid `NarHash`
+- **THEN** the request SHALL succeed rather than returning an `invalid nar URL` error
+- **AND** the upstream GET SHALL target the original path with its query string preserved verbatim (e.g. `?narsize=7415800`)
+- **AND** the parsed compression SHALL be `none`
+- **AND** the served narinfo `URL:` SHALL be ncps's own hash-named `nar/<narhash>.nar` with `Compression: none`
+
+#### Scenario: Conventional hash-named upstream URL is unaffected
+
+- **WHEN** an upstream narinfo has a conventional hash-named `URL:`
+- **THEN** it SHALL be parsed and served exactly as before
+- **AND** no opaque upstream path SHALL be recorded
+
+#### Scenario: Opaque URL without a usable NarHash is rejected
+
+- **WHEN** an upstream narinfo has an opaque `URL:` (with or without a `.nar` token) but no valid fallback `NarHash`
+- **THEN** the system SHALL return a parse error
+- **AND** SHALL NOT fabricate a storage key

--- a/openspec/changes/archive/2026-06-30-support-snix-castore-opaque-urls/tasks.md
+++ b/openspec/changes/archive/2026-06-30-support-snix-castore-opaque-urls/tasks.md
@@ -1,0 +1,33 @@
+## 1. Parser: tolerate `.nar`-less opaque upstream URLs (TDD)
+
+- [x] 1.1 Add failing unit tests in `pkg/nar/url_test.go` for `ParseUpstreamURL` on a snix-castore URL `nar/snix-castore/<blob>?narsize=7415800` with a valid fallback hash: asserts no error, `IsOpaque()` true, `Compression == none`, `Hash == fallbackHash`, `OpaquePath()` == `nar/snix-castore/<blob>`, and `Query` contains `narsize=7415800`.
+- [x] 1.2 Add failing test that `ParseURL` (strict) STILL rejects the `.nar`-less URL with `ErrInvalidURL` (serve/storage parser unchanged).
+- [x] 1.3 Add failing test that a `.nar`-less URL with an empty/invalid fallback hash returns a parse error and does not fabricate a key.
+- [x] 1.4 Add failing test that reconstructing the upstream URL via `JoinURL` round-trips the query string (`...?narsize=7415800`).
+- [x] 1.5 Implement in `pkg/nar/url.go`: when `parseURLParts` finds no `.nar` token, `ParseUpstreamURL` builds an opaque `URL` (opaquePath = path sans query, `Query` retained, `Compression = none`, `Hash = fallbackHash`); keep `ParseURL` strict. Make 1.1–1.4 green.
+- [x] 1.6 Run `task lint` and `task test` for `pkg/nar`; confirm green.
+
+## 2. Cache pull/serve path wiring (TDD)
+
+- [x] 2.1 Add a failing `pkg/cache` unit test: a stub upstream returning a snix-style narinfo (opaque `.nar`-less `URL:`, `Compression: none`, valid `NarHash`) is fetched via `GetNarInfo` without a 500, and the re-served narinfo `URL:` is ncps's own `nar/<narhash>.nar` with `Compression: none`.
+- [x] 2.2 Verify/adjust `pkg/cache/cache.go` pull path (`pullNarInfo` around the `ParseUpstreamURL` call and the compression switch) so `upstreamNarPath` (incl. query) is captured before the compression branch and the opaque path is persisted regardless of the `none` branch being taken.
+- [x] 2.3 Add a failing test for eviction/re-fetch: an opaque-`none` NAR whose local bytes are gone is re-fetched using the persisted opaque path (with query) rather than ncps's local hash-named URL.
+- [x] 2.4 Implement any wiring needed to make 2.1 and 2.3 green.
+- [x] 2.5 Run `task lint` and `task test` for `pkg/cache`; confirm green.
+
+## 3. Integration coverage
+
+- [x] 3.1 Add an integration test exercising the full loop against a snix-castore-shaped upstream fixture: narinfo pull → NAR GET (query preserved) → store as `none` → serve `<hash>.narinfo` (200) → serve `nar/<narhash>.nar` and verify identical NAR bytes.
+- [x] 3.2 Ensure the fixture asserts the upstream GET received the `?narsize=N` query (regression guard for the snix `400`-without-query behavior).
+
+## 4. Docs and changelog
+
+- [x] 4.1 Add a `## [Unreleased]` → `### Fixed` entry to `CHANGELOG.md` describing snix-castore / `.nar`-less opaque upstream URL support and the fixed `HTTP 500 "invalid nar URL"`.
+- [x] 4.2 Update `docs/` (Developer Guide → Architecture → Request Flow, and any upstream/URL section) to document that narinfo `URL:` is treated as an opaque path per the Nix binary-cache protocol, including the snix-castore `.nar`-less form.
+- [x] 4.3 If docs are generated/aggregated (`docs/docs.md`, `docs/!!!meta.json`), regenerate or update them consistently.
+
+## 5. Verify
+
+- [x] 5.1 Run `task fmt`, `task lint`, and `task test`; confirm each exits 0.
+- [x] 5.2 Run `openspec validate support-snix-castore-opaque-urls --no-interactive` (with `OPENSPEC_TELEMETRY=0`, `HOME=$TMPDIR`) and confirm it passes.
+- [x] 5.3 Manually confirm against a real snix narinfo shape (e.g. `nar/snix-castore/<blob>?narsize=N`, `Compression: none`) that parsing succeeds and no 500 is produced.

--- a/openspec/specs/upstream-fetch-resilience/spec.md
+++ b/openspec/specs/upstream-fetch-resilience/spec.md
@@ -45,9 +45,28 @@ SHALL NOT be retried.
 
 ### Requirement: Opaque (non hash-named) upstream NAR URLs MUST be tolerated
 
-An upstream narinfo whose `URL:` field is not hash-named (the filename before `.nar` is not a valid Nix hash — e.g. cachix's `nar/<uuidv4>.nar.zst`) SHALL be proxied successfully rather than rejected. The system SHALL derive its local storage key from the narinfo `NarHash` (re-encoded as a bare nix32 digest), SHALL preserve the original opaque upstream path verbatim for the upstream GET, and SHALL re-serve the NAR to downstream clients under its own hash-named URL keyed off the `NarHash`. Conventional hash-named upstream URLs SHALL continue to be handled exactly as before.
+The system MUST proxy an upstream narinfo whose `URL:` field is not a conventional
+hash-named `nar/<hash>.nar[.<compression>]` path rather than rejecting it. This
+covers two opaque shapes:
 
-When an opaque upstream URL is encountered but the narinfo carries no usable `NarHash`, the system SHALL surface a parse error rather than fabricate a storage key.
+1. **Non-hash filename that still ends in `.nar[.<compression>]`** — e.g. cachix's
+   `nar/<uuidv4>.nar.zst` (the stem before `.nar` is not a valid Nix hash).
+2. **No `.nar` token at all** — e.g. snix-castore's
+   `nar/snix-castore/<base64-blob>?narsize=N`, served with `Compression: none`.
+
+For any opaque URL the system SHALL derive its local storage key from the narinfo
+`NarHash` (re-encoded as a bare nix32 digest), SHALL preserve the original opaque
+upstream path **including its query string** verbatim for the upstream GET, and
+SHALL re-serve the NAR to downstream clients under its own hash-named URL keyed off
+the `NarHash`. For a `.nar`-less opaque URL the compression SHALL be taken as `none`
+(the URL carries no compression extension and such upstreams advertise
+`Compression: none`). Conventional hash-named upstream URLs SHALL continue to be
+handled exactly as before.
+
+When an opaque upstream URL is encountered but the narinfo carries no usable
+`NarHash`, the system SHALL surface a parse error rather than fabricate a storage
+key. The strict parser used for ncps's own serve/storage keys SHALL remain
+unchanged, so ncps continues to emit only hash-named URLs to clients.
 
 #### Scenario: Opaque upstream URL is proxied successfully
 
@@ -55,6 +74,14 @@ When an opaque upstream URL is encountered but the narinfo carries no usable `Na
 - **THEN** the request SHALL succeed rather than failing with an invalid-nar-hash error
 - **AND** the served narinfo `URL:` SHALL be ncps's own hash-named URL derived from the `NarHash`
 - **AND** the NAR bytes SHALL be fetched from the original opaque upstream path
+
+#### Scenario: snix-castore `.nar`-less upstream URL is proxied successfully
+
+- **WHEN** an upstream narinfo has an opaque `URL:` with no `.nar` token and a query string (e.g. `nar/snix-castore/<blob>?narsize=7415800`), `Compression: none`, and a valid `NarHash`
+- **THEN** the request SHALL succeed rather than returning an `invalid nar URL` error
+- **AND** the upstream GET SHALL target the original path with its query string preserved verbatim (e.g. `?narsize=7415800`)
+- **AND** the parsed compression SHALL be `none`
+- **AND** the served narinfo `URL:` SHALL be ncps's own hash-named `nar/<narhash>.nar` with `Compression: none`
 
 #### Scenario: Conventional hash-named upstream URL is unaffected
 
@@ -64,7 +91,7 @@ When an opaque upstream URL is encountered but the narinfo carries no usable `Na
 
 #### Scenario: Opaque URL without a usable NarHash is rejected
 
-- **WHEN** an upstream narinfo has an opaque `URL:` but no valid fallback `NarHash`
+- **WHEN** an upstream narinfo has an opaque `URL:` (with or without a `.nar` token) but no valid fallback `NarHash`
 - **THEN** the system SHALL return a parse error
 - **AND** SHALL NOT fabricate a storage key
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1762,11 +1762,12 @@ func (c *Cache) lookupOriginalNarURL(ctx context.Context, normalizedNarURL nar.U
 	if ni.URL != nil && *ni.URL != "" {
 		originalURL, parseErr := nar.ParseURL(*ni.URL)
 		if parseErr == nil {
-			// If the upstream URL was opaque (e.g. cachix UUID), restore the
-			// preserved path so the upstream GET targets it rather than ncps's
-			// own hash-named URL (which only exists locally).
+			// If the upstream URL was opaque (e.g. cachix UUID, or snix-castore
+			// with a ?narsize=N query), restore the preserved path and query so
+			// the upstream GET targets it rather than ncps's own hash-named URL
+			// (which only exists locally).
 			if ni.UpstreamURL != nil && *ni.UpstreamURL != "" {
-				originalURL = originalURL.WithOpaquePath(*ni.UpstreamURL)
+				originalURL = originalURL.WithOpaqueUpstreamRef(*ni.UpstreamURL)
 			}
 
 			return originalURL
@@ -4276,9 +4277,10 @@ func (c *Cache) pullNarInfo(
 		return
 	}
 
-	// Preserve the opaque upstream path (if any) before narURL is potentially
-	// rewritten below, so it can be persisted for re-fetch after eviction.
-	upstreamNarPath := narURL.OpaquePath()
+	// Preserve the opaque upstream path (including any query string, e.g.
+	// snix-castore's ?narsize=N) before narURL is potentially rewritten below, so
+	// it can be persisted for re-fetch after eviction.
+	upstreamNarPath := narURL.OpaqueUpstreamRef()
 
 	// Signal that we've successfully fetched the narinfo (no streaming for narinfo)
 	ds.startOnce.Do(func() { close(ds.start) })
@@ -4299,11 +4301,25 @@ func (c *Cache) pullNarInfo(
 	// narURL is modified within a background goroutine.
 	narURLForBG := narURL
 
+	// For an opaque upstream URL (cachix UUID, or snix-castore with a ?narsize=N
+	// query), the download must target the opaque path+query while local storage
+	// and serving key off ncps's own hash-named URL. Pass the opaque URL as the
+	// preferred upstream download URL and a clean hash-named key as the
+	// storage/serve URL, so the upstream query (e.g. ?narsize) never leaks into
+	// the nar_file storage key (which would 404 the NAR on a subsequent read).
+	var preferredDownloadURL *nar.URL
+
+	if narURLForBG.IsOpaque() {
+		opaqueDownloadURL := narURLForBG
+		preferredDownloadURL = &opaqueDownloadURL
+		narURLForBG = nar.URL{Hash: narURLForBG.Hash, Compression: narURLForBG.Compression}
+	}
+
 	// narPrefetchDisabled is a test-only seam: it lets tests deterministically
 	// reproduce an orphan narinfo (backing NAR never lands in storage) without
 	// racing a background NAR download.
 	if !narPrefetchDisabled(ctx) {
-		c.prePullNar(ctx, detachedCtx, &narURLForBG, nil, uc, narInfo)
+		c.prePullNar(ctx, detachedCtx, &narURLForBG, preferredDownloadURL, uc, narInfo)
 	}
 
 	// For Compression:none upstreams, NARs are stored as zstd files and served as
@@ -4324,7 +4340,10 @@ func (c *Cache) pullNarInfo(
 	// the NAR is genuinely chunked (HasNarInChunks), so the happy path is unchanged.
 	switch {
 	case narInfo.Compression == nar.CompressionTypeNone.String():
-		normalizedURL := nar.URL{Hash: narURL.Hash, Compression: nar.CompressionTypeNone, Query: narURL.Query}
+		// ncps's own hash-named serve URL never carries the upstream's query
+		// (e.g. snix-castore's ?narsize=N); that query is preserved separately on
+		// the opaque upstream path for re-fetch, not on the URL clients see.
+		normalizedURL := nar.URL{Hash: narURL.Hash, Compression: nar.CompressionTypeNone}
 		narInfo.Compression = nar.CompressionTypeNone.String()
 		narInfo.URL = normalizedURL.String() // → "nar/hash.nar"
 
@@ -4336,7 +4355,7 @@ func (c *Cache) pullNarInfo(
 		// hash-named URL keyed off the NarHash, preserving compression. The
 		// opaque path itself is persisted (upstreamNarPath) so the NAR can
 		// still be re-fetched from upstream after the local copy is evicted.
-		rewrittenURL := nar.URL{Hash: narURL.Hash, Compression: narURL.Compression, Query: narURL.Query}
+		rewrittenURL := nar.URL{Hash: narURL.Hash, Compression: narURL.Compression}
 		narInfo.URL = rewrittenURL.String()
 	case c.isEagerCDC():
 		// Eager CDC: advertise Compression: none predictively so clients always
@@ -4352,7 +4371,10 @@ func (c *Cache) pullNarInfo(
 		// 404), and in-flight staging serves the uncompressed bytes across the
 		// pull+chunk window. Lazy CDC is excluded (isEagerCDC gates on !lazy): it
 		// keeps the whole xz file servable as .nar.xz until migration completes.
-		normalizedURL := nar.URL{Hash: narURL.Hash, Compression: nar.CompressionTypeNone, Query: narURL.Query}
+		// ncps's own hash-named serve URL never carries the upstream's query
+		// (e.g. snix-castore's ?narsize=N); that query is preserved separately on
+		// the opaque upstream path for re-fetch, not on the URL clients see.
+		normalizedURL := nar.URL{Hash: narURL.Hash, Compression: nar.CompressionTypeNone}
 		narInfo.Compression = nar.CompressionTypeNone.String()
 		narInfo.URL = normalizedURL.String() // → "nar/hash.nar"
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4340,10 +4340,16 @@ func (c *Cache) pullNarInfo(
 	// the NAR is genuinely chunked (HasNarInChunks), so the happy path is unchanged.
 	switch {
 	case narInfo.Compression == nar.CompressionTypeNone.String():
-		// ncps's own hash-named serve URL never carries the upstream's query
-		// (e.g. snix-castore's ?narsize=N); that query is preserved separately on
-		// the opaque upstream path for re-fetch, not on the URL clients see.
-		normalizedURL := nar.URL{Hash: narURL.Hash, Compression: nar.CompressionTypeNone}
+		// Preserve any query on a conventional hash-named URL. Only an OPAQUE
+		// upstream URL (e.g. snix-castore's ?narsize=N) has its query dropped from
+		// ncps's own hash-named serve URL: that query is meaningful solely to the
+		// upstream GET and is preserved separately on the persisted opaque path,
+		// never on the URL clients see.
+		normalizedURL := nar.URL{Hash: narURL.Hash, Compression: nar.CompressionTypeNone, Query: narURL.Query}
+		if narURL.IsOpaque() {
+			normalizedURL.Query = nil
+		}
+
 		narInfo.Compression = nar.CompressionTypeNone.String()
 		narInfo.URL = normalizedURL.String() // → "nar/hash.nar"
 
@@ -4371,10 +4377,14 @@ func (c *Cache) pullNarInfo(
 		// 404), and in-flight staging serves the uncompressed bytes across the
 		// pull+chunk window. Lazy CDC is excluded (isEagerCDC gates on !lazy): it
 		// keeps the whole xz file servable as .nar.xz until migration completes.
-		// ncps's own hash-named serve URL never carries the upstream's query
-		// (e.g. snix-castore's ?narsize=N); that query is preserved separately on
-		// the opaque upstream path for re-fetch, not on the URL clients see.
-		normalizedURL := nar.URL{Hash: narURL.Hash, Compression: nar.CompressionTypeNone}
+		// Preserve any query on a conventional hash-named URL; drop it only for an
+		// OPAQUE upstream URL (the query is meaningful solely to the upstream GET
+		// and is preserved separately on the persisted opaque path).
+		normalizedURL := nar.URL{Hash: narURL.Hash, Compression: nar.CompressionTypeNone, Query: narURL.Query}
+		if narURL.IsOpaque() {
+			normalizedURL.Query = nil
+		}
+
 		narInfo.Compression = nar.CompressionTypeNone.String()
 		narInfo.URL = normalizedURL.String() // → "nar/hash.nar"
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -555,6 +555,135 @@ Sig: cache.nixos.org-1:eGSj5WPpZRjwzx7eWpCyZdNsFHjhtGTZF8T4FccYXjHNkTOZoGPfplgFP
 	assert.Equal(t, []byte(narBody), got2)
 }
 
+// TestGetNarInfoSnixCastoreOpaqueURL exercises the snix-castore variant of an
+// opaque upstream narinfo: the URL: field has NO ".nar" token and carries a
+// required ?narsize=N query (e.g. cache.snix.dev's
+// "nar/snix-castore/<blob>?narsize=N", Compression: none). ncps must proxy it
+// rather than 500 with "invalid nar URL", re-serve it under its own hash-named
+// none URL, and persist the opaque path WITH its query so an evicted NAR can be
+// re-fetched (snix returns 400 without ?narsize).
+func TestGetNarInfoSnixCastoreOpaqueURL(t *testing.T) {
+	t.Parallel()
+
+	const (
+		narInfoHash = "0123456789abcdfghijklmnpqrsvwxyz"
+		narHash     = "188g68hrjilbsjifcj70k8729zqhm9sl1q336vg5wxwzw0qp0sk4"
+		narSize     = 50308
+		opaqueURL   = "nar/snix-castore/CiUSIATh-lHQ2Dp92sJJfOGg0-s8mLizwHc0z3OtQ953fwSUGNoC?narsize=50308"
+		opaquePath  = "/nar/snix-castore/CiUSIATh-lHQ2Dp92sJJfOGg0-s8mLizwHc0z3OtQ953fwSUGNoC"
+	)
+
+	// A snix-castore narinfo: Compression: none, FileSize == NarSize, no FileHash.
+	narInfoText := fmt.Sprintf(`StorePath: /nix/store/%s-snix-1.0
+URL: %s
+Compression: none
+FileSize: %d
+NarHash: sha256:%s
+NarSize: %d
+References: %s-snix-1.0
+Sig: cache.nixos.org-1:eGSj5WPpZRjwzx7eWpCyZdNsFHjhtGTZF8T4FccYXjHNkTOZoGPfplgFP1w5bEST0/FtfV7f3AmQUVEv1NAEDg==
+`, narInfoHash, opaqueURL, narSize, narHash, narSize, narInfoHash)
+
+	narBody := testhelper.MustRandString(narSize)
+
+	// Records the query strings snix saw on the opaque NAR GETs; the upstream
+	// serves the NAR ONLY when ?narsize=N is present (mirroring snix's 400).
+	var sawNarsizeQuery atomic.Bool
+
+	ts := testdata.NewTestServer(t, 40)
+	t.Cleanup(ts.Close)
+
+	ts.AddMaybeHandler(func(w http.ResponseWriter, r *http.Request) bool {
+		switch r.URL.Path {
+		case "/" + narInfoHash + ".narinfo":
+			_, _ = w.Write([]byte(narInfoText))
+
+			return true
+		case opaquePath:
+			if r.URL.Query().Get("narsize") == "" {
+				// snix rejects a NAR GET without the ?narsize=N query.
+				w.WriteHeader(http.StatusBadRequest)
+
+				return true
+			}
+
+			sawNarsizeQuery.Store(true)
+			w.Header().Set("Content-Length", strconv.Itoa(len(narBody)))
+			_, _ = w.Write([]byte(narBody))
+
+			return true
+		}
+
+		return false
+	})
+
+	c, dbClient, localStore, _, rebind, cleanup := setupSQLiteFactory(t)
+	t.Cleanup(cleanup)
+
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{})
+	require.NoError(t, err)
+
+	c.AddUpstreamCaches(newContext(), uc)
+	c.SetRecordAgeIgnoreTouch(0)
+
+	<-c.GetHealthChecker().Trigger()
+
+	ni, err := c.GetNarInfo(context.Background(), narInfoHash)
+	require.NoError(t, err, "snix-castore opaque upstream URL must not fail with 500")
+
+	// ncps re-serves the NAR under its own hash-named none URL keyed off NarHash.
+	wantURL := "nar/" + narHash + ".nar"
+	assert.Equal(t, wantURL, ni.URL, "served narinfo URL should be ncps's own hash-named none URL")
+	assert.Equal(t, "none", ni.Compression)
+
+	// The opaque upstream path is persisted WITH its query for later re-fetch.
+	var upstreamURL sql.NullString
+
+	err = dbClient.DB().QueryRowContext(context.Background(),
+		rebind("SELECT upstream_url FROM narinfos WHERE hash = ?"), narInfoHash).
+		Scan(&upstreamURL)
+	require.NoError(t, err)
+	assert.True(t, upstreamURL.Valid, "upstream_url should be persisted")
+	assert.Equal(t, opaqueURL, upstreamURL.String, "persisted opaque path must retain ?narsize")
+
+	narURL, err := nar.ParseURL(ni.URL)
+	require.NoError(t, err)
+
+	// The NAR is prefetched in the background; wait for it to land in the store.
+	require.Eventually(t, func() bool {
+		return c.HasNarInStore(context.Background(), narURL)
+	}, downloadPollTimeout, 10*time.Millisecond, "prefetched snix NAR should land in the store")
+
+	_, _, rc, err := c.GetNar(context.Background(), narURL)
+	require.NoError(t, err, "the NAR should be fetchable via the opaque upstream path")
+
+	defer rc.Close()
+
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(narBody), got)
+	assert.True(t, sawNarsizeQuery.Load(), "upstream GET must carry the ?narsize query")
+
+	// Evict local bytes and confirm re-fetch reconstructs the opaque path + query.
+	// A Compression:none NAR is physically stored under its servable compressed
+	// variant (canonically .nar.zst), so evict that representation.
+	zstdURL := narURL
+	zstdURL.Compression = nar.CompressionTypeZstd
+	require.NoError(t, localStore.DeleteNar(context.Background(), zstdURL))
+	require.False(t, c.HasNarInStore(context.Background(), narURL))
+	sawNarsizeQuery.Store(false)
+
+	_, _, rc2, err := c.GetNar(context.Background(), narURL)
+	require.NoError(t, err, "evicted snix NAR must be re-fetchable via the persisted opaque path+query")
+
+	defer rc2.Close()
+
+	got2, err := io.ReadAll(rc2)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(narBody), got2)
+	assert.True(t, sawNarsizeQuery.Load(), "re-fetch GET must carry the restored ?narsize query")
+}
+
 func testGetNarInfo(factory cacheFactory) func(*testing.T) {
 	return func(t *testing.T) {
 		ts := testdata.NewTestServer(t, 40)

--- a/pkg/nar/url.go
+++ b/pkg/nar/url.go
@@ -175,7 +175,10 @@ func parseOpaqueNoNarURL(u string) (pathPart string, query url.Values, ok bool) 
 		return "", nil, false
 	}
 
-	filename := filepath.Base(pathPart)
+	// Extract the filename without filepath.Base: a narinfo URL path always uses
+	// "/" separators, whereas filepath.Base treats "\" as a separator on Windows.
+	// pathPart is guaranteed to contain "/" by the check above.
+	filename := pathPart[strings.LastIndex(pathPart, "/")+1:]
 	if filename == "" || filename == "." || strings.Contains(filename, ".nar") {
 		return "", nil, false
 	}

--- a/pkg/nar/url.go
+++ b/pkg/nar/url.go
@@ -64,6 +64,27 @@ func ParseURL(u string) (URL, error) {
 func ParseUpstreamURL(u, fallbackHash string) (URL, error) {
 	pathPart, hash, ct, query, err := parseURLParts(u)
 	if err != nil {
+		// Recover ".nar"-less opaque upstream URLs (e.g. snix-castore's
+		// "nar/snix-castore/<blob>?narsize=N"). The Nix binary-cache protocol
+		// treats the narinfo URL as an opaque path relative to the cache root, so
+		// a pull-through proxy must tolerate paths without a ".nar" token rather
+		// than reject them. Such URLs carry no compression extension and are
+		// served uncompressed, so compression is none; the storage key comes from
+		// the narinfo NarHash. Only genuine cache-relative paths are recovered —
+		// not bare tokens like "helloworld".
+		if op, oq, ok := parseOpaqueNoNarURL(u); errors.Is(err, ErrInvalidURL) && ok {
+			if verr := ValidateHash(fallbackHash); verr != nil {
+				return URL{}, fmt.Errorf("opaque nar URL %q needs a valid fallback hash: %w", u, verr)
+			}
+
+			return URL{
+				Hash:        fallbackHash,
+				Compression: CompressionTypeNone,
+				Query:       oq,
+				opaquePath:  op,
+			}, nil
+		}
+
 		return URL{}, err
 	}
 
@@ -141,6 +162,32 @@ func parseURLParts(u string) (pathPart, hash string, ct CompressionType, query u
 	return pathPart, hash, ct, query, nil
 }
 
+// parseOpaqueNoNarURL recognises an opaque upstream NAR URL that has no ".nar"
+// token at all (e.g. snix-castore's "nar/snix-castore/<blob>?narsize=N"). It
+// returns the path (query stripped), the parsed query, and ok=true only for a
+// genuine cache-relative path: the path must contain a "/" separator (a bare
+// token such as "helloworld" is not a NAR URL) and its filename must not itself
+// contain ".nar" (that is a malformed conventional URL, handled by parseURLParts,
+// not an opaque one). The caller supplies compression (none) and the storage key.
+func parseOpaqueNoNarURL(u string) (pathPart string, query url.Values, ok bool) {
+	pathPart, rawQuery, _ := strings.Cut(u, "?")
+	if pathPart == "" || !strings.Contains(pathPart, "/") {
+		return "", nil, false
+	}
+
+	filename := filepath.Base(pathPart)
+	if filename == "" || filename == "." || strings.Contains(filename, ".nar") {
+		return "", nil, false
+	}
+
+	query, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return "", nil, false
+	}
+
+	return pathPart, query, true
+}
+
 // IsOpaque reports whether the URL carries a preserved opaque upstream path
 // (i.e. the narinfo URL was not hash-named and the storage key was derived
 // from the narinfo NarHash instead).
@@ -156,6 +203,42 @@ func (u URL) OpaquePath() string { return u.opaquePath }
 // targets the original path while local storage stays keyed off Hash.
 func (u URL) WithOpaquePath(path string) URL {
 	u.opaquePath = path
+
+	return u
+}
+
+// OpaqueUpstreamRef returns the opaque upstream path together with its query
+// string (e.g. snix-castore's "nar/snix-castore/<blob>?narsize=N"), the form
+// that must be persisted so the upstream GET can be reconstructed verbatim after
+// local eviction. It returns "" for a conventional hash-named URL. Opaque URLs
+// that carry no query (e.g. cachix UUID NARs) yield just the path, so the
+// persisted representation is unchanged for them.
+func (u URL) OpaqueUpstreamRef() string {
+	if u.opaquePath == "" {
+		return ""
+	}
+
+	if q := u.Query.Encode(); q != "" {
+		return u.opaquePath + "?" + q
+	}
+
+	return u.opaquePath
+}
+
+// WithOpaqueUpstreamRef returns a copy of the URL with an opaque upstream
+// reference (as produced by OpaqueUpstreamRef) restored: the path becomes the
+// opaque path used for the upstream GET and any query string is parsed back onto
+// the URL so it survives onto the reconstructed request. A reference without a
+// query behaves exactly like WithOpaquePath.
+func (u URL) WithOpaqueUpstreamRef(ref string) URL {
+	path, rawQuery, hasQuery := strings.Cut(ref, "?")
+	u.opaquePath = path
+
+	if hasQuery {
+		if q, err := url.ParseQuery(rawQuery); err == nil {
+			u.Query = q
+		}
+	}
 
 	return u
 }

--- a/pkg/nar/url_test.go
+++ b/pkg/nar/url_test.go
@@ -210,11 +210,11 @@ func TestParseUpstreamURL(t *testing.T) {
 
 		// The query string MUST survive onto the reconstructed upstream GET
 		// (snix returns 400 without ?narsize=N).
-		base, err := url.Parse("http://example.com")
+		base, err := url.Parse("https://example.com")
 		require.NoError(t, err)
 		assert.Equal(
 			t,
-			"http://example.com/nar/snix-castore/CiUSIATh-lHQ2Dp92sJJfOGg0-s8mLizwHc0z3OtQ953fwSUGNoC?narsize=7415800",
+			"https://example.com/nar/snix-castore/CiUSIATh-lHQ2Dp92sJJfOGg0-s8mLizwHc0z3OtQ953fwSUGNoC?narsize=7415800",
 			got.JoinURL(base).String(),
 		)
 	})
@@ -271,9 +271,9 @@ func TestParseUpstreamURL(t *testing.T) {
 		restored := own.WithOpaqueUpstreamRef(ref)
 		assert.True(t, restored.IsOpaque())
 
-		base, err := url.Parse("http://example.com")
+		base, err := url.Parse("https://example.com")
 		require.NoError(t, err)
-		assert.Equal(t, "http://example.com/"+u, restored.JoinURL(base).String())
+		assert.Equal(t, "https://example.com/"+u, restored.JoinURL(base).String())
 	})
 }
 

--- a/pkg/nar/url_test.go
+++ b/pkg/nar/url_test.go
@@ -185,6 +185,40 @@ func TestParseUpstreamURL(t *testing.T) {
 		)
 	})
 
+	t.Run("snix-castore .nar-less opaque URL preserves path+query and keys off the fallback hash", func(t *testing.T) {
+		t.Parallel()
+
+		const u = "nar/snix-castore/CiUSIATh-lHQ2Dp92sJJfOGg0-s8mLizwHc0z3OtQ953fwSUGNoC?narsize=7415800"
+
+		got, err := nar.ParseUpstreamURL(u, fallback)
+		require.NoError(t, err)
+
+		// Storage key comes from the fallback (NarHash), not the URL.
+		fp, err := got.ToFilePath()
+		require.NoError(t, err)
+
+		wantFP, err := nar.FilePath(fallback, nar.CompressionTypeNone.ToFileExtension())
+		require.NoError(t, err)
+		assert.Equal(t, wantFP, fp)
+
+		// A .nar-less opaque URL carries no compression extension; it is none.
+		assert.Equal(t, nar.CompressionTypeNone, got.Compression)
+
+		// The opaque upstream path is preserved verbatim (query stripped) for the GET.
+		assert.True(t, got.IsOpaque())
+		assert.Equal(t, "nar/snix-castore/CiUSIATh-lHQ2Dp92sJJfOGg0-s8mLizwHc0z3OtQ953fwSUGNoC", got.OpaquePath())
+
+		// The query string MUST survive onto the reconstructed upstream GET
+		// (snix returns 400 without ?narsize=N).
+		base, err := url.Parse("http://example.com")
+		require.NoError(t, err)
+		assert.Equal(
+			t,
+			"http://example.com/nar/snix-castore/CiUSIATh-lHQ2Dp92sJJfOGg0-s8mLizwHc0z3OtQ953fwSUGNoC?narsize=7415800",
+			got.JoinURL(base).String(),
+		)
+	})
+
 	t.Run("opaque URL with an invalid fallback hash errors", func(t *testing.T) {
 		t.Parallel()
 
@@ -192,11 +226,54 @@ func TestParseUpstreamURL(t *testing.T) {
 		assert.ErrorIs(t, err, nar.ErrInvalidHash)
 	})
 
+	t.Run("snix-castore .nar-less opaque URL with an invalid fallback hash errors", func(t *testing.T) {
+		t.Parallel()
+
+		const u = "nar/snix-castore/CiUSIATh-lHQ2Dp92sJJfOGg0-s8mLizwHc0z3OtQ953fwSUGNoC?narsize=7415800"
+
+		_, err := nar.ParseUpstreamURL(u, "not-a-hash")
+		assert.ErrorIs(t, err, nar.ErrInvalidHash)
+	})
+
+	t.Run("strict ParseURL still rejects a .nar-less opaque URL", func(t *testing.T) {
+		t.Parallel()
+
+		const u = "nar/snix-castore/CiUSIATh-lHQ2Dp92sJJfOGg0-s8mLizwHc0z3OtQ953fwSUGNoC?narsize=7415800"
+
+		_, err := nar.ParseURL(u)
+		assert.ErrorIs(t, err, nar.ErrInvalidURL)
+	})
+
 	t.Run("structurally invalid URL errors even with a valid fallback", func(t *testing.T) {
 		t.Parallel()
 
 		_, err := nar.ParseUpstreamURL("helloworld", fallback)
 		assert.ErrorIs(t, err, nar.ErrInvalidURL)
+	})
+
+	t.Run("opaque upstream ref round-trips path and query for eviction re-fetch", func(t *testing.T) {
+		t.Parallel()
+
+		const u = "nar/snix-castore/CiUSIATh-lHQ2Dp92sJJfOGg0-s8mLizwHc0z3OtQ953fwSUGNoC?narsize=7415800"
+
+		got, err := nar.ParseUpstreamURL(u, fallback)
+		require.NoError(t, err)
+
+		// The persisted opaque reference retains the query string.
+		ref := got.OpaqueUpstreamRef()
+		assert.Equal(t, u, ref)
+
+		// On eviction the reference is restored onto ncps's own none URL; the
+		// reconstructed upstream GET MUST target the original path AND query.
+		own, err := nar.ParseURL("nar/" + fallback + ".nar")
+		require.NoError(t, err)
+
+		restored := own.WithOpaqueUpstreamRef(ref)
+		assert.True(t, restored.IsOpaque())
+
+		base, err := url.Parse("http://example.com")
+		require.NoError(t, err)
+		assert.Equal(t, "http://example.com/"+u, restored.JoinURL(base).String())
 	})
 }
 


### PR DESCRIPTION
## Summary

Fixes intermittent `HTTP 500 "invalid nar URL"` when serving `<hash>.narinfo`
for store paths available on `cache.snix.dev`.

**Root cause (confirmed against production logs):** snix serves narinfos whose
`URL:` field is a snix-castore reference — `nar/snix-castore/<blob>?narsize=N`,
`Compression: none`, **no `.nar` extension**. ncps's `nar.ParseUpstreamURL`
required a `.nar` token, so it rejected these with `ErrInvalidURL` and the
narinfo request 500'd. It was intermittent because upstream selection races all
healthy upstreams (first responder wins); a retry that landed on
cache.nixos.org served a conventional URL and succeeded.

**Fix:** follow the Nix HTTP binary-cache protocol, where the narinfo `URL:` is
an opaque path relative to the cache root. This generalizes the existing opaque
(cachix UUID) handling to `.nar`-less URLs:

- `ParseUpstreamURL` recovers a genuine cache-relative `.nar`-less path as
  `Compression: none`, keyed off the narinfo `NarHash`, preserving the full path
  **and query** for the upstream GET (snix returns `400` without `?narsize=N`).
- The initial pull now splits the opaque **download** URL (path + query) from
  ncps's own hash-named **storage/serve** key, so the upstream query never leaks
  into the `nar_file` key (which otherwise 404'd the NAR on a later read).
- New `OpaqueUpstreamRef` / `WithOpaqueUpstreamRef` persist and restore the
  opaque path + query so an evicted NAR re-fetches correctly.
- Strict `ParseURL` is unchanged — ncps still emits only hash-named URLs to
  clients. Conventional and cachix-style URLs are unaffected.

No config, schema, or migration changes.

## Test plan

- [x] `task fmt` (0 changed), `task lint` (0 issues), `task test` (all green)
- [x] `pkg/nar`: parser unit tests (snix parse, query round-trip, strict
      `ParseURL` still rejects, invalid-fallback rejected)
- [x] `pkg/cache`: `TestGetNarInfoSnixCastoreOpaqueURL` — full pull → store →
      serve → evict → re-fetch; asserts `?narsize` reaches the upstream GET and
      never leaks into ncps's storage key; existing cachix opaque test still
      passes