### PR TITLE
fix(cache): batch completed-chunk serve query (#1463)

### DIFF
--- a/openspec/changes/archive/2026-08-16-fix-serve-chunks-sql-var-limit/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-16-fix-serve-chunks-sql-var-limit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-16

--- a/openspec/changes/archive/2026-08-16-fix-serve-chunks-sql-var-limit/design.md
+++ b/openspec/changes/archive/2026-08-16-fix-serve-chunks-sql-var-limit/design.md
@@ -1,0 +1,96 @@
+## Context
+
+`streamCompleteChunks` (`pkg/cache/cache.go`) is the fast path for serving a NAR
+that has finished CDC chunking (`total_chunks > 0`). It loads the NAR's chunk
+links in a single query:
+
+```go
+links, err := c.dbClient.Ent().NarFileChunk.Query().
+    Where(entnarfilechunk.NarFileID(int(narFileID))).
+    Order(entnarfilechunk.ByChunkIndex()).
+    WithChunk().          // eager-load → SELECT … FROM chunks WHERE id IN ($1 … $N)
+    All(ctx)
+```
+
+`.WithChunk()` compiles to a follow-up `WHERE id IN (…)` with one bound parameter
+per chunk. Once `N` exceeds the driver's parameter limit (SQLite 32766, verified
+empirically for `mattn/go-sqlite3 v1.14.49`; PostgreSQL 65535) the query fails with
+`too many SQL variables`. At the default CDC average of 64 KiB, a NAR over ~2 GiB
+crosses the SQLite limit; issue #1463's ~8 GB NAR (~124k chunks) is far over. The
+handler has already returned `HTTP 200` with a streaming body, so the client
+receives a truncated NAR and reports `bad archive: unexpected end of nar`.
+
+The fix pattern already lives in the same file. `streamProgressiveChunks` (the
+in-progress path) walks chunk links in bounded pages with
+`ChunkIndexGTE(idx)` + `Order(ByChunkIndex())` + `Limit(progressivePollBatchSize)`
+(256), so its eager-load never binds more than 256 parameters. `fsck`'s
+size-mismatch detection was fixed the same way (spec `fsck`: "MUST scale beyond
+database driver parameter limits").
+
+## Goals / Non-Goals
+
+**Goals:**
+- Serve completed chunked NARs of any chunk count on SQLite, PostgreSQL, and MySQL.
+- Preserve exact chunk ordering, the completeness check, and byte-for-byte output.
+- Reuse the batching idiom already established in the same file.
+
+**Non-Goals:**
+- No change to CDC sizing, the progressive path, `fsck`, or migrate commands.
+- No new config flag; the batch size is a fixed internal constant.
+- No lazy streaming of chunk hashes into the prefetch pipeline — the hash slice is
+  still built eagerly (bounded by chunk count, as today); only the DB query is bounded.
+
+## Decisions
+
+**Decision: Replace the single unbounded query with a keyset walk over `chunk_index`.**
+Loop: query `NarFileChunk` where `NarFileID == id` AND `ChunkIndexGT(last)`,
+ordered by `chunk_index`, `Limit(batchSize)`, `WithChunk()`; append each
+`link.Edges.Chunk.Hash` to `chunkHashes`; advance `last` to the last row's
+`ChunkIndex`; stop when a page returns fewer than `batchSize` rows. Then hand
+`chunkHashes` to the unchanged `streamChunksWithPrefetch`.
+
+- *Why keyset over `OFFSET`*: `chunk_index` is monotonic per NAR and already the
+  sort key; a `> last` cursor is an indexed range scan with stable ordering and no
+  large-offset penalty. This matches `streamProgressiveChunks`.
+- *Why keep the completeness check*: the existing
+  `len(chunkHashes) != totalChunks → ErrNotFound` guard (spec
+  `chunked-nar-serving-integrity`) still runs against the accumulated slice, so the
+  integrity contract is unchanged.
+
+**Decision: Introduce a dedicated batch-size constant (e.g. `completeChunkQueryBatchSize`).**
+A fixed constant sized well under every driver limit (in the same 256–512 band as
+the existing `progressivePollBatchSize`/`cdcCleanupHashBatchSize` constants). Not a
+flag — no operational tuning need, and a hardcoded safe value keeps parity with the
+other batch constants.
+- *Alternative rejected*: reuse `progressivePollBatchSize` directly. Kept separate
+  so the fast path can be tuned independently and the intent reads clearly at the
+  call site.
+
+**Decision: Cursor on `chunk_index`, not primary-key `id`.**
+`chunk_index` is the ordering key and is dense/monotonic within a NAR; `WithChunk()`
+still eager-loads by chunk `id` per page, bounded to `batchSize` parameters.
+
+## Risks / Trade-offs
+
+- **[More round-trips]** One `SELECT` becomes `ceil(chunks / batchSize)` queries
+  (~243 at batchSize 512 for 124k chunks). → Each is a cheap covering-index range
+  scan; cost is negligible against multi-GB stream transfer and overlaps the
+  existing prefetch pipeline. Same trade-off already accepted for the progressive path.
+- **[Ordering regression]** A wrong cursor/order could drop or duplicate chunks. →
+  Mirrors the proven `streamProgressiveChunks` idiom; the completeness check
+  (`count == total_chunks`) and a multi-batch order-preservation test guard it.
+- **[Off-by-one at page boundary]** `GT(last)` must advance to the last row's index,
+  not the loop counter. → Covered by a test whose chunk count is an exact multiple
+  and a non-multiple of `batchSize`.
+
+## Migration Plan
+
+Pure query-shape change in one function. No schema, migration, ORM regeneration, or
+API change. Ships in a normal release; rollback is reverting the commit. No data or
+state migration. Deployable while the previous version still serves traffic.
+
+## Open Questions
+
+- Exact batch-size value (256 vs 512). Leaning 512 — halves round-trips versus the
+  progressive path while staying ~64× under the SQLite limit. Final value chosen in
+  implementation; either satisfies the spec.

--- a/openspec/changes/archive/2026-08-16-fix-serve-chunks-sql-var-limit/proposal.md
+++ b/openspec/changes/archive/2026-08-16-fix-serve-chunks-sql-var-limit/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Serving a large chunked NAR fails with `error getting chunks: too many SQL variables` (issue #1463). The completed-chunk fast serve path loads every chunk link for a NAR in one unbounded query, so any NAR with more chunks than the database driver's bound-parameter limit (SQLite 32766, PostgreSQL 65535) can never be served — the client gets an `HTTP 200` with a truncated body and `bad archive: unexpected end of nar`. At the default CDC average of 64 KiB, this triggers for any NAR larger than ~2 GiB on SQLite.
+
+## What Changes
+
+- Replace the unbounded eager-load in `streamCompleteChunks` (`pkg/cache/cache.go`) — `NarFileChunk.Query()…WithChunk().All(ctx)` — with a bounded keyset walk over `chunk_index`, using `ChunkIndexGT(last)` + `Limit(batchSize)` and accumulating chunk hashes page by page. This mirrors the fix already shipped for `fsck` (`chunksForNarFile`) and the batching already present in the progressive serve path (`streamProgressiveChunks`, `Limit(256)`).
+- The completed-chunk fast serve path becomes independent of chunk count: a NAR with any number of chunks reassembles and serves correctly on SQLite, PostgreSQL, and MySQL.
+- No change to ordering, completeness checks, streaming/prefetch behavior, or wire output — the produced chunk-hash sequence is byte-for-byte identical to today's for NARs under the limit.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `chunked-nar-serving-integrity`: Add a requirement that the completed-chunk fast serve path MUST reassemble NARs whose chunk count exceeds the database driver's bound-parameter limit, by querying chunk links in bounded batches rather than a single unbounded parameterized query.
+
+## Impact
+
+- **Code**: `pkg/cache/cache.go` — `streamCompleteChunks` query only. No schema, migration, ORM-regeneration, or API-surface change.
+- **Behavior**: Fixes #1463. NARs previously unservable (chunk count > driver limit) now serve; all smaller NARs unaffected.
+- **I/O / latency**: The single `SELECT` becomes `ceil(chunks / batchSize)` sequential indexed range queries (e.g. ~243 queries at batchSize 512 for a 124k-chunk / 8 GB NAR). Each is a cheap covering-index scan; the added round-trips are negligible against multi-GB stream transfer and overlap with the existing prefetch pipeline.
+- **Memory**: Unchanged-to-lower peak. Chunk hashes are still collected into one slice (bounded by chunk count, as today), but Ent no longer materializes all junction+chunk entity rows at once — it holds one batch at a time.
+
+## Non-goals
+
+- Not changing CDC chunk sizing, the chunking algorithm, or default parameters.
+- Not streaming chunk hashes lazily into the prefetch pipeline (the hash slice is still built eagerly); only the DB query is bounded.
+- Not touching the progressive path, `fsck`, or the migrate commands, which already batch.
+- Not adding a configurable batch-size flag; a fixed internal constant (well under every driver limit) suffices.

--- a/openspec/changes/archive/2026-08-16-fix-serve-chunks-sql-var-limit/specs/chunked-nar-serving-integrity/spec.md
+++ b/openspec/changes/archive/2026-08-16-fix-serve-chunks-sql-var-limit/specs/chunked-nar-serving-integrity/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: The completed-chunk fast serve path MUST scale beyond database driver parameter limits
+
+MUST reassemble and serve a completed chunked NAR regardless of how many chunks it
+has, even when that count exceeds the database driver's bound-parameter limit
+(SQLite 32766, PostgreSQL 65535). When a NAR has completed chunking
+(`total_chunks > 0`), the fast serve path (`streamCompleteChunks`) SHALL retrieve
+its `nar_file_chunks` links in bounded batches ordered by `chunk_index`, rather
+than in a single query whose bound-parameter count grows with the chunk count. The
+batch size SHALL be a fixed internal constant well under every supported driver's
+limit. The ordered sequence of chunk hashes produced by the batched retrieval MUST
+be identical to the sequence a single ordered query would produce, so the streamed
+NAR bytes are unchanged.
+
+Before this change, `streamCompleteChunks` issued
+`NarFileChunk.Query()…WithChunk().All(ctx)`, whose eager-load compiled to
+`SELECT … FROM chunks WHERE id IN ($1 … $N)` with one parameter per chunk. For a
+NAR with more chunks than the driver limit (e.g. an ~8 GB NAR at the default 64 KiB
+average chunk size yields ~124k chunks), the query failed with `too many SQL
+variables`, and the client received an `HTTP 200` with a truncated body
+(`bad archive: unexpected end of nar`).
+
+#### Scenario: NAR with chunk count above the SQLite parameter limit serves successfully
+
+- **WHEN** a completed chunked NAR `H` has `total_chunks` greater than the SQLite bound-parameter limit (> 32766) and a client requests `GET /nar/<H>.nar` against a SQLite-backed cache
+- **THEN** the fast serve path SHALL retrieve all chunk links in bounded batches without raising `too many SQL variables`
+- **AND** the cache SHALL stream the fully reassembled NAR with `HTTP 200`
+- **AND** the response body SHALL contain every chunk exactly once, in ascending `chunk_index` order
+
+#### Scenario: Batched retrieval preserves chunk order and completeness
+
+- **WHEN** the fast serve path retrieves the chunk links for a completed NAR whose chunk count spans multiple batches
+- **THEN** the concatenated per-batch results SHALL equal the chunk-hash sequence of a single query ordered by `chunk_index`
+- **AND** the completeness check (collected chunk count equals `total_chunks`) SHALL still run and SHALL still return `storage.ErrNotFound` when links are missing
+
+#### Scenario: NARs below the parameter limit are unaffected
+
+- **WHEN** a completed chunked NAR has a chunk count at or below the driver parameter limit
+- **THEN** the batched retrieval SHALL produce the same ordered chunk-hash sequence and the same streamed bytes as before this change
+- **AND** the existing successful serve path behavior SHALL NOT change

--- a/openspec/changes/archive/2026-08-16-fix-serve-chunks-sql-var-limit/tasks.md
+++ b/openspec/changes/archive/2026-08-16-fix-serve-chunks-sql-var-limit/tasks.md
@@ -1,0 +1,16 @@
+## 1. Red test (TDD)
+
+- [x] 1.1 Add a package-internal test in `pkg/cache` that fabricates one completed `nar_file` with `total_chunks` above the SQLite parameter limit (> 32766) by inserting that many `chunk` + `nar_file_chunk` rows, then calls `streamCompleteChunks` and asserts it currently fails with `too many SQL variables` (RED against `main`).
+- [x] 1.2 Add a test asserting the batched retrieval returns chunk hashes in ascending `chunk_index` order and preserves the completeness check (`storage.ErrNotFound` when a link is missing), including chunk counts that are both an exact multiple and a non-multiple of the batch size (page-boundary / off-by-one guard).
+
+## 2. Implementation
+
+- [x] 2.1 Add a `completeChunkQueryBatchSize` constant in `pkg/cache/cache.go` near `progressivePollBatchSize`, sized well under every driver limit (256–512).
+- [x] 2.2 Replace the unbounded `NarFileChunk.Query()…WithChunk().All(ctx)` in `streamCompleteChunks` with a keyset walk: loop querying `NarFileID(id)` AND `ChunkIndexGT(last)`, `Order(ByChunkIndex())`, `Limit(completeChunkQueryBatchSize)`, `WithChunk()`; append each `link.Edges.Chunk.Hash` to `chunkHashes`; advance `last` to the last row's `ChunkIndex`; stop when a page returns fewer than the batch size.
+- [x] 2.3 Keep the missing-edge guard (`errMissingChunkEdge`) and the `len(chunkHashes) != totalChunks → ErrNotFound` completeness check against the accumulated slice; leave `streamChunksWithPrefetch` unchanged.
+
+## 3. Verification
+
+- [x] 3.1 Confirm the red tests from §1 now pass (GREEN); confirm NARs below the limit still produce identical ordered hashes/bytes.
+- [x] 3.2 Run `task fmt`, `task lint`, and `task test` (race detector) and confirm each exits zero.
+- [x] 3.3 Run `openspec validate --change fix-serve-chunks-sql-var-limit --no-interactive` and confirm it passes.

--- a/openspec/specs/chunked-nar-serving-integrity/spec.md
+++ b/openspec/specs/chunked-nar-serving-integrity/spec.md
@@ -65,3 +65,43 @@ is always genuine post-completion loss, never a mid-chunking race.
 - **THEN** the cache SHALL take the progressive streaming path
 - **AND** the completed-path completeness check SHALL NOT run for `H`
 - **AND** the request SHALL NOT be resolved to `404` on account of incomplete links
+
+### Requirement: The completed-chunk fast serve path MUST scale beyond database driver parameter limits
+
+MUST reassemble and serve a completed chunked NAR regardless of how many chunks it
+has, even when that count exceeds the database driver's bound-parameter limit
+(SQLite 32766, PostgreSQL 65535). When a NAR has completed chunking
+(`total_chunks > 0`), the fast serve path (`streamCompleteChunks`) SHALL retrieve
+its `nar_file_chunks` links in bounded batches ordered by `chunk_index`, rather
+than in a single query whose bound-parameter count grows with the chunk count. The
+batch size SHALL be a fixed internal constant well under every supported driver's
+limit. The ordered sequence of chunk hashes produced by the batched retrieval MUST
+be identical to the sequence a single ordered query would produce, so the streamed
+NAR bytes are unchanged.
+
+Before this change, `streamCompleteChunks` issued
+`NarFileChunk.Query()…WithChunk().All(ctx)`, whose eager-load compiled to
+`SELECT … FROM chunks WHERE id IN ($1 … $N)` with one parameter per chunk. For a
+NAR with more chunks than the driver limit (e.g. an ~8 GB NAR at the default 64 KiB
+average chunk size yields ~124k chunks), the query failed with `too many SQL
+variables`, and the client received an `HTTP 200` with a truncated body
+(`bad archive: unexpected end of nar`).
+
+#### Scenario: NAR with chunk count above the SQLite parameter limit serves successfully
+
+- **WHEN** a completed chunked NAR `H` has `total_chunks` greater than the SQLite bound-parameter limit (> 32766) and a client requests `GET /nar/<H>.nar` against a SQLite-backed cache
+- **THEN** the fast serve path SHALL retrieve all chunk links in bounded batches without raising `too many SQL variables`
+- **AND** the cache SHALL stream the fully reassembled NAR with `HTTP 200`
+- **AND** the response body SHALL contain every chunk exactly once, in ascending `chunk_index` order
+
+#### Scenario: Batched retrieval preserves chunk order and completeness
+
+- **WHEN** the fast serve path retrieves the chunk links for a completed NAR whose chunk count spans multiple batches
+- **THEN** the concatenated per-batch results SHALL equal the chunk-hash sequence of a single query ordered by `chunk_index`
+- **AND** the completeness check (collected chunk count equals `total_chunks`) SHALL still run and SHALL still return `storage.ErrNotFound` when links are missing
+
+#### Scenario: NARs below the parameter limit are unaffected
+
+- **WHEN** a completed chunked NAR has a chunk count at or below the driver parameter limit
+- **THEN** the batched retrieval SHALL produce the same ordered chunk-hash sequence and the same streamed bytes as before this change
+- **AND** the existing successful serve path behavior SHALL NOT change

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -68,6 +68,15 @@ const (
 	// which is critical for databases like MySQL under parallel test load.
 	progressivePollBatchSize = 256
 
+	// completeChunkQueryBatchSize bounds the number of nar_file_chunk links
+	// fetched per query on the completed-chunk fast serve path
+	// (collectCompleteChunkHashes). Each page's WithChunk eager-load binds at most
+	// this many parameters, so it stays well under every driver limit (older SQLite
+	// ≤ 999, modern SQLite ≤ 32766, Postgres ≤ 65535). Without this bound a NAR
+	// with more chunks than the driver limit failed to serve with "too many SQL
+	// variables" (issue #1463).
+	completeChunkQueryBatchSize = 512
+
 	// cdcCleanupHashBatchSize bounds the size of `WHERE hash IN (…)`
 	// batches issued by the CDC delayed-cleanup job. Stays well under
 	// driver parameter limits (Postgres ≤ 65535, modern SQLite ≤
@@ -8765,36 +8774,74 @@ func (c *Cache) streamCompleteChunks(
 	totalChunks int64,
 	raw bool,
 ) error {
-	// Get all chunks at once, ordered by their position in the NAR.
-	// Query the junction entity directly (rather than chunk + edge
-	// HasNarFileLinks with edge-ordering, which Ent compiles to a
-	// Postgres-incompatible `ORDER BY <join_table>.chunk_index` after
-	// the implicit GROUP BY chunk.id). Eager-load Chunk on each link.
-	chunkHashes := make([]string, 0, totalChunks)
-
-	links, err := c.dbClient.Ent().NarFileChunk.Query().
-		Where(entnarfilechunk.NarFileID(int(narFileID))).
-		Order(entnarfilechunk.ByChunkIndex()).
-		WithChunk().
-		All(ctx)
+	chunkHashes, err := c.collectCompleteChunkHashes(ctx, narFileID, totalChunks)
 	if err != nil {
-		return fmt.Errorf("error getting chunks: %w", err)
-	}
-
-	for _, link := range links {
-		if link.Edges.Chunk == nil {
-			return fmt.Errorf("nar_file_chunk %d: %w", link.ID, errMissingChunkEdge)
-		}
-
-		chunkHashes = append(chunkHashes, link.Edges.Chunk.Hash)
-	}
-
-	if len(chunkHashes) != int(totalChunks) {
-		return fmt.Errorf("expected %d chunks but got %d: %w", totalChunks, len(chunkHashes), storage.ErrNotFound)
+		return err
 	}
 
 	// Use prefetch pipeline to overlap I/O operations
 	return c.streamChunksWithPrefetch(ctx, w, chunkHashes, raw)
+}
+
+// collectCompleteChunkHashes returns the ordered chunk hashes for a completed
+// chunked NAR (total_chunks > 0), retrieving the junction links in bounded batches
+// so the number of bound parameters never exceeds the database driver's limit
+// (SQLite 32766, PostgreSQL 65535). A single unbounded
+// NarFileChunk.Query()…WithChunk().All(ctx) compiled its eager-load to
+// SELECT … FROM chunks WHERE id IN ($1 … $N) with one parameter per chunk, so a
+// NAR with more chunks than the driver limit failed with "too many SQL variables"
+// (issue #1463). The junction entity is queried directly (rather than chunk + edge
+// HasNarFileLinks with edge-ordering, which Ent compiles to a Postgres-incompatible
+// `ORDER BY <join_table>.chunk_index` after the implicit GROUP BY chunk.id); Chunk
+// is eager-loaded on each link. The completeness check
+// (len(chunkHashes) == totalChunks) still runs against the accumulated result.
+func (c *Cache) collectCompleteChunkHashes(
+	ctx context.Context,
+	narFileID int64,
+	totalChunks int64,
+) ([]string, error) {
+	chunkHashes := make([]string, 0, totalChunks)
+
+	// Keyset walk over chunk_index: each page fetches at most
+	// completeChunkQueryBatchSize links (so the WithChunk eager-load binds at most
+	// that many parameters), advancing past the last index seen. Mirrors the
+	// batching already used by streamProgressiveChunks.
+	lastIndex := -1
+
+	for {
+		links, err := c.dbClient.Ent().NarFileChunk.Query().
+			Where(
+				entnarfilechunk.NarFileID(int(narFileID)),
+				entnarfilechunk.ChunkIndexGT(lastIndex),
+			).
+			Order(entnarfilechunk.ByChunkIndex()).
+			WithChunk().
+			Limit(completeChunkQueryBatchSize).
+			All(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error getting chunks: %w", err)
+		}
+
+		for _, link := range links {
+			if link.Edges.Chunk == nil {
+				return nil, fmt.Errorf("nar_file_chunk %d: %w", link.ID, errMissingChunkEdge)
+			}
+
+			chunkHashes = append(chunkHashes, link.Edges.Chunk.Hash)
+		}
+
+		if len(links) < completeChunkQueryBatchSize {
+			break
+		}
+
+		lastIndex = links[len(links)-1].ChunkIndex
+	}
+
+	if len(chunkHashes) != int(totalChunks) {
+		return nil, fmt.Errorf("expected %d chunks but got %d: %w", totalChunks, len(chunkHashes), storage.ErrNotFound)
+	}
+
+	return chunkHashes, nil
 }
 
 // prefetchedChunk holds a chunk reader and any error from fetching it.

--- a/pkg/cache/serve_complete_chunks_sql_var_limit_internal_test.go
+++ b/pkg/cache/serve_complete_chunks_sql_var_limit_internal_test.go
@@ -1,0 +1,156 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kalbasit/ncps/ent"
+	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/storage"
+	"github.com/kalbasit/ncps/testdata"
+)
+
+// fakeChunkHash returns a deterministic, unique, non-empty 64-hex chunk hash for
+// index i. The Chunk schema only constrains hash to NotEmpty + unique, so this is
+// a valid stand-in without needing real content.
+func fakeChunkHash(i int) string { return fmt.Sprintf("%064x", i) }
+
+// seedCompletedChunkedNar creates a completed chunked nar_file with numChunks
+// distinct chunks and junction links. Chunk rows are inserted ascending by index,
+// but links are inserted in DESCENDING chunk_index order so that rowid/insertion
+// order is the reverse of chunk_index order — a retrieval that fails to honor
+// ORDER BY chunk_index would return hashes in the wrong order. Inserts are batched
+// well under driver parameter limits so seeding itself never overflows.
+func seedCompletedChunkedNar(ctx context.Context, t *testing.T, c *Cache, numChunks int) *ent.NarFile {
+	t.Helper()
+
+	client := c.dbClient.Ent()
+
+	nf, err := client.NarFile.Create().
+		SetHash(testdata.Nar1.NarHash).
+		SetCompression(nar.CompressionTypeNone.String()).
+		SetQuery("").
+		SetFileSize(1).
+		SetTotalChunks(int64(numChunks)).
+		Save(ctx)
+	require.NoError(t, err)
+
+	const insertBatch = 500
+
+	// Insert chunks (ascending index) and remember each chunk's DB id by index.
+	chunkIDByIndex := make([]int, numChunks)
+
+	for start := 0; start < numChunks; start += insertBatch {
+		end := min(start+insertBatch, numChunks)
+
+		builders := make([]*ent.ChunkCreate, 0, end-start)
+		for i := start; i < end; i++ {
+			builders = append(builders, client.Chunk.Create().
+				SetHash(fakeChunkHash(i)).
+				SetSize(1).
+				SetCompressedSize(1))
+		}
+
+		created, err := client.Chunk.CreateBulk(builders...).Save(ctx)
+		require.NoError(t, err)
+
+		for j, ch := range created {
+			chunkIDByIndex[start+j] = ch.ID
+		}
+	}
+
+	// Insert links in DESCENDING chunk_index order, batched.
+	for start := numChunks; start > 0; start -= insertBatch {
+		end := max(start-insertBatch, 0)
+
+		builders := make([]*ent.NarFileChunkCreate, 0, start-end)
+		for i := start - 1; i >= end; i-- {
+			builders = append(builders, client.NarFileChunk.Create().
+				SetNarFileID(nf.ID).
+				SetChunkID(chunkIDByIndex[i]).
+				SetChunkIndex(i))
+		}
+
+		_, err := client.NarFileChunk.CreateBulk(builders...).Save(ctx)
+		require.NoError(t, err)
+	}
+
+	return nf
+}
+
+// TestCollectCompleteChunkHashes_AboveSQLiteParamLimit is the regression test for
+// issue #1463: a completed chunked NAR with more chunks than the database driver's
+// bound-parameter limit (SQLite 32766) must be retrievable. The pre-fix
+// implementation loaded every chunk link in a single unbounded
+// NarFileChunk.Query()…WithChunk().All(ctx), whose eager-load compiled to
+// SELECT … WHERE id IN ($1 … $N) and failed with "too many SQL variables".
+func TestCollectCompleteChunkHashes_AboveSQLiteParamLimit(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := newCDCCacheForStreaming(t)
+
+	// Strictly above the SQLite bound-parameter limit (32766), independent of the
+	// internal batch size.
+	const numChunks = 33000
+
+	nf := seedCompletedChunkedNar(ctx, t, c, numChunks)
+
+	hashes, err := c.collectCompleteChunkHashes(ctx, int64(nf.ID), int64(numChunks))
+	require.NoError(t, err,
+		"a NAR with more chunks than the driver parameter limit must be retrievable via batched queries")
+	require.Len(t, hashes, numChunks)
+
+	// Hashes must come back in ascending chunk_index order despite descending
+	// insertion order.
+	want := make([]string, numChunks)
+	for i := range want {
+		want[i] = fakeChunkHash(i)
+	}
+
+	assert.Equal(t, want, hashes, "chunk hashes must be ordered by chunk_index")
+}
+
+// TestCollectCompleteChunkHashes_ExactMultipleOfBatchSize guards the page-boundary
+// walk: when the chunk count is an exact multiple of the batch size, the final
+// full page must be followed by a terminating empty page rather than looping or
+// over-reading.
+func TestCollectCompleteChunkHashes_ExactMultipleOfBatchSize(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := newCDCCacheForStreaming(t)
+
+	numChunks := 2 * completeChunkQueryBatchSize
+
+	nf := seedCompletedChunkedNar(ctx, t, c, numChunks)
+
+	hashes, err := c.collectCompleteChunkHashes(ctx, int64(nf.ID), int64(numChunks))
+	require.NoError(t, err)
+	require.Len(t, hashes, numChunks)
+
+	for i := range hashes {
+		require.Equal(t, fakeChunkHash(i), hashes[i])
+	}
+}
+
+// TestCollectCompleteChunkHashes_MissingLinkFailsCompleteness verifies the
+// completeness check still fires after batching: if fewer links exist than
+// total_chunks declares, retrieval returns storage.ErrNotFound rather than a short
+// success.
+func TestCollectCompleteChunkHashes_MissingLinkFailsCompleteness(t *testing.T) {
+	t.Parallel()
+
+	c, ctx := newCDCCacheForStreaming(t)
+
+	const seeded = 5
+
+	nf := seedCompletedChunkedNar(ctx, t, c, seeded)
+
+	// Declare one more chunk than actually linked.
+	_, err := c.collectCompleteChunkHashes(ctx, int64(nf.ID), int64(seeded+1))
+	require.ErrorIs(t, err, storage.ErrNotFound,
+		"an incomplete link set must fail the completeness check")
+}


### PR DESCRIPTION
## Summary

Fixes #1463 — serving a large chunked NAR failed with `error getting chunks: too many SQL variables`, leaving the client with a truncated `HTTP 200` (`bad archive: unexpected end of nar`).

The completed-chunk fast serve path `streamCompleteChunks` loaded every `nar_file_chunk` link in one unbounded `NarFileChunk.Query()…WithChunk().All(ctx)`. The `WithChunk()` eager-load compiles to `SELECT … FROM chunks WHERE id IN ($1 … $N)` with one bound parameter per chunk, so any NAR with more chunks than the driver's parameter limit (SQLite 32766, PostgreSQL 65535) could never be served. At the default 64 KiB average chunk size this triggers for NARs over ~2 GiB; the reported ~8 GB NAR yields ~124k chunks.

## What changed

- Extract the retrieval into `collectCompleteChunkHashes`, which walks the junction links in bounded pages keyed on `chunk_index` (`ChunkIndexGT` + `Limit(completeChunkQueryBatchSize=512)` + `WithChunk()`), accumulating hashes per page. Each page binds at most 512 parameters, independent of chunk count.
- Mirrors the batching already used by `streamProgressiveChunks` and the `fsck` size-mismatch fix.
- Ordering, the missing-edge guard, the completeness check (`len == total_chunks` → `storage.ErrNotFound`), and `streamChunksWithPrefetch` are all unchanged — output is byte-for-byte identical for NARs under the old limit.
- No schema, migration, ORM-regeneration, or API change.

## Test plan

- [x] RED reproduced: unbounded query fails with `too many SQL variables` at 33,000 chunks (> SQLite 32766 limit); GREEN after batching.
- [x] `TestCollectCompleteChunkHashes_AboveSQLiteParamLimit` — 33k chunks retrieved in ascending `chunk_index` order across 65 pages.
- [x] `TestCollectCompleteChunkHashes_ExactMultipleOfBatchSize` — page-boundary / empty-trailing-page walk.
- [x] `TestCollectCompleteChunkHashes_MissingLinkFailsCompleteness` — completeness check still fires (`storage.ErrNotFound`).
- [x] `task fmt`, `task lint`, `task test` (race detector) all pass.