### PR TITLE
fix(upstream): negotiate transport zstd only for uncompressed NARs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,21 @@ project loosely follows [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- **A compressing reverse proxy in front of an upstream no longer corrupts
+  already-compressed NARs.** ncps sent `Accept-Encoding: zstd` on *every*
+  upstream NAR fetch and transparently stripped any `Content-Encoding: zstd` it
+  got back. For a NAR the narinfo already declared compressed that bought
+  effectively nothing — zstd over zstd/xz yields ~0% — while inviting a proxy
+  (Caddy's `encode zstd`, nginx, a CDN) to wrap the body. Where the upstream's
+  own content was not in fact compressed, ncps was left holding a raw NAR that it
+  stored and served as `Compression: zstd`, and nix failed with `input compression not recognized`. ncps was uniquely exposed because it always
+  advertised zstd while nix's own curl frequently is not built with it, so such a
+  proxy compressed for ncps alone and the same store path substituted fine
+  directly. Transport zstd is now negotiated only for NARs whose content is
+  uncompressed (the Harmonia shape the negotiation exists for); a
+  `Content-Encoding: zstd` response is still transparently decompressed whether
+  or not it was solicited. (#1470)
+
 - **Upstream narinfos that declare their compression only in the `Compression:`
   header are no longer desynced from the NAR ncps stores.** ncps derived a NAR's
   compression exclusively from the file extension on the narinfo `URL:` field.

--- a/openspec/changes/archive/2026-09-06-negotiate-transport-zstd-only-when-uncompressed/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-06-negotiate-transport-zstd-only-when-uncompressed/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-06

--- a/openspec/changes/archive/2026-09-06-negotiate-transport-zstd-only-when-uncompressed/design.md
+++ b/openspec/changes/archive/2026-09-06-negotiate-transport-zstd-only-when-uncompressed/design.md
@@ -1,0 +1,91 @@
+## Context
+
+See proposal.md — Why. The mechanics that shape the approach:
+
+`upstream.Cache.GetNar(ctx, narURL, mutators...)` (`pkg/cache/upstream/cache.go`)
+already receives the `nar.URL`, so `narURL.Compression` is in scope at the exact
+point the `Accept-Encoding` mutator is built. There is a single production call
+site, `getNarFromUpstream` in `pkg/cache/cache.go`, which passes the download URL
+— the opaque/preferred URL when one exists, otherwise the NAR URL.
+
+The value being branched on is only trustworthy because of the change archived as
+`narinfo-compression-authoritative`: before it, an Attic-shaped narinfo resolved
+to `none` even though its content was zstd, so gating on
+`narURL.Compression == none` would have mis-fired precisely on the shape that
+motivates this change. That ordering is a hard dependency, not a coincidence.
+
+The response side (`Content-Encoding: zstd` → transparent decompress) is
+deliberately untouched, so this change is confined to what ncps *asks for*.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Stop ncps from soliciting a transfer encoding it cannot safely reconcile.
+- Keep the negotiation exactly where it pays: uncompressed NARs.
+
+**Non-Goals:**
+
+- See proposal.md — Non-goals. At the design level, additionally: no new
+  configuration knob. The correct behaviour is derivable from the narinfo, so
+  making it opt-in would only preserve a foot-gun.
+
+## Decisions
+
+**1. Gate on the resolved compression at the mutator, not at the call site.**
+
+The rule ("only negotiate for uncompressed content") is a property of the
+upstream fetch, not of any particular caller, so it belongs in `GetNar` beside
+the matching decompression logic where the two can be read together.
+
+*Alternative rejected:* have `getNarFromUpstream` pass a mutator conditionally.
+That scatters the invariant across packages and would silently lapse the moment a
+second caller appears.
+
+**2. Leave the transparent `Content-Encoding: zstd` strip unconditional.**
+
+Decompressing a declared transfer encoding is correct regardless of whether we
+solicited it — refusing to would break a conforming-but-eager upstream and turn a
+working fetch into a corrupt one. This change removes the case where ncps invited
+the encoding; it does not try to police upstreams that send it unbidden.
+
+*Alternative rejected:* strip only when we negotiated. That would make ncps
+mishandle a legitimately transfer-encoded response and buys nothing, since we no
+longer ask.
+
+**3. Make the existing test's fake upstream honour `Accept-Encoding`.**
+
+The skipped transport-level subtest's server sets `Content-Encoding: zstd`
+unconditionally. That models an upstream that lies regardless of the request,
+which no real proxy does — Caddy, nginx and CDNs all compress only when the
+client advertises. Left as-is the subtest cannot pass under any correct
+implementation, because it does not react to what ncps asks for.
+
+Making the fixture realistic is what lets the subtest be un-skipped, and it
+narrows what the test proves to the case this change actually fixes. The residual
+case — an upstream sending an unsolicited `Content-Encoding: zstd` over a raw body
+— is a protocol violation that remains unhandled by design (Decision 2), and is
+no longer represented by a test.
+
+## Risks / Trade-offs
+
+- **An upstream that usefully double-compressed is no longer asked to.** →
+  Negligible: zstd over zstd/xz yields ~0% and costs CPU on both ends. The change
+  is a net win on the wire budget in every realistic case.
+- **A future caller could pass a `nar.URL` whose `Compression` is not the
+  resolved value**, re-opening the gap silently. → The requirement is expressed in
+  terms of the *resolved* compression, and the unit test asserts the header per
+  compression type at the `GetNar` boundary, so a regression fails there rather
+  than surfacing as a corrupt NAR.
+- **Removing the skipped subtest's unrealistic form loses coverage of the
+  lying-upstream case.** → Accepted deliberately: it was never a passing test, the
+  behaviour is unsupported per Decision 2, and keeping a permanently-red case has
+  already proven to cost more (a stale skip pointing at a closed issue) than it
+  documented.
+
+## Migration Plan
+
+No database migration, no configuration change, no persisted-state change. The
+change alters one outbound request header. Rollback is a plain revert; nothing
+written under the new behaviour is unreadable by the previous version, since the
+bytes stored are the upstream's own compressed NAR either way.

--- a/openspec/changes/archive/2026-09-06-negotiate-transport-zstd-only-when-uncompressed/proposal.md
+++ b/openspec/changes/archive/2026-09-06-negotiate-transport-zstd-only-when-uncompressed/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+`upstream.GetNar` sends `Accept-Encoding: zstd` on **every** upstream NAR fetch and transparently strips any `Content-Encoding: zstd` it gets back. For a NAR the narinfo already declares compressed, that request buys close to nothing — zstd over zstd/xz is wasted CPU on both ends — and it is actively harmful: a compressing proxy in front of the upstream (Caddy's `encode zstd`, nginx, a CDN) honours the request and wraps the body. If the upstream's own content was not in fact compressed, ncps strips the encoding, is left holding a **raw** NAR, and goes on to store and serve it as `Compression: zstd`; nix then fails with `input compression not recognized`.
+
+ncps is uniquely exposed because it *always* advertises zstd while nix's own curl frequently is not built with it — so such a proxy compresses for ncps alone, and the same store path that substitutes fine directly fails through ncps. This gap was found while diagnosing #1470, confirmed not to be that reporter's failure mode, and left behind as a skipped test.
+
+## What Changes
+
+- Request `Accept-Encoding: zstd` from an upstream only when the NAR's resolved compression is `none`. A NAR already declared `zstd`/`xz`/etc. is fetched without transport negotiation, so there is nothing for a proxy to wrap and ncps keeps the upstream's own bytes.
+- Transparent stripping of `Content-Encoding: zstd` is unchanged — it remains correct HTTP behaviour for any response that carries one.
+- Un-skip the transport-level subtest in `pkg/cache/attic_narinfo_url_compression_test.go` and make its fake upstream model a real proxy (apply the encoding only when the client advertises it).
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `upstream-fetch-resilience`: adds a requirement governing when ncps negotiates transport-level zstd on an upstream NAR fetch. The capability already owns upstream NAR GET behaviour (opaque URLs, retries, compression resolution).
+
+## Non-goals
+
+- **Does not** change the downstream/server side. Client-facing `Accept-Encoding` handling and transparent re-compression (`api-surface`, `architecture`) are untouched.
+- **Does not** change transparent decompression of a `Content-Encoding: zstd` response. An upstream that sends one *unsolicited* over a raw body is nonconforming and remains unsupported; this change removes the case where ncps itself invited the problem.
+- **Does not** revisit the narinfo `Compression:` resolution from #1470, which this depends on: `narURL.Compression` is only trustworthy because of it.
+- **Does not** add sniffing or heuristics to detect a lying upstream.
+
+## Impact
+
+- Code: `pkg/cache/upstream/cache.go` (`GetNar`). Single call site, `pkg/cache/cache.go` `getNarFromUpstream`.
+- Spec: `openspec/specs/upstream-fetch-resilience/spec.md`.
+- Network: slightly **more** bytes on the wire in the rare case an upstream was usefully double-compressing an already-compressed NAR; realistically unchanged, since compressing compressed data yields ~0%. Uncompressed NARs (Harmonia) keep the negotiation and are unaffected.
+- CPU: reduced on both ends — one fewer compress/decompress pass per compressed-NAR fetch.
+- Memory: unchanged. Data: no migration.

--- a/openspec/changes/archive/2026-09-06-negotiate-transport-zstd-only-when-uncompressed/proposal.md
+++ b/openspec/changes/archive/2026-09-06-negotiate-transport-zstd-only-when-uncompressed/proposal.md
@@ -23,7 +23,7 @@ None.
 ## Non-goals
 
 - **Does not** change the downstream/server side. Client-facing `Accept-Encoding` handling and transparent re-compression (`api-surface`, `architecture`) are untouched.
-- **Does not** change transparent decompression of a `Content-Encoding: zstd` response. An upstream that sends one *unsolicited* over a raw body is nonconforming and remains unsupported; this change removes the case where ncps itself invited the problem.
+- **Does not** change transparent decompression of a `Content-Encoding: zstd` response. Such a response is still decoded whether or not the system negotiated it — decoding a declared transfer encoding is correct regardless. What stays unsupported is narrower and is about the *decoded* body: if that body then fails to match the compression the narinfo declares, the system does not detect or repair the mismatch. This change removes the case where ncps itself invited that mismatch.
 - **Does not** revisit the narinfo `Compression:` resolution from #1470, which this depends on: `narURL.Compression` is only trustworthy because of it.
 - **Does not** add sniffing or heuristics to detect a lying upstream.
 

--- a/openspec/changes/archive/2026-09-06-negotiate-transport-zstd-only-when-uncompressed/specs/upstream-fetch-resilience/spec.md
+++ b/openspec/changes/archive/2026-09-06-negotiate-transport-zstd-only-when-uncompressed/specs/upstream-fetch-resilience/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Transport-level zstd is negotiated only for uncompressed NARs
+
+The system SHALL send `Accept-Encoding: zstd` on an upstream NAR fetch only when
+the NAR's resolved compression is `none`, and SHALL NOT send it for a NAR whose
+narinfo declares any other compression. Transport-level compression of content
+that is already compressed yields effectively no bandwidth saving, and requesting
+it invites a compressing proxy in front of the upstream to wrap the body — which
+the system then strips, leaving it holding bytes that do not match the
+compression the narinfo declares.
+
+The system SHALL continue to transparently decompress a response that carries
+`Content-Encoding: zstd`, since that remains the correct handling of a transfer
+encoding whether or not it was solicited.
+
+This requirement depends on the narinfo `Compression:` header being authoritative
+when the URL carries no compression extension: the resolved compression is only
+trustworthy because of that.
+
+#### Scenario: Uncompressed NAR still negotiates transport zstd
+
+- **WHEN** the system fetches a NAR whose resolved compression is `none`
+- **THEN** the request SHALL carry `Accept-Encoding: zstd`
+- **AND** a `Content-Encoding: zstd` response SHALL be transparently decompressed
+
+#### Scenario: Compressed NAR is fetched without transport negotiation
+
+- **WHEN** the system fetches a NAR whose resolved compression is `zstd`, `xz`, or any other non-`none` compression
+- **THEN** the request SHALL NOT carry `Accept-Encoding: zstd`
+
+#### Scenario: A compressing proxy no longer corrupts a compressed NAR
+
+- **GIVEN** an upstream serving an uncompressed body for a narinfo that declares `Compression: zstd`, behind a proxy that applies zstd only when the client advertises it
+- **WHEN** the system fetches that NAR
+- **THEN** the proxy SHALL NOT wrap the body, because the system did not advertise the encoding
+- **AND** the bytes the system stores and serves SHALL decode under the compression the narinfo declares
+
+#### Scenario: An unsolicited Content-Encoding is still handled
+
+- **WHEN** an upstream returns `Content-Encoding: zstd` on a response the system did not negotiate it for
+- **THEN** the system SHALL still transparently decompress the body rather than treating the encoding as content

--- a/openspec/changes/archive/2026-09-06-negotiate-transport-zstd-only-when-uncompressed/tasks.md
+++ b/openspec/changes/archive/2026-09-06-negotiate-transport-zstd-only-when-uncompressed/tasks.md
@@ -1,0 +1,29 @@
+## 1. Pin the request-side contract
+
+- [x] 1.1 Add a RED table test in `pkg/cache/upstream` asserting what `GetNar` puts on the wire per resolved compression: `none` sends `Accept-Encoding: zstd`; `zstd` and `xz` do not. Assert against the header the fake upstream actually receives, not against internals.
+- [x] 1.2 Confirm it fails only on the compressed rows (the `none` row must already pass, proving the test is not vacuous).
+
+## 2. Gate the negotiation
+
+- [x] 2.1 In `upstream.GetNar`, build the `Accept-Encoding: zstd` mutator only when `narURL.Compression == nar.CompressionTypeNone`, leaving caller-supplied mutators applied in both branches.
+- [x] 2.2 Update the `GetNar` doc comment to state the rule and why it exists (a compressing proxy wrapping already-compressed content).
+- [x] 2.3 Run task 1.1 to green.
+- [x] 2.4 Confirm the transparent `Content-Encoding: zstd` decompression below is untouched and still unconditional.
+
+## 3. Close the gap the skipped test described
+
+- [x] 3.1 Make the fake upstream in `TestAtticNarInfoURLWithoutCompressionExtension` apply `Content-Encoding: zstd` only when the request advertises it, so it models a real compressing proxy rather than an upstream that lies unconditionally.
+- [x] 3.2 Delete the `t.Skip` from the transport-level subtest and confirm it now passes: the served bytes must decode under the `Compression:` the narinfo advertises.
+- [x] 3.3 Update the test's header comment — the transport variant is now covered rather than deferred — and remove the wording that describes it as an open gap.
+
+## 4. Guard the paths that must not change
+
+- [x] 4.1 Confirm Harmonia (`Compression: none` + transport zstd) still negotiates and still round-trips: the `none` row of 1.1 plus the existing upstream tests must stay green.
+- [x] 4.2 Confirm the single production call site (`getNarFromUpstream`) needs no change, and that the CDC preferred-download path — which fetches the compressed URL — is correct under the new rule.
+- [x] 4.3 Confirm no downstream/server-side `Accept-Encoding` behaviour changed (`pkg/server`): its tests must stay green.
+
+## 5. Verify and finish
+
+- [x] 5.1 Run `task fmt`, `task lint`, and `task test`; all must exit zero, with no remaining `t.Skip` in `pkg/cache/attic_narinfo_url_compression_test.go`.
+- [x] 5.2 Run `openspec validate --no-interactive --strict` for this change.
+- [x] 5.3 Add a `CHANGELOG.md` entry under Fixed, describing the proxy interaction rather than just the header change.

--- a/openspec/specs/upstream-fetch-resilience/spec.md
+++ b/openspec/specs/upstream-fetch-resilience/spec.md
@@ -233,3 +233,44 @@ bare `nar/<storePathHash>.nar` while `Compression:` is `zstd`.
 - **THEN** the upstream GET SHALL target the original extension-less upstream path, not ncps's re-serve URL
 - **AND** any query string on that path SHALL be carried onto the GET
 - **AND** that path SHALL be persisted so the NAR can be re-fetched from upstream after the local copy is evicted
+
+### Requirement: Transport-level zstd is negotiated only for uncompressed NARs
+
+The system SHALL send `Accept-Encoding: zstd` on an upstream NAR fetch only when
+the NAR's resolved compression is `none`, and SHALL NOT send it for a NAR whose
+narinfo declares any other compression. Transport-level compression of content
+that is already compressed yields effectively no bandwidth saving, and requesting
+it invites a compressing proxy in front of the upstream to wrap the body — which
+the system then strips, leaving it holding bytes that do not match the
+compression the narinfo declares.
+
+The system SHALL continue to transparently decompress a response that carries
+`Content-Encoding: zstd`, since that remains the correct handling of a transfer
+encoding whether or not it was solicited.
+
+This requirement depends on the narinfo `Compression:` header being authoritative
+when the URL carries no compression extension: the resolved compression is only
+trustworthy because of that.
+
+#### Scenario: Uncompressed NAR still negotiates transport zstd
+
+- **WHEN** the system fetches a NAR whose resolved compression is `none`
+- **THEN** the request SHALL carry `Accept-Encoding: zstd`
+- **AND** a `Content-Encoding: zstd` response SHALL be transparently decompressed
+
+#### Scenario: Compressed NAR is fetched without transport negotiation
+
+- **WHEN** the system fetches a NAR whose resolved compression is `zstd`, `xz`, or any other non-`none` compression
+- **THEN** the request SHALL NOT carry `Accept-Encoding: zstd`
+
+#### Scenario: A compressing proxy no longer corrupts a compressed NAR
+
+- **GIVEN** an upstream serving an uncompressed body for a narinfo that declares `Compression: zstd`, behind a proxy that applies zstd only when the client advertises it
+- **WHEN** the system fetches that NAR
+- **THEN** the proxy SHALL NOT wrap the body, because the system did not advertise the encoding
+- **AND** the bytes the system stores and serves SHALL decode under the compression the narinfo declares
+
+#### Scenario: An unsolicited Content-Encoding is still handled
+
+- **WHEN** an upstream returns `Content-Encoding: zstd` on a response the system did not negotiate it for
+- **THEN** the system SHALL still transparently decompress the body rather than treating the encoding as content

--- a/pkg/cache/attic_narinfo_url_compression_test.go
+++ b/pkg/cache/attic_narinfo_url_compression_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,10 +63,11 @@ import (
 //     NAR, which it then serves while still advertising Compression: zstd.
 //
 // The reporter of #1470 turned out to be on the CONTENT-level variant, and the
-// compression-resolution fix cured them — so the transport-level variant was
-// never their failure mode. It is kept here because the gap it describes is real
-// and code-verified, not because anything is known to hit it. See the skip
-// below.
+// compression-resolution fix cured them. The TRANSPORT-level variant was never
+// their failure mode, but it was a real gap of its own and is now closed too:
+// ncps no longer requests transport zstd for a NAR the narinfo already declares
+// compressed, so the proxy modelled below has nothing to wrap and ncps keeps the
+// upstream's own compressed bytes.
 func TestAtticNarInfoURLWithoutCompressionExtension(t *testing.T) {
 	t.Parallel()
 
@@ -80,35 +82,6 @@ func TestAtticNarInfoURLWithoutCompressionExtension(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
-			if tt.transportEncoding {
-				// Skipped because ncps genuinely fails this case, not because the
-				// test is flaky or wrong. It is a standing description of an open
-				// gap; no fix is planned or in flight, so do not read this as
-				// waiting on anything.
-				//
-				// The gap: upstream.GetNar unconditionally sends
-				// Accept-Encoding: zstd and transparently strips any
-				// Content-Encoding: zstd it gets back. An upstream that applies zstd
-				// at the TRANSPORT level over an uncompressed body therefore leaves
-				// ncps holding a raw NAR, which it stores and serves under a
-				// .nar.zst key while the narinfo advertises Compression: zstd —
-				// nix then reports "input compression not recognized". Resolving the
-				// declared compression (which this file's other subtest covers)
-				// makes the labels agree but cannot make those bytes true.
-				//
-				// Such an upstream is arguably nonconforming and breaks plain nix
-				// too (NixOS/nix#10275). What makes it ncps-specific is that ncps
-				// always advertises zstd while nix's curl often is not built with
-				// it, so a proxy may compress for ncps alone. No real upstream has
-				// been observed doing this.
-				//
-				// To close it: stop requesting transport zstd for content the
-				// narinfo already declares compressed (a change in
-				// pkg/cache/upstream). This subtest should then pass with no edit
-				// here, and the skip can be deleted.
-				t.Skip("open gap, no fix planned: upstream states zstd via Content-Encoding over a raw body")
-			}
 
 			const (
 				// Attic addresses NARs by the 32-char store path hash, which is
@@ -146,7 +119,13 @@ References: %s-attic-1.0
 
 					return true
 				case atticPath:
-					if tt.transportEncoding {
+					// Model a real compressing proxy (Caddy `encode zstd`, nginx, a
+					// CDN): it applies the encoding only when the client advertises
+					// it. That is precisely what made ncps's formerly-unconditional
+					// Accept-Encoding: zstd the trigger — nix's own curl frequently
+					// is not built with zstd, so the proxy compressed for ncps alone
+					// and the same path substituted fine directly.
+					if tt.transportEncoding && strings.Contains(r.Header.Get("Accept-Encoding"), "zstd") {
 						w.Header().Set("Content-Encoding", "zstd")
 					}
 

--- a/pkg/cache/upstream/cache.go
+++ b/pkg/cache/upstream/cache.go
@@ -531,9 +531,11 @@ func (c *Cache) HasNarInfo(ctx context.Context, hash string) (bool, error) {
 }
 
 // GetNar returns the NAR archive from the cache server.
-// It always sends Accept-Encoding: zstd to request compressed transfer when possible.
-// If the response has Content-Encoding: zstd, the body is transparently decompressed
-// so the caller always receives raw (uncompressed) NAR bytes.
+// For a Compression:none NAR it sends Accept-Encoding: zstd to request compressed
+// transfer; it deliberately does NOT for a NAR whose content is already
+// compressed (see the rationale at the header below). If the response carries
+// Content-Encoding: zstd it is transparently decompressed regardless of whether
+// we negotiated it, since that is the correct handling of a transfer encoding.
 // NOTE: It's the caller responsibility to close the body.
 func (c *Cache) GetNar(ctx context.Context, narURL nar.URL, mutators ...func(*http.Request)) (*http.Response, error) {
 	u := narURL.JoinURL(c.url).String()
@@ -561,13 +563,29 @@ func (c *Cache) GetNar(ctx context.Context, narURL nar.URL, mutators ...func(*ht
 		Info().
 		Msg("download the nar from upstream")
 
-	// Always request zstd-compressed transfer for bandwidth savings.
-	// Upstreams that don't support it (e.g. nix-serve) will simply ignore this header.
-	zstdMutator := func(r *http.Request) {
-		r.Header.Set("Accept-Encoding", "zstd")
-	}
+	// Request zstd-compressed transfer for bandwidth savings, but ONLY for a NAR
+	// whose content is uncompressed — the Harmonia shape this negotiation exists
+	// for. Upstreams that don't support it (e.g. nix-serve) simply ignore the
+	// header.
+	//
+	// Asking for it on an already-compressed NAR is not merely wasted CPU on both
+	// ends (zstd over zstd/xz yields ~0%): a compressing proxy in front of the
+	// upstream (Caddy's `encode zstd`, nginx, a CDN) honours the request and wraps
+	// the body, which this function then transparently strips below. Were the
+	// upstream's own content not in fact compressed, ncps would be left holding a
+	// raw NAR that it goes on to store and serve as `Compression: zstd`, and nix
+	// fails with "input compression not recognized". ncps was uniquely exposed to
+	// that because it always advertised zstd while nix's own curl frequently is
+	// not built with it, so such a proxy compressed for ncps alone.
+	allMutators := mutators
 
-	allMutators := append([]func(*http.Request){zstdMutator}, mutators...)
+	if narURL.Compression == nar.CompressionTypeNone {
+		zstdMutator := func(r *http.Request) {
+			r.Header.Set("Accept-Encoding", "zstd")
+		}
+
+		allMutators = append([]func(*http.Request){zstdMutator}, mutators...)
+	}
 
 	resp, err := c.doRequest(ctx, http.MethodGet, u, allMutators...)
 	if err != nil {

--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -806,7 +807,13 @@ func TestGetNarAcceptEncodingMatchesContentCompression(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			var gotAcceptEncoding string
+			// Guarded: the handler runs on the server's goroutine, and doRequest
+			// may retry, so more than one handler invocation can overlap the
+			// test's read.
+			var (
+				mu                sync.Mutex
+				gotAcceptEncoding string
+			)
 
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if strings.HasSuffix(r.URL.Path, "/nix-cache-info") {
@@ -815,7 +822,9 @@ func TestGetNarAcceptEncodingMatchesContentCompression(t *testing.T) {
 					return
 				}
 
+				mu.Lock()
 				gotAcceptEncoding = r.Header.Get("Accept-Encoding")
+				mu.Unlock()
 
 				_, _ = io.WriteString(w, "some-nar-bytes")
 			}))
@@ -837,11 +846,15 @@ func TestGetNarAcceptEncodingMatchesContentCompression(t *testing.T) {
 				_ = resp.Body.Close()
 			})
 
+			mu.Lock()
+			sentAcceptEncoding := gotAcceptEncoding
+			mu.Unlock()
+
 			if tt.wantZstdReq {
-				assert.Contains(t, gotAcceptEncoding, "zstd",
+				assert.Contains(t, sentAcceptEncoding, "zstd",
 					"an uncompressed NAR should still negotiate transport zstd")
 			} else {
-				assert.NotContains(t, gotAcceptEncoding, "zstd",
+				assert.NotContains(t, sentAcceptEncoding, "zstd",
 					"a NAR whose content is already %s must not request transport zstd", tt.compression)
 			}
 		})
@@ -869,7 +882,10 @@ func TestGetNarDecompressesUnsolicitedContentEncoding(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, zw.Close())
 
-	var gotAcceptEncoding string
+	var (
+		mu                sync.Mutex
+		gotAcceptEncoding string
+	)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/nix-cache-info") {
@@ -881,7 +897,9 @@ func TestGetNarDecompressesUnsolicitedContentEncoding(t *testing.T) {
 		// Unsolicited: the NAR below is declared zstd, so ncps does not negotiate
 		// transport zstd, yet this upstream applies it anyway. Recorded here and
 		// asserted on the test goroutine — testify must not FailNow off it.
+		mu.Lock()
 		gotAcceptEncoding = r.Header.Get("Accept-Encoding")
+		mu.Unlock()
 
 		w.Header().Set("Content-Encoding", "zstd")
 		_, _ = w.Write(compressed.Bytes())
@@ -904,7 +922,11 @@ func TestGetNarDecompressesUnsolicitedContentEncoding(t *testing.T) {
 	got, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	assert.NotContains(t, gotAcceptEncoding, "zstd",
+	mu.Lock()
+	sentAcceptEncoding := gotAcceptEncoding
+	mu.Unlock()
+
+	assert.NotContains(t, sentAcceptEncoding, "zstd",
 		"precondition: a zstd NAR must not have negotiated transport zstd")
 	assert.Equal(t, body, string(got),
 		"an unsolicited Content-Encoding: zstd must still be transparently decompressed")

--- a/pkg/cache/upstream/cache_test.go
+++ b/pkg/cache/upstream/cache_test.go
@@ -1,6 +1,7 @@
 package upstream_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/kalbasit/ncps/pkg/cache/upstream"
 	"github.com/kalbasit/ncps/pkg/nar"
+	"github.com/kalbasit/ncps/pkg/zstd"
 	"github.com/kalbasit/ncps/testdata"
 	"github.com/kalbasit/ncps/testhelper"
 )
@@ -772,4 +774,140 @@ func newContext() context.Context {
 	return zerolog.
 		New(io.Discard).
 		WithContext(context.Background())
+}
+
+// TestGetNarAcceptEncodingMatchesContentCompression pins what ncps puts on the
+// wire when fetching a NAR from an upstream.
+//
+// Asking for transport-level zstd on a NAR the narinfo already declares
+// compressed buys close to nothing — zstd over zstd/xz yields ~0% — and it is
+// actively harmful: a compressing proxy in front of the upstream (Caddy's
+// `encode zstd`, nginx, a CDN) honours the request and wraps the body, which
+// GetNar then transparently strips. If the upstream's own content was not in
+// fact compressed, ncps is left holding a raw NAR that it stores and serves as
+// `Compression: zstd`, and nix fails with "input compression not recognized".
+//
+// ncps is uniquely exposed because it always advertises zstd while nix's own
+// curl frequently is not built with it, so such a proxy compresses for ncps
+// alone. Negotiate only where it can pay: an uncompressed NAR, the Harmonia
+// shape this negotiation exists for.
+func TestGetNarAcceptEncodingMatchesContentCompression(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name        string
+		compression nar.CompressionType
+		wantZstdReq bool
+	}{
+		{name: "uncompressed NAR still negotiates zstd", compression: nar.CompressionTypeNone, wantZstdReq: true},
+		{name: "zstd NAR does not ask for transport zstd", compression: nar.CompressionTypeZstd, wantZstdReq: false},
+		{name: "xz NAR does not ask for transport zstd", compression: nar.CompressionTypeXz, wantZstdReq: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotAcceptEncoding string
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasSuffix(r.URL.Path, "/nix-cache-info") {
+					_, _ = io.WriteString(w, testdata.NixStoreInfo(40))
+
+					return
+				}
+
+				gotAcceptEncoding = r.Header.Get("Accept-Encoding")
+
+				_, _ = io.WriteString(w, "some-nar-bytes")
+			}))
+			t.Cleanup(ts.Close)
+
+			uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{})
+			require.NoError(t, err)
+
+			narURL := nar.URL{
+				Hash:        "188g68hrjilbsjifcj70k8729zqhm9sl1q336vg5wxwzw0qp0sk4",
+				Compression: tt.compression,
+			}
+
+			resp, err := uc.GetNar(context.Background(), narURL)
+			require.NoError(t, err)
+
+			t.Cleanup(func() {
+				_, _ = io.Copy(io.Discard, resp.Body)
+				_ = resp.Body.Close()
+			})
+
+			if tt.wantZstdReq {
+				assert.Contains(t, gotAcceptEncoding, "zstd",
+					"an uncompressed NAR should still negotiate transport zstd")
+			} else {
+				assert.NotContains(t, gotAcceptEncoding, "zstd",
+					"a NAR whose content is already %s must not request transport zstd", tt.compression)
+			}
+		})
+	}
+}
+
+// TestGetNarDecompressesUnsolicitedContentEncoding pins that the transparent
+// Content-Encoding handling stays unconditional.
+//
+// Now that a compressed NAR is fetched WITHOUT Accept-Encoding: zstd, any
+// Content-Encoding: zstd on such a response is unsolicited. Decompressing it is
+// still correct — a transfer encoding is a property of the response, not of what
+// we asked for — and refusing to would turn a working fetch from an eager but
+// conforming upstream into a corrupt one. This guards against a future
+// "only strip what we negotiated" simplification.
+func TestGetNarDecompressesUnsolicitedContentEncoding(t *testing.T) {
+	t.Parallel()
+
+	const body = "the-underlying-nar-bytes"
+
+	var compressed bytes.Buffer
+
+	zw := zstd.NewPooledWriter(&compressed)
+	_, err := zw.Write([]byte(body))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	var gotAcceptEncoding string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/nix-cache-info") {
+			_, _ = io.WriteString(w, testdata.NixStoreInfo(40))
+
+			return
+		}
+
+		// Unsolicited: the NAR below is declared zstd, so ncps does not negotiate
+		// transport zstd, yet this upstream applies it anyway. Recorded here and
+		// asserted on the test goroutine — testify must not FailNow off it.
+		gotAcceptEncoding = r.Header.Get("Accept-Encoding")
+
+		w.Header().Set("Content-Encoding", "zstd")
+		_, _ = w.Write(compressed.Bytes())
+	}))
+	t.Cleanup(ts.Close)
+
+	uc, err := upstream.New(newContext(), testhelper.MustParseURL(t, ts.URL), &upstream.Options{})
+	require.NoError(t, err)
+
+	narURL := nar.URL{
+		Hash:        "188g68hrjilbsjifcj70k8729zqhm9sl1q336vg5wxwzw0qp0sk4",
+		Compression: nar.CompressionTypeZstd,
+	}
+
+	resp, err := uc.GetNar(context.Background(), narURL)
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	got, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	assert.NotContains(t, gotAcceptEncoding, "zstd",
+		"precondition: a zstd NAR must not have negotiated transport zstd")
+	assert.Equal(t, body, string(got),
+		"an unsolicited Content-Encoding: zstd must still be transparently decompressed")
+	assert.Empty(t, resp.Header.Get("Content-Encoding"),
+		"the consumed transfer encoding must be stripped from the response headers")
 }


### PR DESCRIPTION
## Summary

Closes the last open gap from #1470 — the one the quarantined subtest described.

ncps sent `Accept-Encoding: zstd` on **every** upstream NAR fetch and transparently stripped any `Content-Encoding: zstd` it got back. For a NAR the narinfo already declares compressed, that request buys effectively nothing (zstd over zstd/xz yields ~0%) while inviting a compressing proxy in front of the upstream — Caddy's `encode zstd`, nginx, a CDN — to wrap the body. Where the upstream's own content was **not** in fact compressed, ncps was left holding a raw NAR that it stored and served as `Compression: zstd`, and nix failed with `input compression not recognized`.

What made ncps uniquely exposed: it always advertised zstd, while nix's own curl frequently is not built with it. So such a proxy compressed **for ncps alone**, and the same store path substituted fine directly — the exact asymmetry reported in #1470.

## What changed

Transport zstd is now negotiated only for a NAR whose resolved compression is `none` — the Harmonia shape the negotiation exists for. The gate lives in `GetNar` beside the matching decompression, so the two read together instead of being scattered across packages.

**Transparent decompression stays unconditional.** A transfer encoding is a property of the response, not of what we asked for; refusing to decode one would turn a working fetch from an eager-but-conforming upstream into a corrupt one. This change removes the case where ncps *invited* the encoding — it does not police upstreams that send it unbidden. `TestGetNarDecompressesUnsolicitedContentEncoding` pins that, so a future "only strip what we negotiated" simplification fails loudly.

**Dependency worth noting:** this only works because of the archived `narinfo-compression-authoritative` change. Before it, an Attic-shaped narinfo resolved to `none` despite zstd content — so gating on `Compression == none` would have mis-fired on precisely the shape that motivates this.

## The quarantined subtest is un-skipped

Its fake upstream set `Content-Encoding: zstd` **unconditionally**, modelling an upstream that lies regardless of the request. No real proxy does that — Caddy, nginx and CDNs all compress only when the client advertises — and left that way the subtest could not pass under *any* correct implementation, because it never reacted to what ncps asked for. Making the fixture realistic is what lets it run.

That does narrow what it proves: an upstream sending an **unsolicited** `Content-Encoding: zstd` over a raw body is a protocol violation that remains unsupported by design, and is no longer represented by a test. Called out in `design.md` — Risks.

`pkg/cache/attic_narinfo_url_compression_test.go` now has zero skips.

## Test plan

- [x] `task fmt`, `task lint` (0 issues), `task test` — green, before and after restacking onto current `main`
- [x] `TestGetNarAcceptEncodingMatchesContentCompression` — `none` negotiates; `zstd`/`xz` do not (the `none` row passed before the fix, so the test is not vacuous)
- [x] `TestGetNarDecompressesUnsolicitedContentEncoding` — unconditional strip preserved
- [x] `TestAtticNarInfoURLWithoutCompressionExtension` — both subtests pass, no skips
- [x] Harmonia (`Compression: none` + transport zstd), nix-serve, cachix and cache.nixos.org paths unchanged; `pkg/server` downstream `Accept-Encoding` untouched

Refs #1470